### PR TITLE
Add Cross-Origin Isolation service worker for iOS/iPad Safari support

### DIFF
--- a/examples/web/RunAnywhereAI/public/coi-serviceworker.js
+++ b/examples/web/RunAnywhereAI/public/coi-serviceworker.js
@@ -1,0 +1,60 @@
+/**
+ * Cross-Origin Isolation Service Worker
+ *
+ * Enables SharedArrayBuffer on browsers that don't support COEP: credentialless
+ * (Safari/WebKit). This is required for multi-threaded WASM (pthreads).
+ *
+ * How it works:
+ * - Intercepts navigation responses and injects COOP + COEP headers
+ * - Intercepts cross-origin responses and injects CORP header
+ * - On first install, claims all clients so it activates immediately
+ */
+
+self.addEventListener('install', () => {
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(self.clients.claim());
+});
+
+self.addEventListener('fetch', (event) => {
+  const { request } = event;
+
+  // Only handle GET requests
+  if (request.method !== 'GET') return;
+
+  if (request.mode === 'navigate') {
+    // Navigation requests (HTML pages): inject COOP + COEP headers
+    event.respondWith(
+      fetch(request).then((response) => {
+        const headers = new Headers(response.headers);
+        headers.set('Cross-Origin-Opener-Policy', 'same-origin');
+        headers.set('Cross-Origin-Embedder-Policy', 'require-corp');
+        return new Response(response.body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers,
+        });
+      })
+    );
+  } else if (request.url.startsWith(self.location.origin)) {
+    // Same-origin requests: pass through unchanged
+    return;
+  } else {
+    // Cross-origin requests: re-fetch and inject CORP header
+    event.respondWith(
+      fetch(request.url, { mode: 'cors', credentials: 'omit' })
+        .then((response) => {
+          const headers = new Headers(response.headers);
+          headers.set('Cross-Origin-Resource-Policy', 'cross-origin');
+          return new Response(response.body, {
+            status: response.status,
+            statusText: response.statusText,
+            headers,
+          });
+        })
+        .catch(() => fetch(request))
+    );
+  }
+});

