### PR TITLE
ci(swift): add auto-tag workflow on push to main

### DIFF
--- a/.github/workflows/swift-auto-tag.yml
+++ b/.github/workflows/swift-auto-tag.yml
@@ -1,0 +1,74 @@
+# =============================================================================
+# Swift SDK Auto-Tag (Phase 1 CI/CD)
+#
+# Merges to main automatically create a new git tag swift-vX.Y.Z to mark
+# official Swift SDK release points. Full build/publish automation will be
+# added later. No builds, no publishing, no macOS runners in this phase.
+#
+# PR description: Merges to main auto-create swift-vX.Y.Z tags to mark
+# official Swift SDK release points. Full build/publish automation will be
+# added later.
+# =============================================================================
+
+name: Swift SDK Auto-Tag
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    name: Create Swift SDK Tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Configure Git
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+      - name: Compute Next Tag
+        id: next_tag
+        run: |
+          set -e
+          # List swift-v* tags, strip prefix, keep only X.Y.Z (no prerelease)
+          LATEST=$(git tag -l 'swift-v*' | sed 's/^swift-v//' | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n1 || true)
+          if [ -z "$LATEST" ]; then
+            NEXT="0.1.1"
+          else
+            MAJOR=$(echo "$LATEST" | cut -d. -f1)
+            MINOR=$(echo "$LATEST" | cut -d. -f2)
+            PATCH=$(echo "$LATEST" | cut -d. -f3)
+            PATCH=$((PATCH + 1))
+            NEXT="$MAJOR.$MINOR.$PATCH"
+          fi
+          NEW_TAG="swift-v$NEXT"
+          echo "tag=$NEW_TAG" >> "$GITHUB_OUTPUT"
+          echo "Computed next tag: $NEW_TAG"
+
+      - name: Skip If Tag Exists
+        id: skip
+        run: |
+          NEW_TAG="${{ steps.next_tag.outputs.tag }}"
+          if git rev-parse "$NEW_TAG" >/dev/null 2>&1; then
+            echo "Tag $NEW_TAG already exists, skipping (idempotent rerun)"
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create and Push Tag
+        if: steps.skip.outputs.skip != 'true'
+        run: |
+          NEW_TAG="${{ steps.next_tag.outputs.tag }}"
+          git tag -a "$NEW_TAG" -m "Swift SDK Release $NEW_TAG"
+          git push origin "$NEW_TAG"
+          echo "Pushed tag: $NEW_TAG"

--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ No cloud. No latency. No data leaves the device.
 | **React Native** | Beta | [npm](#react-native) | [docs.runanywhere.ai/react-native](https://docs.runanywhere.ai/react-native/introduction) |
 | **Flutter** | Beta | [pub.dev](#flutter) | [docs.runanywhere.ai/flutter](https://docs.runanywhere.ai/flutter/introduction) |
 
+*Merges to main automatically create Swift SDK tags `swift-vX.Y.Z`; full build and publish automation will be added later.*
+
 ---
 
 ## Quick Start


### PR DESCRIPTION
## Description
This change introduces Phase 1 CI/CD automation for the Swift SDK by automatically creating versioned git tags on every push (merge) to `main`. The workflow computes the next `swift-vMAJOR.MINOR.PATCH` tag and pushes it to mark an official Swift SDK release point.

This phase is intentionally limited to tagging only. It does not run build scripts, publish artifacts, or require macOS runners. Full build and publish automation will be added in a later phase.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds CI/CD workflow to auto-tag Swift SDK releases on pushes to `main`, with README update.
> 
>   - **CI/CD Workflow**:
>     - Adds `swift-auto-tag.yml` to create versioned git tags `swift-vMAJOR.MINOR.PATCH` on pushes to `main`.
>     - Computes next tag by incrementing PATCH version of latest tag.
>     - Skips tagging if the computed tag already exists.
>   - **Documentation**:
>     - Updates `README.md` to mention automatic Swift SDK tagging on merges to `main`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for f84e92971b4bf825e80c9a11ee3a7effad255c71. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Implemented automated tagging system for Swift SDK releases that automatically computes and creates version tags when changes are merged to the main branch, with skip logic for existing tags.
  * Updated README documentation to inform users about the new automatic Swift SDK tagging functionality and note that additional build and publish automation will be added in the future.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

Introduces Phase 1 CI/CD automation for Swift SDK by auto-creating `swift-vX.Y.Z` tags on pushes to main, which triggers the existing `swift-sdk-release.yml` workflow. The implementation computes the next patch version and includes idempotent tag existence checking.

**Key Changes:**
- Adds workflow to auto-increment PATCH version and create git tags
- Updates README to document auto-tagging behavior
- Uses `ubuntu-latest` runner (no macOS required for tagging-only phase)

**Critical Issue:**
- The workflow triggers on ALL pushes to main without path filtering, meaning changes to Kotlin, Flutter, or any other SDK will create new Swift tags unnecessarily

**Minor Concerns:**
- Initial version hardcoded to `0.1.1` should be verified against intended Swift SDK versioning
- Semantic version regex doesn't validate reasonable version bounds

<h3>Confidence Score: 2/5</h3>

- This PR should not be merged without fixing the path-based trigger issue that will create Swift tags on every commit to main
- The workflow has a critical logical flaw where it triggers on all pushes to main regardless of which files changed, which violates the PR's stated intent and will pollute the tag namespace with unnecessary Swift SDK releases whenever any code is merged
- `.github/workflows/swift-auto-tag.yml` requires path-based filtering to only trigger for Swift SDK changes

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/swift-auto-tag.yml | Introduces auto-tagging workflow that triggers on all pushes to main without path filtering, which could create unnecessary tags |
| README.md | Documents the auto-tagging behavior clearly in the SDK table |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Dev as Developer
    participant Main as main branch
    participant AutoTag as swift-auto-tag.yml
    participant Git as Git Repository
    participant Release as swift-sdk-release.yml
    participant GH as GitHub Release

    Dev->>Main: Push/merge changes
    Main->>AutoTag: Trigger (on push to main)
    AutoTag->>Git: Fetch all tags (fetch-depth: 0)
    AutoTag->>Git: List swift-v* tags
    Git-->>AutoTag: Return existing tags
    AutoTag->>AutoTag: Compute next PATCH version
    AutoTag->>Git: Check if new tag exists
    alt Tag already exists
        Git-->>AutoTag: Tag found
        AutoTag->>AutoTag: Skip (idempotent)
    else Tag doesn't exist
        Git-->>AutoTag: Tag not found
        AutoTag->>Git: Create annotated tag swift-vX.Y.Z
        AutoTag->>Git: Push tag to origin
        Git->>Release: Trigger swift-sdk-release.yml
        Release->>Release: Build & test Swift SDK
        Release->>Release: Update binaries
        Release->>GH: Create GitHub Release
    end
```

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->