### PR TITLE
fix: enable AndroidX support in gradle.properties

### DIFF
--- a/examples/flutter/RunAnywhereAI/android/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/flutter/RunAnywhereAI/android/gradle/wrapper/gradle-wrapper.properties
@@ -3,3 +3,7 @@ distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-all.zip
+org.gradle.jvmargs=-Xmx6g -XX:+UseG1GC -XX:MaxMetaspaceSize=512m -XX:+HeapDumpOnOutOfMemoryError -XX:+UseStringDeduplication -Dfile.encoding=UTF-8
+org.gradle.daemon=true
+org.gradle.parallel=true
+org.gradle.configureondemand=true


### PR DESCRIPTION
## Description
Brief description of the changes made.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Tests pass locally
- [ ] Tested on Macbook if swift changes
- [ ] Tested on Tablet/iPad if swift changes
- [ ] Added/updated tests for changes

## Labels
Please add the appropriate label(s):
- [ ] `iOS SDK` - Changes to iOS/Swift SDK
- [ ] `Android SDK` - Changes to Android/Kotlin SDK
- [ ] `iOS Sample` - Changes to iOS example app
- [ ] `Android Sample` - Changes to Android example app

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)

## Screenshots - Attach all the relevant UI changes screenshots for iOS/Android and MacOS/Tablet/large screen sizes
- 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enable AndroidX support by optimizing Gradle build properties in `gradle-wrapper.properties`.
> 
>   - **Gradle Properties**:
>     - Added `org.gradle.jvmargs` for memory and performance optimizations in `gradle-wrapper.properties`.
>     - Enabled `org.gradle.daemon`, `org.gradle.parallel`, and `org.gradle.configureondemand` for improved build performance in `gradle-wrapper.properties`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for 8f2b9b89c63780b1234a86df19a5b185a53658e7. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Optimized Gradle build configuration with enhanced memory management, garbage collection settings, and enabled daemon mode and parallel build execution for improved build performance and efficiency.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>


This PR attempts to add Gradle build optimization settings and AndroidX support to the Flutter example app's Android configuration. However, the changes are being made to the wrong file.

- **Critical Issue**: The `org.gradle.*` settings are added to `gradle-wrapper.properties`, which is only for Gradle wrapper configuration. These settings belong in `gradle.properties` (which doesn't exist in this project yet).
- **Missing AndroidX settings**: Despite the PR title mentioning "enable AndroidX support", no AndroidX properties (`android.useAndroidX=true`, `android.enableJetifier=true`) are included.
- The added JVM args and build optimizations are reasonable values, but will not be applied from this file location.

<h3>Confidence Score: 1/5</h3>


- This PR will not achieve its stated goal - settings are in the wrong file and will be ignored by Gradle
- The settings are placed in `gradle-wrapper.properties` instead of `gradle.properties`, meaning they won't be recognized by Gradle. The PR title promises AndroidX support but doesn't add the required AndroidX properties.
- examples/flutter/RunAnywhereAI/android/gradle/wrapper/gradle-wrapper.properties - settings in wrong file

<h3>Important Files Changed</h3>



File Analysis



| Filename | Score | Overview |
|----------|-------|----------|
| examples/flutter/RunAnywhereAI/android/gradle/wrapper/gradle-wrapper.properties | 1/5 | Critical issue: Gradle build settings (`org.gradle.jvmargs`, `org.gradle.daemon`, etc.) are being added to the wrong file. These settings belong in `gradle.properties`, not `gradle-wrapper.properties`. Additionally, the PR title mentions AndroidX support but no AndroidX settings are actually added. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GW as gradle-wrapper.properties
    participant GP as gradle.properties (missing)
    participant Gradle as Gradle Build System

    Dev->>GW: Add org.gradle.* settings
    Note over GW: Wrong file!
    Gradle->>GW: Read wrapper config
    Note over Gradle: Only reads distributionUrl,<br/>distributionPath, etc.
    Gradle--xGW: Ignores org.gradle.* settings
    Gradle->>GP: Look for build settings
    Note over GP: File doesn't exist
    Gradle-->>Dev: Build uses defaults<br/>(settings not applied)
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->