### PR TITLE
feat(ios): add download stage labels to model progress (#354)

### DIFF
--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/ModelSelectionRows.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/ModelSelectionRows.swift
@@ -356,18 +356,12 @@ struct FlatModelRow: View {
             let progressStream = try await RunAnywhere.downloadModel(model.id)
 
             for await progress in progressStream {
-                await MainActor.run {
-                    self.downloadProgress = progress.overallProgress
-                    if progress.stage != .completed {
-                        self.downloadStage = progress.stage
-                    }
-                }
-
                 switch progress.state {
                 case .completed:
                     await MainActor.run {
                         self.downloadProgress = 1.0
                         self.isDownloading = false
+                        self.downloadStage = .downloading
                         onDownloadCompleted()
                     }
                     return
@@ -381,6 +375,10 @@ struct FlatModelRow: View {
                     return
 
                 default:
+                    await MainActor.run {
+                        self.downloadProgress = progress.overallProgress
+                        self.downloadStage = progress.stage
+                    }
                     continue
                 }
             }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/SimplifiedModelsView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/SimplifiedModelsView.swift
@@ -357,18 +357,12 @@ private struct SimplifiedModelRow: View {
             let progressStream = try await RunAnywhere.downloadModel(model.id)
 
             for await progress in progressStream {
-                await MainActor.run {
-                    self.downloadProgress = progress.overallProgress
-                    if progress.stage != .completed {
-                        self.downloadStage = progress.stage
-                    }
-                }
-
                 switch progress.state {
                 case .completed:
                     await MainActor.run {
                         self.downloadProgress = 1.0
                         self.isDownloading = false
+                        self.downloadStage = .downloading
                         onDownloadCompleted()
                     }
                     return
@@ -382,6 +376,10 @@ private struct SimplifiedModelRow: View {
                     return
 
                 default:
+                    await MainActor.run {
+                        self.downloadProgress = progress.overallProgress
+                        self.downloadStage = progress.stage
+                    }
                     continue
                 }
             }


### PR DESCRIPTION
## Description
Closes #354

Adds contextual download stage labels ("Downloading…", "Extracting…", "Validating…") alongside the progress percentage when downloading models in the iOS sample app. Previously, only a bare percentage (e.g., `45%`) was shown, giving users no indication of what phase the model setup was in.

The fix leverages the SDK's existing `DownloadStage.displayName` property — no new strings or enums were needed. A `@State` variable `downloadStage` tracks the current stage from the progress stream and is rendered inline with the progress percentage.

**Before:** `45%`
**After:** `Downloading… 45%` → `Extracting… 85%` → `Validating… 97%`

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`sdk/runanywhere-kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`sdk/runanywhere-flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`sdk/runanywhere-react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`sdk/runanywhere-web`)
- [ ] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

**Sample Apps:**
- [x] `iOS Sample` - Changes to iOS example app (`examples/ios`)
- [ ] `Android Sample` - Changes to Android example app (`examples/android`)
- [ ] `Flutter Sample` - Changes to Flutter example app (`examples/flutter`)
- [ ] `React Native Sample` - Changes to React Native example app (`examples/react-native`)
- [ ] `Web Sample` - Changes to Web example app (`examples/web`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)

## Screenshots
_N/A — UI text-only change. The progress label area now reads `"Downloading… 45%"` instead of `"45%"` during model download._
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds download stage labels to model download progress in iOS sample app, enhancing user feedback.
> 
>   - **Behavior**:
>     - Adds download stage labels ("Downloading…", "Extracting…", "Validating…") to model download progress in `FlatModelRow` and `SimplifiedModelRow`.
>     - Uses `DownloadStage.displayName` to display current stage with progress percentage.
>   - **State Management**:
>     - Introduces `@State` variable `downloadStage` in `FlatModelRow` and `SimplifiedModelRow` to track current download stage.
>   - **Logging**:
>     - Updates logging in `SimplifiedModelRow` to include download stage in progress output.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for cfb48f640cb57478d9f42b5ba0366a5e25882358. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Progress display now includes the current download stage name alongside percentage for clearer, stage-aware feedback.
* **Bug Fixes**
  * Download state handling improved: progress and stage are consistently initialized, updated during streaming, and reset on completion or error to avoid stale or misleading UI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds contextual download stage labels ("Downloading…", "Extracting…", "Validating…") alongside the progress percentage in both `FlatModelRow` and `SimplifiedModelRow`. The implementation leverages the SDK's existing `DownloadStage.displayName` property, keeping changes minimal and well-scoped to the iOS sample app.

- Both views add a `@State private var downloadStage: DownloadStage = .downloading` and update it from the progress stream
- The progress text now reads e.g. `"Downloading… 45%"` instead of just `"45%"`
- Debug print in `SimplifiedModelsView` updated to include the stage name
- **Issue found**: `downloadStage` is not reset to `.downloading` when a download is retried (after failure or error), which could briefly show a stale stage label on the next attempt

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — the changes are minimal, well-scoped to sample app UI text, and the identified issue is low-severity.
- The PR makes a small, focused UI improvement that correctly uses existing SDK APIs. The only issue found is a missing state reset on download retry, which would cause a brief stale label flash — a minor UX glitch, not a crash or data integrity issue.
- Both files have the same missing `downloadStage` reset in `downloadModel()` — a one-line fix in each.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/ModelSelectionRows.swift | Adds `downloadStage` state and displays it in the progress label. Missing reset of `downloadStage` on download retry. |
| examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/SimplifiedModelsView.swift | Adds `downloadStage` state and displays it in the progress label. Same missing reset issue on retry. Also updates debug print to include stage name. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant View as FlatModelRow / SimplifiedModelRow
    participant SDK as RunAnywhere.downloadModel()
    participant Stream as DownloadProgress Stream

    User->>View: Tap Download
    View->>View: isDownloading = true, downloadProgress = 0.0
    View->>SDK: await RunAnywhere.downloadModel(id)
    SDK-->>View: progressStream
    loop For each progress update
        Stream-->>View: DownloadProgress(stage, percentage)
        View->>View: downloadProgress = progress.percentage
        View->>View: downloadStage = progress.stage
        View->>View: Render "{stage.displayName}… {progress}%"
    end
    alt Stage == .completed
        View->>View: isDownloading = false
        View->>User: Show "Ready" / "Use" button
    else Stage == .failed or error
        View->>View: isDownloading = false, downloadProgress = 0.0
        View->>User: Show download button again
    end
```

<sub>Last reviewed commit: cfb48f6</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=20c5a1fb-ed57-4e08-840a-9128622c3bd6))

<!-- /greptile_comment -->