### PR TITLE
Fix duplicate models and incorrect metadata in RN Settings screen

### DIFF
--- a/examples/react-native/RunAnywhereAI/src/screens/SettingsScreen.tsx
+++ b/examples/react-native/RunAnywhereAI/src/screens/SettingsScreen.tsx
@@ -647,14 +647,12 @@ export const SettingsScreen: React.FC = () => {
     const framework = model.format === 'onnx' ? LLMFramework.ONNX : LLMFramework.LlamaCpp;
     const frameworkName = FrameworkDisplayNames[framework] || framework;
 
-    // Get model size - prefer actual size for downloaded models
-    // TODO: Replace with actual disk size once SDK exposes it (e.g., sizeOnDisk or actualSize)
+    // Get model size estimate based on download size (may differ from actual on-disk size)
     const downloadedModel = downloadedModels.find((m) => m.id === model.id);
     const modelSize =
-      downloadedModel?.downloadSize ?? // Use downloaded model's size (closer to actual) when available
-      model.downloadSize ?? // Fall back to catalog expected size
+      downloadedModel?.downloadSize ?? // Prefer size from downloaded model when available
+      model.downloadSize ?? // Fall back to catalog's expected download size
       0;
-
     return (
       <View key={model.id} style={styles.catalogModelRow}>
         <View style={styles.catalogModelInfo}>


### PR DESCRIPTION
## Description
Fixes UX and metadata issues in the React Native Settings → Model Catalog screen by removing duplicate model listings, correcting framework labels for ONNX models, and improving model size handling for downloaded models. This aligns the React Native behavior with the iOS Settings UI.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Lint passes locally
- [ ] Added/updated tests for changes (not applicable – UI/metadata fix)

### Platform-Specific Testing

**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [x] Tested on Android (JavaScript/TypeScript via Metro bundler)

> Note: Android native build is currently blocked locally due to a missing Gradle wrapper JAR in the example project, which is unrelated to this change. JavaScript/TypeScript logic and rendering paths were verified via Metro.

## Labels

**Sample Apps:**
- [x] `React Native Sample`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (not required)

## Screenshots
N/A – UI logic and metadata corrections only (no visual layout changes).

Fixes #277

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes duplicate models and incorrect metadata in React Native Settings screen by removing duplicates, correcting ONNX labels, and improving model size handling.
> 
>   - **Behavior**:
>     - Removes duplicate model listings in `SettingsScreen.tsx` by eliminating `storedModels` state and related logic.
>     - Corrects framework labels for ONNX models in `renderCatalogModelRow()` by using `LLMFramework.ONNX`.
>     - Improves model size handling in `handleDeleteDownloadedModel()` and `renderCatalogModelRow()` by preferring actual disk usage over expected size.
>   - **Misc**:
>     - Updates storage info retrieval in `loadData()` to use new SDK API fields.
>     - Removes unused import `StoredModel` from `SettingsScreen.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for 8356d92508191982beb16094f90c0b520f6bb4a6. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR fixes UX and metadata issues in the React Native Settings screen by eliminating duplicate model listings and correcting framework labels for ONNX models.

**Key Changes:**
- Removed `storedModels` state and related legacy code that was causing duplicate model listings in the UI
- Corrected framework detection logic in `renderCatalogModelRow()` to properly identify ONNX models using `model.format === 'onnx'` instead of incorrectly using `compatibleFrameworks[0]`
- Updated storage info retrieval in `loadData()` to use the new nested SDK API structure (`storage.deviceStorage.totalSpace`, `storage.appStorage.totalSize`, etc.)
- Improved model size handling to prefer actual downloaded model size over catalog expected size
- Removed unused `StoredModel` import

The changes align the React Native implementation with the iOS Settings UI behavior and the updated SDK API structure defined in `RunAnywhere+Storage.ts`.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with no blocking issues
- The changes are straightforward bug fixes that remove duplicate code, correct metadata display, and align with the updated SDK API. All changes follow established patterns and improve code quality by eliminating redundant state management.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| examples/react-native/RunAnywhereAI/src/screens/SettingsScreen.tsx | Removed duplicate model state management, corrected ONNX framework labels, and aligned storage API with new SDK structure |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant SettingsScreen
    participant RunAnywhere SDK
    participant FileSystem

    User->>SettingsScreen: Open Settings Screen
    SettingsScreen->>RunAnywhere SDK: getStorageInfo()
    RunAnywhere SDK->>FileSystem: Get device storage
    FileSystem-->>RunAnywhere SDK: deviceStorage {totalSpace, freeSpace}
    RunAnywhere SDK->>FileSystem: Get app storage size
    FileSystem-->>RunAnywhere SDK: appStorage {totalSize, cacheSize}
    RunAnywhere SDK->>FileSystem: Get models storage
    FileSystem-->>RunAnywhere SDK: modelStorage {totalSize, modelCount}
    RunAnywhere SDK-->>SettingsScreen: StorageInfo (nested structure)
    
    SettingsScreen->>RunAnywhere SDK: getAvailableModels()
    RunAnywhere SDK-->>SettingsScreen: ModelInfo[] (catalog)
    
    SettingsScreen->>RunAnywhere SDK: getDownloadedModels()
    RunAnywhere SDK-->>SettingsScreen: ModelInfo[] (downloaded)
    
    SettingsScreen->>SettingsScreen: renderCatalogModelRow()
    Note over SettingsScreen: Framework detection:<br/>format === 'onnx' → LLMFramework.ONNX<br/>otherwise → LLMFramework.LlamaCpp
    
    SettingsScreen->>SettingsScreen: Display unified model list
    Note over SettingsScreen: No duplicates:<br/>Single source from catalog<br/>with download status overlay
```

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated Settings screen storage display to show Total Storage, App, Models, Cache, and Available space using the latest storage info.
  * Enhanced model rows to auto-detect framework (e.g., ONNX/LlamaCpp) and show a computed model size (prefers downloaded size when available).
  * Removed legacy "Downloaded Models" section for a cleaner model list.

* **Bug Fixes**
  * Delete confirmation now shows the accurate freed size when removing a downloaded model.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->