### PR TITLE
chore(security): add gitleaks pre-commit hook to block secrets before…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,6 +2,12 @@
 # See https://pre-commit.com for more information
 
 repos:
+  # Secret scanning (blocks commits containing API keys, tokens, URLs)
+  - repo: https://github.com/gitleaks/gitleaks
+    rev: v8.30.0
+    hooks:
+      - id: gitleaks
+
   # General hooks
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v4.5.0
@@ -73,6 +79,7 @@ default_language_version:
 # Skip these hooks during CI (they run in dedicated CI jobs)
 ci:
   skip:
+    - gitleaks
     - android-sdk-lint
     - android-app-lint
     - ios-sdk-swiftlint-fix


### PR DESCRIPTION
chore(security): add gitleaks pre-commit hook to block secrets before commit

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced repository security with automated secret-scanning to prevent accidental credential exposure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds `gitleaks` as a pre-commit hook to catch secrets before they're committed locally. The hook complements the existing CI-based secret scanning workflow (`.github/workflows/secret-scan.yml`) by providing immediate feedback during development.

**Key changes:**
- Adds `gitleaks` v8.30.0 hook to `.pre-commit-config.yaml` at the top of the hooks list for early detection
- Skips `gitleaks` in CI runs (added to `ci.skip` section) since secret scanning already runs in a dedicated GitHub Actions workflow
- Uses existing `.gitleaks.toml` configuration with custom rules for RunAnywhere-specific secrets (API keys, Railway URLs, Supabase credentials)

The change follows security best practices by implementing defense-in-depth: blocking secrets at commit time (pre-commit hook) and again at PR/push time (CI workflow).

<h3>Confidence Score: 5/5</h3>

- This PR is safe to merge with minimal risk
- The changes are minimal, well-scoped, and follow security best practices. The gitleaks hook adds protection without breaking existing workflows. Skipping it in CI is correct since secret scanning already runs in a dedicated workflow, avoiding redundant scans. The configuration is compatible with the existing `.gitleaks.toml` setup.
- No files require special attention

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .pre-commit-config.yaml | Adds `gitleaks` pre-commit hook for local secret scanning before commits, skips it in CI where it runs separately |

</details>



<sub>Last reviewed commit: d92f1c5</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->