### PR TITLE
fix(core): catch auth errors to allow offline model discovery (#366)

### DIFF
--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/RunAnywhere.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/RunAnywhere.swift
@@ -319,7 +319,14 @@ public enum RunAnywhere {
             logger.info("Initializing services for \(environment.description) mode...")
 
             // Step 1: Configure HTTP transport
-            try await setupHTTP(params: params, environment: environment, logger: logger)
+            do {
+                try await setupHTTP(params: params, environment: environment, logger: logger)
+            } catch {
+                // If HTTP/auth setup fails (e.g. device is offline), log warning but
+                // continue initialization so local/cached models remain accessible.
+                logger.warning("⚠️ HTTP/Auth setup failed (offline?): \(error.localizedDescription)")
+                logger.info("Continuing SDK init in offline mode – local models will be available")
+            }
 
             // Step 1.5: Flush any queued telemetry events now that HTTP is configured
             // This ensures events queued during initialization are sent


### PR DESCRIPTION
## Description
Fixes #366 — Downloaded models disappear when the device is offline.

**Root cause:** `RunAnywhere.availableModels()` calls `ensureServicesReady()` → `completeServicesInitialization()` → `setupHTTP()`. When offline, `setupHTTP` throws (authentication fails), which prevents the remaining initialization steps from executing — including `CppBridge.ModelRegistry.discoverDownloadedModels()`. The UI then receives an empty model list instead of showing already-downloaded models.

**Fix:** Wrap `setupHTTP` in a `do-catch` block so auth failures are logged as warnings while initialization continues. This allows Steps 2–6 (C++ state, service bridges, model paths, device registration, and **local model discovery**) to proceed normally in offline mode.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)

## Testing
- [x] Code path analysis confirms `discoverDownloadedModels()` executes regardless of auth status
- [x] `availableModels()` returns local models via `CppBridge.ModelRegistry.shared.getAll()`
- [x] No behavior change when online (auth succeeds, catch block is never entered)

### Platforms Tested
- [x] iOS

## Labels
- `bug`
- `ios-sdk`

## Checklist
- [x] My code follows the project's style guidelines
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Wrap `setupHTTP` in `do-catch` block in `RunAnywhere.swift` to allow offline model discovery by continuing initialization despite auth errors.
> 
>   - **Behavior**:
>     - Wrap `setupHTTP` in `do-catch` block in `completeServicesInitialization()` in `RunAnywhere.swift` to log auth errors as warnings and continue initialization.
>     - Ensures `CppBridge.ModelRegistry.discoverDownloadedModels()` executes even if offline.
>   - **Testing**:
>     - Confirms `discoverDownloadedModels()` runs regardless of auth status.
>     - `availableModels()` returns local models via `CppBridge.ModelRegistry.shared.getAll()`.
>     - No behavior change when online; catch block not entered.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for ae0b5cfad8a51a2c05cab4700fe5f0719333a799. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced network error handling - the app now gracefully continues running with full access to local and cached models even when network initialization encounters issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes #366 by wrapping `setupHTTP` in a `do-catch` block inside `completeServicesInitialization()`, allowing the SDK to continue initialization when authentication fails (e.g., device is offline). This ensures `discoverDownloadedModels()` (Step 6) still executes, so previously downloaded models remain visible in the UI.

- The core fix is correct: local model discovery now proceeds regardless of auth failures
- **Missing auth retry**: After an offline init, `hasCompletedServicesInit` is set to `true` and subsequent calls to `ensureServicesReady()` skip re-initialization entirely. Since HTTP configuration succeeds before authentication throws, the `httpNeedsInit` guard also won't trigger a retry. The SDK remains unauthenticated for the rest of the app session until a restart.
- Consider adding a lightweight auth-retry mechanism (e.g., checking `isAuthenticated` before network-dependent operations) to recover gracefully when connectivity returns

<h3>Confidence Score: 3/5</h3>

- PR fixes the immediate offline model discovery bug but introduces a session-long auth gap with no retry mechanism
- The change correctly fixes the reported issue (downloaded models disappearing offline), and the approach is minimal. However, it creates a secondary issue: the SDK will remain unauthenticated for the entire app session after an offline initialization, with no mechanism to retry auth when connectivity returns. This could degrade the user experience for network-dependent features.
- Pay close attention to `sdk/runanywhere-swift/Sources/RunAnywhere/Public/RunAnywhere.swift` — the interaction between `hasCompletedServicesInit`, `httpNeedsInit`, and the auth retry path needs consideration.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-swift/Sources/RunAnywhere/Public/RunAnywhere.swift | Wraps `setupHTTP` in do-catch so offline auth failures don't block local model discovery. Fix is effective for the reported issue, but leaves the SDK permanently unauthenticated for the rest of the session after an offline init — no retry mechanism when the device comes back online. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant RunAnywhere
    participant setupHTTP
    participant CppBridge
    participant ModelRegistry

    App->>RunAnywhere: availableModels()
    RunAnywhere->>RunAnywhere: ensureServicesReady()
    RunAnywhere->>RunAnywhere: completeServicesInitialization()
    
    Note over RunAnywhere: Step 1: Configure HTTP
    RunAnywhere->>setupHTTP: try await setupHTTP()
    setupHTTP->>CppBridge: HTTP.configure() ✓
    setupHTTP->>CppBridge: Auth.authenticate()
    CppBridge-->>setupHTTP: ❌ throws (offline)
    setupHTTP-->>RunAnywhere: catch → log warning

    Note over RunAnywhere: Steps 2-4 continue normally
    RunAnywhere->>CppBridge: State.initialize() ✓
    RunAnywhere->>CppBridge: initializeServices() ✓
    RunAnywhere->>CppBridge: ModelPaths.setBaseDirectory() ✓

    Note over RunAnywhere: Step 5: Device registration
    RunAnywhere->>CppBridge: Device.registerIfNeeded()
    CppBridge-->>RunAnywhere: catch → non-critical warning

    Note over RunAnywhere: Step 6: Local model discovery ✅
    RunAnywhere->>ModelRegistry: discoverDownloadedModels()
    ModelRegistry-->>RunAnywhere: discoveredCount

    RunAnywhere->>RunAnywhere: hasCompletedServicesInit = true
    RunAnywhere-->>App: return local models

    Note over App,ModelRegistry: ⚠️ Later, device comes online
    App->>RunAnywhere: availableModels()
    RunAnywhere->>RunAnywhere: ensureServicesReady()
    Note over RunAnywhere: hasCompletedServicesInit == true → returns immediately
    Note over RunAnywhere: Auth never retried ⚠️
    RunAnywhere-->>App: returns local models only (still unauthenticated)
```

<sub>Last reviewed commit: ae0b5cf</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=20c5a1fb-ed57-4e08-840a-9128622c3bd6))

<!-- /greptile_comment -->