### PR TITLE
Add x86_64 ABI support for Android emulator development

### DIFF
--- a/sdk/runanywhere-kotlin/modules/runanywhere-core-llamacpp/build.gradle.kts
+++ b/sdk/runanywhere-kotlin/modules/runanywhere-core-llamacpp/build.gradle.kts
@@ -139,8 +139,8 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         ndk {
-            // Target ARM 64-bit only (modern Android devices)
-            abiFilters += listOf("arm64-v8a")
+            // Support ARM64 devices and x86_64 emulators
+            abiFilters += listOf("arm64-v8a", "x86_64")
         }
     }
 

--- a/sdk/runanywhere-kotlin/modules/runanywhere-core-onnx/build.gradle.kts
+++ b/sdk/runanywhere-kotlin/modules/runanywhere-core-onnx/build.gradle.kts
@@ -148,8 +148,8 @@ android {
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 
         ndk {
-            // Target ARM 64-bit only (modern Android devices)
-            abiFilters += listOf("arm64-v8a")
+            // Support ARM64 devices and x86_64 emulators
+            abiFilters += listOf("arm64-v8a", "x86_64")
         }
     }
 

--- a/sdk/runanywhere-react-native/packages/core/android/build.gradle
+++ b/sdk/runanywhere-react-native/packages/core/android/build.gradle
@@ -113,7 +113,7 @@ android {
         targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
 
         ndk {
-            abiFilters 'arm64-v8a'
+            abiFilters 'arm64-v8a', 'x86_64'
         }
 
         externalNativeBuild {
@@ -122,7 +122,7 @@ android {
                 arguments "-DANDROID_STL=c++_shared",
                           // Fix NitroModules prefab path - use app's build directory
                           "-DREACT_NATIVE_NITRO_BUILD_DIR=${rootProject.buildDir}"
-                abiFilters 'arm64-v8a'
+                abiFilters 'arm64-v8a', 'x86_64'
             }
         }
     }

--- a/sdk/runanywhere-react-native/packages/llamacpp/android/build.gradle
+++ b/sdk/runanywhere-react-native/packages/llamacpp/android/build.gradle
@@ -109,7 +109,7 @@ android {
         targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
 
         ndk {
-            abiFilters 'arm64-v8a'
+            abiFilters 'arm64-v8a', 'x86_64'
         }
 
         externalNativeBuild {
@@ -118,7 +118,7 @@ android {
                 arguments "-DANDROID_STL=c++_shared",
                           // Fix NitroModules prefab path - use app's build directory
                           "-DREACT_NATIVE_NITRO_BUILD_DIR=${rootProject.buildDir}"
-                abiFilters 'arm64-v8a'
+                abiFilters 'arm64-v8a', 'x86_64'
             }
         }
     }

--- a/sdk/runanywhere-react-native/packages/onnx/android/build.gradle
+++ b/sdk/runanywhere-react-native/packages/onnx/android/build.gradle
@@ -109,7 +109,7 @@ android {
         targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')
 
         ndk {
-            abiFilters 'arm64-v8a'
+            abiFilters 'arm64-v8a', 'x86_64'
         }
 
         externalNativeBuild {
@@ -118,7 +118,7 @@ android {
                 arguments "-DANDROID_STL=c++_shared",
                           // Fix NitroModules prefab path - use app's build directory
                           "-DREACT_NATIVE_NITRO_BUILD_DIR=${rootProject.buildDir}"
-                abiFilters 'arm64-v8a'
+                abiFilters 'arm64-v8a', 'x86_64'
             }
         }
     }


### PR DESCRIPTION
## Summary
Enables running the SDK on Android Studio x86_64 emulators by adding `x86_64` to the abiFilters in backend modules.

## Problem
The SDK currently filters ABIs to `arm64-v8a` only, which prevents developers from testing on Android Studio emulators (which typically use x86_64 architecture).

## Solution
Add `x86_64` to the abiFilters. The native libraries are already built for x86_64 in the CI/CD pipeline (`commons-release.yml` builds for `arm64-v8a`, `armeabi-v7a`, `x86_64`), so no native code changes are needed.

## Files Changed
| Module | File |
|--------|------|
| Kotlin LlamaCPP | `sdk/runanywhere-kotlin/modules/runanywhere-core-llamacpp/build.gradle.kts` |
| Kotlin ONNX | `sdk/runanywhere-kotlin/modules/runanywhere-core-onnx/build.gradle.kts` |
| React Native Core | `sdk/runanywhere-react-native/packages/core/android/build.gradle` |
| React Native ONNX | `sdk/runanywhere-react-native/packages/onnx/android/build.gradle` |
| React Native LlamaCPP | `sdk/runanywhere-react-native/packages/llamacpp/android/build.gradle` |

Note: Flutter already includes x86_64 support.

## Test plan
- [ ] Build and run on Android x86_64 emulator
- [ ] Verify LLM inference works on emulator
- [ ] Verify STT/TTS works on emulator
- [ ] Confirm ARM64 physical device still works

Fixes #325

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the x86_64 Android architecture, enabling compatibility with x86_64-based emulators and devices in addition to existing ARM64 support.
  * Builds and native libraries will now include both ARM64 and x86_64 binaries, improving emulator testing and enabling broader device compatibility without changing app behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->