### PR TITLE
Vaibhav/improve diffusion model dialog

### DIFF
--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/DiffusionViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/DiffusionViewModel.swift
@@ -22,6 +22,8 @@ class DiffusionViewModel: ObservableObject {
     @Published var downloadProgress: Double = 0.0
     @Published var downloadStatus: String = ""
 
+    @Published var isLoadingModel = false
+
     @Published var isGenerating = false
     @Published var progress: Float = 0.0
     @Published var statusMessage: String = "Ready"
@@ -120,8 +122,11 @@ class DiffusionViewModel: ObservableObject {
             return
         }
 
+        isLoadingModel = true
         statusMessage = "Loading model..."
         errorMessage = nil
+
+        defer { isLoadingModel = false }
 
         do {
             // App only supports Apple SD 1.5 (CoreML); use .sd15 for configuration

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/ImageGenerationView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/ImageGenerationView.swift
@@ -231,9 +231,24 @@ struct DiffusionModelPickerView: View {
     @ObservedObject var viewModel: DiffusionViewModel
     @Binding var isPresented: Bool
 
+    private static let firstLoadBannerText = "First load may take 1–2 minutes depending on model size and device performance."
+
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
+                // First-load info banner
+                HStack(spacing: AppSpacing.small) {
+                    Image(systemName: "clock.badge.checkmark")
+                        .font(.body)
+                        .foregroundStyle(AppColors.primaryAccent)
+                    Text(Self.firstLoadBannerText)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                .background(AppColors.backgroundSecondary)
+
                 if viewModel.availableModels.isEmpty {
                     VStack(spacing: AppSpacing.large) {
                         Image(systemName: "photo.artframe")
@@ -258,15 +273,24 @@ struct DiffusionModelPickerView: View {
                                 }
                                 Spacer()
                                 if model.isDownloaded {
-                                    Button("Load") {
-                                        viewModel.selectedModel = model
-                                        Task {
-                                            await viewModel.loadSelectedModel()
-                                            if viewModel.isModelLoaded { isPresented = false }
+                                    if viewModel.isLoadingModel && viewModel.selectedModel?.id == model.id {
+                                        HStack(spacing: AppSpacing.small) {
+                                            ProgressView()
+                                            Text("Loading...")
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
                                         }
+                                    } else {
+                                        Button("Load") {
+                                            viewModel.selectedModel = model
+                                            Task {
+                                                await viewModel.loadSelectedModel()
+                                                if viewModel.isModelLoaded { isPresented = false }
+                                            }
+                                        }
+                                        .buttonStyle(.borderedProminent)
+                                        .disabled(viewModel.isDownloading)
                                     }
-                                    .buttonStyle(.borderedProminent)
-                                    .disabled(viewModel.isDownloading)
                                 } else {
                                     Button("Download") {
                                         viewModel.selectedModel = model


### PR DESCRIPTION
## Description
Brief description of the changes made.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`sdk/runanywhere-kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`sdk/runanywhere-flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`sdk/runanywhere-react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`sdk/runanywhere-web`)
- [ ] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

**Sample Apps:**
- [ ] `iOS Sample` - Changes to iOS example app (`examples/ios`)
- [ ] `Android Sample` - Changes to Android example app (`examples/android`)
- [ ] `Flutter Sample` - Changes to Flutter example app (`examples/flutter`)
- [ ] `React Native Sample` - Changes to React Native example app (`examples/react-native`)
- [ ] `Web Sample` - Changes to Web example app (`examples/web`)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)

## Screenshots
Attach relevant UI screenshots for changes (if applicable):
- Mobile (Phone)
- Tablet / iPad
- Desktop / Mac

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add model loading state tracking and UI feedback for diffusion models in iOS app.
> 
>   - **Behavior**:
>     - Add `isLoadingModel` to `DiffusionViewModel` to track model loading state.
>     - Update `loadSelectedModel()` in `DiffusionViewModel.swift` to set `isLoadingModel` during model load.
>   - **UI Updates**:
>     - In `ImageGenerationView.swift`, show loading indicator and message in `DiffusionModelPickerView` when `isLoadingModel` is true.
>     - Add first-load info banner in `DiffusionModelPickerView` to inform users about potential delays.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for d25cc05e7cb52f10ac97c5efbd7e3132a24db5b6. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR improves the diffusion model picker dialog in the iOS sample app with two changes:

- **Loading state indicator**: Adds an `isLoadingModel` published property to `DiffusionViewModel` and uses it in `DiffusionModelPickerView` to show a spinner + "Loading..." text on the selected model row while the model loads, replacing the "Load" button.
- **First-load info banner**: Adds a static banner at the top of the model picker explaining that the first load may take 1-2 minutes depending on model size and device.

One issue to address: the "Load" button on non-selected models is not disabled when a model is loading, which can lead to concurrent `loadSelectedModel()` calls.

<h3>Confidence Score: 3/5</h3>

- Low-risk UI change in a sample app, but has a concurrency bug that should be fixed before merging.
- The changes are small and well-structured, but the "Load" button on non-loading models isn't disabled during a model load, which allows concurrent model loading — a functional bug. The ViewModel changes are clean with proper defer-based cleanup.
- Pay close attention to `ImageGenerationView.swift` — the Load button's disabled state needs to also account for `isLoadingModel`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/DiffusionViewModel.swift | Adds `@Published var isLoadingModel` flag with proper lifecycle management using `defer` to reset the flag when `loadSelectedModel()` completes or throws. Clean, straightforward change. |
| examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/ImageGenerationView.swift | Adds a first-load info banner and a loading spinner for the selected model. However, the "Load" button on non-selected models is not disabled during loading, allowing concurrent model load calls. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PickerView as DiffusionModelPickerView
    participant VM as DiffusionViewModel
    participant RA as RunAnywhere SDK

    User->>PickerView: Taps "Load" on model
    PickerView->>VM: selectedModel = model
    PickerView->>VM: loadSelectedModel()
    VM->>VM: isLoadingModel = true
    VM->>VM: statusMessage = "Loading model..."
    Note over PickerView: Shows spinner + "Loading..." for selected model
    VM->>RA: loadDiffusionModel(path, id, name, config)
    RA-->>VM: Success / Error
    alt Success
        VM->>VM: isModelLoaded = true
        VM->>VM: isLoadingModel = false (defer)
        PickerView->>PickerView: isPresented = false (dismiss)
    else Error
        VM->>VM: errorMessage = "Load failed: ..."
        VM->>VM: isLoadingModel = false (defer)
        Note over PickerView: "Load" button reappears
    end
```

<sub>Last reviewed commit: d25cc05</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=20c5a1fb-ed57-4e08-840a-9128622c3bd6))

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a first-load informational banner in the model picker to guide users.
  * Introduced a visible loading state so the UI shows a progress indicator with “Loading...” during model loads.
  * Replaced unconditional Load behavior with a state-aware UI that reflects current load status.
  * The Load button is disabled while a download is in progress for clearer feedback.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->