### PR TITLE
fix: log telemetry/analytics catch errors at debug level for observability

### DIFF
--- a/sdk/runanywhere-web/packages/llamacpp/src/Foundation/LlamaCppBridge.ts
+++ b/sdk/runanywhere-web/packages/llamacpp/src/Foundation/LlamaCppBridge.ts
@@ -451,12 +451,24 @@ export class LlamaCppBridge {
 
   shutdown(): void {
     if (this._module && this._loaded) {
-      try { this._module._rac_shutdown(); } catch { /* ignore */ }
+      try {
+        this._module._rac_shutdown();
+      } catch (err) {
+        logger.debug(
+          `LlamaCpp module shutdown failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
     }
 
     // Clean up platform adapter
     if (this._platformAdapter) {
-      try { this._platformAdapter.cleanup(); } catch { /* ignore */ }
+      try {
+        this._platformAdapter.cleanup();
+      } catch (err) {
+        logger.debug(
+          `Platform adapter cleanup failed (non-fatal): ${err instanceof Error ? err.message : String(err)}`,
+        );
+      }
       this._platformAdapter = null;
     }
 


### PR DESCRIPTION
Fixes #398

Telemetry/analytics were swallowing errors in empty catch blocks, so when something broke you had no way to see it. This adds `logger.debug()` in those shutdown catches so if something fails you’ll see it when debug logging is on. Behavior is unchanged — telemetry still never throws.

Only LlamaCppBridge.ts is in this repo; the other files from the issue aren’t here so I updated the two shutdown catch blocks there (`_rac_shutdown` and `_platformAdapter.cleanup()`).

**Tests (all passed):**

| Test | Command | Result |
|------|---------|--------|
| Web SDK build | `cd sdk/runanywhere-web && npm run build` | Pass |
| Web SDK typecheck | `npm run typecheck` | Pass |
| Web SDK lint | `npm run lint` | Pass |
| Web example build | `cd examples/web/RunAnywhereAI && npm run build` | Pass (Vite, 72 modules) |
| Pre-commit (changed file) | `pre-commit run --files .../LlamaCppBridge.ts` | Pass |


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds debug-level logging for errors in `LlamaCppBridge` shutdown catch blocks without changing telemetry behavior.
> 
>   - **Behavior**:
>     - Adds `logger.debug()` in `shutdown()` of `LlamaCppBridge` for errors in `_rac_shutdown` and `_platformAdapter.cleanup()` catch blocks.
>     - Telemetry behavior unchanged; errors logged at debug level, no exceptions thrown.
>   - **Tests**:
>     - Web SDK build, typecheck, and lint all pass.
>     - Web example build passes with Vite (72 modules).
>     - Pre-commit check on `LlamaCppBridge.ts` passes.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for 2f3f4c1a5e01e971b2962fc81192e10cff891dd9. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Public TypeScript API and types added (chat/model descriptors, RunAnywhere interface, type aliases) and isSDKError exported.
* **Bug Fixes**
  * Improved shutdown error handling: non-fatal errors during module and platform adapter cleanup are now logged without changing behavior.
* **Documentation**
  * Added TypeScript usage section to README with examples and typing notes.
* **Tests**
  * Added TypeScript type-level tests for the public API.
* **Chores**
  * Package and build metadata updated to emit consolidated declaration files and added type-check scripts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaces two empty catch blocks in `LlamaCppBridge.shutdown()` with debug-level logging for observability. The changes add `logger.debug()` calls in the catch handlers for `_rac_shutdown()` and `_platformAdapter.cleanup()`, logging the error message with a `[Telemetry]` prefix and noting that failures are non-fatal. This preserves the existing behavior where telemetry/analytics errors never throw, while providing visibility when debug logging is enabled.

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-tested, and only add observability without altering behavior. Empty catch blocks are replaced with debug logging that explicitly notes errors are non-fatal, maintaining the existing telemetry pattern while improving debuggability
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-web/packages/llamacpp/src/Foundation/LlamaCppBridge.ts | Added debug-level logging for telemetry errors in shutdown catch blocks without changing behavior |

</details>



<sub>Last reviewed commit: 2f3f4c1</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->