### PR TITLE
fix(ios-sdk): add XCFramework simulator slice validation and pre-validate third-party deps (#273)

### DIFF
--- a/sdk/runanywhere-commons/README.md
+++ b/sdk/runanywhere-commons/README.md
@@ -262,7 +262,7 @@ All XCFrameworks produced by `build-ios.sh` include a fat simulator slice contai
 | `lipo failed to combine simulator slices` | SIMULATORARM64 or SIMULATOR build produced no output | Check CMake output for that platform; re-run without `--skip-download` |
 | `missing a simulator slice` | XCFramework was created without simulator platform | Delete `build/ios/` and `dist/` then re-run `build-ios.sh` |
 | `missing arm64` in simulator slice | Sherpa-ONNX or llama.cpp dependency was downloaded without simulator support | Delete `third_party/` and re-run (dependency will be re-fetched) |
-| App crashes on simulator, not device | Simulator slice is present but empty/corrupt (was previously silently produced by `lipo || true`) | Clean and rebuild: `./scripts/build-ios.sh --clean` |
+| App crashes on simulator, not device | Simulator slice is present but empty/corrupt (was previously silently produced by `lipo \|\| true`) | Clean and rebuild: `./scripts/build-ios.sh --clean` |
 
 **Verifying XCFramework simulator slices manually:**
 ```bash

--- a/sdk/runanywhere-commons/scripts/build-ios.sh
+++ b/sdk/runanywhere-commons/scripts/build-ios.sh
@@ -114,7 +114,6 @@ validate_xcframework() {
     # Locate the simulator slice directory
     local SIM_SLICE=""
     for d in "${XCFW_PATH}"/ios-arm64_x86_64-simulator \
-              "${XCFW_PATH}"/ios-arm64_x86_64-simulator.xcarchive \
               "${XCFW_PATH}"/ios-arm64-simulator; do
         [[ -d "$d" ]] && SIM_SLICE="$d" && break
     done
@@ -180,11 +179,10 @@ validate_third_party_deps() {
         if ! echo "$ARCH_INFO" | grep -q "arm64"; then
             log_error "Sherpa-ONNX simulator library is missing arm64 — ONNX backend will not work on Apple Silicon simulators. Re-download dependencies."
         fi
+        log_info "Third-party dependency pre-validation passed"
     else
         log_warn "Could not locate Sherpa-ONNX simulator binary for pre-validation — proceeding anyway."
     fi
-
-    log_info "Third-party dependency pre-validation passed"
 }
 
 show_help() {
@@ -810,7 +808,7 @@ main() {
 
     # Step 1b: Pre-validate third-party dependencies have simulator architecture support.
     # Catches missing or broken xcframeworks before any build time is spent (fixes: #273).
-    if [[ "$SKIP_BACKENDS" != true && ("$BUILD_BACKEND" == "all" || "$BUILD_BACKEND" == "onnx") ]]; then
+    if [[ "$SKIP_BACKENDS" != true && ("$BUILD_BACKEND" == "all" || "$BUILD_BACKEND" == "onnx" || "$BUILD_BACKEND" == "rag") ]]; then
         validate_third_party_deps
     fi
 

--- a/sdk/runanywhere-commons/scripts/build-ios.sh
+++ b/sdk/runanywhere-commons/scripts/build-ios.sh
@@ -100,6 +100,93 @@ require_cmd() {
     fi
 }
 
+# =============================================================================
+# Validate XCFramework simulator slice architectures
+# Ensures both arm64 (Apple Silicon) and x86_64 (Intel) are present so the
+# framework works in ALL simulator configurations, not just one.
+# =============================================================================
+validate_xcframework() {
+    local XCFW_PATH=$1
+    local FRAMEWORK_NAME=$2
+
+    log_step "Validating ${FRAMEWORK_NAME}.xcframework simulator slice..."
+
+    # Locate the simulator slice directory
+    local SIM_SLICE=""
+    for d in "${XCFW_PATH}"/ios-arm64_x86_64-simulator \
+              "${XCFW_PATH}"/ios-arm64_x86_64-simulator.xcarchive \
+              "${XCFW_PATH}"/ios-arm64-simulator; do
+        [[ -d "$d" ]] && SIM_SLICE="$d" && break
+    done
+
+    if [[ -z "$SIM_SLICE" ]]; then
+        log_error "${FRAMEWORK_NAME}.xcframework is missing a simulator slice — simulator builds will fail. Re-run without --skip-download and ensure SIMULATORARM64 and SIMULATOR builds both succeeded."
+    fi
+
+    local BIN="${SIM_SLICE}/${FRAMEWORK_NAME}.framework/${FRAMEWORK_NAME}"
+    if [[ ! -f "$BIN" ]]; then
+        log_error "Simulator binary not found at expected path: ${BIN}"
+    fi
+
+    local ARCH_INFO
+    ARCH_INFO=$(lipo -info "$BIN" 2>&1)
+
+    if ! echo "$ARCH_INFO" | grep -q "arm64"; then
+        log_error "${FRAMEWORK_NAME} simulator slice is missing arm64 (Apple Silicon). lipo reports: ${ARCH_INFO}"
+    fi
+
+    if ! echo "$ARCH_INFO" | grep -q "x86_64"; then
+        log_warn "${FRAMEWORK_NAME} simulator slice is missing x86_64 — Intel Mac simulators will not be supported."
+        log_warn "lipo reports: ${ARCH_INFO}"
+    fi
+
+    log_info "${FRAMEWORK_NAME}.xcframework ✓  $(echo "$ARCH_INFO" | sed 's/.*are: //' | sed 's/.*is architecture: //')"
+}
+
+# =============================================================================
+# Pre-validate third-party dependencies for simulator architecture support
+# Catches bad dep downloads before wasting build time.
+# =============================================================================
+validate_third_party_deps() {
+    log_header "Validating Third-Party Simulator Dependencies"
+
+    # --- Sherpa-ONNX (ONNX backend) ---
+    local SHERPA_XCFW="${PROJECT_ROOT}/third_party/sherpa-onnx-ios/sherpa-onnx.xcframework"
+
+    if [[ ! -d "$SHERPA_XCFW" ]]; then
+        log_error "Sherpa-ONNX XCFramework not found at ${SHERPA_XCFW}. Run without --skip-download first to fetch it."
+    fi
+
+    # Find the simulator slice
+    local SHERPA_SIM_SLICE=""
+    for d in "${SHERPA_XCFW}"/ios-arm64_x86_64-simulator \
+              "${SHERPA_XCFW}"/ios-arm64-simulator; do
+        [[ -d "$d" ]] && SHERPA_SIM_SLICE="$d" && break
+    done
+
+    if [[ -z "$SHERPA_SIM_SLICE" ]]; then
+        log_error "Sherpa-ONNX is missing a simulator slice — cannot build ONNX backend for simulator. Check the downloaded xcframework at: ${SHERPA_XCFW}"
+    fi
+
+    # Find and validate the simulator library binary
+    local SHERPA_BIN
+    SHERPA_BIN=$(find "$SHERPA_SIM_SLICE" \( -name "libsherpa-onnx.a" -o -name "sherpa-onnx" \) | head -1)
+
+    if [[ -n "$SHERPA_BIN" ]]; then
+        local ARCH_INFO
+        ARCH_INFO=$(lipo -info "$SHERPA_BIN" 2>&1)
+        log_info "Sherpa-ONNX simulator: $(echo "$ARCH_INFO" | sed 's/.*are: //' | sed 's/.*is architecture: //')"
+
+        if ! echo "$ARCH_INFO" | grep -q "arm64"; then
+            log_error "Sherpa-ONNX simulator library is missing arm64 — ONNX backend will not work on Apple Silicon simulators. Re-download dependencies."
+        fi
+    else
+        log_warn "Could not locate Sherpa-ONNX simulator binary for pre-validation — proceeding anyway."
+    fi
+
+    log_info "Third-party dependency pre-validation passed"
+}
+
 show_help() {
     head -45 "$0" | tail -40
     exit 0
@@ -463,6 +550,8 @@ EOF
 
     log_info "Created: ${XCFW_PATH}"
     echo "  Size: $(du -sh "${XCFW_PATH}" | cut -f1)"
+
+    validate_xcframework "${XCFW_PATH}" "${FRAMEWORK_NAME}"
 }
 
 # =============================================================================
@@ -656,6 +745,8 @@ EOF
 
         log_info "Created: ${XCFW_PATH}"
         echo "  Size: $(du -sh "${XCFW_PATH}" | cut -f1)"
+
+        validate_xcframework "${XCFW_PATH}" "${FRAMEWORK_NAME}"
     else
         log_warn "Could not create ${FRAMEWORK_NAME}.xcframework"
     fi
@@ -715,6 +806,12 @@ main() {
         if [[ "$INCLUDE_MACOS" == true ]]; then
             download_macos_deps
         fi
+    fi
+
+    # Step 1b: Pre-validate third-party dependencies have simulator architecture support.
+    # Catches missing or broken xcframeworks before any build time is spent (fixes: #273).
+    if [[ "$SKIP_BACKENDS" != true && ("$BUILD_BACKEND" == "all" || "$BUILD_BACKEND" == "onnx") ]]; then
+        validate_third_party_deps
     fi
 
     # Step 2: Build for all iOS platforms


### PR DESCRIPTION
## Description
Fixes #273 — iOS simulator builds were silently producing corrupt or empty XCFramework simulator slices because `lipo -create` in `create_backend_xcframework()` used `2>/dev/null || true`, swallowing failures and letting the build report success with broken frameworks that crash at simulator launch.

Two additions to `build-ios.sh`:
- `validate_third_party_deps()` — pre-validates that Sherpa-ONNX has a simulator slice with `arm64` before any build time is spent
- `validate_xcframework()` — post-creation check using `lipo -info` that the simulator slice contains both `arm64` (Apple Silicon) and `x86_64` (Intel), called after every `xcodebuild -create-xcframework`

Also adds an **iOS Simulator Support** section to `sdk/runanywhere-commons/README.md` with a troubleshooting table and manual `lipo -info` verification commands.

## Type of Change
- [x] Bug fix
- [x] Documentation update

## Testing
- [x] Lint passes locally
- [ ] Added/updated tests for changes

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [x] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

## Labels
- [x] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)

## Screenshots
N/A — build script and documentation changes only.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds validation for XCFramework simulator slices and pre-validation for third-party dependencies in `build-ios.sh`, addressing issue #273.
> 
>   - **Behavior**:
>     - Adds `validate_xcframework()` in `build-ios.sh` to ensure simulator slices contain both `arm64` and `x86_64` architectures.
>     - Adds `validate_third_party_deps()` in `build-ios.sh` to pre-validate Sherpa-ONNX simulator slice for `arm64`.
>     - Updates `create_backend_xcframework()` to call `validate_xcframework()` after XCFramework creation.
>   - **Documentation**:
>     - Adds **iOS Simulator Support** section in `README.md` with troubleshooting and verification steps for simulator slices.
>   - **Misc**:
>     - Fixes issue #273 by ensuring simulator builds do not silently fail.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for 81856c07dd2f3c4aeed88a100c5d442c4e05a070. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added iOS Simulator Support guidance for XCFrameworks, including verification commands and a troubleshooting table for common simulator build failures.

* **Bug Fixes**
  * Added simulator-architecture validations and earlier pre-build checks to detect missing simulator slices; now surface clear errors for missing arm64 and warnings for missing x86_64 to catch issues before heavy builds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds two validation functions to `build-ios.sh` to prevent silent XCFramework simulator build failures (fixes #273):

- **`validate_xcframework()`** — post-creation check using `lipo -info` to verify the simulator slice contains `arm64` (required) and `x86_64` (warned if missing). Called after every `xcodebuild -create-xcframework` in both `create_xcframework()` and `create_backend_xcframework()`.
- **`validate_third_party_deps()`** — pre-build check that Sherpa-ONNX has a valid simulator slice with `arm64`, called before any compilation starts to fail fast on broken dependencies.

Also adds an iOS Simulator Support section to the README with a troubleshooting table and manual `lipo -info` verification commands.

- The pre-validation condition at line 818 should also include `"rag"` since the RAG backend depends on Sherpa-ONNX too.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one minor logic gap in the pre-validation condition.
- The validation functions are well-implemented and correctly placed. The only issue is that `validate_third_party_deps` won't run for `--backend rag` builds despite the RAG backend depending on Sherpa-ONNX. This is a coverage gap rather than a regression — the `rag` backend worked the same way before this PR, just without any pre-validation. The post-creation `validate_xcframework` call will still catch issues after build time is spent.
- `sdk/runanywhere-commons/scripts/build-ios.sh` — pre-validation condition on line 818 should include the `rag` backend

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-commons/scripts/build-ios.sh | Adds `validate_xcframework()` and `validate_third_party_deps()` functions and calls them at the right points. One logic gap: pre-validation condition misses the `rag` backend which also depends on Sherpa-ONNX. |
| sdk/runanywhere-commons/README.md | Adds a clear iOS Simulator Support section with a troubleshooting table and manual verification commands. Documentation is accurate and well-structured. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[main] --> B[Download deps]
    B --> C{Backend includes onnx?}
    C -->|Yes| D[validate_third_party_deps]
    C -->|No| E[Skip pre-validation]
    D --> F{Sherpa-ONNX present?}
    F -->|No| G[log_error + exit]
    F -->|Yes| H{Simulator slice exists?}
    H -->|No| G
    H -->|Yes| I{arm64 in simulator?}
    I -->|No| G
    I -->|Yes| J[Pre-validation passed]
    E --> K[Build platforms: OS, SIMULATORARM64, SIMULATOR]
    J --> K
    K --> L[create_xcframework / create_backend_xcframework]
    L --> M[xcodebuild -create-xcframework]
    M --> N[validate_xcframework]
    N --> O{Simulator slice in XCFramework?}
    O -->|No| P[log_error + exit]
    O -->|Yes| Q{arm64 present?}
    Q -->|No| P
    Q -->|Yes| R{x86_64 present?}
    R -->|No| S[log_warn only]
    R -->|Yes| T[Validation passed ✓]
```

<sub>Last reviewed commit: 81856c0</sub>

<!-- greptile_other_comments_section -->

**Context used:**

- Context from `dashboard` - CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=20c5a1fb-ed57-4e08-840a-9128622c3bd6))

<!-- /greptile_comment -->