### PR TITLE
Move chat analytics to SDK

### DIFF
--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Services/AnalyticsAdapter.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Services/AnalyticsAdapter.swift
@@ -1,0 +1,248 @@
+import Foundation
+import SwiftUI
+import RunAnywhereSDK
+
+// MARK: - SDK Analytics Adapter
+
+/// Adapter that bridges sample app analytics needs with SDK analytics capabilities
+@MainActor
+class AnalyticsAdapter: ObservableObject {
+    static let shared = AnalyticsAdapter()
+    
+    private let sdk = RunAnywhereSDK.shared
+    private var currentSessionId: UUID?
+    
+    // Published properties for UI binding
+    @Published var currentSession: GenerationSession?
+    @Published var allSessions: [GenerationSession] = []
+    @Published var sessionSummary: SessionSummary?
+    
+    private init() {
+        // Load existing sessions on initialization
+        Task {
+            await loadSessions()
+        }
+    }
+    
+    // MARK: - Session Management
+    
+    /// Start a new conversation session
+    func startConversationSession(modelId: String) async -> UUID {
+        let session = await sdk.startAnalyticsSession(modelId: modelId, type: .chat)
+        currentSessionId = session.id
+        currentSession = session
+        await loadSessions()
+        return session.id
+    }
+    
+    /// End the current session
+    func endCurrentSession() async {
+        guard let sessionId = currentSessionId else { return }
+        await sdk.endAnalyticsSession(sessionId)
+        currentSessionId = nil
+        currentSession = nil
+        await loadSessions()
+    }
+    
+    /// Get the current session ID
+    func getCurrentSessionId() -> UUID? {
+        return currentSessionId
+    }
+    
+    // MARK: - Analytics Data Access
+    
+    /// Load all sessions for display
+    func loadSessions() async {
+        allSessions = await sdk.getAllAnalyticsSessions()
+        
+        // Update current session if we have one
+        if let sessionId = currentSessionId {
+            currentSession = await sdk.getAnalyticsSession(sessionId)
+            sessionSummary = await sdk.getSessionSummary(sessionId)
+        }
+    }
+    
+    /// Get generations for a specific session
+    func getGenerations(for sessionId: UUID) async -> [Generation] {
+        return await sdk.getGenerations(for: sessionId)
+    }
+    
+    /// Get session summary
+    func getSessionSummary(for sessionId: UUID) async -> SessionSummary? {
+        return await sdk.getSessionSummary(sessionId)
+    }
+    
+    /// Observe live metrics for a generation
+    func observeLiveMetrics(for generationId: UUID) -> AsyncStream<LiveGenerationMetrics> {
+        return sdk.observeLiveMetrics(for: generationId)
+    }
+    
+    // MARK: - Analytics Conversion Helpers
+    
+    /// Convert SDK Generation to sample app MessageAnalytics format (for backward compatibility)
+    func convertToMessageAnalytics(_ generation: Generation, conversation: Conversation?) -> MessageAnalytics? {
+        guard let performance = generation.performance else { return nil }
+        guard let conversation = conversation else { return nil }
+        
+        return MessageAnalytics(
+            messageId: generation.id.uuidString,
+            conversationId: conversation.id,
+            modelId: performance.modelId,
+            modelName: performance.modelId, // Using ID as name for now
+            framework: performance.routingFramework ?? "unknown",
+            timestamp: generation.timestamp,
+            timeToFirstToken: performance.timeToFirstToken,
+            totalGenerationTime: performance.totalGenerationTime,
+            thinkingTime: nil, // Not tracked separately in SDK
+            responseTime: performance.totalGenerationTime,
+            inputTokens: performance.inputTokens,
+            outputTokens: performance.outputTokens,
+            thinkingTokens: nil, // Not separated in SDK
+            responseTokens: performance.outputTokens,
+            averageTokensPerSecond: performance.tokensPerSecond,
+            messageLength: performance.outputTokens * 4, // Rough estimation
+            wasThinkingMode: false, // Would need to be tracked separately
+            wasInterrupted: false, // Would need to be tracked separately
+            retryCount: 0,
+            completionStatus: .complete, // Would need more detailed tracking
+            tokensPerSecondHistory: [], // Not available in SDK currently
+            generationMode: .streaming, // Default assumption
+            contextWindowUsage: 0.0, // Not tracked in SDK
+            generationParameters: MessageAnalytics.GenerationParameters()
+        )
+    }
+    
+    /// Convert SDK GenerationSession to sample app ConversationAnalytics format
+    func convertToConversationAnalytics(_ session: GenerationSession, summary: SessionSummary?) -> ConversationAnalytics? {
+        guard let summary = summary else { return nil }
+        
+        let modelsUsed = Set([session.modelId])
+        
+        return ConversationAnalytics(
+            conversationId: session.id.uuidString,
+            startTime: session.startTime,
+            endTime: session.endTime,
+            messageCount: summary.totalGenerations,
+            averageTTFT: summary.averageTimeToFirstToken,
+            averageGenerationSpeed: summary.averageTokensPerSecond,
+            totalTokensUsed: summary.totalInputTokens + summary.totalOutputTokens,
+            modelsUsed: modelsUsed,
+            thinkingModeUsage: 0.0, // Not tracked in SDK
+            completionRate: 1.0, // Assume all complete for now
+            averageMessageLength: summary.totalOutputTokens / max(summary.totalGenerations, 1),
+            currentModel: session.modelId,
+            ongoingMetrics: nil
+        )
+    }
+    
+    // MARK: - Performance Helpers
+    
+    /// Get average metrics for the current model
+    func getAverageMetrics(for modelId: String) async -> AverageMetrics? {
+        return await sdk.getAverageMetrics(for: modelId)
+    }
+    
+    /// Get performance summary for display
+    func getPerformanceSummary(for sessionId: UUID) async -> PerformanceSummary? {
+        guard let summary = await sdk.getSessionSummary(sessionId) else { return nil }
+        guard let session = await sdk.getAnalyticsSession(sessionId) else { return nil }
+        
+        return PerformanceSummary(
+            averageResponseTime: summary.totalDuration / Double(max(summary.totalGenerations, 1)),
+            totalTokens: summary.totalInputTokens + summary.totalOutputTokens,
+            mainModel: session.modelId,
+            completionRate: 1.0, // Assume all complete
+            averageTokensPerSecond: summary.averageTokensPerSecond
+        )
+    }
+}
+
+// MARK: - Legacy Analytics Models for Backward Compatibility
+
+/// Simplified version of the original MessageAnalytics for compatibility
+struct MessageAnalytics: Codable {
+    // Identifiers
+    let messageId: String
+    let conversationId: String
+    let modelId: String
+    let modelName: String
+    let framework: String
+    let timestamp: Date
+
+    // Timing Metrics
+    let timeToFirstToken: TimeInterval?
+    let totalGenerationTime: TimeInterval
+    let thinkingTime: TimeInterval?
+    let responseTime: TimeInterval?
+
+    // Token Metrics
+    let inputTokens: Int
+    let outputTokens: Int
+    let thinkingTokens: Int?
+    let responseTokens: Int
+    let averageTokensPerSecond: Double
+
+    // Quality Metrics
+    let messageLength: Int
+    let wasThinkingMode: Bool
+    let wasInterrupted: Bool
+    let retryCount: Int
+    let completionStatus: CompletionStatus
+
+    // Performance Indicators
+    let tokensPerSecondHistory: [Double]
+    let generationMode: GenerationMode
+
+    // Context Information
+    let contextWindowUsage: Double
+    let generationParameters: GenerationParameters
+
+    enum CompletionStatus: String, Codable {
+        case complete
+        case interrupted
+        case failed
+        case timeout
+    }
+
+    enum GenerationMode: String, Codable {
+        case streaming
+        case nonStreaming
+    }
+
+    struct GenerationParameters: Codable {
+        let temperature: Double
+        let maxTokens: Int
+        let topP: Double?
+        let topK: Int?
+
+        init(temperature: Double = 0.7, maxTokens: Int = 500, topP: Double? = nil, topK: Int? = nil) {
+            self.temperature = temperature
+            self.maxTokens = maxTokens
+            self.topP = topP
+            self.topK = topK
+        }
+    }
+}
+
+/// Simplified ConversationAnalytics for compatibility
+struct ConversationAnalytics: Codable {
+    let conversationId: String
+    let startTime: Date
+    let endTime: Date?
+    let messageCount: Int
+
+    // Aggregate Metrics
+    let averageTTFT: TimeInterval
+    let averageGenerationSpeed: Double
+    let totalTokensUsed: Int
+    let modelsUsed: Set<String>
+
+    // Efficiency Metrics
+    let thinkingModeUsage: Double
+    let completionRate: Double
+    let averageMessageLength: Int
+
+    // Real-time Metrics
+    let currentModel: String?
+    let ongoingMetrics: MessageAnalytics?
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Services/ConversationStore.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Services/ConversationStore.swift
@@ -2,8 +2,6 @@ import Foundation
 import SwiftUI
 import RunAnywhereSDK
 
-// Note: MessageAnalytics and ConversationAnalytics are defined in ChatViewModel.swift
-
 // MARK: - Conversation Store
 
 @MainActor
@@ -197,10 +195,6 @@ struct Conversation: Identifiable, Codable {
     var modelName: String?
     var frameworkName: String?
 
-    // NEW: Conversation-level analytics
-    var analytics: ConversationAnalytics?
-    var performanceSummary: PerformanceSummary?
-
     var summary: String {
         guard !messages.isEmpty else { return "No messages" }
 
@@ -219,34 +213,6 @@ struct Conversation: Identifiable, Codable {
             .replacingOccurrences(of: "\n", with: " ")
 
         return String(preview.prefix(100))
-    }
-}
-
-// Performance summary for quick access
-struct PerformanceSummary: Codable {
-    let averageResponseTime: TimeInterval
-    let totalTokens: Int
-    let mainModel: String?
-    let completionRate: Double
-    let averageTokensPerSecond: Double
-
-    init(from messages: [Message]) {
-        let analyticsMessages = messages.compactMap { $0.analytics }
-
-        if !analyticsMessages.isEmpty {
-            averageResponseTime = analyticsMessages.compactMap { $0.totalGenerationTime }.reduce(0, +) / Double(analyticsMessages.count)
-            totalTokens = analyticsMessages.reduce(0) { $0 + $1.inputTokens + $1.outputTokens }
-            mainModel = analyticsMessages.first?.modelName
-            let completed = analyticsMessages.filter { $0.completionStatus == .complete }.count
-            completionRate = Double(completed) / Double(analyticsMessages.count)
-            averageTokensPerSecond = analyticsMessages.compactMap { $0.averageTokensPerSecond }.reduce(0, +) / Double(analyticsMessages.count)
-        } else {
-            averageResponseTime = 0
-            totalTokens = 0
-            mainModel = nil
-            completionRate = 0
-            averageTokensPerSecond = 0
-        }
     }
 }
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ChatViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ChatViewModel.swift
@@ -2,7 +2,7 @@
 //  ChatViewModel.swift
 //  RunAnywhereAI
 //
-//  Simplified version that uses SDK directly
+//  Simplified version that uses SDK analytics
 //
 
 import Foundation
@@ -10,118 +10,13 @@ import SwiftUI
 import RunAnywhereSDK
 import os.log
 
-// MARK: - Analytics Models
-
-public struct MessageAnalytics: Codable {
-    // Identifiers
-    let messageId: String
-    let conversationId: String
-    let modelId: String
-    let modelName: String
-    let framework: String
-    let timestamp: Date
-
-    // Timing Metrics
-    let timeToFirstToken: TimeInterval?
-    let totalGenerationTime: TimeInterval
-    let thinkingTime: TimeInterval?
-    let responseTime: TimeInterval?
-
-    // Token Metrics
-    let inputTokens: Int
-    let outputTokens: Int
-    let thinkingTokens: Int?
-    let responseTokens: Int
-    let averageTokensPerSecond: Double
-
-    // Quality Metrics
-    let messageLength: Int
-    let wasThinkingMode: Bool
-    let wasInterrupted: Bool
-    let retryCount: Int
-    let completionStatus: CompletionStatus
-
-    // Performance Indicators
-    let tokensPerSecondHistory: [Double] // Real-time speed tracking
-    let generationMode: GenerationMode // streaming vs non-streaming
-
-    // Context Information
-    let contextWindowUsage: Double // percentage
-    let generationParameters: GenerationParameters
-
-    public enum CompletionStatus: String, Codable {
-        case complete
-        case interrupted
-        case failed
-        case timeout
-    }
-
-    public enum GenerationMode: String, Codable {
-        case streaming
-        case nonStreaming
-    }
-
-    public struct GenerationParameters: Codable {
-        let temperature: Double
-        let maxTokens: Int
-        let topP: Double?
-        let topK: Int?
-
-        init(temperature: Double = 0.7, maxTokens: Int = 500, topP: Double? = nil, topK: Int? = nil) {
-            self.temperature = temperature
-            self.maxTokens = maxTokens
-            self.topP = topP
-            self.topK = topK
-        }
-    }
-}
-
-public struct ConversationAnalytics: Codable {
-    let conversationId: String
-    let startTime: Date
-    let endTime: Date?
-    let messageCount: Int
-
-    // Aggregate Metrics
-    let averageTTFT: TimeInterval
-    let averageGenerationSpeed: Double
-    let totalTokensUsed: Int
-    let modelsUsed: Set<String>
-
-    // Efficiency Metrics
-    let thinkingModeUsage: Double // percentage
-    let completionRate: Double // successful / total
-    let averageMessageLength: Int
-
-    // Real-time Metrics
-    let currentModel: String?
-    let ongoingMetrics: MessageAnalytics?
-}
-
-// Simple model reference for messages
-public struct MessageModelInfo: Codable {
-    public let modelId: String
-    public let modelName: String
-    public let framework: String
-
-    public init(from modelInfo: ModelInfo) {
-        self.modelId = modelInfo.id
-        self.modelName = modelInfo.name
-        self.framework = modelInfo.compatibleFrameworks.first?.rawValue ?? "unknown"
-    }
-}
-
-// Local Message type for the app
+// Local Message type for the app (simplified, no analytics)
 public struct Message: Identifiable, Codable {
     public let id: UUID
     public let role: Role
     public let content: String
     public let thinkingContent: String?
     public let timestamp: Date
-
-    // NEW: Analytics data
-    public let analytics: MessageAnalytics?
-    public let modelInfo: MessageModelInfo? // Link to specific model used
 
     public enum Role: String, Codable {
         case system
@@ -134,17 +29,13 @@ public struct Message: Identifiable, Codable {
         role: Role,
         content: String,
         thinkingContent: String? = nil,
-        timestamp: Date = Date(),
-        analytics: MessageAnalytics? = nil,
-        modelInfo: MessageModelInfo? = nil
+        timestamp: Date = Date()
     ) {
         self.id = id
         self.role = role
         self.content = content
         self.thinkingContent = thinkingContent
         self.timestamp = timestamp
-        self.analytics = analytics
-        self.modelInfo = modelInfo
     }
 }
 
@@ -167,12 +58,14 @@ class ChatViewModel: ObservableObject {
     @Published var error: Error?
     @Published var isModelLoaded = false
     @Published var loadedModelName: String?
-    @Published var useStreaming = true  // Enable streaming for real-time token display
+    @Published var useStreaming = true
 
     private let sdk = RunAnywhereSDK.shared
     private let conversationStore = ConversationStore.shared
+    private let analyticsAdapter = AnalyticsAdapter.shared
     private var generationTask: Task<Void, Never>?
     @Published var currentConversation: Conversation?
+    private var currentAnalyticsSessionId: UUID?
 
     private let logger = Logger(subsystem: "com.runanywhere.RunAnywhereAI", category: "ChatViewModel")
 
@@ -184,7 +77,7 @@ class ChatViewModel: ObservableObject {
         // Always start with a new conversation for a fresh chat experience
         let conversation = conversationStore.createConversation()
         currentConversation = conversation
-        messages = [] // Start with empty messages array
+        messages = []
 
         // Add system message only if model is already loaded
         if isModelLoaded {
@@ -211,9 +104,6 @@ class ChatViewModel: ObservableObject {
         Task {
             await ensureSettingsAreApplied()
         }
-
-        // Delay analytics initialization to avoid crash during SDK startup
-        // Analytics will be initialized when the view appears or when first used
     }
 
     private func addSystemMessage() {
@@ -243,7 +133,7 @@ class ChatViewModel: ObservableObject {
         }
         logger.info("✅ canSend is true, proceeding")
 
-                let prompt = currentInput
+        let prompt = currentInput
         currentInput = ""
         isGenerating = true
         error = nil
@@ -254,6 +144,11 @@ class ChatViewModel: ObservableObject {
         // Save user message to conversation
         if let conversation = currentConversation {
             conversationStore.addMessage(userMessage, to: conversation)
+        }
+
+        // Start analytics session if we don't have one
+        if currentAnalyticsSessionId == nil {
+            currentAnalyticsSessionId = await startAnalyticsSession()
         }
 
         // Create assistant message that we'll update with streaming tokens
@@ -268,19 +163,14 @@ class ChatViewModel: ObservableObject {
                 logger.info("📝 Checking model status - isModelLoaded: \(self.isModelLoaded), loadedModelName: \(self.loadedModelName ?? "nil")")
 
                 // Check if we need to reload the model in SDK
-                // This handles cases where the app was restarted but UI state shows model as loaded
                 if isModelLoaded, let _ = loadedModelName {
                     logger.info("📝 Model appears loaded, checking SDK state")
-                    // Try to ensure the model is actually loaded in the SDK
-                    // Get the model from ModelListViewModel
                     if let model = ModelListViewModel.shared.currentModel {
                         do {
-                            // This will reload the model if it's not already loaded
                             _ = try await sdk.loadModel(model.id)
                             logger.info("✅ Ensured model '\(model.name)' is loaded in SDK")
                         } catch {
                             logger.error("Failed to ensure model is loaded: \(error)")
-                            // If loading fails, update our state
                             await MainActor.run {
                                 self.isModelLoaded = false
                                 self.loadedModelName = nil
@@ -298,65 +188,32 @@ class ChatViewModel: ObservableObject {
 
                 logger.info("🎯 Starting generation with prompt: \(String(prompt.prefix(50)))..., streaming: \(self.useStreaming)")
 
-                // Send only the new user message - LLM.swift manages history internally
-                let fullPrompt = prompt
-                logger.info("📝 Sending new message only: \(fullPrompt)")
-
                 // Get SDK configuration for generation options
                 let effectiveSettings = await sdk.getGenerationSettings()
                 let options = GenerationOptions(
                     maxTokens: effectiveSettings.maxTokens,
                     temperature: Float(effectiveSettings.temperature)
-                    // No context passed - it's all in the prompt now
                 )
 
                 logger.info("📝 Generation options created, useStreaming: \(self.useStreaming)")
 
                 if useStreaming {
-                    // Use streaming generation for real-time updates
+                    // Use SDK streaming with analytics
+                    let stream = sdk.generateStream(prompt: prompt, options: options)
                     var fullResponse = ""
                     var isInThinkingMode = false
                     var thinkingContent = ""
                     var responseContent = ""
-                    var _ = Date() // lastTokenTime tracking for future use
-                    let _ : TimeInterval = 30.0 // 30 seconds timeout for thinking (not used yet)
 
-                    // Analytics tracking
-                    let startTime = Date()
-                    var firstTokenTime: Date? = nil
-                    var thinkingStartTime: Date? = nil
-                    var thinkingEndTime: Date? = nil
-                    var tokensPerSecondHistory: [Double] = []
-                    var totalTokensReceived = 0
-                    var wasInterrupted = false
-
-                    logger.info("📤 Sending prompt to SDK.generateStream")
-                    let stream = sdk.generateStream(prompt: fullPrompt, options: options)
+                    logger.info("📤 Using SDK streaming generation")
 
                     // Stream tokens as they arrive
                     for try await token in stream {
                         fullResponse += token
-                        // Track token timing (lastTokenTime could be used for timeout detection)
-                        totalTokensReceived += 1
-
-                        // Track first token time
-                        if firstTokenTime == nil {
-                            firstTokenTime = Date()
-                        }
-
-                        // Calculate real-time tokens per second every 10 tokens
-                        if totalTokensReceived % 10 == 0 {
-                            let elapsed = Date().timeIntervalSince(firstTokenTime ?? startTime)
-                            if elapsed > 0 {
-                                let currentSpeed = Double(totalTokensReceived) / elapsed
-                                tokensPerSecondHistory.append(currentSpeed)
-                            }
-                        }
 
                         // Check for thinking tags
                         if fullResponse.contains("<think>") && !isInThinkingMode {
                             isInThinkingMode = true
-                            thinkingStartTime = Date()
                             logger.info("🧠 Entering thinking mode")
                         }
 
@@ -368,7 +225,6 @@ class ChatViewModel: ObservableObject {
                                     thinkingContent = String(fullResponse[thinkingStart.upperBound..<thinkingEnd.lowerBound])
                                     responseContent = String(fullResponse[thinkingEnd.upperBound...])
                                     isInThinkingMode = false
-                                    thinkingEndTime = Date()
                                     logger.info("🧠 Exiting thinking mode - found closing tag")
                                 }
                             } else {
@@ -404,136 +260,35 @@ class ChatViewModel: ObservableObject {
 
                     logger.info("Streaming completed with response: \(fullResponse)")
 
-                    // Analytics: Mark end time and check for interruption
-                    let endTime = Date()
-                    wasInterrupted = isInThinkingMode && !fullResponse.contains("</think>")
+                    // Handle final content processing
+                    await MainActor.run {
+                        if messageIndex < self.messages.count {
+                            let finalContent: String
+                            let finalThinking: String?
 
-                    // Handle edge case: Stream ended while still in thinking mode (token limit reached)
-                    if isInThinkingMode && !fullResponse.contains("</think>") {
-                        logger.warning("⚠️ Stream ended while in thinking mode - handling gracefully")
-                        wasInterrupted = true
-
-                        // Check if we have any thinking content to show
-                        if !thinkingContent.isEmpty {
-                            // Show the partial thinking content and treat the rest as response
-                            let remainingContent = fullResponse
-                                .replacingOccurrences(of: "<think>", with: "")
-                                .replacingOccurrences(of: thinkingContent, with: "")
-                                .trimmingCharacters(in: .whitespacesAndNewlines)
-
-                            await MainActor.run {
-                                if messageIndex < self.messages.count {
-                                    // Generate intelligent response based on thinking content
-                                    let intelligentResponse = remainingContent.isEmpty ?
-                                        self.generateThinkingSummaryResponse(from: thinkingContent) : remainingContent
-
-                                    let updatedMessage = Message(
-                                        id: self.messages[messageIndex].id,
-                                        role: self.messages[messageIndex].role,
-                                        content: intelligentResponse,
-                                        thinkingContent: thinkingContent.trimmingCharacters(in: .whitespacesAndNewlines),
-                                        timestamp: self.messages[messageIndex].timestamp
-                                    )
-                                    self.messages[messageIndex] = updatedMessage
-                                }
+                            if let thinkingRange = fullResponse.range(of: "<think>"),
+                               let thinkingEndRange = fullResponse.range(of: "</think>") {
+                                finalThinking = String(fullResponse[thinkingRange.upperBound..<thinkingEndRange.lowerBound]).trimmingCharacters(in: .whitespacesAndNewlines)
+                                finalContent = String(fullResponse[thinkingEndRange.upperBound...]).trimmingCharacters(in: .whitespacesAndNewlines)
+                            } else {
+                                finalThinking = nil
+                                finalContent = fullResponse.trimmingCharacters(in: .whitespacesAndNewlines)
                             }
-                        } else {
-                            // No thinking content, treat entire response as regular content
-                            let cleanContent = fullResponse
-                                .replacingOccurrences(of: "<think>", with: "")
-                                .trimmingCharacters(in: .whitespacesAndNewlines)
 
-                            await MainActor.run {
-                                if messageIndex < self.messages.count {
-                                    let fallbackResponse = cleanContent.isEmpty ?
-                                        "I need to think more about this. Could you rephrase your question?" : cleanContent
-
-                                    let updatedMessage = Message(
-                                        id: self.messages[messageIndex].id,
-                                        role: self.messages[messageIndex].role,
-                                        content: fallbackResponse,
-                                        thinkingContent: nil,
-                                        timestamp: self.messages[messageIndex].timestamp
-                                    )
-                                    self.messages[messageIndex] = updatedMessage
-                                }
-                            }
-                        }
-                    } else {
-                        // Normal completion with proper closing tag
-                        if let thinkingRange = fullResponse.range(of: "<think>"),
-                           let thinkingEndRange = fullResponse.range(of: "</think>") {
-                            thinkingContent = String(fullResponse[thinkingRange.upperBound..<thinkingEndRange.lowerBound])
-                            responseContent = String(fullResponse[thinkingEndRange.upperBound...])
-
-                            await MainActor.run {
-                                if messageIndex < self.messages.count {
-                                    let updatedMessage = Message(
-                                        id: self.messages[messageIndex].id,
-                                        role: self.messages[messageIndex].role,
-                                        content: responseContent.trimmingCharacters(in: .whitespacesAndNewlines),
-                                        thinkingContent: thinkingContent.trimmingCharacters(in: .whitespacesAndNewlines),
-                                        timestamp: self.messages[messageIndex].timestamp
-                                    )
-                                    self.messages[messageIndex] = updatedMessage
-                                }
-                            }
+                            let updatedMessage = Message(
+                                id: self.messages[messageIndex].id,
+                                role: self.messages[messageIndex].role,
+                                content: finalContent,
+                                thinkingContent: finalThinking,
+                                timestamp: self.messages[messageIndex].timestamp
+                            )
+                            self.messages[messageIndex] = updatedMessage
                         }
                     }
 
-                    // Collect analytics for streaming generation
-                    if let conversationId = currentConversation?.id,
-                       messageIndex < messages.count {
-                        let finalResponseContent = responseContent.trimmingCharacters(in: .whitespacesAndNewlines)
-                        let finalThinkingContent = thinkingContent.isEmpty ? nil : thinkingContent.trimmingCharacters(in: .whitespacesAndNewlines)
-
-                        let analytics = collectMessageAnalytics(
-                            messageId: messages[messageIndex].id.uuidString,
-                            conversationId: conversationId,
-                            startTime: startTime,
-                            endTime: endTime,
-                            firstTokenTime: firstTokenTime,
-                            thinkingStartTime: thinkingStartTime,
-                            thinkingEndTime: thinkingEndTime,
-                            inputText: prompt,
-                            outputText: finalResponseContent,
-                            thinkingText: finalThinkingContent,
-                            tokensPerSecondHistory: tokensPerSecondHistory,
-                            wasInterrupted: wasInterrupted,
-                            options: options
-                        )
-
-                        // Update message with analytics
-                        await MainActor.run {
-                            if let analytics = analytics, messageIndex < self.messages.count {
-                                let currentMessage = self.messages[messageIndex]
-                                let modelInfo = ModelListViewModel.shared.currentModel != nil ? MessageModelInfo(from: ModelListViewModel.shared.currentModel!) : nil
-
-                                self.logger.info("📊 Attaching analytics to message \(messageIndex): tokens/sec = \(analytics.averageTokensPerSecond), time = \(analytics.totalGenerationTime)")
-
-                                let updatedMessage = Message(
-                                    id: currentMessage.id,
-                                    role: currentMessage.role,
-                                    content: currentMessage.content,
-                                    thinkingContent: currentMessage.thinkingContent,
-                                    timestamp: currentMessage.timestamp,
-                                    analytics: analytics,
-                                    modelInfo: modelInfo
-                                )
-                                self.messages[messageIndex] = updatedMessage
-
-                                // Update conversation-level analytics
-                                self.updateConversationAnalytics()
-                            }
-                        }
-                    }
                 } else {
-                    // Use non-streaming generation to get thinking content
-                    let startTime = Date()
-                    let wasInterrupted = false
-                    let result = try await sdk.generate(prompt: fullPrompt, options: options)
-                    let endTime = Date()
-
+                    // Use SDK non-streaming generation with analytics
+                    let result = try await sdk.generate(prompt: prompt, options: options)
                     logger.info("Generation completed with result: \(result.text)")
 
                     // Update the assistant message with the complete response
@@ -541,6 +296,7 @@ class ChatViewModel: ObservableObject {
                         if messageIndex < self.messages.count {
                             let currentMessage = self.messages[messageIndex]
                             let updatedMessage = Message(
+                                id: currentMessage.id,
                                 role: currentMessage.role,
                                 content: result.text,
                                 thinkingContent: result.thinkingContent,
@@ -549,58 +305,9 @@ class ChatViewModel: ObservableObject {
                             self.messages[messageIndex] = updatedMessage
                         }
                     }
-
-                    // Collect analytics for non-streaming generation
-                    if let conversationId = currentConversation?.id,
-                       messageIndex < messages.count {
-                        let analytics = collectMessageAnalytics(
-                            messageId: messages[messageIndex].id.uuidString,
-                            conversationId: conversationId,
-                            startTime: startTime,
-                            endTime: endTime,
-                            firstTokenTime: nil, // Not applicable for non-streaming
-                            thinkingStartTime: nil, // Not tracked separately in non-streaming
-                            thinkingEndTime: nil,
-                            inputText: prompt,
-                            outputText: result.text,
-                            thinkingText: result.thinkingContent,
-                            tokensPerSecondHistory: [], // Not applicable for non-streaming
-                            wasInterrupted: wasInterrupted,
-                            options: options
-                        )
-
-                        // Update message with analytics
-                        await MainActor.run {
-                            if let analytics = analytics, messageIndex < self.messages.count {
-                                let currentMessage = self.messages[messageIndex]
-                                let modelInfo = ModelListViewModel.shared.currentModel != nil ? MessageModelInfo(from: ModelListViewModel.shared.currentModel!) : nil
-
-                                self.logger.info("📊 Attaching analytics to message \(messageIndex): tokens/sec = \(analytics.averageTokensPerSecond), time = \(analytics.totalGenerationTime)")
-
-                                let updatedMessage = Message(
-                                    id: currentMessage.id,
-                                    role: currentMessage.role,
-                                    content: currentMessage.content,
-                                    thinkingContent: currentMessage.thinkingContent,
-                                    timestamp: currentMessage.timestamp,
-                                    analytics: analytics,
-                                    modelInfo: modelInfo
-                                )
-                                self.messages[messageIndex] = updatedMessage
-
-                                // Update conversation-level analytics
-                                self.updateConversationAnalytics()
-                            }
-                        }
-                    }
-
-                    // No need to update context - it's managed in messages array
                 }
             } catch {
                 logger.error("❌ Generation failed with error: \(error)")
-                logger.error("❌ Error type: \(type(of: error))")
-                logger.error("❌ Error details: \(String(describing: error))")
-
                 await MainActor.run {
                     self.error = error
                     // Add error message to chat
@@ -613,6 +320,7 @@ class ChatViewModel: ObservableObject {
                         }
                         let currentMessage = self.messages[messageIndex]
                         let updatedMessage = Message(
+                            id: currentMessage.id,
                             role: currentMessage.role,
                             content: errorMessage,
                             timestamp: currentMessage.timestamp
@@ -625,23 +333,35 @@ class ChatViewModel: ObservableObject {
             await MainActor.run {
                 self.isGenerating = false
 
-                // Save final assistant message to conversation with analytics
+                // Save final assistant message to conversation
                 if messageIndex < self.messages.count,
                    let conversation = self.currentConversation {
-                    // Update conversation with final message including analytics
                     var updatedConversation = conversation
                     updatedConversation.messages = self.messages
                     updatedConversation.modelName = self.loadedModelName
 
-                    // Log analytics status
-                    let analyticsCount = self.messages.compactMap { $0.analytics }.count
-                    self.logger.info("💾 Saving conversation with \(self.messages.count) messages, \(analyticsCount) have analytics")
-
+                    self.logger.info("💾 Saving conversation with \(self.messages.count) messages")
                     self.conversationStore.updateConversation(updatedConversation)
                 }
             }
         }
     }
+
+    // MARK: - Analytics Session Management
+
+    private func startAnalyticsSession() async -> UUID {
+        let modelId = ModelListViewModel.shared.currentModel?.id ?? "unknown"
+        return await analyticsAdapter.startConversationSession(modelId: modelId)
+    }
+
+    private func endAnalyticsSession() async {
+        if currentAnalyticsSessionId != nil {
+            await analyticsAdapter.endCurrentSession()
+            currentAnalyticsSessionId = nil
+        }
+    }
+
+    // MARK: - UI Actions
 
     func clearChat() {
         generationTask?.cancel()
@@ -649,6 +369,11 @@ class ChatViewModel: ObservableObject {
         currentInput = ""
         isGenerating = false
         error = nil
+
+        // End current analytics session
+        Task {
+            await endAnalyticsSession()
+        }
 
         // Create new conversation
         let conversation = conversationStore.createConversation()
@@ -687,8 +412,6 @@ class ChatViewModel: ObservableObject {
     }
 
     func checkModelStatus() async {
-        // Check if a model is currently loaded in the SDK
-        // Since we can't directly access SDK's current model, we'll check via ModelListViewModel
         let modelListViewModel = ModelListViewModel.shared
 
         await MainActor.run {
@@ -701,7 +424,6 @@ class ChatViewModel: ObservableObject {
                     do {
                         _ = try await sdk.loadModel(currentModel.id)
                         logger.info("Verified model '\(currentModel.name)' is loaded in SDK")
-
                     } catch {
                         logger.error("Failed to verify model is loaded: \(error)")
                         await MainActor.run {
@@ -713,7 +435,6 @@ class ChatViewModel: ObservableObject {
             } else {
                 self.isModelLoaded = false
                 self.loadedModelName = nil
-
             }
 
             // Update system message
@@ -737,7 +458,6 @@ class ChatViewModel: ObservableObject {
                     self.addSystemMessage()
                 }
             } else {
-                // If no model object is passed, check the current model state
                 await self.checkModelStatus()
             }
         }
@@ -750,6 +470,11 @@ class ChatViewModel: ObservableObject {
     }
 
     func loadConversation(_ conversation: Conversation) {
+        // End current analytics session when switching conversations
+        Task {
+            await endAnalyticsSession()
+        }
+
         currentConversation = conversation
 
         // For new conversations (empty messages), start fresh
@@ -762,10 +487,7 @@ class ChatViewModel: ObservableObject {
             }
         } else {
             messages = conversation.messages
-
-            // Log analytics status
-            let analyticsCount = messages.compactMap { $0.analytics }.count
-            logger.info("📂 Loaded conversation with \(self.messages.count) messages, \(analyticsCount) have analytics")
+            logger.info("📂 Loaded conversation with \(self.messages.count) messages")
         }
 
         // Update model info if available
@@ -795,245 +517,9 @@ class ChatViewModel: ObservableObject {
 
     deinit {
         NotificationCenter.default.removeObserver(self)
-    }
-
-    // MARK: - Context Management
-
-    private func buildFullPrompt() -> String {
-        // Since LLM.swift handles its own template formatting, we should pass raw messages
-        // Let's try a simple conversation format first
-        var promptParts: [String] = []
-
-        logger.info("Building simple prompt from \(self.messages.count) messages")
-
-        // Build conversation in a simple format
-        var hasMessages = false
-        for (_, message) in messages.enumerated() {
-            switch message.role {
-            case .user:
-                if hasMessages {
-                    promptParts.append("")  // Add blank line between exchanges
-                }
-                promptParts.append("User: \(message.content)")
-                hasMessages = true
-            case .assistant:
-                // Only add assistant messages that have content
-                if !message.content.isEmpty {
-                    promptParts.append("Assistant: \(message.content)")
-                }
-            case .system:
-                // Skip system messages in the prompt
-                continue
-            }
-        }
-
-        // Don't add "Assistant:" at the end - let the model complete naturally
-
-        let fullPrompt = promptParts.joined(separator: "\n")
-        logger.info("📝 Built simple prompt with \(promptParts.count) parts")
-        logger.info("📝 Final prompt:\n\(fullPrompt)")
-        return fullPrompt
-    }
-
-    // MARK: - Thinking Summary Generation
-
-    private func generateThinkingSummaryResponse(from thinkingContent: String) -> String {
-        let thinking = thinkingContent.trimmingCharacters(in: .whitespacesAndNewlines)
-
-        // Extract key insights from thinking content
-        let keyPhrases = extractKeyPhrasesFromThinking(thinking)
-
-        if !keyPhrases.isEmpty {
-            // Create natural response based on thinking
-            if thinking.lowercased().contains("user") && thinking.lowercased().contains("help") {
-                return "I'm here to help! \(keyPhrases.first ?? "")"
-            } else if thinking.lowercased().contains("question") || thinking.lowercased().contains("ask") {
-                return "That's a good question. \(keyPhrases.first ?? "")"
-            } else if thinking.lowercased().contains("consider") || thinking.lowercased().contains("think") {
-                return "Let me consider this. \(keyPhrases.first ?? "")"
-            } else {
-                return keyPhrases.first ?? "I was analyzing your message. How can I help you further?"
-            }
-        }
-
-        // Fallback based on thinking content length and context
-        if thinking.count > 200 {
-            return "I was thinking through this carefully. Could you help me understand what you're looking for?"
-        } else {
-            return "I'm processing your message. What would be most helpful for you?"
+        // End analytics session on deinit
+        Task {
+            await endAnalyticsSession()
         }
     }
-
-    private func extractKeyPhrasesFromThinking(_ thinking: String) -> [String] {
-        var keyPhrases: [String] = []
-
-        // Split into sentences and find meaningful ones
-        let sentences = thinking.components(separatedBy: CharacterSet(charactersIn: ".!?"))
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { $0.count > 10 && $0.count < 100 }
-
-        // Look for sentences that seem like conclusions or key insights
-        for sentence in sentences.prefix(3) {
-            let lowercased = sentence.lowercased()
-
-            // Skip meta-thinking sentences
-            if lowercased.contains("i should") ||
-               lowercased.contains("let me") ||
-               lowercased.contains("i need to") ||
-               lowercased.contains("maybe i") {
-                continue
-            }
-
-            // Include substantive thoughts
-            if lowercased.contains("because") ||
-               lowercased.contains("since") ||
-               lowercased.contains("this means") ||
-               lowercased.contains("the key is") ||
-               lowercased.contains("important") {
-                keyPhrases.append(sentence)
-            }
-        }
-
-        // If no good phrases found, take first substantial sentence
-        if keyPhrases.isEmpty {
-            if let firstGoodSentence = sentences.first(where: { $0.count > 20 && $0.count < 80 }) {
-                keyPhrases.append(firstGoodSentence + "...")
-            }
-        }
-
-        return keyPhrases
-    }
-
-    // MARK: - Analytics Service
-
-    private func collectMessageAnalytics(
-        messageId: String,
-        conversationId: String,
-        startTime: Date,
-        endTime: Date,
-        firstTokenTime: Date?,
-        thinkingStartTime: Date?,
-        thinkingEndTime: Date?,
-        inputText: String,
-        outputText: String,
-        thinkingText: String?,
-        tokensPerSecondHistory: [Double],
-        wasInterrupted: Bool,
-        options: GenerationOptions
-    ) -> MessageAnalytics? {
-
-        guard let modelName = loadedModelName,
-              let currentModel = ModelListViewModel.shared.currentModel else {
-            logger.warning("Cannot create analytics - no model info available")
-            return nil
-        }
-
-        let totalGenerationTime = endTime.timeIntervalSince(startTime)
-        let timeToFirstToken = firstTokenTime?.timeIntervalSince(startTime)
-
-        var thinkingTime: TimeInterval? = nil
-        var responseTime: TimeInterval? = nil
-
-        if let thinkingStart = thinkingStartTime, let thinkingEnd = thinkingEndTime {
-            thinkingTime = thinkingEnd.timeIntervalSince(thinkingStart)
-            responseTime = totalGenerationTime - (thinkingTime ?? 0)
-        }
-
-        // Calculate token counts
-        let inputTokens = estimateTokenCount(inputText)
-        let outputTokens = estimateTokenCount(outputText)
-        let thinkingTokens = thinkingText != nil ? estimateTokenCount(thinkingText!) : nil
-        let responseTokens = outputTokens - (thinkingTokens ?? 0)
-
-        // Calculate average tokens per second
-        let averageTokensPerSecond = totalGenerationTime > 0 ? Double(outputTokens) / totalGenerationTime : 0
-
-        // Determine completion status
-        let completionStatus: MessageAnalytics.CompletionStatus = wasInterrupted ? .interrupted : .complete
-
-        // Create generation parameters
-        let generationParameters = MessageAnalytics.GenerationParameters(
-            temperature: Double(options.temperature),
-            maxTokens: options.maxTokens,
-            topP: Double(options.topP),
-            topK: nil // topK not available in current GenerationOptions
-        )
-
-        return MessageAnalytics(
-            messageId: messageId,
-            conversationId: conversationId,
-            modelId: currentModel.id,
-            modelName: modelName,
-            framework: currentModel.compatibleFrameworks.first?.rawValue ?? "unknown",
-            timestamp: startTime,
-            timeToFirstToken: timeToFirstToken,
-            totalGenerationTime: totalGenerationTime,
-            thinkingTime: thinkingTime,
-            responseTime: responseTime,
-            inputTokens: inputTokens,
-            outputTokens: outputTokens,
-            thinkingTokens: thinkingTokens,
-            responseTokens: responseTokens,
-            averageTokensPerSecond: averageTokensPerSecond,
-            messageLength: outputText.count,
-            wasThinkingMode: thinkingText != nil,
-            wasInterrupted: wasInterrupted,
-            retryCount: 0,
-            completionStatus: completionStatus,
-            tokensPerSecondHistory: tokensPerSecondHistory,
-            generationMode: useStreaming ? .streaming : .nonStreaming,
-            contextWindowUsage: 0.0, // TODO: Calculate based on model context size
-            generationParameters: generationParameters
-        )
-    }
-
-    // Simple token estimation (approximate)
-    private func estimateTokenCount(_ text: String) -> Int {
-        // Rough estimation: ~4 characters per token for English text
-        return Int(ceil(Double(text.count) / 4.0))
-    }
-
-    private func updateConversationAnalytics() {
-        guard let conversation = currentConversation else { return }
-
-        let analyticsMessages = messages.compactMap { $0.analytics }
-
-        if !analyticsMessages.isEmpty {
-            let averageTTFT = analyticsMessages.compactMap { $0.timeToFirstToken }.reduce(0, +) / Double(analyticsMessages.count)
-            let averageGenerationSpeed = analyticsMessages.map { $0.averageTokensPerSecond }.reduce(0, +) / Double(analyticsMessages.count)
-            let totalTokensUsed = analyticsMessages.reduce(0) { $0 + $1.inputTokens + $1.outputTokens }
-            let modelsUsed = Set(analyticsMessages.map { $0.modelName })
-
-            let thinkingMessages = analyticsMessages.filter { $0.wasThinkingMode }
-            let thinkingModeUsage = Double(thinkingMessages.count) / Double(analyticsMessages.count)
-
-            let completedMessages = analyticsMessages.filter { $0.completionStatus == .complete }
-            let completionRate = Double(completedMessages.count) / Double(analyticsMessages.count)
-
-            let averageMessageLength = analyticsMessages.reduce(0) { $0 + $1.messageLength } / analyticsMessages.count
-
-            let conversationAnalytics = ConversationAnalytics(
-                conversationId: conversation.id,
-                startTime: conversation.createdAt,
-                endTime: Date(),
-                messageCount: messages.count,
-                averageTTFT: averageTTFT,
-                averageGenerationSpeed: averageGenerationSpeed,
-                totalTokensUsed: totalTokensUsed,
-                modelsUsed: modelsUsed,
-                thinkingModeUsage: thinkingModeUsage,
-                completionRate: completionRate,
-                averageMessageLength: averageMessageLength,
-                currentModel: loadedModelName,
-                ongoingMetrics: nil
-            )
-
-            // Update conversation in store
-            var updatedConversation = conversation
-            updatedConversation.analytics = conversationAnalytics
-            updatedConversation.performanceSummary = PerformanceSummary(from: messages)
-            conversationStore.updateConversation(updatedConversation)
-        }
-    }
-
 }

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/RunAnywhereSDK+Analytics.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/RunAnywhereSDK+Analytics.swift
@@ -1,0 +1,160 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Analytics APIs
+
+extension RunAnywhereSDK {
+    
+    /// Access to the generation analytics service
+    public var generationAnalytics: GenerationAnalyticsService {
+        serviceContainer.generationAnalytics
+    }
+    
+    /// Get analytics session by ID
+    /// - Parameter sessionId: The session ID to look up
+    /// - Returns: The generation session if found
+    public func getAnalyticsSession(_ sessionId: UUID) async -> GenerationSession? {
+        return await generationAnalytics.getSession(sessionId)
+    }
+    
+    /// Get all analytics sessions
+    /// - Returns: Array of all generation sessions
+    public func getAllAnalyticsSessions() async -> [GenerationSession] {
+        return await generationAnalytics.getAllSessions()
+    }
+    
+    /// Get session summary with aggregated metrics
+    /// - Parameter sessionId: The session ID
+    /// - Returns: Session summary with aggregated metrics
+    public func getSessionSummary(_ sessionId: UUID) async -> SessionSummary? {
+        return await generationAnalytics.getSessionSummary(sessionId)
+    }
+    
+    /// Get average metrics for a specific model
+    /// - Parameters:
+    ///   - modelId: The model ID to get metrics for
+    ///   - limit: Maximum number of recent sessions to consider
+    /// - Returns: Average metrics across sessions
+    public func getAverageMetrics(for modelId: String, limit: Int = 10) async -> AverageMetrics? {
+        return await generationAnalytics.getAverageMetrics(for: modelId, limit: limit)
+    }
+    
+    /// Observe live metrics for a specific generation
+    /// - Parameter generationId: The generation ID to observe
+    /// - Returns: Async stream of live generation metrics
+    public func observeLiveMetrics(for generationId: UUID) -> AsyncStream<LiveGenerationMetrics> {
+        return generationAnalytics.observeLiveMetrics(for: generationId)
+    }
+    
+    /// Get generations for a specific session
+    /// - Parameter sessionId: The session ID
+    /// - Returns: Array of generations in the session
+    public func getGenerations(for sessionId: UUID) async -> [Generation] {
+        return await generationAnalytics.getGenerations(for: sessionId)
+    }
+    
+    /// Get currently active analytics sessions
+    /// - Returns: Array of active generation sessions
+    public func getActiveAnalyticsSessions() async -> [GenerationSession] {
+        return await generationAnalytics.getActiveSessions()
+    }
+    
+    /// Get the current session ID if any is active
+    /// - Returns: Current session ID or nil
+    public func getCurrentSessionId() async -> UUID? {
+        return await generationAnalytics.getCurrentSessionId()
+    }
+    
+    /// Start a new analytics session
+    /// - Parameters:
+    ///   - modelId: The model ID for the session
+    ///   - type: The type of session (chat, document, etc.)
+    /// - Returns: The created generation session
+    public func startAnalyticsSession(modelId: String, type: SessionType) async -> GenerationSession {
+        return await generationAnalytics.startSession(modelId: modelId, type: type)
+    }
+    
+    /// End an analytics session
+    /// - Parameter sessionId: The session ID to end
+    public func endAnalyticsSession(_ sessionId: UUID) async {
+        await generationAnalytics.endSession(sessionId)
+    }
+}
+
+// MARK: - Analytics UI
+
+@available(iOS 14.0, macOS 11.0, *)
+extension RunAnywhereSDK {
+    
+    /// Create an analytics view for displaying session and generation analytics
+    /// - Returns: SwiftUI view that displays comprehensive analytics
+    public func createAnalyticsView() -> some View {
+        AnalyticsView()
+    }
+    
+    /// Create a simple analytics summary view
+    /// - Returns: SwiftUI view with basic analytics summary
+    public func createAnalyticsSummaryView() -> some View {
+        AnalyticsSummaryView()
+    }
+}
+
+// MARK: - Simple Analytics Summary View
+
+@available(iOS 14.0, macOS 11.0, *)
+struct AnalyticsSummaryView: View {
+    @StateObject private var viewModel = AnalyticsViewModel()
+    
+    var body: some View {
+        VStack(spacing: 16) {
+            Text("Analytics Summary")
+                .font(.headline)
+            
+            HStack(spacing: 20) {
+                VStack {
+                    Text("\(viewModel.allSessions.count)")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.blue)
+                    Text("Sessions")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                VStack {
+                    Text("\(viewModel.totalGenerations)")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.green)
+                    Text("Generations")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                VStack {
+                    Text(viewModel.formattedTokenCount(viewModel.totalTokens))
+                        .font(.title2)
+                        .fontWeight(.bold)
+                        .foregroundColor(.orange)
+                    Text("Tokens")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+            }
+            
+            if let mostActiveModel = viewModel.mostActiveModel {
+                Text("Most Used: \(mostActiveModel)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.systemGray6))
+        )
+        .task {
+            await viewModel.loadData()
+        }
+    }
+}

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/UI/AnalyticsView.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/UI/AnalyticsView.swift
@@ -1,0 +1,607 @@
+import SwiftUI
+import Foundation
+
+#if canImport(UIKit)
+import UIKit
+#elseif canImport(AppKit)
+import AppKit
+#endif
+
+// MARK: - SDK Analytics UI Components
+
+/// Main analytics view that displays session and generation analytics
+@available(iOS 14.0, macOS 11.0, *)
+public struct AnalyticsView: View {
+    @StateObject private var viewModel = AnalyticsViewModel()
+    @State private var selectedTab = 0
+    
+    public init() {}
+    
+    public var body: some View {
+        NavigationView {
+            TabView(selection: $selectedTab) {
+                // Sessions Overview
+                SessionsOverviewView(viewModel: viewModel)
+                    .tabItem {
+                        Label("Sessions", systemImage: "chart.bar.doc.horizontal")
+                    }
+                    .tag(0)
+                
+                // Live Metrics
+                LiveMetricsView(viewModel: viewModel)
+                    .tabItem {
+                        Label("Live", systemImage: "waveform.path.ecg")
+                    }
+                    .tag(1)
+                
+                // Performance Analysis
+                PerformanceAnalysisView(viewModel: viewModel)
+                    .tabItem {
+                        Label("Performance", systemImage: "speedometer")
+                    }
+                    .tag(2)
+                
+                // Model Comparison
+                ModelComparisonView(viewModel: viewModel)
+                    .tabItem {
+                        Label("Models", systemImage: "cube.box")
+                    }
+                    .tag(3)
+            }
+            .navigationTitle("Analytics")
+            .navigationBarTitleDisplayMode(.large)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Button("Refresh") {
+                        Task {
+                            await viewModel.refresh()
+                        }
+                    }
+                }
+            }
+        }
+        .task {
+            await viewModel.loadData()
+        }
+    }
+}
+
+// MARK: - Sessions Overview View
+
+@available(iOS 14.0, macOS 11.0, *)
+struct SessionsOverviewView: View {
+    @ObservedObject var viewModel: AnalyticsViewModel
+    
+    var body: some View {
+        ScrollView {
+            LazyVStack(spacing: 16) {
+                // Summary Cards
+                HStack(spacing: 16) {
+                    SummaryCard(
+                        title: "Total Sessions",
+                        value: "\(viewModel.allSessions.count)",
+                        icon: "chart.bar.doc.horizontal",
+                        color: .blue
+                    )
+                    
+                    SummaryCard(
+                        title: "Active Sessions",
+                        value: "\(viewModel.activeSessions.count)",
+                        icon: "play.circle",
+                        color: .green
+                    )
+                }
+                
+                // Sessions List
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("Recent Sessions")
+                        .font(.headline)
+                        .padding(.horizontal)
+                    
+                    ForEach(viewModel.allSessions.prefix(10), id: \.id) { session in
+                        SessionRowView(session: session) {
+                            await viewModel.selectSession(session.id)
+                        }
+                        .padding(.horizontal)
+                    }
+                }
+            }
+            .padding()
+        }
+        .refreshable {
+            await viewModel.refresh()
+        }
+    }
+}
+
+// MARK: - Session Row View
+
+@available(iOS 14.0, macOS 11.0, *)
+struct SessionRowView: View {
+    let session: GenerationSession
+    let onTap: () async -> Void
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text(session.modelId)
+                        .font(.headline)
+                        .lineLimit(1)
+                    
+                    Text(session.sessionType.rawValue.capitalized)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+                
+                Spacer()
+                
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text(session.startTime, style: .time)
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    
+                    if session.endTime != nil {
+                        Image(systemName: "checkmark.circle.fill")
+                            .foregroundColor(.green)
+                            .font(.caption)
+                    } else {
+                        Image(systemName: "play.circle.fill")
+                            .foregroundColor(.blue)
+                            .font(.caption)
+                    }
+                }
+            }
+            
+            // Session metrics
+            HStack(spacing: 16) {
+                MetricChip(
+                    label: "Generations",
+                    value: "\(session.generationCount)",
+                    color: .blue
+                )
+                
+                if session.averageTokensPerSecond > 0 {
+                    MetricChip(
+                        label: "Avg Speed",
+                        value: String(format: "%.1f tok/s", session.averageTokensPerSecond),
+                        color: .green
+                    )
+                }
+                
+                if session.totalDuration > 0 {
+                    MetricChip(
+                        label: "Duration",
+                        value: String(format: "%.1fs", session.totalDuration),
+                        color: .orange
+                    )
+                }
+                
+                Spacer()
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.systemGray6))
+        )
+        .onTapGesture {
+            Task {
+                await onTap()
+            }
+        }
+    }
+}
+
+// MARK: - Live Metrics View
+
+@available(iOS 14.0, macOS 11.0, *)
+struct LiveMetricsView: View {
+    @ObservedObject var viewModel: AnalyticsViewModel
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                if let currentGeneration = viewModel.currentGeneration,
+                   let liveMetrics = viewModel.currentLiveMetrics {
+                    
+                    // Live generation in progress
+                    VStack(alignment: .leading, spacing: 16) {
+                        Text("Live Generation")
+                            .font(.title2)
+                            .fontWeight(.semibold)
+                        
+                        LiveGenerationCard(
+                            generation: currentGeneration,
+                            metrics: liveMetrics
+                        )
+                    }
+                    .padding()
+                    
+                } else {
+                    // No active generation
+                    VStack(spacing: 16) {
+                        Image(systemName: "waveform.path.ecg")
+                            .font(.system(size: 60))
+                            .foregroundColor(.secondary.opacity(0.6))
+                        
+                        Text("No Active Generation")
+                            .font(.title2)
+                            .fontWeight(.medium)
+                        
+                        Text("Live metrics will appear here during text generation")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding()
+                }
+                
+                Spacer()
+            }
+        }
+    }
+}
+
+// MARK: - Live Generation Card
+
+@available(iOS 14.0, macOS 11.0, *)
+struct LiveGenerationCard: View {
+    let generation: Generation
+    let metrics: LiveGenerationMetrics
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("Generation \(generation.sequenceNumber)")
+                    .font(.headline)
+                
+                Spacer()
+                
+                Text("LIVE")
+                    .font(.caption)
+                    .fontWeight(.bold)
+                    .foregroundColor(.white)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(Color.red)
+                    .cornerRadius(4)
+            }
+            
+            // Real-time metrics
+            HStack(spacing: 16) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Elapsed Time")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(String(format: "%.1fs", metrics.elapsedTime))
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.blue)
+                }
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Tokens Generated")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text("\(metrics.tokensGenerated)")
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.green)
+                }
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Current Speed")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(String(format: "%.1f tok/s", metrics.currentTokensPerSecond))
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.orange)
+                }
+                
+                Spacer()
+            }
+            
+            if let ttft = metrics.timeToFirstToken {
+                HStack {
+                    Text("Time to First Token:")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(String(format: "%.3fs", ttft))
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundColor(.purple)
+                }
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.systemGray6))
+                .overlay(
+                    RoundedRectangle(cornerRadius: 12)
+                        .strokeBorder(Color.blue.opacity(0.3), lineWidth: 2)
+                )
+        )
+    }
+}
+
+// MARK: - Performance Analysis View
+
+@available(iOS 14.0, macOS 11.0, *)
+struct PerformanceAnalysisView: View {
+    @ObservedObject var viewModel: AnalyticsViewModel
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                if let selectedSession = viewModel.selectedSession,
+                   let sessionSummary = viewModel.selectedSessionSummary {
+                    
+                    // Session details
+                    SessionDetailCard(session: selectedSession, summary: sessionSummary)
+                    
+                    // Generations in session
+                    VStack(alignment: .leading, spacing: 12) {
+                        Text("Generations")
+                            .font(.headline)
+                        
+                        ForEach(viewModel.selectedSessionGenerations, id: \.id) { generation in
+                            GenerationRowView(generation: generation)
+                        }
+                    }
+                    
+                } else {
+                    // No session selected
+                    VStack(spacing: 16) {
+                        Image(systemName: "speedometer")
+                            .font(.system(size: 60))
+                            .foregroundColor(.secondary.opacity(0.6))
+                        
+                        Text("Select a Session")
+                            .font(.title2)
+                            .fontWeight(.medium)
+                        
+                        Text("Choose a session from the Sessions tab to view detailed performance analysis")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+// MARK: - Model Comparison View
+
+@available(iOS 14.0, macOS 11.0, *)
+struct ModelComparisonView: View {
+    @ObservedObject var viewModel: AnalyticsViewModel
+    
+    var body: some View {
+        ScrollView {
+            VStack(spacing: 20) {
+                // Model comparison cards
+                ForEach(viewModel.modelMetrics.keys.sorted(), id: \.self) { modelId in
+                    if let metrics = viewModel.modelMetrics[modelId] {
+                        ModelMetricsCard(modelId: modelId, metrics: metrics)
+                    }
+                }
+                
+                if viewModel.modelMetrics.isEmpty {
+                    VStack(spacing: 16) {
+                        Image(systemName: "cube.box")
+                            .font(.system(size: 60))
+                            .foregroundColor(.secondary.opacity(0.6))
+                        
+                        Text("No Model Data")
+                            .font(.title2)
+                            .fontWeight(.medium)
+                        
+                        Text("Model comparison data will appear here after running generations")
+                            .font(.subheadline)
+                            .foregroundColor(.secondary)
+                            .multilineTextAlignment(.center)
+                    }
+                }
+            }
+            .padding()
+        }
+    }
+}
+
+// MARK: - Supporting Views
+
+@available(iOS 14.0, macOS 11.0, *)
+struct SummaryCard: View {
+    let title: String
+    let value: String
+    let icon: String
+    let color: Color
+    
+    var body: some View {
+        VStack(spacing: 8) {
+            Image(systemName: icon)
+                .font(.title2)
+                .foregroundColor(color)
+            
+            Text(value)
+                .font(.title2)
+                .fontWeight(.bold)
+            
+            Text(title)
+                .font(.caption)
+                .foregroundColor(.secondary)
+        }
+        .frame(maxWidth: .infinity)
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(color.opacity(0.1))
+        )
+    }
+}
+
+@available(iOS 14.0, macOS 11.0, *)
+struct MetricChip: View {
+    let label: String
+    let value: String
+    let color: Color
+    
+    var body: some View {
+        HStack(spacing: 4) {
+            Text(value)
+                .font(.caption)
+                .fontWeight(.semibold)
+                .foregroundColor(color)
+            
+            Text(label)
+                .font(.caption2)
+                .foregroundColor(.secondary)
+        }
+    }
+}
+
+@available(iOS 14.0, macOS 11.0, *)
+struct SessionDetailCard: View {
+    let session: GenerationSession
+    let summary: SessionSummary
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Session Details")
+                .font(.headline)
+            
+            VStack(alignment: .leading, spacing: 8) {
+                DetailRow(label: "Model ID", value: session.modelId)
+                DetailRow(label: "Type", value: session.sessionType.rawValue.capitalized)
+                DetailRow(label: "Started", value: session.startTime.formatted())
+                
+                if let endTime = session.endTime {
+                    DetailRow(label: "Ended", value: endTime.formatted())
+                }
+                
+                DetailRow(label: "Total Generations", value: "\(summary.totalGenerations)")
+                DetailRow(label: "Total Duration", value: String(format: "%.1fs", summary.totalDuration))
+                DetailRow(label: "Avg TTFT", value: String(format: "%.3fs", summary.averageTimeToFirstToken))
+                DetailRow(label: "Avg Speed", value: String(format: "%.1f tok/s", summary.averageTokensPerSecond))
+                DetailRow(label: "Total Tokens", value: "\(summary.totalInputTokens + summary.totalOutputTokens)")
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.systemGray6))
+        )
+    }
+}
+
+@available(iOS 14.0, macOS 11.0, *)
+struct DetailRow: View {
+    let label: String
+    let value: String
+    
+    var body: some View {
+        HStack {
+            Text(label)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+            
+            Spacer()
+            
+            Text(value)
+                .font(.subheadline)
+                .fontWeight(.medium)
+        }
+    }
+}
+
+@available(iOS 14.0, macOS 11.0, *)
+struct GenerationRowView: View {
+    let generation: Generation
+    
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 4) {
+                Text("Generation #\(generation.sequenceNumber)")
+                    .font(.subheadline)
+                    .fontWeight(.medium)
+                
+                Text(generation.timestamp.formatted(date: .omitted, time: .shortened))
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
+            
+            Spacer()
+            
+            if let performance = generation.performance {
+                VStack(alignment: .trailing, spacing: 4) {
+                    Text(String(format: "%.1fs", performance.totalGenerationTime))
+                        .font(.caption)
+                        .fontWeight(.medium)
+                        .foregroundColor(.blue)
+                    
+                    Text(String(format: "%.1f tok/s", performance.tokensPerSecond))
+                        .font(.caption)
+                        .foregroundColor(.green)
+                }
+            }
+        }
+        .padding(.vertical, 8)
+    }
+}
+
+@available(iOS 14.0, macOS 11.0, *)
+struct ModelMetricsCard: View {
+    let modelId: String
+    let metrics: AverageMetrics
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text(modelId)
+                .font(.headline)
+            
+            HStack(spacing: 20) {
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Sessions")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text("\(metrics.sessionCount)")
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.blue)
+                }
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Generations")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text("\(metrics.generationCount)")
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.green)
+                }
+                
+                VStack(alignment: .leading, spacing: 4) {
+                    Text("Avg Speed")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                    Text(String(format: "%.1f tok/s", metrics.averageTokensPerSecond))
+                        .font(.title3)
+                        .fontWeight(.semibold)
+                        .foregroundColor(.orange)
+                }
+                
+                Spacer()
+            }
+        }
+        .padding()
+        .background(
+            RoundedRectangle(cornerRadius: 12)
+                .fill(Color(.systemGray6))
+        )
+    }
+}

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/UI/AnalyticsViewModel.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/UI/AnalyticsViewModel.swift
@@ -1,0 +1,257 @@
+import Foundation
+import SwiftUI
+
+// MARK: - Analytics View Model
+
+/// ViewModel for the SDK Analytics View
+@available(iOS 14.0, macOS 11.0, *)
+@MainActor
+class AnalyticsViewModel: ObservableObject {
+    
+    // MARK: - Published Properties
+    
+    @Published var allSessions: [GenerationSession] = []
+    @Published var activeSessions: [GenerationSession] = []
+    @Published var selectedSession: GenerationSession?
+    @Published var selectedSessionSummary: SessionSummary?
+    @Published var selectedSessionGenerations: [Generation] = []
+    @Published var modelMetrics: [String: AverageMetrics] = [:]
+    
+    // Live metrics
+    @Published var currentGeneration: Generation?
+    @Published var currentLiveMetrics: LiveGenerationMetrics?
+    
+    // Loading states
+    @Published var isLoading = false
+    @Published var errorMessage: String?
+    
+    // MARK: - Private Properties
+    
+    private let sdk = RunAnywhereSDK.shared
+    private var liveMetricsTask: Task<Void, Never>?
+    
+    // MARK: - Initialization
+    
+    init() {
+        // Start observing for live generation updates
+        startLiveMetricsObservation()
+    }
+    
+    deinit {
+        liveMetricsTask?.cancel()
+    }
+    
+    // MARK: - Public Methods
+    
+    /// Load all analytics data
+    func loadData() async {
+        isLoading = true
+        errorMessage = nil
+        
+        do {
+            // Load sessions
+            await loadSessions()
+            
+            // Load model metrics
+            await loadModelMetrics()
+            
+        } catch {
+            errorMessage = "Failed to load analytics data: \(error.localizedDescription)"
+        }
+        
+        isLoading = false
+    }
+    
+    /// Refresh all data
+    func refresh() async {
+        await loadData()
+    }
+    
+    /// Select a session for detailed analysis
+    func selectSession(_ sessionId: UUID) async {
+        // Find the session
+        guard let session = allSessions.first(where: { $0.id == sessionId }) else {
+            return
+        }
+        
+        selectedSession = session
+        
+        // Load session details
+        selectedSessionSummary = await sdk.getSessionSummary(sessionId)
+        selectedSessionGenerations = await sdk.getGenerations(for: sessionId)
+    }
+    
+    /// Clear selected session
+    func clearSelection() {
+        selectedSession = nil
+        selectedSessionSummary = nil
+        selectedSessionGenerations = []
+    }
+    
+    // MARK: - Private Methods
+    
+    /// Load all sessions
+    private func loadSessions() async {
+        allSessions = await sdk.getAllAnalyticsSessions()
+        activeSessions = await sdk.getActiveAnalyticsSessions()
+    }
+    
+    /// Load model metrics for comparison
+    private func loadModelMetrics() async {
+        // Get unique model IDs from sessions
+        let modelIds = Set(allSessions.map { $0.modelId })
+        
+        var metrics: [String: AverageMetrics] = [:]
+        
+        for modelId in modelIds {
+            if let modelAverage = await sdk.getAverageMetrics(for: modelId) {
+                metrics[modelId] = modelAverage
+            }
+        }
+        
+        modelMetrics = metrics
+    }
+    
+    /// Start observing live metrics for any active generation
+    private func startLiveMetricsObservation() {
+        liveMetricsTask = Task { [weak self] in
+            while !Task.isCancelled {
+                await self?.checkForLiveGeneration()
+                
+                // Check every second
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+            }
+        }
+    }
+    
+    /// Check for active generation and observe its live metrics
+    private func checkForLiveGeneration() async {
+        // Get current session ID
+        guard let currentSessionId = await sdk.getCurrentSessionId() else {
+            // No active session, clear live metrics
+            currentGeneration = nil
+            currentLiveMetrics = nil
+            return
+        }
+        
+        // Get generations for current session
+        let generations = await sdk.getGenerations(for: currentSessionId)
+        
+        // Find the most recent generation that might be active
+        guard let latestGeneration = generations.last else {
+            currentGeneration = nil
+            currentLiveMetrics = nil
+            return
+        }
+        
+        // Check if this generation has completed performance data
+        if latestGeneration.performance != nil {
+            // Generation is complete, clear live metrics
+            currentGeneration = nil
+            currentLiveMetrics = nil
+            return
+        }
+        
+        // This generation might be active, try to get live metrics
+        currentGeneration = latestGeneration
+        
+        // Observe live metrics for this generation
+        observeLiveMetricsForGeneration(latestGeneration.id)
+    }
+    
+    /// Observe live metrics for a specific generation
+    private func observeLiveMetricsForGeneration(_ generationId: UUID) {
+        // Cancel any existing observation
+        liveMetricsTask?.cancel()
+        
+        liveMetricsTask = Task { [weak self] in
+            let metricsStream = self?.sdk.observeLiveMetrics(for: generationId)
+            
+            guard let stream = metricsStream else { return }
+            
+            for await metrics in stream {
+                guard !Task.isCancelled else { break }
+                
+                await MainActor.run {
+                    self?.currentLiveMetrics = metrics
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Helper Extensions
+
+extension AnalyticsViewModel {
+    
+    /// Get formatted session duration
+    func formattedDuration(for session: GenerationSession) -> String {
+        if let endTime = session.endTime {
+            let duration = endTime.timeIntervalSince(session.startTime)
+            return String(format: "%.1fs", duration)
+        } else {
+            let duration = Date().timeIntervalSince(session.startTime)
+            return String(format: "%.1fs (ongoing)", duration)
+        }
+    }
+    
+    /// Get session status string
+    func sessionStatus(for session: GenerationSession) -> String {
+        return session.endTime != nil ? "Completed" : "Active"
+    }
+    
+    /// Get session status color
+    func sessionStatusColor(for session: GenerationSession) -> Color {
+        return session.endTime != nil ? .green : .blue
+    }
+    
+    /// Format token count with appropriate units
+    func formattedTokenCount(_ count: Int) -> String {
+        if count >= 1000 {
+            let thousands = Double(count) / 1000.0
+            return String(format: "%.1fK", thousands)
+        } else {
+            return "\(count)"
+        }
+    }
+    
+    /// Format speed with appropriate precision
+    func formattedSpeed(_ tokensPerSecond: Double) -> String {
+        if tokensPerSecond >= 100 {
+            return String(format: "%.0f", tokensPerSecond)
+        } else if tokensPerSecond >= 10 {
+            return String(format: "%.1f", tokensPerSecond)
+        } else {
+            return String(format: "%.2f", tokensPerSecond)
+        }
+    }
+    
+    /// Get the most active model ID
+    var mostActiveModel: String? {
+        guard !allSessions.isEmpty else { return nil }
+        
+        let modelCounts = Dictionary(grouping: allSessions, by: { $0.modelId })
+            .mapValues { $0.count }
+        
+        return modelCounts.max(by: { $0.value < $1.value })?.key
+    }
+    
+    /// Get total generations across all sessions
+    var totalGenerations: Int {
+        return allSessions.reduce(0) { $0 + $1.generationCount }
+    }
+    
+    /// Get total tokens across all sessions
+    var totalTokens: Int {
+        return allSessions.reduce(0) { $0 + $1.totalInputTokens + $1.totalOutputTokens }
+    }
+    
+    /// Get average session duration
+    var averageSessionDuration: TimeInterval {
+        let completedSessions = allSessions.filter { $0.endTime != nil }
+        guard !completedSessions.isEmpty else { return 0 }
+        
+        let totalDuration = completedSessions.reduce(0.0) { $0 + $1.totalDuration }
+        return totalDuration / Double(completedSessions.count)
+    }
+}


### PR DESCRIPTION
## Description
Migrates all chat performance and state analytics from the `RunAnywhereAI` sample application into the `RunAnywhereSDK`.

The SDK now:
*   Automatically tracks generation performance and session data internally.
*   Provides a comprehensive, in-SDK SwiftUI analytics dashboard (`AnalyticsView`) accessible via `RunAnywhereSDK.shared.createAnalyticsView()`.

The sample app has been significantly simplified by:
*   Removing redundant analytics collection logic from `ChatViewModel` and `ConversationStore`.
*   Replacing its custom analytics UI with the new SDK-provided analytics view in `ChatInterfaceView`.
*   Introducing an `AnalyticsAdapter` to bridge legacy data models for backward compatibility where needed.

This change centralizes analytics within the SDK, ensuring a single source of truth and adhering to the SDK's layered architecture, while greatly reducing the sample app's complexity.

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [x] Refactoring

## Testing
- [x] Tests pass locally
- [ ] Added/updated tests for changes

## Labels
Please add the appropriate label(s):
- [x] `iOS SDK` - Changes to iOS/Swift SDK
- [ ] `Android SDK` - Changes to Android/Kotlin SDK
- [x] `iOS Sample` - Changes to iOS example app
- [ ] `Android Sample` - Changes to Android example app

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)

---
<a href="https://cursor.com/background-agent?bcId=bc-f394405e-16f9-4ffc-acb2-dcd32f5f39ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f394405e-16f9-4ffc-acb2-dcd32f5f39ef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

