### PR TITLE
Optimised llamacpp_backend.cpp

### DIFF
--- a/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
@@ -6,6 +6,7 @@
 #include <chrono>
 #include <cstring>
 #include <string>
+#include <vector>
 
 #include "rac/core/rac_logger.h"
 
@@ -15,39 +16,38 @@
 
 namespace runanywhere {
 
-// =============================================================================
-// UTF-8 VALIDATION HELPER
-// =============================================================================
+// UTF-8 STATE MACHINE (DFA)
 
-static bool is_valid_utf8(const char* string) {
-    if (!string)
-        return true;
+struct Utf8State {
 
-    const unsigned char* bytes = (const unsigned char*)string;
-    int num;
+    uint32_t state = 0;
 
-    while (*bytes != 0x00) {
-        if ((*bytes & 0x80) == 0x00) {
-            num = 1;
-        } else if ((*bytes & 0xE0) == 0xC0) {
-            num = 2;
-        } else if ((*bytes & 0xF0) == 0xE0) {
-            num = 3;
-        } else if ((*bytes & 0xF8) == 0xF0) {
-            num = 4;
-        } else {
-            return false;
-        }
+    // Bjoern Hoehrmann LUT
+    bool process(uint8_t byte) {
+        static const uint8_t utf8d[] = {
+            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 00..1f
+            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 20..3f
+            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 40..5f
+            0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0, // 60..7f
+            1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9, // 80..9f
+            7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7, // a0..bf
+            8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2, // c0..df
+            0xa,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x4,0x3,0x3, // e0..ef
+            0xb,0x6,0x6,0x6,0x5,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8, // f0..ff
+            0x0,0x1,0x2,0x3,0x5,0x8,0x7,0x1,0x1,0x1,0x4,0x6,0x1,0x1,0x1,0x1, // s0..s0
+            1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,0,1,0,1,1,1,1,1,1, // s1..s2
+            1,2,1,1,1,1,1,2,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1, // s3..s4
+            1,2,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,3,1,3,1,1,1,1,1,1, // s5..s6
+            1,3,1,1,1,1,1,3,1,3,1,1,1,1,1,1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1, // s7..s8
+        };
 
-        bytes += 1;
-        for (int i = 1; i < num; ++i) {
-            if ((*bytes & 0xC0) != 0x80)
-                return false;
-            bytes += 1;
-        }
+        uint32_t type = utf8d[byte];
+        state = utf8d[256 + state * 16 + type];
+        return (state == 0);
     }
-    return true;
-}
+    
+    void reset() { state = 0; }
+};
 
 // =============================================================================
 // LOG CALLBACK
@@ -457,12 +457,8 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
     }
 
     int effective_max_tokens = std::min(request.max_tokens, available_tokens);
-    if (effective_max_tokens < request.max_tokens) {
-        LOGI("Capping max_tokens: %d → %d (context=%d, prompt=%d tokens)", request.max_tokens,
-             effective_max_tokens, n_ctx, prompt_tokens);
-    }
-    LOGI("Generation: prompt_tokens=%d, max_tokens=%d, context=%d", prompt_tokens,
-         effective_max_tokens, n_ctx);
+    LOGI("Generation: prompt_tokens=%d, max_tokens=%d, context=%d",
+         prompt_tokens, effective_max_tokens, n_ctx);
 
     llama_batch batch = llama_batch_init(n_ctx, 0, 1);
 
@@ -481,10 +477,27 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
     llama_sampler_reset(sampler_);
 
     const auto vocab = llama_model_get_vocab(model_);
-    std::string cached_token_chars;
-    std::string accumulated_text;
+
+    static const std::vector<std::string> STOP_SEQUENCES = {
+        "<|im_end|>", "<|eot_id|>", "</s>", "<|end|>", "<|endoftext|>",
+        "\n\nUser:", "\n\nHuman:",
+    };
+
+    static const size_t MAX_STOP_LEN = []{
+        size_t m = 0;
+        for (const auto& s : STOP_SEQUENCES) m = std::max(m, s.size());
+        return m;
+    }();
+
+    std::string stop_window;
+    stop_window.reserve(MAX_STOP_LEN * 2);
+
+    std::string partial_utf8_buffer;
+    partial_utf8_buffer.reserve(8);
+
     int n_cur = batch.n_tokens;
     int tokens_generated = 0;
+    bool stop_sequence_hit = false;
 
     while (tokens_generated < effective_max_tokens && !cancel_requested_.load()) {
         const llama_token new_token_id = llama_sampler_sample(sampler_, context_, -1);
@@ -496,41 +509,55 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
             break;
         }
 
-        auto new_token_chars = common_token_to_piece(context_, new_token_id);
-        cached_token_chars += new_token_chars;
-        accumulated_text += new_token_chars;
+        const std::string new_token_chars =
+            common_token_to_piece(context_, new_token_id);
 
-        static const std::vector<std::string> stop_sequences = {
-            "<|im_end|>",
-            "<|eot_id|>",
-            "</s>",
-            "<|end|>",
-            "<|endoftext|>",
-            "\n\nUser:",
-            "\n\nHuman:",
-        };
+        partial_utf8_buffer.append(new_token_chars);
 
-        bool hit_stop_sequence = false;
-        for (const auto& stop_seq : stop_sequences) {
-            size_t pos = accumulated_text.find(stop_seq);
-            if (pos != std::string::npos) {
-                LOGI("Stop sequence detected: %s", stop_seq.c_str());
-                hit_stop_sequence = true;
-                break;
+        Utf8State scanner_state;
+        size_t valid_upto = 0;
+        for (size_t i = 0; i < partial_utf8_buffer.size(); ++i) {
+            scanner_state.process(static_cast<uint8_t>(partial_utf8_buffer[i]));
+            if (scanner_state.state == 0) {
+                valid_upto = i + 1;
             }
         }
 
-        if (hit_stop_sequence) {
-            break;
-        }
+        if (valid_upto > 0) {
+            std::string valid_chunk = partial_utf8_buffer.substr(0, valid_upto);
+            stop_window.append(valid_chunk);
+            partial_utf8_buffer.erase(0, valid_upto);
 
-        if (is_valid_utf8(cached_token_chars.c_str())) {
-            if (!callback(cached_token_chars)) {
-                LOGI("Generation cancelled by callback");
-                cancel_requested_.store(true);
+            size_t found_stop_pos = std::string::npos;
+            for (const auto& stop_seq : STOP_SEQUENCES) {
+                size_t pos = stop_window.find(stop_seq);
+                if (pos != std::string::npos) {
+                    if (found_stop_pos == std::string::npos || pos < found_stop_pos) {
+                        found_stop_pos = pos;
+                    }
+                }
+            }
+
+            if (found_stop_pos != std::string::npos) {
+                LOGI("Stop sequence detected");
+                stop_sequence_hit = true;
+                if (found_stop_pos > 0) {
+                    if (!callback(stop_window.substr(0, found_stop_pos))) {
+                        cancel_requested_.store(true);
+                    }
+                }
                 break;
             }
-            cached_token_chars.clear();
+
+            if (stop_window.size() > MAX_STOP_LEN) {
+                size_t safe_len = stop_window.size() - MAX_STOP_LEN;
+                if (!callback(stop_window.substr(0, safe_len))) {
+                    LOGI("Generation cancelled by callback");
+                    cancel_requested_.store(true);
+                    break;
+                }
+                stop_window.erase(0, safe_len);
+            }
         }
 
         batch.n_tokens = 0;
@@ -545,8 +572,8 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
         }
     }
 
-    if (!cached_token_chars.empty() && is_valid_utf8(cached_token_chars.c_str())) {
-        callback(cached_token_chars);
+    if (!cancel_requested_.load() && !stop_sequence_hit && !stop_window.empty()) {
+        callback(stop_window);
     }
 
     llama_memory_clear(llama_get_memory(context_), true);


### PR DESCRIPTION
### **Changes**

- using a LUT & DFA based utf-8 scanning approach. [here](https://bjoern.hoehrmann.de/utf-8/decoder/dfa/)
- Converted O(n^2) stop scanning to constant time using a rolling tail buffer.
- Reserving memory so that the += allocations don't cause too many allocations and memcpys.

### **Results**

- Tested against old code.
- 2.8x ~ 3.3x improvement 


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Optimized `llamacpp_backend.cpp` with DFA-based UTF-8 validation and efficient stop sequence detection, improving performance by 2.8x ~ 3.3x.
> 
>   - **UTF-8 Scanning**:
>     - Replaced `is_valid_utf8()` with `Utf8State` struct using DFA for UTF-8 validation.
>     - Utilizes a LUT for efficient byte processing.
>   - **Stop Sequence Detection**:
>     - Replaced O(n^2) stop scanning with a rolling buffer in `generate_stream()`.
>     - Uses `stop_window` to efficiently detect stop sequences.
>   - **Memory Optimization**:
>     - Reserves memory for `stop_window` and `partial_utf8_buffer` to reduce allocations.
>   - **Performance**:
>     - Achieves 2.8x ~ 3.3x performance improvement in text generation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for a37fb27509411c384ebc655e1f684fd223967f8f. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Prevents invalid UTF-8 characters in streamed output by buffering and validating partial multibyte sequences.
  - Reliably detects stop sequences across token boundaries, avoiding accidental output beyond stop points.
  - Ensures remaining buffered text is emitted correctly at the end when no stop or cancellation occurs.

- Refactor
  - Streamlined streaming generation to accumulate and emit text via sliding windows and UTF-8 state validation.
  - Consolidated stop-sequence logic for more predictable behavior.
  - Replaced scattered logs with a unified generation summary log.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR implements significant performance optimizations to the LlamaCpp text generation backend, achieving 2.8x-3.3x speedup through three key improvements:

**Key Changes:**
- Replaced simple loop-based UTF-8 validation with Bjoern Hoehrmann's DFA-based state machine for faster, more efficient validation
- Converted O(n²) stop sequence scanning (checking entire accumulated text) to O(1) using a rolling tail buffer of fixed size
- Added memory reservations (`reserve()`) to prevent repeated allocations during string concatenation

**Implementation Details:**
- UTF-8 validation now uses a lookup table (LUT) with 364 bytes to drive a deterministic finite automaton
- Stop sequence detection maintains a rolling window of max 2×MAX_STOP_LEN characters instead of accumulating all generated text
- Partial UTF-8 sequences are buffered separately until complete characters are validated
- Only validated UTF-8 text beyond the stop detection window is streamed to callbacks

The optimizations maintain correct behavior for stop sequence detection and UTF-8 handling while dramatically reducing memory allocations and string scanning overhead.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor issue to verify
- The optimizations are well-designed and use established algorithms (Bjoern Hoehrmann's UTF-8 DFA). The rolling window approach for stop sequence detection is sound. However, there's one potential issue with how the UTF-8 scanner state is reinitialized in each iteration that should be verified through testing.
- The main implementation file should be tested thoroughly to ensure the UTF-8 state machine correctly handles multi-byte sequences that span token boundaries

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp | Replaced UTF-8 validation with DFA-based approach and optimized stop sequence detection from O(n²) to O(1) using rolling window buffer |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant generate_stream
    participant Sampler as llama_sampler
    participant Utf8State
    participant StopWindow as Rolling Window
    participant Callback

    Caller->>generate_stream: TextGenerationRequest
    activate generate_stream
    
    generate_stream->>generate_stream: Initialize stop_window (reserve MAX_STOP_LEN*2)
    generate_stream->>generate_stream: Initialize partial_utf8_buffer (reserve 8)
    
    loop For each token (up to max_tokens)
        generate_stream->>Sampler: sample next token
        Sampler-->>generate_stream: new_token_id
        
        generate_stream->>generate_stream: Convert token to string
        generate_stream->>generate_stream: Append to partial_utf8_buffer
        
        generate_stream->>Utf8State: Create scanner_state
        
        loop Scan UTF-8 bytes with DFA
            generate_stream->>Utf8State: process(byte)
            Utf8State-->>generate_stream: state == 0 (complete char)
            generate_stream->>generate_stream: Track valid_upto position
        end
        
        alt valid_upto > 0
            generate_stream->>generate_stream: Extract valid_chunk
            generate_stream->>StopWindow: Append valid_chunk
            generate_stream->>generate_stream: Erase from partial_utf8_buffer
            
            loop Check stop sequences (O(1) in rolling window)
                generate_stream->>StopWindow: find(stop_seq)
                alt Stop sequence found
                    generate_stream->>Callback: Send text before stop
                    generate_stream-->>Caller: Break (stop detected)
                end
            end
            
            alt stop_window.size() > MAX_STOP_LEN
                generate_stream->>generate_stream: Calculate safe_len
                generate_stream->>Callback: Send safe text
                generate_stream->>StopWindow: Erase sent portion
            end
        end
        
        generate_stream->>Sampler: Decode next token batch
    end
    
    generate_stream->>Callback: Send remaining stop_window
    deactivate generate_stream
    generate_stream-->>Caller: Generation complete
```

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->