### PR TITLE
Added loading while model is Loading, also add a Placeholder

### DIFF
--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/DiffusionViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/DiffusionViewModel.swift
@@ -22,6 +22,8 @@ class DiffusionViewModel: ObservableObject {
     @Published var downloadProgress: Double = 0.0
     @Published var downloadStatus: String = ""
 
+    @Published var isLoadingModel = false
+
     @Published var isGenerating = false
     @Published var progress: Float = 0.0
     @Published var statusMessage: String = "Ready"
@@ -120,8 +122,11 @@ class DiffusionViewModel: ObservableObject {
             return
         }
 
+        isLoadingModel = true
         statusMessage = "Loading model..."
         errorMessage = nil
+
+        defer { isLoadingModel = false }
 
         do {
             // App only supports Apple SD 1.5 (CoreML); use .sd15 for configuration

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/ImageGenerationView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/ImageGenerationView.swift
@@ -231,9 +231,24 @@ struct DiffusionModelPickerView: View {
     @ObservedObject var viewModel: DiffusionViewModel
     @Binding var isPresented: Bool
 
+    private static let firstLoadBannerText = "First load may take 1–2 minutes depending on model size and device performance."
+
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
+                // First-load info banner
+                HStack(spacing: AppSpacing.small) {
+                    Image(systemName: "clock.badge.checkmark")
+                        .font(.body)
+                        .foregroundStyle(AppColors.primaryAccent)
+                    Text(Self.firstLoadBannerText)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                .background(AppColors.backgroundSecondary)
+
                 if viewModel.availableModels.isEmpty {
                     VStack(spacing: AppSpacing.large) {
                         Image(systemName: "photo.artframe")
@@ -258,15 +273,24 @@ struct DiffusionModelPickerView: View {
                                 }
                                 Spacer()
                                 if model.isDownloaded {
-                                    Button("Load") {
-                                        viewModel.selectedModel = model
-                                        Task {
-                                            await viewModel.loadSelectedModel()
-                                            if viewModel.isModelLoaded { isPresented = false }
+                                    if viewModel.isLoadingModel && viewModel.selectedModel?.id == model.id {
+                                        HStack(spacing: AppSpacing.small) {
+                                            ProgressView()
+                                            Text("Loading...")
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
                                         }
+                                    } else {
+                                        Button("Load") {
+                                            viewModel.selectedModel = model
+                                            Task {
+                                                await viewModel.loadSelectedModel()
+                                                if viewModel.isModelLoaded { isPresented = false }
+                                            }
+                                        }
+                                        .buttonStyle(.borderedProminent)
+                                        .disabled(viewModel.isDownloading)
                                     }
-                                    .buttonStyle(.borderedProminent)
-                                    .disabled(viewModel.isDownloading)
                                 } else {
                                     Button("Download") {
                                         viewModel.selectedModel = model


### PR DESCRIPTION
## Description
Brief description of the changes made.

## Type of Change
- [ ] Bug fix
- [X] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [X] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`sdk/runanywhere-kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`sdk/runanywhere-flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`sdk/runanywhere-react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`sdk/runanywhere-web`)
- [ ] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

**Sample Apps:**
- [ ] `iOS Sample` - Changes to iOS example app (`examples/ios`)
- [ ] `Android Sample` - Changes to Android example app (`examples/android`)
- [ ] `Flutter Sample` - Changes to Flutter example app (`examples/flutter`)
- [ ] `React Native Sample` - Changes to React Native example app (`examples/react-native`)
- [ ] `Web Sample` - Changes to Web example app (`examples/web`)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)

## Screenshots
Attach relevant UI screenshots for changes (if applicable):
- Mobile (Phone)
- Tablet / iPad
- Desktop / Mac

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add loading indicator and placeholder for model loading in iOS app's diffusion feature.
> 
>   - **Behavior**:
>     - Adds `isLoadingModel` state to `DiffusionViewModel` to track model loading status.
>     - Updates `loadSelectedModel()` in `DiffusionViewModel` to set `isLoadingModel` during model loading.
>     - `ImageGenerationView` shows progress indicator and message when model is loading.
>     - `DiffusionModelPickerView` displays loading state with progress view and disables buttons when loading.
>   - **UI**:
>     - Adds first-load info banner in `DiffusionModelPickerView`.
>     - Updates button styles and disables buttons during model download or loading.
>   - **Misc**:
>     - Updates API key and base URL in `RunAnywhereAIApp.swift` for production mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for fea8053ddafba3bbb9acad333a450b2f496c3ca1. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added first-load information banner displaying estimated model load duration
  
* **UI/Style**
  * Enhanced loading feedback with progress indicator during model loading
  * Load button now shows disabled state while model is downloading and improved visual appearance

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds a loading indicator to the diffusion model picker and a first-load info banner in the iOS sample app. It introduces an `isLoadingModel` state in `DiffusionViewModel` that tracks when a model is being loaded, and updates `DiffusionModelPickerView` to show a spinner for the actively-loading model.

- Adds `isLoadingModel` `@Published` property to `DiffusionViewModel` with `defer`-based cleanup
- Adds a first-load timing info banner at the top of the model picker sheet
- Shows per-model loading spinner in `DiffusionModelPickerView` while a model loads
- **Commits a hardcoded production API key and backend URL** in `RunAnywhereAIApp.swift`, replacing the previous placeholder values — this is a security concern already flagged in a prior review thread
- Buttons for other models (both Load and Download) are not fully disabled during a model load, which can cause `selectedModel` to be overwritten and the loading spinner to disappear prematurely

<h3>Confidence Score: 2/5</h3>

- The feature changes are low-risk, but the hardcoded production API key is a security concern that should be addressed before merge.
- Score of 2 reflects the committed production API key in `RunAnywhereAIApp.swift` (a significant security issue) combined with incomplete button disabling during model loading that can cause UI inconsistencies. The loading indicator feature itself is implemented correctly.
- `examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift` contains a hardcoded production API key that needs to be reverted. `examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/ImageGenerationView.swift` has incomplete button disabling during model loading.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift | Replaces placeholder strings with a hardcoded production API key and backend URL. This is a security issue — credentials are now committed to git history. |
| examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/DiffusionViewModel.swift | Adds `isLoadingModel` published property with correct `defer`-based cleanup in `loadSelectedModel()`. The pattern is sound for single-load scenarios. |
| examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/ImageGenerationView.swift | Adds first-load info banner and per-model loading spinner in `DiffusionModelPickerView`. Other downloaded models' Load buttons remain enabled during a model load, allowing concurrent loads. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PickerView as DiffusionModelPickerView
    participant VM as DiffusionViewModel
    participant RA as RunAnywhere

    User->>PickerView: Tap "Load" button
    PickerView->>VM: selectedModel = model
    PickerView->>VM: loadSelectedModel()
    VM->>VM: isLoadingModel = true
    VM->>VM: statusMessage = "Loading model..."
    Note over PickerView: Spinner shown for selected model
    VM->>RA: loadDiffusionModel(path, id, name, config)
    RA-->>VM: Model loaded successfully
    VM->>VM: isModelLoaded = true
    VM->>VM: defer { isLoadingModel = false }
    Note over PickerView: Spinner removed, sheet dismissed
```

<sub>Last reviewed commit: 233087f</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=20c5a1fb-ed57-4e08-840a-9128622c3bd6))

<!-- /greptile_comment -->