### PR TITLE
Optimise energy_vad

### DIFF
--- a/sdk/runanywhere-commons/include/rac/features/vad/rac_vad_energy.h
+++ b/sdk/runanywhere-commons/include/rac/features/vad/rac_vad_energy.h
@@ -232,7 +232,7 @@ RAC_API rac_result_t rac_energy_vad_process_audio(rac_energy_vad_handle_t handle
  * @param sample_count Number of samples
  * @return RMS energy value, or 0.0 if empty
  */
-RAC_API float rac_energy_vad_calculate_rms(const float* audio_data, size_t sample_count);
+RAC_API float rac_energy_vad_calculate_rms(const float* __restrict audio_data,size_t sample_count);
 
 // =============================================================================
 // PAUSE/RESUME API

--- a/sdk/runanywhere-commons/src/features/vad/energy_vad.cpp
+++ b/sdk/runanywhere-commons/src/features/vad/energy_vad.cpp
@@ -27,7 +27,7 @@
 
 struct rac_energy_vad {
     
-    // Hot data -> accesed frequently 
+    // Hot data -> accessed frequently 
 
     bool is_active;
     bool is_currently_speaking;


### PR DESCRIPTION
## Description
Optimised structuring, rms calculation, vector.erase

- Restructured the vad energy structure to ensure the hot variables are nearby
-  Instead of using vector.erase(begin), now using a ring to turn O(N) ops into O(1)
- manually unroll the rms calculation loop. 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimized `energy_vad.cpp` by restructuring data, using a ring buffer, and unrolling RMS calculation loop for improved performance.
> 
>   - **Data Structure**:
>     - Restructured `rac_energy_vad` to place frequently accessed variables together.
>   - **Performance Optimization**:
>     - Replaced `vector.erase(begin)` with a ring buffer in `update_debug_statistics()` and other relevant functions.
>     - Manually unrolled loop in `rac_energy_vad_calculate_rms()` for RMS calculation.
>   - **Misc**:
>     - Updated initialization and reset logic for ring buffer in `rac_energy_vad_create()`, `rac_energy_vad_pause()`, `rac_energy_vad_resume()`, and `rac_energy_vad_notify_tts_finish()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for b4d6439c83b9228fc2aacc4c37160112dc79f324. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Optimized `energy_vad.cpp` for better performance through data structure reorganization, ring buffer implementation, and loop unrolling.

**Key Changes:**
- Restructured `rac_energy_vad` struct to place hot (frequently accessed) variables together for improved cache locality
- Replaced O(N) `vector.erase(begin)` with O(1) ring buffer operations in `update_debug_statistics()`
- Manually unrolled RMS calculation loop by factor of 4 with separate accumulators to enable instruction-level parallelism

**Critical Issue:**
- Ring buffer iteration bug in `rac_energy_vad_get_statistics()` at lines 685-689 will produce incorrect statistics after buffer wraps. The loop iterates indices 0 to count-1, but after wrapping, valid data is not contiguous starting at index 0.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge - contains a critical logic bug in ring buffer statistics calculation
- The ring buffer optimization is well-intentioned, but the implementation has a critical bug in `rac_energy_vad_get_statistics()` that will cause incorrect calculations after the buffer wraps around. This will affect debugging and monitoring functionality.
- sdk/runanywhere-commons/src/features/vad/energy_vad.cpp requires fixing the ring buffer iteration logic before merge

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-commons/src/features/vad/energy_vad.cpp | Performance optimizations with ring buffer implementation, but critical bug in statistics calculation when buffer wraps |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant VAD as energy_vad
    participant RingBuffer as recent_energy_values

    Client->>VAD: rac_energy_vad_process_audio(audio_data)
    VAD->>VAD: rac_energy_vad_calculate_rms(audio_data)
    Note over VAD: Unrolled loop (4x)<br/>s0, s1, s2, s3 accumulators
    VAD->>VAD: update_debug_statistics(energy)
    VAD->>RingBuffer: recent_energy_values[ring_buffer_write_index] = energy
    Note over RingBuffer: O(1) ring buffer write<br/>(replaces vector.erase)
    VAD->>VAD: ring_buffer_write_index++
    alt write_index >= size
        VAD->>VAD: ring_buffer_write_index = 0
    end
    VAD->>VAD: ring_buffer_count++
    
    Client->>VAD: rac_energy_vad_get_statistics()
    VAD->>RingBuffer: iterate for average/max
    Note over RingBuffer: BUG: iterates indices 0..count-1<br/>instead of circular buffer order
    RingBuffer-->>VAD: incorrect values after wrap
    VAD-->>Client: return stats
```

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Optimized voice activity detection to use a fixed-size, circular buffer for energy statistics, reducing memory churn and improving responsiveness.
  * Audio processing math unrolled for faster RMS computation while preserving results.

* **Bug Fixes**
  * Improved reset/pause/resume handling to maintain correct recent-energy statistics and more reliable VAD state.

* **Documentation**
  * Minor comments clarified behavior of the updated statistics mechanism.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->