### PR TITLE
feat(kotlin-sdk): implement secure native library downloading with SH…

### DIFF
--- a/sdk/runanywhere-kotlin/build-logic/build.gradle.kts
+++ b/sdk/runanywhere-kotlin/build-logic/build.gradle.kts
@@ -1,0 +1,22 @@
+plugins {
+    `kotlin-dsl`
+}
+
+repositories {
+    mavenCentral()
+    google()
+    gradlePluginPortal()
+}
+
+gradlePlugin {
+    plugins {
+        create("nativeDownloader") {
+            id = "com.runanywhere.native-downloader"
+            implementationClass = "com.runanywhere.buildlogic.NativeLibraryDownloadPlugin"
+        }
+    }
+}
+
+dependencies {
+    
+}

--- a/sdk/runanywhere-kotlin/build-logic/settings.gradle.kts
+++ b/sdk/runanywhere-kotlin/build-logic/settings.gradle.kts
@@ -1,0 +1,1 @@
+rootProject.name = "build-logic"

--- a/sdk/runanywhere-kotlin/build-logic/src/main/kotlin/NativeLibraryDownloadPlugin.kt
+++ b/sdk/runanywhere-kotlin/build-logic/src/main/kotlin/NativeLibraryDownloadPlugin.kt
@@ -1,0 +1,118 @@
+package com.runanywhere.buildlogic
+
+import org.gradle.api.DefaultTask
+import org.gradle.api.Plugin
+import org.gradle.api.Project
+import org.gradle.api.file.ArchiveOperations
+import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.FileSystemOperations
+import org.gradle.api.file.RelativePath
+import org.gradle.api.provider.ListProperty
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
+import org.gradle.api.tasks.OutputDirectory
+import org.gradle.api.tasks.TaskAction
+import java.io.File
+import java.net.HttpURLConnection
+import java.net.URL
+import java.security.MessageDigest
+import javax.inject.Inject
+
+// A Gradle plugin that provides a task to securely download and verify native libraries using SHA-256 checksums.
+abstract class DownloadAndVerifyNativeLibTask @Inject constructor(
+    private val fsOps: FileSystemOperations,
+    private val archiveOps: ArchiveOperations
+) : DefaultTask() {
+
+    // Inputs for the task: download URL, expected SHA256 URL, allowed .so files, and output directory
+    @get:Input
+    abstract val downloadUrl: Property<String>
+    
+    @get:Input
+    abstract val expectedSha256Url: Property<String>
+
+    @get:Input
+    abstract val allowedSoFiles: ListProperty<String>
+
+    @get:OutputDirectory
+    abstract val outputDir: DirectoryProperty
+
+    // The main action of the task: download the file, verify its checksum, and extract it if valid
+    @TaskAction
+    fun execute() {
+        val url = downloadUrl.get()
+        val shaUrl = expectedSha256Url.get()
+        val validFiles = allowedSoFiles.get()
+        val destDir = outputDir.get().asFile
+        
+        // Ensure output directory exists
+        destDir.mkdirs()
+        
+        val tempFile = File(temporaryDir, "downloaded.zip")
+
+        logger.lifecycle("Fetching expected SHA256 from $shaUrl...")
+
+        // Grab the first sequence of non-whitespace characters (the hash itself)
+        val expectedHash = URL(shaUrl).readText().trim().split("\\s+".toRegex()).first()
+
+        logger.lifecycle("Downloading $url...")
+        var connection: HttpURLConnection? = null
+        val digest = MessageDigest.getInstance("SHA-256")
+
+        try {
+            connection = URL(url).openConnection() as HttpURLConnection
+            connection.connectTimeout = 30_000   // 30 seconds connect timeout
+            connection.readTimeout = 120_000     // 2 minutes read timeout for large files
+            
+            // Stream the download directly to a temp file while updating the digest
+            connection.inputStream.use { input ->
+                tempFile.outputStream().use { output ->
+                    val buffer = ByteArray(8192) // 8 KB buffer for efficient reading
+                    var bytesRead = input.read(buffer)
+                    while (bytesRead != -1) {
+                        output.write(buffer, 0, bytesRead)
+                        digest.update(buffer, 0, bytesRead)
+                        bytesRead = input.read(buffer)
+                    }
+                }
+            }
+        } finally {
+            connection?.disconnect() // Clean up hanging sockets
+        }
+
+        // Verify Checksum
+        val calculatedHash = digest.digest().joinToString("") { "%02x".format(it) } // Convert to hex string
+        check(calculatedHash.equals(expectedHash, ignoreCase = true)) {
+            tempFile.delete() // Nuke the bad file
+            "Security failure: Checksum mismatch for $url!\nExpected: $expectedHash\nGot:      $calculatedHash"
+        }
+
+        logger.lifecycle("Checksum verified! Extracting...")
+        
+        // Extract only the allowed .so files, flattening the directory structure
+        fsOps.copy {
+            from(archiveOps.zipTree(tempFile))
+            into(destDir)
+        
+            include("**/*.so")
+            eachFile {
+                if (validFiles.contains(name)) {
+                    // Flatten the directory structure
+                    relativePath = RelativePath(true, name)
+                } else {
+                    exclude()
+                }
+            }
+            includeEmptyDirs = false
+        }
+        
+        tempFile.delete()
+        logger.lifecycle("Successfully extracted to $destDir")
+    }
+}
+
+class NativeLibraryDownloadPlugin : Plugin<Project> {
+    override fun apply(project: Project) {
+        
+    }
+}

