### PR TITLE
Check if cmake is installed on the system

### DIFF
--- a/sdk/runanywhere-commons/scripts/build-ios.sh
+++ b/sdk/runanywhere-commons/scripts/build-ios.sh
@@ -80,6 +80,15 @@ log_error()  { echo -e "${RED}[✗]${NC} $1"; exit 1; }
 log_step()   { echo -e "${BLUE}==>${NC} $1"; }
 log_time()   { echo -e "${CYAN}[⏱]${NC} $1"; }
 log_header() { echo -e "\n${GREEN}═══════════════════════════════════════════${NC}"; echo -e "${GREEN} $1${NC}"; echo -e "${GREEN}═══════════════════════════════════════════${NC}"; }
+require_cmd() {
+    local cmd="$1"
+    local hint="$2"
+    if ! command -v "${cmd}" >/dev/null 2>&1; then
+        log_warn "Required tool '${cmd}' is not installed or not in PATH."
+        [[ -n "${hint}" ]] && log_warn "${hint}"
+        log_error "Cannot continue without '${cmd}'."
+    fi
+}
 
 show_help() {
     head -45 "$0" | tail -40
@@ -140,6 +149,7 @@ build_platform() {
     local PLATFORM_DIR="${BUILD_DIR}/${PLATFORM}"
 
     log_step "Building for ${PLATFORM}..."
+    require_cmd "cmake" "Install it with: brew install cmake (macOS) or: sudo apt-get install cmake (Debian/Ubuntu)"
     mkdir -p "${PLATFORM_DIR}"
     cd "${PLATFORM_DIR}"
 


### PR DESCRIPTION
## Description

During the initial setup I've noticed that the project assumes cmake is installed on the system. As cmake is not a part of OS distribution, it's reasonable to check if it's installed.

## Type of Change
- [x] Bug fix

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`sdk/runanywhere-kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`sdk/runanywhere-flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`sdk/runanywhere-react-native`)
- [x] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

**Sample Apps:**
- [ ] `iOS Sample` - Changes to iOS example app (`examples/ios`)
- [ ] `Android Sample` - Changes to Android example app (`examples/android`)
- [ ] `Flutter Sample` - Changes to Flutter example app (`examples/flutter`)
- [ ] `React Native Sample` - Changes to React Native example app (`examples/react-native`)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)

## Screenshots
Attach relevant UI screenshots for changes (if applicable):
- Mobile (Phone)
- Tablet / iPad
- Desktop / Mac

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a check for `cmake` installation in `build-ios.sh` to prevent build failures.
> 
>   - **Behavior**:
>     - Adds `require_cmd()` function to `build-ios.sh` to check if `cmake` is installed before proceeding with the build.
>     - Logs a warning and error if `cmake` is not found, providing installation hints for macOS and Debian/Ubuntu.
>   - **Functions**:
>     - Introduces `require_cmd()` in `build-ios.sh` to encapsulate command existence checks.
>   - **Misc**:
>     - Adds a call to `require_cmd("cmake")` in `build_platform()` in `build-ios.sh`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for 9cc8b81c4720297e2ba88875ce8ef5ebbd2969b0. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR updates `sdk/runanywhere-commons/scripts/build-ios.sh` to fail fast when `cmake` is not installed or not on `PATH`, by adding a small `require_cmd` helper and calling it at the start of `build_platform()`.

This fits the existing script’s pattern of explicit preflight checks and user-friendly logging, and prevents a later, harder-to-interpret failure when the script tries to invoke `cmake` during the iOS build steps.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk.
- Change is localized to the iOS build script, uses standard `command -v` semantics, and fails early with clear instructions without affecting build behavior when cmake is present.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-commons/scripts/build-ios.sh | Adds a `require_cmd` helper and uses it to fail fast with a clear message when `cmake` is missing before invoking the build. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant U as User
    participant S as build-ios.sh
    participant SH as Shell
    participant C as cmake

    U->>S: ./scripts/build-ios.sh
    S->>S: build_platform(PLATFORM)
    S->>SH: command -v cmake
    alt cmake missing
        S->>S: log_warn(hint)
        S->>S: log_error(exit 1)
    else cmake present
        S->>C: cmake <configure>
        S->>C: cmake --build
    end
```

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved iOS build reliability by adding validation checks for required build dependencies. The build process now fails gracefully with clear error messages when essential tools are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->