### PR TITLE
feat: implement documentation link in settings screen (#263)

### DIFF
--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsScreen.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.platform.LocalUriHandler
 import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.text.input.PasswordVisualTransformation
 import androidx.compose.ui.text.input.VisualTransformation
@@ -57,6 +58,7 @@ fun SettingsScreen(
     val context = LocalContext.current
     var showApiKeyDialog by remember { mutableStateOf(false) }
     var showDeleteConfirmDialog by remember { mutableStateOf<StoredModel?>(null) }
+    val uriHandler = LocalUriHandler.current
 
     Column(
         modifier = Modifier
@@ -324,8 +326,9 @@ fun SettingsScreen(
                 modifier = Modifier
                     .fillMaxWidth()
                     .clickable {
-                        // TODO: Open documentation URL
-                        // iOS equivalent: Link(destination: URL(string: "https://docs.runanywhere.ai")!)
+                        // TODO: Update to Android-specific documentation when available
+                        // Currently links to general SDK docs (Swift-focused) as placeholder
+                        uriHandler.openUri("https://docs.runanywhere.ai")
                     }
                     .padding(vertical = 8.dp),
                 verticalAlignment = Alignment.CenterVertically


### PR DESCRIPTION
## Description
### Changes
- Implement clickable Documentation link in Settings screen
- Open https://docs.runanywhere.ai in browser when Documentation button is tapped

### Technical Details
#### Why use uriHandler?
- Standard approach for opening external URLs in Jetpack Compose
- Traditional method using `Intent(Intent.ACTION_VIEW, Uri.parse(url))` is also possible, but `LocalUriHandler` is more declarative and concise in Compose
- `LocalUriHandler.current` automatically provides platform-appropriate URI handling
- Can be used directly within Composables without Context dependency
- Opens URL in default browser on Android

#### Meaning of TODO
- Current link points to Swift SDK documentation (Kotlin Multiplatform docs not yet available)
- This link should be updated when Android-specific documentation becomes available
- General SDK documentation provided as temporary placeholder


## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Tests pass locally
- [ ] Tested on Macbook if swift changes
- [ ] Tested on Tablet/iPad if swift changes
- [ ] Added/updated tests for changes

## Labels
Please add the appropriate label(s):
- [ ] `iOS SDK` - Changes to iOS/Swift SDK
- [ ] `Android SDK` - Changes to Android/Kotlin SDK
- [ ] `iOS Sample` - Changes to iOS example app
- [x] `Android Sample` - Changes to Android example app

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)

## Screenshots - Attach all the relevant UI changes screenshots for iOS/Android and MacOS/Tablet/large screen sizes
- 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a clickable documentation link in `SettingsScreen.kt` using `LocalUriHandler` to open a placeholder URL in the browser.
> 
>   - **Behavior**:
>     - Adds a clickable "Documentation" link in `SettingsScreen.kt`.
>     - Opens `https://docs.runanywhere.ai` in the default browser when clicked.
>   - **Technical Details**:
>     - Uses `LocalUriHandler` for URI handling in Jetpack Compose.
>     - Current link is a placeholder for Swift SDK documentation; will update to Android-specific docs later.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for 40976032015cea871191217a1248ad0316673341. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed the Documentation link in the Settings About section to properly open the docs website.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Implemented clickable Documentation link in Settings screen that opens https://docs.runanywhere.ai in the default browser.

**Key Changes:**
- Added `LocalUriHandler` import and initialization
- Made Documentation row clickable using `uriHandler.openUri()`
- Updated TODO comment to clarify link points to Swift SDK docs as temporary placeholder
- Implementation matches iOS pattern using declarative Compose approach

**Technical Approach:**
Uses `LocalUriHandler.current` which provides platform-appropriate URI handling without requiring Context dependency - a clean, idiomatic Compose solution.

<h3>Confidence Score: 5/5</h3>


- This PR is safe to merge with no concerns
- Simple, well-implemented feature that adds clickable documentation link. Uses standard Compose API (`LocalUriHandler`) appropriately, matches iOS implementation pattern, includes clear TODO for future updates, and has no side effects or edge cases to consider.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsScreen.kt | Added clickable Documentation link that opens https://docs.runanywhere.ai using `LocalUriHandler` - clean implementation matching iOS pattern |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SettingsScreen
    participant UriHandler
    participant Browser

    User->>SettingsScreen: Tap "Documentation" link
    SettingsScreen->>UriHandler: openUri("https://docs.runanywhere.ai")
    UriHandler->>Browser: Launch default browser with URL
    Browser-->>User: Display documentation page
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->