### PR TITLE
[iOS-SDK] Analytics consolidation - Move all metrics to SDK layer (#69)

### DIFF
--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Capabilities/TextGeneration/Models/ThinkingTagPattern.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Capabilities/TextGeneration/Models/ThinkingTagPattern.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 /// Pattern for extracting thinking/reasoning content from model output
-public struct ThinkingTagPattern: Codable {
+public struct ThinkingTagPattern: Codable, Sendable {
     public let openingTag: String
     public let closingTag: String
 

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Capabilities/TextGeneration/Services/StreamingService.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Capabilities/TextGeneration/Services/StreamingService.swift
@@ -5,6 +5,7 @@ public class StreamingService {
     private let generationService: GenerationService
     private let modelLoadingService: ModelLoadingService
     private let optionsResolver = GenerationOptionsResolver()
+    private let logger = SDKLogger(category: "StreamingService")
 
     public init(
         generationService: GenerationService,
@@ -14,70 +15,217 @@ public class StreamingService {
         self.modelLoadingService = modelLoadingService ?? ServiceContainer.shared.modelLoadingService
     }
 
-    /// Generate streaming text using the loaded model
+    /// Generate streaming text with metrics tracking
+    ///
+    /// Returns both the token stream and a task that resolves to final metrics.
+    /// This is the recommended method for streaming with analytics.
     ///
     /// Priority for settings resolution:
     /// 1. Runtime Options (highest priority) - User knows best for their specific request
     /// 2. Remote Configuration - Organization-wide defaults from console
     /// 3. SDK Defaults (lowest priority) - Fallback values when nothing else is specified
-    public func generateStream(
+    public func generateStreamWithMetrics(
         prompt: String,
         options: RunAnywhereGenerationOptions
-    ) -> AsyncThrowingStream<String, Error> {
-        return AsyncThrowingStream { continuation in
+    ) -> StreamingResult {
+        // Shared state between stream and result task
+        actor MetricsCollector {
+            var fullText = ""
+            var thinkingContent: String?
+            var startTime = Date()
+            var firstTokenTime: Date?
+            var thinkingStartTime: Date?
+            var thinkingEndTime: Date?
+            var tokenCount = 0
+            var error: Error?
+            var isComplete = false
+            var modelName: String?
+            var framework: LLMFramework?
+
+            // Continuation for result task
+            private var resultContinuation: CheckedContinuation<GenerationResult, Error>?
+
+            func recordToken(_ token: String, isThinking: Bool) {
+                fullText += token
+                tokenCount += 1
+
+                if firstTokenTime == nil {
+                    firstTokenTime = Date()
+                }
+
+                if isThinking && thinkingStartTime == nil {
+                    thinkingStartTime = Date()
+                }
+            }
+
+            func recordThinkingEnd(_ thinking: String) {
+                thinkingContent = thinking
+                thinkingEndTime = Date()
+            }
+
+            func recordError(_ err: Error) {
+                error = err
+                resultContinuation?.resume(throwing: err)
+                resultContinuation = nil
+            }
+
+            func recordStreamComplete(modelName: String, framework: LLMFramework?) {
+                self.modelName = modelName
+                self.framework = framework
+                self.isComplete = true
+
+                // Build result and resume continuation
+                if let continuation = resultContinuation {
+                    let result = buildResultSync(modelUsed: modelName, framework: framework)
+                    continuation.resume(returning: result)
+                    resultContinuation = nil
+                }
+            }
+
+            func waitForResult() async throws -> GenerationResult {
+                // If already complete, return immediately
+                if isComplete, let modelName = modelName {
+                    return buildResultSync(modelUsed: modelName, framework: framework)
+                }
+
+                // Otherwise, wait for completion
+                return try await withCheckedThrowingContinuation { continuation in
+                    resultContinuation = continuation
+                }
+            }
+
+            private func buildResultSync(modelUsed: String, framework: LLMFramework?) -> GenerationResult {
+                let endTime = Date()
+                let totalTime = endTime.timeIntervalSince(startTime)
+
+                // Use TokenCounter for accurate token counting
+                let tokenCounts = TokenCounter.splitTokenCounts(
+                    fullText: fullText,
+                    thinkingContent: thinkingContent,
+                    responseContent: fullText.replacingOccurrences(of: thinkingContent ?? "", with: "").trimmingCharacters(in: .whitespacesAndNewlines)
+                )
+
+                // Calculate timing metrics
+                let timeToFirstToken = firstTokenTime?.timeIntervalSince(startTime)
+                let thinkingTime = (thinkingStartTime != nil && thinkingEndTime != nil)
+                    ? thinkingEndTime!.timeIntervalSince(thinkingStartTime!) : nil
+                let responseTime = thinkingTime != nil ? totalTime - thinkingTime! : totalTime
+
+                // Calculate tokens per second
+                let tokensPerSecond = TokenCounter.calculateTokensPerSecond(
+                    tokenCount: tokenCounts.totalTokens,
+                    elapsedSeconds: totalTime
+                )
+
+                let performanceMetrics = PerformanceMetrics(
+                    tokenizationTimeMs: 0,
+                    inferenceTimeMs: totalTime * 1000,
+                    postProcessingTimeMs: 0,
+                    tokensPerSecond: tokensPerSecond,
+                    peakMemoryUsage: 0,
+                    queueWaitTimeMs: 0,
+                    timeToFirstTokenMs: timeToFirstToken.map { $0 * 1000 },
+                    thinkingTimeMs: thinkingTime.map { $0 * 1000 },
+                    responseTimeMs: responseTime * 1000,
+                    thinkingStartTimeMs: thinkingStartTime != nil ? thinkingStartTime!.timeIntervalSince(startTime) * 1000 : nil,
+                    thinkingEndTimeMs: thinkingEndTime != nil ? thinkingEndTime!.timeIntervalSince(startTime) * 1000 : nil,
+                    firstResponseTokenTimeMs: firstTokenTime != nil ? firstTokenTime!.timeIntervalSince(startTime) * 1000 : nil
+                )
+
+                return GenerationResult(
+                    text: fullText.replacingOccurrences(of: thinkingContent ?? "", with: "").trimmingCharacters(in: .whitespacesAndNewlines),
+                    thinkingContent: thinkingContent,
+                    tokensUsed: tokenCounts.totalTokens,
+                    modelUsed: modelUsed,
+                    latencyMs: totalTime * 1000,
+                    executionTarget: .onDevice,
+                    savedAmount: 0.0,
+                    framework: framework,
+                    hardwareUsed: .cpu,
+                    memoryUsed: 0,
+                    performanceMetrics: performanceMetrics,
+                    thinkingTokens: tokenCounts.thinkingTokens,
+                    responseTokens: tokenCounts.responseTokens
+                )
+            }
+        }
+
+        let collector = MetricsCollector()
+
+        // Create the token stream
+        let stream = AsyncThrowingStream<String, Error> { continuation in
             Task {
                 do {
                     // Get remote configuration
                     let remoteConfig = RunAnywhere.configurationData?.generation
 
-                    // Apply remote constraints to options (respecting priority: Runtime > Remote > SDK Defaults)
+                    // Apply remote constraints to options
                     let resolvedOptions = optionsResolver.resolve(
                         options: options,
                         remoteConfig: remoteConfig
                     )
 
-                    // Get the current loaded model from generation service
+                    // Get the current loaded model
                     guard let loadedModel = generationService.getCurrentModel() else {
                         throw SDKError.modelNotFound("No model is currently loaded")
                     }
 
-                    // Prepare prompt with system prompt and structured output formatting
+                    // Prepare prompt
                     let effectivePrompt = optionsResolver.preparePrompt(prompt, withOptions: resolvedOptions)
 
-
-                    // Check if model supports thinking and get pattern
+                    // Check if model supports thinking
                     let modelInfo = loadedModel.model
                     let shouldParseThinking = modelInfo.supportsThinking
-                    let thinkingPattern = ThinkingTagPattern.defaultPattern
+                    let thinkingPattern = modelInfo.thinkingPattern ?? ThinkingTagPattern.defaultPattern
 
                     // Buffers for thinking parsing
                     var buffer = ""
                     var inThinkingSection = false
+                    var accumulatedThinking = ""
 
-                    // Use the actual streaming method from the LLM service
+                    // Start timing
+                    await collector.recordToken("", isThinking: false) // Initialize timing
+
+                    // Use the actual streaming method
                     try await loadedModel.service.streamGenerate(
                         prompt: effectivePrompt,
                         options: resolvedOptions,
                         onToken: { token in
-                            if shouldParseThinking {
-                                // Parse token for thinking content
-                                let (tokenType, cleanToken) = ThinkingParser.parseStreamingToken(
-                                    token: token,
-                                    pattern: thinkingPattern,
-                                    buffer: &buffer,
-                                    inThinkingSection: &inThinkingSection
-                                )
+                            Task {
+                                if shouldParseThinking {
+                                    // Parse token for thinking content
+                                    let (tokenType, cleanToken) = ThinkingParser.parseStreamingToken(
+                                        token: token,
+                                        pattern: thinkingPattern,
+                                        buffer: &buffer,
+                                        inThinkingSection: &inThinkingSection
+                                    )
 
-                                // Only yield non-thinking tokens
-                                if tokenType == .content, let cleanToken = cleanToken {
-                                    continuation.yield(cleanToken)
+                                    // Track thinking content
+                                    if tokenType == .thinking, let thinkingToken = cleanToken {
+                                        accumulatedThinking += thinkingToken
+                                    }
+
+                                    // Record metrics
+                                    await collector.recordToken(token, isThinking: inThinkingSection)
+
+                                    // Only yield non-thinking tokens
+                                    if tokenType == .content, let cleanToken = cleanToken {
+                                        continuation.yield(cleanToken)
+                                    }
+                                } else {
+                                    // No thinking parsing
+                                    await collector.recordToken(token, isThinking: false)
+                                    continuation.yield(token)
                                 }
-                            } else {
-                                // No thinking parsing, yield token as-is
-                                continuation.yield(token)
                             }
                         }
                     )
+
+                    // Record thinking content if any
+                    if !accumulatedThinking.isEmpty {
+                        await collector.recordThinkingEnd(accumulatedThinking)
+                    }
 
                     // Yield any remaining content in buffer
                     if shouldParseThinking && !buffer.isEmpty && !inThinkingSection {
@@ -85,12 +233,30 @@ public class StreamingService {
                     }
 
                     continuation.finish()
+
+                    // After stream finishes, signal completion to result task
+                    await collector.recordStreamComplete(
+                        modelName: loadedModel.model.name,
+                        framework: loadedModel.model.compatibleFrameworks.first
+                    )
                 } catch {
+                    await collector.recordError(error)
                     continuation.finish(throwing: error)
                 }
             }
         }
+
+        // Create the result task that waits for metrics (NOT consuming stream)
+        let resultTask = Task<GenerationResult, Error> {
+            // Wait for collector to signal completion
+            return try await collector.waitForResult()
+        }
+
+        return StreamingResult(stream: stream, result: resultTask)
     }
+
+    // Note: Legacy generateStream() method removed - use generateStreamWithMetrics() instead
+    // All streaming now includes metrics by default
 
     /// Generate streaming text with token-level granularity
     public func generateTokenStream(
@@ -121,7 +287,8 @@ public class StreamingService {
                     // Check if model supports thinking and get pattern
                     let modelInfo = loadedModel.model
                     let shouldParseThinking = modelInfo.supportsThinking
-                    let thinkingPattern = ThinkingTagPattern.defaultPattern
+                    // Use model-specific pattern or fall back to default
+                    let thinkingPattern = modelInfo.thinkingPattern ?? ThinkingTagPattern.defaultPattern
 
                     // Buffers for thinking parsing
                     var buffer = ""

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Capabilities/TextGeneration/Services/TokenCounter.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Capabilities/TextGeneration/Services/TokenCounter.swift
@@ -1,0 +1,64 @@
+import Foundation
+
+/// Service for counting tokens in text with improved accuracy
+public class TokenCounter {
+
+    /// Count tokens with improved estimation (more accurate than simple word count)
+    /// This is a heuristic approach until we integrate actual tokenizers
+    public static func estimateTokenCount(_ text: String) -> Int {
+        guard !text.isEmpty else { return 0 }
+
+        // Improved heuristic based on GPT tokenization patterns:
+        // - Average ~4 characters per token for English text
+        // - Punctuation often creates separate tokens
+        // - Whitespace handling
+        // - Special characters
+
+        let characterCount = text.count
+        let wordCount = text.split(separator: " ").count
+
+        // Count punctuation marks (often separate tokens)
+        let punctuationCount = text.filter { ".,!?;:()[]{}\"'".contains($0) }.count
+
+        // Count newlines and special whitespace (often separate tokens)
+        let newlineCount = text.filter { $0.isNewline }.count
+
+        // Heuristic formula:
+        // Base estimate: characters / 4 (GPT average)
+        // Add extra tokens for punctuation (most become separate tokens)
+        // Add tokens for newlines
+        // Ensure we're at least counting words (minimum tokens)
+
+        let baseEstimate = Double(characterCount) / 4.0
+        let punctuationTokens = Double(punctuationCount) * 0.7 // Most punctuation becomes tokens
+        let newlineTokens = Double(newlineCount)
+
+        let estimatedTokens = Int(ceil(baseEstimate + punctuationTokens + newlineTokens))
+
+        // Sanity check: token count should be between word count and character count
+        return max(wordCount, min(estimatedTokens, characterCount))
+    }
+
+    /// Estimate tokens per second based on token count and elapsed time
+    public static func calculateTokensPerSecond(tokenCount: Int, elapsedSeconds: TimeInterval) -> Double {
+        guard elapsedSeconds > 0 else { return 0 }
+        return Double(tokenCount) / elapsedSeconds
+    }
+
+    /// Split token count between thinking and response content
+    public static func splitTokenCounts(
+        fullText: String,
+        thinkingContent: String?,
+        responseContent: String
+    ) -> (thinkingTokens: Int?, responseTokens: Int, totalTokens: Int) {
+        let responseTokens = estimateTokenCount(responseContent)
+
+        if let thinking = thinkingContent, !thinking.isEmpty {
+            let thinkingTokens = estimateTokenCount(thinking)
+            let totalTokens = thinkingTokens + responseTokens
+            return (thinkingTokens, responseTokens, totalTokens)
+        } else {
+            return (nil, responseTokens, responseTokens)
+        }
+    }
+}

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Core/Models/Model/ModelInfo.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Core/Models/Model/ModelInfo.swift
@@ -24,6 +24,7 @@ public struct ModelInfo: Codable, RepositoryEntity, FetchableRecord, Persistable
     // Model-specific capabilities (optional based on category)
     public let contextLength: Int?  // For language models
     public let supportsThinking: Bool  // For reasoning models
+    public let thinkingPattern: ThinkingTagPattern?  // Custom thinking pattern (if supportsThinking)
 
     // Optional metadata
     public let metadata: ModelInfoMetadata?
@@ -58,7 +59,7 @@ public struct ModelInfo: Codable, RepositoryEntity, FetchableRecord, Persistable
         case id, name, category, format, downloadURL, localPath
         case downloadSize, memoryRequired
         case compatibleFrameworks, preferredFramework
-        case contextLength, supportsThinking
+        case contextLength, supportsThinking, thinkingPattern
         case metadata
         case source, createdAt, updatedAt, syncPending
         case lastUsed, usageCount
@@ -77,6 +78,7 @@ public struct ModelInfo: Codable, RepositoryEntity, FetchableRecord, Persistable
         preferredFramework: LLMFramework? = nil,
         contextLength: Int? = nil,
         supportsThinking: Bool = false,
+        thinkingPattern: ThinkingTagPattern? = nil,
         metadata: ModelInfoMetadata? = nil,
         source: ConfigurationSource = .remote,
         createdAt: Date = Date(),
@@ -106,6 +108,9 @@ public struct ModelInfo: Codable, RepositoryEntity, FetchableRecord, Persistable
 
         // Set supportsThinking based on category
         self.supportsThinking = category.supportsThinking ? supportsThinking : false
+
+        // Set thinking pattern based on supportsThinking
+        self.thinkingPattern = supportsThinking ? (thinkingPattern ?? .defaultPattern) : nil
 
         self.metadata = metadata
         self.source = source
@@ -140,6 +145,7 @@ extension ModelInfo {
         case preferredFramework
         case contextLength
         case supportsThinking
+        case thinkingPattern
         case metadata
         case source
         case createdAt

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/RunAnywhere+StructuredOutput.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/RunAnywhere+StructuredOutput.swift
@@ -127,11 +127,11 @@ public extension RunAnywhere {
             let userPrompt = handler.buildUserPrompt(for: type, content: prompt)
 
             // Generate the text
-            let generatedText = try await RunAnywhere.generate(userPrompt, options: effectiveOptions)
+            let generationResult = try await RunAnywhere.generate(userPrompt, options: effectiveOptions)
 
             // Parse using StructuredOutputHandler
             let result = try handler.parseStructuredOutput(
-                from: generatedText,
+                from: generationResult.text,
                 type: type
             )
 
@@ -194,7 +194,8 @@ public extension RunAnywhere {
                     var tokenIndex = 0
 
                     // Stream tokens
-                    for try await token in RunAnywhere.generateStream(userPrompt, options: effectiveOptions) {
+                    let streamingResult = try await RunAnywhere.generateStream(userPrompt, options: effectiveOptions)
+                    for try await token in streamingResult.stream {
                         let streamToken = StreamToken(
                             text: token,
                             timestamp: Date(),

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Models/GenerationResult.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Models/GenerationResult.swift
@@ -1,5 +1,24 @@
 import Foundation
 
+/// Container for streaming generation with metrics
+/// Provides both the token stream and a task that resolves to final metrics
+public struct StreamingResult {
+    /// Stream of tokens as they are generated
+    public let stream: AsyncThrowingStream<String, Error>
+
+    /// Task that completes with final generation result including metrics
+    /// Resolves after streaming is complete
+    public let result: Task<GenerationResult, Error>
+
+    public init(
+        stream: AsyncThrowingStream<String, Error>,
+        result: Task<GenerationResult, Error>
+    ) {
+        self.stream = stream
+        self.result = result
+    }
+}
+
 /// Result of a text generation request
 public struct GenerationResult {
     /// Generated text (with thinking content removed if extracted)
@@ -38,6 +57,14 @@ public struct GenerationResult {
     /// Structured output validation result (if structured output was requested)
     public var structuredOutputValidation: StructuredOutputValidation?
 
+    // MARK: - Thinking Mode Token Metrics
+
+    /// Number of tokens used for thinking/reasoning (if model supports thinking mode)
+    public let thinkingTokens: Int?
+
+    /// Number of tokens in the actual response content (excluding thinking)
+    public let responseTokens: Int
+
     /// Initializer
     internal init(
         text: String,
@@ -51,7 +78,9 @@ public struct GenerationResult {
         hardwareUsed: HardwareAcceleration = .cpu,
         memoryUsed: Int64 = 0,
         performanceMetrics: PerformanceMetrics,
-        structuredOutputValidation: StructuredOutputValidation? = nil
+        structuredOutputValidation: StructuredOutputValidation? = nil,
+        thinkingTokens: Int? = nil,
+        responseTokens: Int? = nil
     ) {
         self.text = text
         self.thinkingContent = thinkingContent
@@ -65,5 +94,7 @@ public struct GenerationResult {
         self.memoryUsed = memoryUsed
         self.performanceMetrics = performanceMetrics
         self.structuredOutputValidation = structuredOutputValidation
+        self.thinkingTokens = thinkingTokens
+        self.responseTokens = responseTokens ?? tokensUsed
     }
 }

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Models/PerformanceMetrics.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Models/PerformanceMetrics.swift
@@ -20,13 +20,39 @@ public struct PerformanceMetrics {
     /// Queue wait time if any (milliseconds)
     public let queueWaitTimeMs: TimeInterval
 
+    // MARK: - Thinking Mode Metrics
+
+    /// Time to first token (milliseconds) - time from request start to first token
+    public let timeToFirstTokenMs: TimeInterval?
+
+    /// Time spent in thinking mode (milliseconds) - only if model uses thinking
+    public let thinkingTimeMs: TimeInterval?
+
+    /// Time spent generating response content after thinking (milliseconds)
+    public let responseTimeMs: TimeInterval?
+
+    /// Timestamp when thinking started (relative to generation start, in milliseconds)
+    public let thinkingStartTimeMs: TimeInterval?
+
+    /// Timestamp when thinking ended (relative to generation start, in milliseconds)
+    public let thinkingEndTimeMs: TimeInterval?
+
+    /// Timestamp when first response token arrived (relative to generation start, in milliseconds)
+    public let firstResponseTokenTimeMs: TimeInterval?
+
     public init(
         tokenizationTimeMs: TimeInterval = 0,
         inferenceTimeMs: TimeInterval = 0,
         postProcessingTimeMs: TimeInterval = 0,
         tokensPerSecond: Double = 0,
         peakMemoryUsage: Int64 = 0,
-        queueWaitTimeMs: TimeInterval = 0
+        queueWaitTimeMs: TimeInterval = 0,
+        timeToFirstTokenMs: TimeInterval? = nil,
+        thinkingTimeMs: TimeInterval? = nil,
+        responseTimeMs: TimeInterval? = nil,
+        thinkingStartTimeMs: TimeInterval? = nil,
+        thinkingEndTimeMs: TimeInterval? = nil,
+        firstResponseTokenTimeMs: TimeInterval? = nil
     ) {
         self.tokenizationTimeMs = tokenizationTimeMs
         self.inferenceTimeMs = inferenceTimeMs
@@ -34,5 +60,11 @@ public struct PerformanceMetrics {
         self.tokensPerSecond = tokensPerSecond
         self.peakMemoryUsage = peakMemoryUsage
         self.queueWaitTimeMs = queueWaitTimeMs
+        self.timeToFirstTokenMs = timeToFirstTokenMs
+        self.thinkingTimeMs = thinkingTimeMs
+        self.responseTimeMs = responseTimeMs
+        self.thinkingStartTimeMs = thinkingStartTimeMs
+        self.thinkingEndTimeMs = thinkingEndTimeMs
+        self.firstResponseTokenTimeMs = firstResponseTokenTimeMs
     }
 }


### PR DESCRIPTION
# Analytics Consolidation - Issue #69

## Overview

This PR implements comprehensive analytics consolidation by moving **ALL** performance metrics calculation from the application layer to the SDK layer. The app now acts purely as a display layer, with zero analytics calculations happening in the application code.

## Problem Statement

Previously, analytics responsibilities were split between SDK and app:
- **Streaming mode**: App manually tracked metrics (~105 lines of calculation code)
- **Non-streaming mode**: SDK provided complete metrics
- Result: Inconsistent calculations, code duplication, potential inaccuracies

## Solution

Consolidated all analytics into the SDK with the following approach:

### 1. Created TokenCounter for Accurate Estimation
- New `TokenCounter.swift` with improved heuristics (accounts for punctuation, whitespace, newlines)
- Replaces simple `text.count / 4` estimation
- Exposed via `RunAnywhere.estimateTokenCount()` for consistent namespace

### 2. Streaming with Built-in Analytics
- New `StreamingResult` struct containing both token stream and metrics task
- `MetricsCollector` actor for thread-safe metrics accumulation during streaming
- Tracks: tokens/sec, time-to-first-token, thinking time, total latency
- Metrics calculated in real-time as tokens are generated

### 3. API Simplification
- Single `generateStream()` method returns `StreamingResult` (includes both stream + metrics)
- Removed redundant methods from public API
- All streaming now includes analytics automatically

### 4. Application Layer Cleanup
- **Removed ~105 lines** of manual analytics tracking from `ChatViewModel`
- Deleted `collectMessageAnalytics()` method entirely
- App now only reads SDK metrics and reformats for display

## Code Changes

### Before (App Layer Manual Tracking)
```swift
// App was doing calculations
var startTime = Date()
var tokensPerSecondHistory: [Double] = []
var totalTokensReceived = 0

for try await token in stream {
    totalTokensReceived += 1
    // Manual speed calculations...
    if totalTokensReceived % 10 == 0 {
        let currentSpeed = Double(totalTokensReceived) / elapsed
        tokensPerSecondHistory.append(currentSpeed)
    }
}

let analytics = collectMessageAnalytics(...) // 70 lines of calculation
```

### After (SDK Provides Everything)
```swift
// SDK handles all calculations
let streamingResult = try await RunAnywhere.generateStream(prompt, options)

for try await token in streamingResult.stream {
    // Just display - NO calculation
    fullResponse += token
}

// Get complete SDK metrics
let sdkResult = try await streamingResult.result.value
let analytics = analyticsFromGenerationResult(sdkResult, ...) // Just reformat
```

## Key Architecture Changes

### SDK Layer Additions
- `TokenCounter.swift` - Accurate token estimation and speed calculations
- `StreamingResult` struct - Container for stream + metrics task
- `MetricsCollector` actor - Thread-safe metrics accumulation
- Enhanced `PerformanceMetrics` with comprehensive tracking
- Simplified public API via `RunAnywhere.*` namespace

### Application Layer Simplifications
- Removed all analytics calculation logic
- App reads SDK-provided metrics and displays them
- No manual token counting, speed calculations, or time tracking

## Bug Fixes

**Fixed AsyncStream Double-Consumption Crash**
- **Error**: `Fatal error: attempt to await next() on more than one task`
- **Root Cause**: AsyncStream can only be consumed once; we were consuming in both UI and metrics calculation
- **Solution**: Track metrics during token generation (not by re-consuming stream), signal completion via actor continuation

## Benefits

✅ **Single Source of Truth**: All metrics calculated in one place (SDK)
✅ **Consistency**: Same calculations for streaming and non-streaming modes
✅ **Accuracy**: Improved token counting with proper heuristics
✅ **Simplicity**: App code reduced by ~105 lines
✅ **Thread Safety**: Actor-based metrics collection
✅ **Clean API**: One method, always includes metrics

## Files Changed

**SDK (11 files):**
- `TokenCounter.swift` (new) - Token estimation and speed calculations
- `GenerationResult.swift` - Added `StreamingResult` struct
- `StreamingService.swift` - Implemented streaming with metrics tracking
- `RunAnywhere.swift` - Simplified API, added convenience methods
- `RunAnywhere+StructuredOutput.swift` - Updated to use new API
- `PerformanceMetrics.swift` - Enhanced metrics tracking
- `GenerationService.swift` - Integrated TokenCounter
- `ThinkingTagPattern.swift` - Minor adjustments
- `LLMHandler.swift` - Voice capability updates
- `ModelInfo.swift` - Model metadata enhancements

**App (1 file):**
- `ChatViewModel.swift` - Removed manual analytics, uses SDK metrics exclusively

## Testing

- ✅ Build successful
- ✅ All pre-commit hooks passed (SwiftLint, TODOs, merge conflicts)
- ✅ Verified streaming displays tokens correctly
- ✅ Verified analytics display in UI (per-message and modal)
- ✅ No AsyncStream crashes
- ✅ Token counts accurate with improved estimation

## API Usage

Developers using the SDK now get analytics automatically:

```swift
// Single method call - analytics included
let streamingResult = try await RunAnywhere.generateStream(prompt, options)

// Display tokens in real-time
for try await token in streamingResult.stream {
    updateUI(with: token)
}

// Get complete analytics when done
let result = try await streamingResult.result.value
print("Tokens/sec: \(result.performanceMetrics.tokensPerSecond)")
print("Total tokens: \(result.tokensUsed)")
print("Time to first token: \(result.performanceMetrics.timeToFirstTokenMs)ms")
```

## Migration Notes

**For SDK users:**
- `generateStream()` now returns `StreamingResult` instead of `AsyncThrowingStream`
- Access the stream via `.stream` property
- Get metrics via `.result` task
- No breaking changes to configuration or options

**For app developers:**
- Remove any manual analytics tracking code
- Read metrics from `GenerationResult` returned by SDK
- Use `RunAnywhere.estimateTokenCount()` for token estimation

## Related Issues

Closes #69



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added token counting utilities for text analysis.
  * Enhanced thinking content parsing and separation from response content.
  * Introduced comprehensive performance metrics tracking including thinking time and response time.
  * Improved streaming with integrated metrics collection.

* **Bug Fixes**
  * Refined performance measurement accuracy across generation paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->