### PR TITLE
Implement modality system for type-safe model validation

### DIFF
--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
@@ -167,14 +167,17 @@ struct RunAnywhereAIApp: App {
                 LLMSwiftAdapter(),
                 models: [
                     // SmolLM2 360M - smallest and fastest
+                    // Explicit modality specification
                     try! ModelRegistration(
                         url: "https://huggingface.co/prithivMLmods/SmolLM2-360M-GGUF/resolve/main/SmolLM2-360M.Q8_0.gguf",
                         framework: .llamaCpp,
                         id: "smollm2-360m-q8-0",
                         name: "SmolLM2 360M Q8_0",
+                        modality: .textToText,  // ✅ Explicit modality for text generation
                         memoryRequirement: 500_000_000
                     ),
                     // Qwen 2.5 0.5B - small but capable
+                    // Modality auto-inferred from framework (llamaCpp → textToText)
                     try! ModelRegistration(
                         url: "https://huggingface.co/Triangle104/Qwen2.5-0.5B-Instruct-Q6_K-GGUF/resolve/main/qwen2.5-0.5b-instruct-q6_k.gguf",
                         framework: .llamaCpp,
@@ -233,15 +236,18 @@ struct RunAnywhereAIApp: App {
                 WhisperKitAdapter.shared,
                 models: [
                     // Whisper Tiny - smallest and fastest
+                    // Explicit modality specification
                     try! ModelRegistration(
                         url: "https://huggingface.co/argmaxinc/whisperkit-coreml/tree/main/openai_whisper-tiny.en",
                         framework: .whisperKit,
                         id: "whisper-tiny",
                         name: "Whisper Tiny",
+                        modality: .voiceToText,  // ✅ Explicit modality for speech recognition
                         format: .mlmodel,  // Explicitly specify Core ML format
                         memoryRequirement: 39_000_000
                     ),
                     // Whisper Base - better quality
+                    // Modality auto-inferred from framework (whisperKit → voiceToText)
                     try! ModelRegistration(
                         url: "https://huggingface.co/argmaxinc/whisperkit-coreml/tree/main/openai_whisper-base",
                         framework: .whisperKit,

--- a/sdk/runanywhere-swift/Modules/LLMSwift/Sources/LLMSwift/LLMSwiftAdapter.swift
+++ b/sdk/runanywhere-swift/Modules/LLMSwift/Sources/LLMSwift/LLMSwiftAdapter.swift
@@ -17,6 +17,9 @@ public class LLMSwiftAdapter: UnifiedFrameworkAdapter {
         // Check format support
         guard supportedFormats.contains(model.format) else { return false }
 
+        // Check modality support
+        guard supportedModalities.contains(model.modality) else { return false }
+
         // Check quantization compatibility
         if let metadata = model.metadata, let quantization = metadata.quantizationLevel {
             return isQuantizationSupported(quantization.rawValue)

--- a/sdk/runanywhere-swift/Modules/WhisperKitTranscription/Sources/WhisperKitTranscription/WhisperKitAdapter.swift
+++ b/sdk/runanywhere-swift/Modules/WhisperKitTranscription/Sources/WhisperKitTranscription/WhisperKitAdapter.swift
@@ -27,11 +27,21 @@ public class WhisperKitAdapter: UnifiedFrameworkAdapter {
     // MARK: - UnifiedFrameworkAdapter Implementation
 
     public func canHandle(model: ModelInfo) -> Bool {
-        // Check if model is for speech recognition and compatible with WhisperKit
-        let canHandle = model.category == .speechRecognition &&
-                       model.compatibleFrameworks.contains(.whisperKit)
-        logger.debug("canHandle(\(model.name, privacy: .public)): \(canHandle)")
-        return canHandle
+        // Check format, modality, and framework compatibility
+        guard supportedFormats.contains(model.format) else {
+            logger.debug("canHandle(\(model.name, privacy: .public)): false - unsupported format \(model.format.rawValue)")
+            return false
+        }
+        guard supportedModalities.contains(model.modality) else {
+            logger.debug("canHandle(\(model.name, privacy: .public)): false - unsupported modality \(model.modality.rawValue)")
+            return false
+        }
+        guard model.compatibleFrameworks.contains(.whisperKit) else {
+            logger.debug("canHandle(\(model.name, privacy: .public)): false - not compatible with WhisperKit")
+            return false
+        }
+        logger.debug("canHandle(\(model.name, privacy: .public)): true")
+        return true
     }
 
     public func createService(for modality: FrameworkModality) -> Any? {

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Components/WakeWord/WakeWordComponent.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Components/WakeWord/WakeWordComponent.swift
@@ -157,14 +157,32 @@ public struct WakeWordMetadata: Sendable {
 
 /// Protocol for registering external Wake Word implementations
 public protocol WakeWordServiceProvider {
+    /// Modalities this provider can handle
+    static var supportedModalities: Set<FrameworkModality> { get }
+
     /// Create a wake word service for the given configuration
     func createWakeWordService(configuration: WakeWordConfiguration) async throws -> WakeWordService
 
-    /// Check if this provider can handle the given model
+    /// Check if this provider can handle the given model ID
     func canHandle(modelId: String?) -> Bool
+
+    /// Check if this provider can handle the given model (validates modality)
+    func canHandle(model: ModelInfo) -> Bool
 
     /// Provider name for identification
     var name: String { get }
+}
+
+extension WakeWordServiceProvider {
+    /// Default supported modalities for Wake Word providers
+    public static var supportedModalities: Set<FrameworkModality> {
+        [.voiceToText]
+    }
+
+    /// Default implementation: validates model modality
+    public func canHandle(model: ModelInfo) -> Bool {
+        Self.supportedModalities.contains(model.modality)
+    }
 }
 
 // MARK: - Default Wake Word Service

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Core/Models/Model/ModelInfo.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Core/Models/Model/ModelInfo.swift
@@ -8,6 +8,10 @@ public struct ModelInfo: Codable, RepositoryEntity, FetchableRecord, Persistable
     public let name: String
     public let category: ModelCategory  // Type of model (language, speech, vision, etc.)
 
+    /// The specific modality this model performs (e.g., text-to-text, voice-to-text)
+    /// Auto-inferred from category if not explicitly specified during initialization
+    public let modality: FrameworkModality
+
     // Format and location
     public let format: ModelFormat
     public let downloadURL: URL?
@@ -56,7 +60,7 @@ public struct ModelInfo: Codable, RepositoryEntity, FetchableRecord, Persistable
     }
 
     private enum CodingKeys: String, CodingKey {
-        case id, name, category, format, downloadURL, localPath
+        case id, name, category, modality, format, downloadURL, localPath
         case downloadSize, memoryRequired
         case compatibleFrameworks, preferredFramework
         case contextLength, supportsThinking, thinkingPattern
@@ -69,6 +73,7 @@ public struct ModelInfo: Codable, RepositoryEntity, FetchableRecord, Persistable
         id: String,
         name: String,
         category: ModelCategory,
+        modality: FrameworkModality? = nil,
         format: ModelFormat,
         downloadURL: URL? = nil,
         localPath: URL? = nil,
@@ -91,6 +96,10 @@ public struct ModelInfo: Codable, RepositoryEntity, FetchableRecord, Persistable
         self.id = id
         self.name = name
         self.category = category
+
+        // Auto-infer modality from category if not explicitly provided
+        self.modality = modality ?? category.frameworkModality
+
         self.format = format
         self.downloadURL = downloadURL
         self.localPath = localPath
@@ -136,6 +145,7 @@ extension ModelInfo {
         case id
         case name
         case category
+        case modality
         case format
         case downloadURL
         case localPath

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Core/ModuleRegistry.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Core/ModuleRegistry.swift
@@ -181,16 +181,48 @@ public final class ModuleRegistry {
 
 /// Provider for Vision Language Model services
 public protocol VLMServiceProvider {
+    /// Modalities this provider can handle
+    static var supportedModalities: Set<FrameworkModality> { get }
+
     func createVLMService(configuration: VLMConfiguration) async throws -> VLMService
     func canHandle(modelId: String?) -> Bool
+    func canHandle(model: ModelInfo) -> Bool
     var name: String { get }
+}
+
+extension VLMServiceProvider {
+    /// Default supported modalities for VLM providers
+    public static var supportedModalities: Set<FrameworkModality> {
+        [.imageToText, .multimodal]
+    }
+
+    /// Default implementation: validates model modality
+    public func canHandle(model: ModelInfo) -> Bool {
+        Self.supportedModalities.contains(model.modality)
+    }
 }
 
 /// Provider for Speaker Diarization services
 public protocol SpeakerDiarizationServiceProvider {
+    /// Modalities this provider can handle
+    static var supportedModalities: Set<FrameworkModality> { get }
+
     func createSpeakerDiarizationService(configuration: SpeakerDiarizationConfiguration) async throws -> SpeakerDiarizationService
     func canHandle(modelId: String?) -> Bool
+    func canHandle(model: ModelInfo) -> Bool
     var name: String { get }
+}
+
+extension SpeakerDiarizationServiceProvider {
+    /// Default supported modalities for Speaker Diarization providers
+    public static var supportedModalities: Set<FrameworkModality> {
+        [.voiceToText]  // Audio processing
+    }
+
+    /// Default implementation: validates model modality
+    public func canHandle(model: ModelInfo) -> Bool {
+        Self.supportedModalities.contains(model.modality)
+    }
 }
 
 

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Core/Protocols/Frameworks/UnifiedFrameworkAdapter.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Core/Protocols/Frameworks/UnifiedFrameworkAdapter.swift
@@ -69,6 +69,14 @@ public extension UnifiedFrameworkAdapter {
         return framework.supportedModalities
     }
 
+    /// Default implementation: validates both format and modality
+    func canHandle(model: ModelInfo) -> Bool {
+        // Check both format AND modality
+        guard supportedFormats.contains(model.format) else { return false }
+        guard supportedModalities.contains(model.modality) else { return false }
+        return true
+    }
+
     /// Default implementation - does nothing
     func onRegistration() {
         // Default: no-op

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Models/ModelRegistration.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Models/ModelRegistration.swift
@@ -14,6 +14,9 @@ public struct ModelRegistration {
     /// The framework this model is compatible with
     public let framework: LLMFramework
 
+    /// The specific modality this model performs (optional, auto-inferred from framework if nil)
+    public let modality: FrameworkModality?
+
     /// Model format (auto-detected from URL if nil)
     public let format: ModelFormat?
 
@@ -32,6 +35,7 @@ public struct ModelRegistration {
         framework: LLMFramework,
         id: String? = nil,
         name: String? = nil,
+        modality: FrameworkModality? = nil,
         format: ModelFormat? = nil,
         memoryRequirement: Int64? = nil,
         contextLength: Int? = nil,
@@ -43,6 +47,7 @@ public struct ModelRegistration {
 
         self.url = modelURL
         self.framework = framework
+        self.modality = modality
         self.id = id ?? modelURL.lastPathComponent.replacingOccurrences(of: ".", with: "_")
         self.name = name ?? modelURL.lastPathComponent
         self.format = format ?? ModelFormat.detectFromURL(modelURL)
@@ -57,6 +62,7 @@ public struct ModelRegistration {
         framework: LLMFramework,
         id: String? = nil,
         name: String? = nil,
+        modality: FrameworkModality? = nil,
         format: ModelFormat? = nil,
         memoryRequirement: Int64? = nil,
         contextLength: Int? = nil,
@@ -64,6 +70,7 @@ public struct ModelRegistration {
     ) {
         self.url = url
         self.framework = framework
+        self.modality = modality
         self.id = id ?? url.lastPathComponent.replacingOccurrences(of: ".", with: "_")
         self.name = name ?? url.lastPathComponent
         self.format = format ?? ModelFormat.detectFromURL(url)
@@ -81,6 +88,7 @@ public struct ModelRegistration {
             id: id,
             name: name,
             category: category,
+            modality: modality ?? category.frameworkModality,  // Auto-infer from category if not specified
             format: format ?? .gguf,
             downloadURL: url,
             localPath: nil,


### PR DESCRIPTION
## Summary

Implements a proper modality system to prevent runtime errors when incompatible models are used with service providers (resolves #65).

## Changes

### Core Model Changes
- Added `modality` field to `ModelInfo` with auto-inference from `category`
- Added optional `modality` parameter to `ModelRegistration`
- Added `modality` column to database schema

### Service Provider Enhancements
- Added `supportedModalities` static property to all service providers:
  - `VLMServiceProvider` → `.imageToText, .multimodal`
  - `SpeakerDiarizationServiceProvider` → `.voiceToText`
  - `WakeWordServiceProvider` → `.voiceToText`
- Added `canHandle(model: ModelInfo)` method for modality validation

### Component Validation
- Enhanced `STTComponent` and `LLMComponent` to validate modality during initialization
- Clear error messages: `"Model 'X' has modality 'Y' which is not compatible with Z service (expects: W)"`

### Adapter Updates
- Enhanced `UnifiedFrameworkAdapter` with default `canHandle(model:)` validation
- Updated `WhisperKitAdapter` and `LLMSwiftAdapter` to validate both format and modality

### Sample App
- Updated iOS sample app with explicit modality examples
- Demonstrates both explicit and auto-inferred modality usage

## Benefits

 **Early Error Detection** - Catches incompatible model/service combinations at initialization, not runtime  
**Clear Error Messages** - Developers know exactly what's wrong and what's expected  
**Backward Compatible** - Modality is optional with auto-inference from framework  
**Type-Safe** - Compile-time safety for modality validation  
**Self-Documenting** - Clear what each component/provider/adapter supports  

## Example Usage

```swift
//Explicit modality
ModelRegistration(
    url: "whisper.mlmodel",
    framework: .whisperKit,
    id: "whisper-tiny",
    modality: .voiceToText  // Explicit
)

// Auto-inferred (backward compatible)
ModelRegistration(
    url: "llama.gguf",
    framework: .llamaCpp,
    id: "llama-3"
    // Modality auto-inferred as .textToText
)

// ❌ Validation catches errors early
let stt = STTComponent(configuration: STTConfiguration(modelId: "llama-3"))
try await stt.initialize()
// Throws: "Model 'llama-3' has modality 'text-to-text' which is not compatible with STT service (expects: voice-to-text)"


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Models now explicitly specify their task modalities (text-to-text, voice-to-text, multimodal) for improved framework compatibility.
  * Automatic validation prevents incompatible model-provider configurations.
  * Enhanced error messages clearly indicate supported modalities when mismatches occur.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->