--- a/sdk/runanywhere-web/packages/core/package.json
+++ b/sdk/runanywhere-web/packages/core/package.json
@@ -1,15 +1,20 @@
 {
   "name": "@runanywhere/web",
-  "version": "0.1.0-beta.1",
+  "version": "0.1.0-beta.4",
   "description": "RunAnywhere Web SDK - On-device AI inference in the browser via RACommons WASM",
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",
   "types": "./dist/index.d.ts",
+  "sideEffects": false,
   "exports": {
     ".": {
       "import": "./dist/index.js",
       "types": "./dist/index.d.ts"
+    },
+    "./vlm-worker": {
+      "import": "./dist/workers/vlm-worker.js",
+      "types": "./dist/workers/vlm-worker.d.ts"
     },
     "./wasm/*": "./wasm/*"
   },
@@ -23,7 +28,8 @@
     "dev": "tsc --watch",
     "lint": "tsc --noEmit",
     "typecheck": "tsc --noEmit",
-    "clean": "rm -rf dist"
+    "clean": "rm -rf dist",
+    "prepublishOnly": "test -f wasm/racommons.wasm || (echo 'ERROR: WASM not built. Run build-web.sh first.' && exit 1)"
   },
   "keywords": [
     "runanywhere",

--- a/sdk/runanywhere-web/packages/core/src/Foundation/SherpaONNXBridge.ts
+++ b/sdk/runanywhere-web/packages/core/src/Foundation/SherpaONNXBridge.ts
@@ -117,6 +117,20 @@ export class SherpaONNXBridge {
   private _loaded = false;
   private _loading: Promise<void> | null = null;
 
+  /**
+   * Override the default URL to the sherpa-onnx-glue.js file.
+   * Set this before any STT/TTS/VAD model is loaded.
+   *
+   * In a Vite app, resolve it like:
+   * ```typescript
+   * SherpaONNXBridge.shared.wasmUrl = new URL(
+   *   '@runanywhere/web/wasm/sherpa/sherpa-onnx-glue.js',
+   *   import.meta.url,
+   * ).href;
+   * ```
+   */
+  wasmUrl: string | null = null;
+
   static get shared(): SherpaONNXBridge {
     if (!SherpaONNXBridge._instance) {
       SherpaONNXBridge._instance = new SherpaONNXBridge();
@@ -163,7 +177,7 @@ export class SherpaONNXBridge {
     logger.info('Loading Sherpa-ONNX WASM module...');
 
     try {
-      const moduleUrl = wasmUrl ?? new URL('../../wasm/sherpa/sherpa-onnx-glue.js', import.meta.url).href;
+      const moduleUrl = wasmUrl ?? this.wasmUrl ?? new URL('../../wasm/sherpa/sherpa-onnx-glue.js', import.meta.url).href;
       const { default: createModule } = await import(/* @vite-ignore */ moduleUrl);
 
       // Derive the base URL for the .wasm binary

--- a/sdk/runanywhere-web/packages/core/src/Foundation/StructOffsets.ts
+++ b/sdk/runanywhere-web/packages/core/src/Foundation/StructOffsets.ts
@@ -33,6 +33,7 @@ export interface LLMOptionsOffsets {
   maxTokens: number;
   temperature: number;
   topP: number;
+  systemPrompt: number;
 }
 
 export interface LLMResultOffsets {
@@ -197,6 +198,7 @@ export function loadOffsets(m: any): void {
       maxTokens: off('llm_options_max_tokens'),
       temperature: off('llm_options_temperature'),
       topP: off('llm_options_top_p'),
+      systemPrompt: off('llm_options_system_prompt'),
     },
 
     llmResult: {

--- a/sdk/runanywhere-web/packages/core/src/Public/Extensions/RunAnywhere+VoicePipeline.ts
+++ b/sdk/runanywhere-web/packages/core/src/Public/Extensions/RunAnywhere+VoicePipeline.ts
@@ -52,10 +52,10 @@ const logger = new SDKLogger('VoicePipeline');
 // ---------------------------------------------------------------------------
 
 const DEFAULT_OPTIONS: Required<VoicePipelineOptions> = {
-  maxTokens: 150,
+  maxTokens: 60,
   temperature: 0.7,
   systemPrompt:
-    'You are a helpful voice assistant. Keep responses concise — 1-3 sentences. Be conversational and friendly.',
+    'You are a helpful voice assistant. Keep responses concise — 1-2 sentences max.',
   ttsSpeed: 1.0,
   sampleRate: 16000,
 };

--- a/sdk/runanywhere-web/packages/core/src/index.ts
+++ b/sdk/runanywhere-web/packages/core/src/index.ts
@@ -40,10 +40,10 @@ export { VoicePipeline } from './Public/Extensions/RunAnywhere+VoicePipeline';
 export type { VoicePipelineCallbacks, VoicePipelineOptions, VoicePipelineTurnResult } from './Public/Extensions/VoicePipelineTypes';
 export { VLM, VLMImageFormat, VLMModelFamily } from './Public/Extensions/RunAnywhere+VLM';
 export type { VLMImage, VLMGenerationOptions, VLMGenerationResult, VLMStreamingResult } from './Public/Extensions/RunAnywhere+VLM';
-export { ToolCalling, toToolValue, fromToolValue, getStringArg, getNumberArg } from './Public/Extensions/RunAnywhere+ToolCalling';
+export { ToolCalling, ToolCallFormat, toToolValue, fromToolValue, getStringArg, getNumberArg } from './Public/Extensions/RunAnywhere+ToolCalling';
 export type {
   ToolValue, ToolParameterType, ToolParameter, ToolDefinition,
-  ToolCall, ToolResult, ToolCallFormat, ToolCallingOptions, ToolCallingResult, ToolExecutor,
+  ToolCall, ToolResult, ToolCallingOptions, ToolCallingResult, ToolExecutor,
 } from './Public/Extensions/RunAnywhere+ToolCalling';
 export { StructuredOutput } from './Public/Extensions/RunAnywhere+StructuredOutput';
 export type { StructuredOutputConfig, StructuredOutputValidation } from './Public/Extensions/RunAnywhere+StructuredOutput';
@@ -62,6 +62,8 @@ export { SDKError, SDKErrorCode } from './Foundation/ErrorTypes';
 export { SDKLogger, LogLevel } from './Foundation/SDKLogger';
 export { EventBus } from './Foundation/EventBus';
 export type { EventListener, Unsubscribe, SDKEventEnvelope } from './Foundation/EventBus';
+export type { AccelerationMode } from './Foundation/WASMBridge';
+export { SherpaONNXBridge } from './Foundation/SherpaONNXBridge';
 
 // Infrastructure
 export { detectCapabilities, getDeviceInfo } from './Infrastructure/DeviceCapabilities';
@@ -86,3 +88,8 @@ export type {
   VLMWorkerResult, VLMLoadModelParams, VLMProcessOptions,
   VLMWorkerCommand, VLMWorkerResponse, ProgressListener,
 } from './Infrastructure/VLMWorkerBridge';
+
+// VLM Worker entry point — consumers import this in their worker file:
+//   import { startVLMWorkerRuntime } from '@runanywhere/web';
+//   startVLMWorkerRuntime();
+export { startVLMWorkerRuntime } from './Infrastructure/VLMWorkerRuntime';

--- a/sdk/runanywhere-web/wasm/src/wasm_exports.cpp
+++ b/sdk/runanywhere-web/wasm/src/wasm_exports.cpp
@@ -297,6 +297,9 @@ EMSCRIPTEN_KEEPALIVE int rac_wasm_offsetof_llm_options_temperature(void) {
 EMSCRIPTEN_KEEPALIVE int rac_wasm_offsetof_llm_options_top_p(void) {
     return (int)offsetof(rac_llm_options_t, top_p);
 }
+EMSCRIPTEN_KEEPALIVE int rac_wasm_offsetof_llm_options_system_prompt(void) {
+    return (int)offsetof(rac_llm_options_t, system_prompt);
+}
 
 // ---- rac_llm_result_t ----
 EMSCRIPTEN_KEEPALIVE int rac_wasm_offsetof_llm_result_text(void) {


### PR DESCRIPTION
Adds a service worker that injects COOP/COEP/CORP headers so SharedArrayBuffer works on Safari (which doesn't support COEP: credentialless). Chrome/Firefox are unaffected — they get instant COI from server headers. Safari users see a one-time reload on first visit.

## Description
Brief description of the changes made.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`sdk/runanywhere-kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`sdk/runanywhere-flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`sdk/runanywhere-react-native`)
- [ ] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

**Sample Apps:**
- [ ] `iOS Sample` - Changes to iOS example app (`examples/ios`)
- [ ] `Android Sample` - Changes to Android example app (`examples/android`)
- [ ] `Flutter Sample` - Changes to Flutter example app (`examples/flutter`)
- [ ] `React Native Sample` - Changes to React Native example app (`examples/react-native`)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)

## Screenshots
Attach relevant UI screenshots for changes (if applicable):
- Mobile (Phone)
- Tablet / iPad
- Desktop / Mac

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a service worker for cross-origin isolation on Safari, updates SDK for system prompt handling, and enhances package configuration.
> 
>   - **Service Worker**:
>     - Adds `coi-serviceworker.js` to inject COOP/COEP/CORP headers for Safari in `examples/web/RunAnywhereAI/public`.
>     - Handles navigation and cross-origin requests to enable SharedArrayBuffer.
>   - **Main Application**:
>     - Updates `main.ts` to register the service worker and ensure cross-origin isolation on Safari.
>   - **SDK Enhancements**:
>     - Updates `SherpaONNXBridge.ts` to allow overriding the WASM URL.
>     - Adds `systemPrompt` handling in `StructOffsets.ts` and `RunAnywhere+TextGeneration.ts`.
>     - Modifies `VoicePipeline.ts` to adjust default `maxTokens` and `systemPrompt`.
>   - **Package Configuration**:
>     - Updates `package.json` version to `0.1.0-beta.4` and adds `prepublishOnly` script.
>     - Exports `SherpaONNXBridge` and `startVLMWorkerRuntime` in `index.ts`.
>   - **WASM Offsets**:
>     - Adds `rac_wasm_offsetof_llm_options_system_prompt()` in `wasm_exports.cpp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for d532ac411a2677de2fd6828c4b70cfa18dbec616. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR bundles several Web SDK changes: a Cross-Origin Isolation service worker for Safari/iOS `SharedArrayBuffer` support, `systemPrompt` passthrough to the WASM LLM backend, new public exports (`SherpaONNXBridge`, `AccelerationMode`, `startVLMWorkerRuntime`, `ToolCallFormat` as value), voice pipeline default tuning, and a version bump to `0.1.0-beta.4`.

- **COI Service Worker** (`coi-serviceworker.js` + `main.ts`): Injects COOP/COEP/CORP headers via a service worker for Safari, which doesn't support `COEP: credentialless`. Chrome/Firefox are unaffected since the Vite dev server already sets the correct headers. First visit on Safari triggers a one-time reload.
- **System prompt support** (`RunAnywhere+TextGeneration.ts`, `StructOffsets.ts`, `wasm_exports.cpp`): Adds `system_prompt` field offset to `rac_llm_options_t` and wires it through both `generate()` and `generateStream()`. Includes a graceful fallback that injects the system prompt into the user prompt if the WASM module doesn't expose the offset yet.
- **Bug: `topP` missing in `generateStream`**: The streaming path sets `maxTokens`, `temperature`, and the new `systemPrompt`, but omits `topP` — which the non-streaming `generate` path correctly includes. This means `topP` is silently ignored for streaming generation.
- **Voice pipeline defaults tuned**: `maxTokens` reduced from 150 to 60 and system prompt shortened to encourage more concise voice responses.
- **SDK packaging**: Version bump, `sideEffects: false`, `./vlm-worker` sub-path export, and `prepublishOnly` guard for WASM binary.

<h3>Confidence Score: 3/5</h3>

- PR is mostly safe but has a confirmed bug where `topP` is not forwarded in the streaming generation path.
- The COI service worker, system prompt plumbing, and export changes are all well-structured. However, the `generateStream` method is missing `topP` option setting — a bug that causes streaming callers' `topP` value to be silently ignored. This is a functional correctness issue in the SDK's public API.
- `sdk/runanywhere-web/packages/core/src/Public/Extensions/RunAnywhere+TextGeneration.ts` — missing `topP` in streaming path

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| examples/web/RunAnywhereAI/public/coi-serviceworker.js | New service worker that injects COOP/COEP/CORP headers for Safari cross-origin isolation. Missing error handling for navigation fetch failures. |
| examples/web/RunAnywhereAI/src/main.ts | Adds `ensureCrossOriginIsolation()` that registers the COI service worker, waits for activation, and reloads the page. Clean implementation with proper early-return guards. |
| sdk/runanywhere-web/packages/core/package.json | Version bump to 0.1.0-beta.4, adds `sideEffects: false`, `./vlm-worker` export entry, and `prepublishOnly` WASM guard script. |
| sdk/runanywhere-web/packages/core/src/Foundation/SherpaONNXBridge.ts | Adds public `wasmUrl` property to override the default sherpa-onnx-glue.js URL. Falls through correctly via `wasmUrl ?? this.wasmUrl ?? default`. |
| sdk/runanywhere-web/packages/core/src/Foundation/StructOffsets.ts | Adds `systemPrompt` field to `LLMOptionsOffsets` interface and corresponding offset loader. Consistent with existing pattern. |
| sdk/runanywhere-web/packages/core/src/Public/Extensions/RunAnywhere+TextGeneration.ts | Adds system prompt support with fallback injection when WASM offset unavailable. Bug: `generateStream` is missing `topP` option setting (present in `generate`). |
| sdk/runanywhere-web/packages/core/src/Public/Extensions/RunAnywhere+VoicePipeline.ts | Tunes voice pipeline defaults: maxTokens 150→60, system prompt shortened to 1-2 sentences. Behavioral change for all voice pipeline users. |
| sdk/runanywhere-web/packages/core/src/index.ts | Moves `ToolCallFormat` to value export (correct—it's an enum), adds `SherpaONNXBridge`, `AccelerationMode`, and `startVLMWorkerRuntime` exports. |
| sdk/runanywhere-web/wasm/src/wasm_exports.cpp | Adds `rac_wasm_offsetof_llm_options_system_prompt()` offset helper, following existing naming convention and pattern exactly. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Browser
    participant SW as COI Service Worker
    participant Server as Origin Server

    Note over Browser: First visit (Safari)
    Browser->>Browser: crossOriginIsolated === false
    Browser->>SW: navigator.serviceWorker.register('/coi-serviceworker.js')
    SW->>SW: install → skipWaiting()
    SW->>SW: activate → clients.claim()
    Browser->>Browser: window.location.reload()

    Note over Browser: After reload (Safari)
    Browser->>SW: Navigation request (GET /)
    SW->>Server: fetch(request)
    Server-->>SW: HTML response
    SW->>SW: Inject COOP + COEP headers
    SW-->>Browser: Response with isolation headers
    Browser->>Browser: crossOriginIsolated === true ✓

    Note over Browser: Cross-origin resource
    Browser->>SW: fetch(cdn.example.com/model.onnx)
    SW->>Server: fetch(url, {mode:'cors', credentials:'omit'})
    Server-->>SW: Resource response
    SW->>SW: Inject CORP: cross-origin header
    SW-->>Browser: Response with CORP header
```

<sub>Last reviewed commit: d532ac4</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=20c5a1fb-ed57-4e08-840a-9128622c3bd6))

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added cross-origin isolation support for improved Safari and iOS compatibility
  * Introduced system prompt customization for text generation workflows
  * Exposed configurable WASM URL for flexible runtime environments

* **Improvements**
  * Voice assistant now generates more concise responses (reduced default length)
  * Expanded public API exports for enhanced extensibility

* **Chores**
  * Updated SDK version to 0.1.0-beta.4
  * Added build validation for release integrity

<!-- end of auto-generated comment: release notes by coderabbit.ai -->