### PR TITLE
ci: add initial linting setup

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,0 +1,101 @@
+# RunAnywhere Commons - Clang Format Configuration
+# Based on Google style with customizations for consistency with runanywhere-core
+
+BasedOnStyle: Google
+
+# Indentation
+IndentWidth: 4
+TabWidth: 4
+UseTab: Never
+ContinuationIndentWidth: 4
+
+# Line length
+ColumnLimit: 100
+
+# Braces
+BreakBeforeBraces: Attach
+BraceWrapping:
+  AfterClass: false
+  AfterControlStatement: Never
+  AfterEnum: false
+  AfterFunction: false
+  AfterNamespace: false
+  AfterStruct: false
+  AfterUnion: false
+  BeforeCatch: false
+  BeforeElse: false
+  IndentBraces: false
+
+# Functions
+AllowShortFunctionsOnASingleLine: Inline
+AllowShortIfStatementsOnASingleLine: Never
+AllowShortLoopsOnASingleLine: false
+AllowShortBlocksOnASingleLine: Empty
+
+# Include sorting
+IncludeBlocks: Regroup
+IncludeCategories:
+  # Main header (same name as source file)
+  - Regex: '"[^/]*\.h"'
+    Priority: 1
+  # Project headers (rac_*)
+  - Regex: '"rac_.*\.h"'
+    Priority: 2
+  # runanywhere-core headers (ra_*)
+  - Regex: '"(ra_|runanywhere).*\.h"'
+    Priority: 3
+  # Third-party headers
+  - Regex: '<[^/]*\.h>'
+    Priority: 4
+  # System headers
+  - Regex: '<.*>'
+    Priority: 5
+SortIncludes: CaseSensitive
+
+# Alignment
+AlignAfterOpenBracket: Align
+AlignConsecutiveAssignments: None
+AlignConsecutiveDeclarations: None
+AlignEscapedNewlines: Left
+AlignOperands: Align
+AlignTrailingComments: true
+
+# Namespaces
+NamespaceIndentation: None
+CompactNamespaces: false
+FixNamespaceComments: true
+
+# Pointers and References
+DerivePointerAlignment: false
+PointerAlignment: Left
+ReferenceAlignment: Left
+
+# Empty lines
+KeepEmptyLinesAtTheStartOfBlocks: false
+MaxEmptyLinesToKeep: 1
+
+# Other
+AllowAllParametersOfDeclarationOnNextLine: true
+BinPackArguments: true
+BinPackParameters: true
+SpaceAfterCStyleCast: false
+SpaceAfterTemplateKeyword: true
+SpaceBeforeAssignmentOperators: true
+SpaceBeforeParens: ControlStatements
+SpaceInEmptyParentheses: false
+SpacesInAngles: Never
+SpacesInCStyleCastParentheses: false
+SpacesInParentheses: false
+SpacesInSquareBrackets: false
+
+# C/C++ specific
+Language: Cpp
+Standard: c++17
+
+# Penalties (for line breaking decisions)
+PenaltyBreakBeforeFirstCallParameter: 19
+PenaltyBreakComment: 300
+PenaltyBreakFirstLessLess: 120
+PenaltyBreakString: 1000
+PenaltyExcessCharacter: 1000000
+PenaltyReturnTypeOnItsOwnLine: 60

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,96 @@
+name: Lint
+
+on:
+  pull_request:
+    branches: ["main"]
+  push:
+    branches: ["main"]
+
+permissions:
+  contents: read
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Determine diff range
+        id: diff
+        shell: bash
+        run: |
+          if [[ "${GITHUB_EVENT_NAME}" == "pull_request" ]]; then
+            echo "from=${{ github.event.pull_request.base.sha }}" >> "$GITHUB_OUTPUT"
+            echo "to=${{ github.event.pull_request.head.sha }}" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          FROM="${{ github.event.before }}"
+          TO="${{ github.sha }}"
+
+          # Fallback for unusual push payloads (e.g., initial commit)
+          if [[ -z "$FROM" || "$FROM" =~ ^0+$ ]]; then
+            if git rev-parse --verify HEAD~1 >/dev/null 2>&1; then
+              FROM="$(git rev-parse HEAD~1)"
+            else
+              FROM="$(git rev-list --max-parents=0 HEAD)"
+            fi
+          fi
+
+          echo "from=$FROM" >> "$GITHUB_OUTPUT"
+          echo "to=$TO" >> "$GITHUB_OUTPUT"
+
+      - name: Setup Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install pre-commit
+        run: python -m pip install --upgrade pip pre-commit
+
+      - name: Run pre-commit (changed files only)
+        run: |
+          pre-commit run \
+            --from-ref "${{ steps.diff.outputs.from }}" \
+            --to-ref "${{ steps.diff.outputs.to }}" \
+            --show-diff-on-failure \
+            --color always
+
+      - name: Install clang-format
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y clang-format
+
+      - name: clang-format (changed C/C++ files only)
+        shell: bash
+        run: |
+          FROM="${{ steps.diff.outputs.from }}"
+          TO="${{ steps.diff.outputs.to }}"
+
+          files=()
+
+          while IFS= read -r f; do
+            [[ -f "$f" ]] || continue
+
+            # Skip generated code (avoid fighting generated formatting)
+            [[ "$f" == *"/nitrogen/generated/"* ]] && continue
+
+            case "$f" in
+              *.c|*.cc|*.cpp|*.cxx|*.h|*.hh|*.hpp|*.hxx)
+                files+=("$f")
+                ;;
+            esac
+          done < <(git diff --name-only "$FROM" "$TO" --diff-filter=ACMRTUXB)
+
+          if (( ${#files[@]} == 0 )); then
+            echo "No C/C++ files changed."
+            exit 0
+          fi
+
+          clang-format --version
+          clang-format --dry-run --Werror -style=file "${files[@]}"


### PR DESCRIPTION
- Adds a CI lint workflow at .github/workflows/lint.yml that runs on pull requests and pushes to main.

- Computes the correct diff range (PR base→head, push before→after) and runs checks only on changed files

- Runs pre-commit on the changed range for lightweight repo hygiene (whitespace/YAML/merge-conflict, etc.).

- Runs clang-format in check mode (--dry-run --Werror -style=file) on changed C/C++ files only, skipping generated paths like **/nitrogen/generated/**
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds CI linting setup with pre-commit and clang-format for changed files, excluding generated paths.
> 
>   - **CI Workflow**:
>     - Adds `lint.yml` in `.github/workflows` to run on pull requests and pushes to `main`.
>     - Determines diff range (PR base→head, push before→after) to check only changed files.
>     - Uses `pre-commit` for general hygiene checks.
>     - Uses `clang-format` in check mode for C/C++ files, excluding `**/nitrogen/generated/**`.
>   - **Clang Format**:
>     - Adds `.clang-format` file based on Google style with customizations for `runanywhere-core`.
>     - Sets indentation, line length, brace style, include sorting, and other formatting rules.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for cb4fd1d26e3c93df86492683e51f485634c15e46. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>


Introduces CI linting infrastructure with `.clang-format` configuration and a GitHub Actions workflow that runs pre-commit hooks and `clang-format` checks on changed files only.

**Key Changes:**
- Added `.clang-format` with Google-based style: 4-space indents, 100-char line limit, custom include sorting for `rac_*` and `ra_*` headers
- Added `.github/workflows/lint.yml` that intelligently detects diff ranges (PR base→head or push before→after) and runs checks on changed files only
- Workflow runs `pre-commit` hooks for general hygiene (whitespace, YAML, merge conflicts)
- Workflow runs `clang-format --dry-run --Werror` on changed C/C++ files, excluding generated code paths (`**/nitrogen/generated/**`)
- Workflow has proper fallback handling for edge cases like initial commits or unusual push payloads

<h3>Confidence Score: 4/5</h3>


- Safe to merge with minor potential edge case consideration
- The PR adds valuable CI infrastructure without modifying existing code. The workflow logic is well-designed with proper fallback handling. The only minor concern is the potential for pre-commit to fail if dependencies are missing, but this is acceptable for a CI setup.
- `.github/workflows/lint.yml` - verify pre-commit configuration is compatible with all hooks

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .clang-format | Added new clang-format config based on Google style with 4-space indents, 100 char line limit, and custom include sorting |
| .github/workflows/lint.yml | Added new CI lint workflow that runs pre-commit and clang-format on changed files only, with smart diff range detection |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant GH as GitHub
    participant WF as Lint Workflow
    participant PC as pre-commit
    participant CF as clang-format

    Dev->>GH: Push commit or open PR
    GH->>WF: Trigger lint workflow
    
    Note over WF: Checkout with fetch-depth: 0
    
    WF->>WF: Determine diff range
    alt Pull Request
        Note over WF: from = PR base SHA<br/>to = PR head SHA
    else Push to main
        Note over WF: from = github.event.before<br/>to = github.sha
        alt Unusual push (initial commit)
            WF->>WF: Fallback: HEAD~1 or root commit
        end
    end
    
    WF->>PC: Install pre-commit (Python 3.11)
    WF->>PC: Run pre-commit --from-ref FROM --to-ref TO
    PC->>PC: Check changed files:<br/>- trailing-whitespace<br/>- end-of-file-fixer<br/>- check-yaml<br/>- check-merge-conflict
    
    alt pre-commit fails
        PC-->>Dev: Show diff and exit 1
        WF-->>Dev: Workflow fails ❌
    end
    
    WF->>CF: Install clang-format (apt-get)
    WF->>WF: Find changed C/C++ files
    Note over WF: git diff --name-only FROM TO<br/>Filter: *.c, *.cc, *.cpp, *.h, etc.<br/>Skip: **/nitrogen/generated/**
    
    alt No C/C++ files changed
        WF->>Dev: "No C/C++ files changed" ✓
    else C/C++ files changed
        WF->>CF: clang-format --dry-run --Werror -style=file
        CF->>CF: Check formatting against .clang-format
        alt Format violations found
            CF-->>Dev: Show violations and exit 1
            WF-->>Dev: Workflow fails ❌
        else All files properly formatted
            CF-->>Dev: Workflow passes ✓
        end
    end
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Established consistent code formatting standards with customizable rules for indentation, line length, brace alignment, header organization, and alignment preferences.
  * Added automated linting checks on pull requests and commits to enforce formatting standards and prevent inconsistent code style across the codebase.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->