### PR TITLE
Added loading while model is Loading, also add a Placeholder

### DIFF
--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/DiffusionViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/DiffusionViewModel.swift
@@ -22,6 +22,8 @@ class DiffusionViewModel: ObservableObject {
     @Published var downloadProgress: Double = 0.0
     @Published var downloadStatus: String = ""
 
+    @Published var isLoadingModel = false
+
     @Published var isGenerating = false
     @Published var progress: Float = 0.0
     @Published var statusMessage: String = "Ready"
@@ -120,8 +122,11 @@ class DiffusionViewModel: ObservableObject {
             return
         }
 
+        isLoadingModel = true
         statusMessage = "Loading model..."
         errorMessage = nil
+
+        defer { isLoadingModel = false }
 
         do {
             // App only supports Apple SD 1.5 (CoreML); use .sd15 for configuration

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/ImageGenerationView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/ImageGenerationView.swift
@@ -231,9 +231,24 @@ struct DiffusionModelPickerView: View {
     @ObservedObject var viewModel: DiffusionViewModel
     @Binding var isPresented: Bool
 
+    private static let firstLoadBannerText = "First load may take 1–2 minutes depending on model size and device performance."
+
     var body: some View {
         NavigationView {
             VStack(spacing: 0) {
+                // First-load info banner
+                HStack(spacing: AppSpacing.small) {
+                    Image(systemName: "clock.badge.checkmark")
+                        .font(.body)
+                        .foregroundStyle(AppColors.primaryAccent)
+                    Text(Self.firstLoadBannerText)
+                        .font(.subheadline)
+                        .foregroundColor(.secondary)
+                }
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding()
+                .background(AppColors.backgroundSecondary)
+
                 if viewModel.availableModels.isEmpty {
                     VStack(spacing: AppSpacing.large) {
                         Image(systemName: "photo.artframe")
@@ -258,15 +273,24 @@ struct DiffusionModelPickerView: View {
                                 }
                                 Spacer()
                                 if model.isDownloaded {
-                                    Button("Load") {
-                                        viewModel.selectedModel = model
-                                        Task {
-                                            await viewModel.loadSelectedModel()
-                                            if viewModel.isModelLoaded { isPresented = false }
+                                    if viewModel.isLoadingModel && viewModel.selectedModel?.id == model.id {
+                                        HStack(spacing: AppSpacing.small) {
+                                            ProgressView()
+                                            Text("Loading...")
+                                                .font(.caption)
+                                                .foregroundColor(.secondary)
                                         }
+                                    } else {
+                                        Button("Load") {
+                                            viewModel.selectedModel = model
+                                            Task {
+                                                await viewModel.loadSelectedModel()
+                                                if viewModel.isModelLoaded { isPresented = false }
+                                            }
+                                        }
+                                        .buttonStyle(.borderedProminent)
+                                        .disabled(viewModel.isDownloading)
                                     }
-                                    .buttonStyle(.borderedProminent)
-                                    .disabled(viewModel.isDownloading)
                                 } else {
                                     Button("Download") {
                                         viewModel.selectedModel = model


### PR DESCRIPTION
## Summary
- Add loading indicator (spinner + "Loading..." text) while diffusion model is loading
- Add first-load info banner in DiffusionModelPickerView
- Disable buttons appropriately during model loading

> Replaces PR #380 (closed due to force push after credential cleanup)

## Type of Change
- [X] New feature

## Testing
### Platform-Specific Testing
**Swift SDK / iOS Sample:**
- [X] Tested on iPhone (Simulator or Device)

Made with [Cursor](https://cursor.com)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds loading indicator, first-load info banner, and button disabling during model loading in iOS app's `DiffusionModelPickerView`.
> 
>   - **Behavior**:
>     - Adds loading indicator (spinner + "Loading..." text) in `DiffusionModelPickerView` while model is loading.
>     - Adds first-load info banner in `DiffusionModelPickerView` to inform users about potential loading times.
>     - Disables "Load" and "Download" buttons in `DiffusionModelPickerView` during model loading or downloading.
>   - **State Management**:
>     - Introduces `isLoadingModel` state in `DiffusionViewModel` to track model loading status.
>     - Updates `loadSelectedModel()` in `DiffusionViewModel` to set `isLoadingModel` to `true` at start and `false` at end.
>   - **UI Components**:
>     - Updates `ImageGenerationView` to reflect loading status and disable actions appropriately.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for 4c8e1164739de1f77d248a9eea6c4c7245b5097b. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added visual loading indicator that displays during model loading operations
  * Introduced informational banner to guide users during initial setup
  * Enhanced Load button with improved styling and disabled state during model downloads
  * Improved user feedback with clearer indication of loading progress

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Adds a loading state indicator and first-load info banner to the diffusion model picker in the iOS sample app. The ViewModel gets a new `isLoadingModel` published property with a clean `defer`-based reset, and the view replaces the "Load" button with a spinner for the model being loaded.

- `DiffusionViewModel.swift`: Adds `isLoadingModel` flag set/reset around the async `loadSelectedModel()` call using `defer` for safety.
- `ImageGenerationView.swift`: Adds a static info banner about first-load times. Shows inline `ProgressView` + "Loading..." text for the model currently being loaded.
- **Issue found**: "Load" buttons on *other* models in the list are not disabled while a model is loading (only `isDownloading` is checked), which could allow concurrent model loads.

<h3>Confidence Score: 3/5</h3>

- Low-risk UI changes in a sample app, but a missing disabled state could allow concurrent model loads.
- The changes are small and well-structured (defer pattern, clean state management). However, the "Load" button for non-loading models is not disabled during a load, which could lead to concurrent model loading — a functional bug in the UI interaction. This is in a sample/demo app, so blast radius is limited.
- Pay attention to `ImageGenerationView.swift` — the "Load" button's `.disabled()` modifier needs to also check `isLoadingModel`.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/DiffusionViewModel.swift | Adds `isLoadingModel` published property with clean `defer`-based reset in `loadSelectedModel()`. Changes are minimal and correct. |
| examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Diffusion/ImageGenerationView.swift | Adds first-load info banner and loading spinner in model picker. Issue: "Load" buttons on non-loading models are not disabled during a load, allowing concurrent model loads. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant PickerView as DiffusionModelPickerView
    participant VM as DiffusionViewModel
    participant SDK as RunAnywhere SDK

    User->>PickerView: Tap "Load" button
    PickerView->>VM: selectedModel = model
    PickerView->>VM: loadSelectedModel()
    VM->>VM: isLoadingModel = true
    VM->>VM: statusMessage = "Loading model..."
    PickerView-->>User: Show ProgressView + "Loading..."
    VM->>SDK: loadDiffusionModel(path, id, name, config)
    SDK-->>VM: Model loaded successfully
    VM->>VM: isModelLoaded = true
    VM->>VM: defer { isLoadingModel = false }
    PickerView-->>User: Dismiss picker (isPresented = false)
```

<sub>Last reviewed commit: 4c8e116</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=20c5a1fb-ed57-4e08-840a-9128622c3bd6))

<!-- /greptile_comment -->