--- a/sdk/runanywhere-kotlin/modules/runanywhere-core-onnx/build.gradle.kts
+++ b/sdk/runanywhere-kotlin/modules/runanywhere-core-onnx/build.gradle.kts
@@ -168,7 +168,7 @@ val nativeLibVersion: String =
         ?: (System.getenv("SDK_VERSION")?.removePrefix("v") ?: "0.1.5-SNAPSHOT")
 
 val releaseBaseUrl = "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v$nativeLibVersion"
-val targetAbis = listOf("arm64-v8a", "armeabi-v7a", "x86_64")
+val targetAbis = listOf("arm64-v8a", "x86_64")
 val packageType = "RABackendONNX-android"
 val onnxLibs = listOf(
     "librac_backend_onnx.so",

--- a/sdk/runanywhere-kotlin/modules/runanywhere-core-onnx/build.gradle.kts
+++ b/sdk/runanywhere-kotlin/modules/runanywhere-core-onnx/build.gradle.kts
@@ -19,6 +19,7 @@
  */
 
 plugins {
+    id("com.runanywhere.native-downloader")
     alias(libs.plugins.kotlin.multiplatform)
     alias(libs.plugins.android.library)
     alias(libs.plugins.kotlin.serialization)
@@ -160,93 +161,47 @@ android {
     // Downloaded from RABackendONNX-android GitHub release assets, or built locally.
 }
 
-// Native lib version for downloads
+// Securely download native libraries from GitHub releases, with checksum verification and safe extraction
 val nativeLibVersion: String =
     rootProject.findProperty("runanywhere.nativeLibVersion")?.toString()
         ?: project.findProperty("runanywhere.nativeLibVersion")?.toString()
         ?: (System.getenv("SDK_VERSION")?.removePrefix("v") ?: "0.1.5-SNAPSHOT")
 
-// Download ONNX backend libs from GitHub releases (testLocal=false)
+val releaseBaseUrl = "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v$nativeLibVersion"
+val targetAbis = listOf("arm64-v8a", "armeabi-v7a", "x86_64")
+val packageType = "RABackendONNX-android"
+val onnxLibs = listOf(
+    "librac_backend_onnx.so",
+    "librac_backend_onnx_jni.so",
+    "libonnxruntime.so",
+    "libsherpa-onnx-c-api.so",
+    "libsherpa-onnx-cxx-api.so",
+    "libsherpa-onnx-jni.so"
+)
+
+// Create a secure download task for EACH architecture
+val downloadTasks = targetAbis.map { abi ->
+    val sanitizedAbiName = abi.replace("-", "_")
+    
+    tasks.register<com.runanywhere.buildlogic.DownloadAndVerifyNativeLibTask>("downloadJniLibs_$sanitizedAbiName") {
+        val packageName = "$packageType-$abi-v$nativeLibVersion.zip"
+        
+        downloadUrl.set("$releaseBaseUrl/$packageName")
+        expectedSha256Url.set("$releaseBaseUrl/$packageName.sha256")
+        outputDir.set(file("src/androidMain/jniLibs/$abi"))
+        allowedSoFiles.set(onnxLibs)
+
+        onlyIf { !testLocal }
+    }
+}
+
+// Aggregate task to download all ABIs
 tasks.register("downloadJniLibs") {
     group = "runanywhere"
     description = "Download ONNX backend JNI libraries from GitHub releases"
 
     onlyIf { !testLocal }
-
-    val outputDir = file("src/androidMain/jniLibs")
-    val tempDir = file("${layout.buildDirectory.get()}/jni-temp")
-
-    val releaseBaseUrl = "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v$nativeLibVersion"
-    val targetAbis = listOf("arm64-v8a", "armeabi-v7a", "x86_64")
-    val packageType = "RABackendONNX-android"
-
-    val onnxLibs = setOf(
-        "librac_backend_onnx.so",
-        "librac_backend_onnx_jni.so",
-        "libonnxruntime.so",
-        "libsherpa-onnx-c-api.so",
-        "libsherpa-onnx-cxx-api.so",
-        "libsherpa-onnx-jni.so",
-    )
-
-    outputs.dir(outputDir)
-
-    doLast {
-        val existingLibs = outputDir.walkTopDown().filter { it.extension == "so" }.count()
-        if (existingLibs > 0) {
-            logger.lifecycle("ONNX: Skipping download, $existingLibs .so files already present")
-            return@doLast
-        }
-
-        outputDir.deleteRecursively()
-        tempDir.deleteRecursively()
-        outputDir.mkdirs()
-        tempDir.mkdirs()
-
-        logger.lifecycle("ONNX Module: Downloading backend JNI libraries")
-
-        var totalDownloaded = 0
-
-        targetAbis.forEach { abi ->
-            val abiOutputDir = file("$outputDir/$abi")
-            abiOutputDir.mkdirs()
-
-            val packageName = "$packageType-$abi-v$nativeLibVersion.zip"
-            val zipUrl = "$releaseBaseUrl/$packageName"
-            val tempZip = file("$tempDir/$packageName")
-
-            logger.lifecycle("  Downloading: $packageName")
-
-            try {
-                ant.withGroovyBuilder {
-                    "get"("src" to zipUrl, "dest" to tempZip, "verbose" to false)
-                }
-
-                val extractDir = file("$tempDir/extracted-${packageName.replace(".zip", "")}")
-                extractDir.mkdirs()
-                ant.withGroovyBuilder {
-                    "unzip"("src" to tempZip, "dest" to extractDir)
-                }
-
-                extractDir
-                    .walkTopDown()
-                    .filter { it.extension == "so" && it.name in onnxLibs }
-                    .forEach { soFile ->
-                        val targetFile = file("$abiOutputDir/${soFile.name}")
-                        soFile.copyTo(targetFile, overwrite = true)
-                        logger.lifecycle("    ${soFile.name}")
-                        totalDownloaded++
-                    }
-
-                tempZip.delete()
-            } catch (e: Exception) {
-                logger.warn("  Failed to download $packageName: ${e.message}")
-            }
-        }
-
-        tempDir.deleteRecursively()
-        logger.lifecycle("ONNX: $totalDownloaded .so files downloaded")
-    }
+    dependsOn(downloadTasks)
 }
 
 tasks.matching { it.name.contains("merge") && it.name.contains("JniLibFolders") }.configureEach {

--- a/sdk/runanywhere-kotlin/settings.gradle.kts
+++ b/sdk/runanywhere-kotlin/settings.gradle.kts
@@ -1,4 +1,6 @@
 pluginManagement {
+    includeBuild("build-logic")
+    
     repositories {
         google {
             content {


### PR DESCRIPTION
## Description
Fixes #210. 

This PR secures the build-time native library download pipeline in the Kotlin SDK against supply-chain vulnerabilities and network hangs. 

**Key Changes:**
1. **Extracted Build Logic:** Created a new `build-logic` convention plugin to centralize the shared download logic via a custom `DownloadAndVerifyNativeLibTask`.
2. **Removed Unsafe Ant Tasks:** Replaced the legacy `ant.withGroovyBuilder` calls in `runanywhere-core-llamacpp` and `runanywhere-core-onnx`.
3. **Security & Timeouts:** Implemented `HttpURLConnection` with strict timeouts (30s connect / 120s read). The task now calculates the SHA256 hash *during* the stream and validates it against the expected `.sha256` release asset before extracting the binaries.
4. **Configuration Cache & Parallelism:** Replaced the monolithic, synchronous `doLast` blocks. By injecting `FileSystemOperations` and `ArchiveOperations` into a `DefaultTask` with `@Input` and `@OutputDirectory` annotations, Gradle can now safely cache these tasks, execute the ABI downloads in parallel, and fully support the Configuration Cache.
5. **Filtered Extraction:** Safely extracts only the explicitly permitted `.so` files, ignoring unnecessary `META-INF` or `LICENSE` files from the release archives.

> **Important Note for Maintainers:**
> The Kotlin SDK is now fully configured to fetch and verify the `.sha256` checksums before extraction. However, executing the task currently throws a `FileNotFoundException` because the GitHub Release assets (e.g., `v0.1.5-SNAPSHOT`) do not yet contain the `.sha256` files. Once the GitHub Actions release workflow is updated to generate and upload these checksums (as mentioned in the issue description), this task will automatically begin verifying them.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring

## Testing
- [x] Lint passes locally
- [x] Added/updated tests for changes *(Verified via `./gradlew buildEnvironment` and local task execution)*

### Platform-Specific Testing (check all that apply)
*(Note: These changes only affect the Gradle build system for the Kotlin SDK, not the runtime code)*

**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Playground:**
- [ ] Tested on target platform
- [ ] Verified no regressions in existing Playground projects

**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [x] `Kotlin SDK` - Changes to Kotlin SDK (`sdk/runanywhere-kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`sdk/runanywhere-flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`sdk/runanywhere-react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`sdk/runanywhere-web`)
- [ ] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

**Sample Apps:**
- [ ] `iOS Sample` - Changes to iOS example app (`examples/ios`)
- [ ] `Android Sample` - Changes to Android example app (`examples/android`)
- [ ] `Flutter Sample` - Changes to Flutter example app (`examples/flutter`)
- [ ] `React Native Sample` - Changes to React Native example app (`examples/react-native`)
- [ ] `Web Sample` - Changes to Web example app (`examples/web`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)

## Screenshots
N/A - Gradle Build System changes only.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Securely download native libraries in Kotlin SDK using a new plugin with checksum verification, replacing unsafe methods.
> 
>   - **Build Logic**:
>     - Introduced `build-logic` convention plugin with `DownloadAndVerifyNativeLibTask` for secure native library downloading.
>     - Uses `HttpURLConnection` with timeouts and SHA256 checksum verification.
>   - **Modules**:
>     - Updated `runanywhere-core-llamacpp` and `runanywhere-core-onnx` to use the new plugin for downloading native libraries.
>     - Removed legacy `ant.withGroovyBuilder` calls.
>   - **Tasks**:
>     - Added tasks for downloading JNI libraries for each architecture in `runanywhere-core-llamacpp` and `runanywhere-core-onnx`.
>     - Aggregated tasks to download all ABIs with checksum verification.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for 1c54218244924347a467423ead08fd7fcf0a9873. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Automated, per-ABI download and SHA-256 verification of native libraries.
  - Selective extraction of required native binaries into platform-specific folders.
  - Aggregate task to streamline fetching for all supported ABIs.

- Refactor
  - Replaced ad-hoc download/extract logic with dedicated, declarative build tasks.

- Chores
  - Added a reusable build plugin and composite build for centralized native library handling.
  - Updated build wiring so JNI-related steps trigger secure downloads when needed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Replaced unsafe `ant.withGroovyBuilder` download tasks with a centralized Gradle convention plugin that implements SHA256 checksum verification and connection timeouts. The new `DownloadAndVerifyNativeLibTask` downloads native libraries from GitHub releases, verifies their integrity, and extracts only permitted `.so` files.

**Key improvements:**
- SHA256 checksum verification during download stream
- HTTP timeouts (30s connect, 120s read) to prevent hangs
- Parallel ABI downloads with proper Gradle task inputs/outputs
- Configuration cache support
- Filtered extraction of whitelisted `.so` files

**Critical issues found:**
- File filtering logic has a bug where `exclude()` inside `eachFile` doesn't work, potentially extracting unwanted files
- Missing error handling for SHA256 file fetch will cause build failures when checksums aren't published
- SHA256 URL fetch has no timeout, creating potential hang
- ABI mismatch: downloads `armeabi-v7a` libraries that aren't included in `ndk.abiFilters`

<h3>Confidence Score: 2/5</h3>

- This PR requires significant fixes before merging due to critical logic bugs in the file filtering and error handling
- Score reflects three critical issues: the file filtering logic will fail to properly exclude unwanted files due to incorrect `exclude()` usage inside `eachFile`, the missing error handling will cause cryptic failures when SHA256 files don't exist (as acknowledged in the PR description), and the SHA256 fetch has no timeout protection. Additionally, there's an ABI configuration mismatch that wastes CI time downloading unused libraries
- Pay close attention to `NativeLibraryDownloadPlugin.kt` - the file filtering and error handling logic must be fixed before this can work correctly

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-kotlin/build-logic/src/main/kotlin/NativeLibraryDownloadPlugin.kt | Introduced secure download task with SHA256 verification, but has critical bugs: missing error handling for SHA256 fetch, incorrect file filtering logic with `exclude()` inside `eachFile`, and no timeout on checksum URL fetch |
| sdk/runanywhere-kotlin/modules/runanywhere-core-llamacpp/build.gradle.kts | Replaced unsafe ant tasks with new secure download plugin, but `targetAbis` includes `armeabi-v7a` which is not in `ndk.abiFilters`, causing unnecessary downloads of libraries that won't be packaged |
| sdk/runanywhere-kotlin/modules/runanywhere-core-onnx/build.gradle.kts | Replaced unsafe ant tasks with new secure download plugin, but `targetAbis` includes `armeabi-v7a` which is not in `ndk.abiFilters`, causing unnecessary downloads of libraries that won't be packaged |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    Start[Gradle Build Triggered] --> CheckLocal{testLocal flag?}
    CheckLocal -->|true| Skip[Skip download, use local libs]
    CheckLocal -->|false| ParallelDownload[Parallel ABI Downloads]
    
    ParallelDownload --> Arm64[downloadJniLibs_arm64_v8a]
    ParallelDownload --> ArmV7[downloadJniLibs_armeabi_v7a]
    ParallelDownload --> X64[downloadJniLibs_x86_64]
    
    Arm64 --> FetchSHA1[Fetch SHA256 from GitHub]
    ArmV7 --> FetchSHA2[Fetch SHA256 from GitHub]
    X64 --> FetchSHA3[Fetch SHA256 from GitHub]
    
    FetchSHA1 --> Download1[Download ZIP with timeouts]
    FetchSHA2 --> Download2[Download ZIP with timeouts]
    FetchSHA3 --> Download3[Download ZIP with timeouts]
    
    Download1 --> Verify1[Stream & calculate SHA256]
    Download2 --> Verify2[Stream & calculate SHA256]
    Download3 --> Verify3[Stream & calculate SHA256]
    
    Verify1 --> Check1{Checksum match?}
    Verify2 --> Check2{Checksum match?}
    Verify3 --> Check3{Checksum match?}
    
    Check1 -->|no| Fail1[Delete ZIP, throw error]
    Check2 -->|no| Fail2[Delete ZIP, throw error]
    Check3 -->|no| Fail3[Delete ZIP, throw error]
    
    Check1 -->|yes| Extract1[Extract whitelisted .so files]
    Check2 -->|yes| Extract2[Extract whitelisted .so files]
    Check3 -->|yes| Extract3[Extract whitelisted .so files]
    
    Extract1 --> Flatten1[Flatten to jniLibs/arm64-v8a]
    Extract2 --> Flatten2[Flatten to jniLibs/armeabi-v7a]
    Extract3 --> Flatten3[Flatten to jniLibs/x86_64]
    
    Flatten1 --> Merge[Gradle mergeJniLibFolders]
    Flatten2 --> Merge
    Flatten3 --> Merge
    Skip --> Merge
    
    Merge --> Build[Continue build]
```

<sub>Last reviewed commit: 1c54218</sub>

<!-- greptile_other_comments_section -->

<sub>(2/5) Greptile learns from your feedback when you react with thumbs up/down!</sub>

<!-- /greptile_comment -->