### PR TITLE
Fix the unknown within the schema for chat : android

### DIFF
--- a/sdk/runanywhere-kotlin/src/commonMain/kotlin/com/runanywhere/sdk/generation/GenerationService.kt
+++ b/sdk/runanywhere-kotlin/src/commonMain/kotlin/com/runanywhere/sdk/generation/GenerationService.kt
@@ -104,7 +104,7 @@ class GenerationService(
             // Submit analytics (non-blocking, matching iOS pattern)
             submitGenerationAnalytics(
                 generationId = sessionId,
-                modelId = resolvedOptions.model ?: "unknown",
+                modelId = currentModel?.model?.id ?: "unknown",
                 prompt = prompt,
                 response = response,
                 latencyMs = result.latencyMs,
@@ -120,7 +120,7 @@ class GenerationService(
             // Submit analytics for failure
             submitGenerationAnalytics(
                 generationId = sessionId,
-                modelId = resolvedOptions.model ?: "unknown",
+                modelId = currentModel?.model?.id ?: "unknown",
                 prompt = prompt,
                 response = "",
                 latencyMs = System.currentTimeMillis() - session.startTime,
@@ -199,7 +199,7 @@ class GenerationService(
             // Submit analytics (non-blocking, matching iOS pattern and non-streaming generate())
             submitGenerationAnalytics(
                 generationId = sessionId,
-                modelId = resolvedOptions.model ?: "unknown",
+                modelId = currentModel?.model?.id ?: "unknown",
                 prompt = prompt,
                 response = session.partialResponse,
                 latencyMs = result.latencyMs,
@@ -213,7 +213,7 @@ class GenerationService(
             // Submit analytics for failure (matching non-streaming generate())
             submitGenerationAnalytics(
                 generationId = sessionId,
-                modelId = resolvedOptions.model ?: "unknown",
+                modelId = currentModel?.model?.id ?: "unknown",
                 prompt = prompt,
                 response = "",
                 latencyMs = System.currentTimeMillis() - session.startTime,


### PR DESCRIPTION
Previously analytics were reporting 'unknown' for model_id because the code was checking resolvedOptions.model (which is often null). Now correctly uses currentModel?.model?.id to track the actual model being used for generation.

Tested and the supabase is getting the correct record for the chat which was recieving null earlier.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics submissions now record model IDs (derived from the current model) instead of model names across generation and streaming flows.
  * Analytics logging is consistent across success/failure and streaming events; no changes to runtime behavior or error handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->