### PR TITLE
Smonga/whisper kit integration

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -277,22 +277,22 @@ func binaryTargets() -> [Target] {
             .binaryTarget(
                 name: "RACommonsBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RACommons-v\(sdkVersion).zip",
-                checksum: "93372c680f04fc02088044e4f2efc8c93e906a2a8a4983d8b2d8832a22d59c01"
+                checksum: "8ea58562a172ae24d805b1f582ce241981b9e1d812a0a6add538c6e44ab08d1a"
             ),
             .binaryTarget(
                 name: "RABackendLlamaCPPBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RABackendLLAMACPP-v\(sdkVersion).zip",
-                checksum: "f189fc03bc86bf4839ae743e857a09563633ca9fb3f449cc30e82fbec70840fe"
+                checksum: "8003da544b87e274ff11502c18ba8792788b898b727f45fcf9ec3671e985d52f"
             ),
             .binaryTarget(
                 name: "RABackendONNXBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RABackendONNX-v\(sdkVersion).zip",
-                checksum: "a3571b5c46057c55d61eac471a97fc6e4c92bc714afe2002b96c346551950ef9"
+                checksum: "4fd5dec6ae375d75984c9a1312e440ce185818d8a537b32e92cf8c84d4f5e003"
             ),
             .binaryTarget(
                 name: "ONNXRuntimeiOSBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/onnxruntime-ios-v\(sdkVersion).zip",
-                checksum: "9dbb6cfc8f65a9ff3f7351d01afb592698a7c0681b9c0006abdceaaac800ee4b"
+                checksum: "c0605841898d3f9e337010f4e5d25d12a905a32361725b0345579cba1f8b27e2"
             ),
             .binaryTarget(
                 name: "ONNXRuntimemacOSBinary",

--- a/Package.swift
+++ b/Package.swift
@@ -52,11 +52,9 @@ let package = Package(
     products: [
         // =================================================================
         // Core SDK - always needed
-        // Static to prevent SPM from embedding binary target stubs as dynamic frameworks
         // =================================================================
         .library(
             name: "RunAnywhere",
-            type: .static,
             targets: ["RunAnywhere"]
         ),
 
@@ -65,7 +63,6 @@ let package = Package(
         // =================================================================
         .library(
             name: "RunAnywhereONNX",
-            type: .static,
             targets: ["ONNXRuntime"]
         ),
 
@@ -74,7 +71,6 @@ let package = Package(
         // =================================================================
         .library(
             name: "RunAnywhereLlamaCPP",
-            type: .static,
             targets: ["LlamaCPPRuntime"]
         ),
 
@@ -83,7 +79,6 @@ let package = Package(
         // =================================================================
         .library(
             name: "RunAnywhereWhisperKit",
-            type: .static,
             targets: ["WhisperKitRuntime"]
         ),
     ],


### PR DESCRIPTION
## Description
Brief description of the changes made.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Playground:**
- [ ] Tested on target platform
- [ ] Verified no regressions in existing Playground projects
**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`sdk/runanywhere-kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`sdk/runanywhere-flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`sdk/runanywhere-react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`sdk/runanywhere-web`)
- [ ] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

**Sample Apps:**
- [ ] `iOS Sample` - Changes to iOS example app (`examples/ios`)
- [ ] `Android Sample` - Changes to Android example app (`examples/android`)
- [ ] `Flutter Sample` - Changes to Flutter example app (`examples/flutter`)
- [ ] `React Native Sample` - Changes to React Native example app (`examples/react-native`)
- [ ] `Web Sample` - Changes to Web example app (`examples/web`)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)

## Screenshots
Attach relevant UI screenshots for changes (if applicable):
- Mobile (Phone)
- Tablet / iPad
- Desktop / Mac

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Removed static library type and updated binary checksums in `Package.swift` for WhisperKit integration.
> 
>   - **Library Type Changes**:
>     - Removed `.static` type from libraries `RunAnywhere`, `RunAnywhereONNX`, `RunAnywhereLlamaCPP`, and `RunAnywhereWhisperKit` in `Package.swift`.
>   - **Binary Target Updates**:
>     - Updated checksums for `RACommonsBinary`, `RABackendLlamaCPPBinary`, `RABackendONNXBinary`, and `ONNXRuntimeiOSBinary` in `Package.swift`.
>   - **Integration**:
>     - Integrates WhisperKit by ensuring `RunAnywhereWhisperKit` is properly configured in `Package.swift`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for 4533a99882dd5a6ad3a6ad4c55e3cade49062489. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Reverted xcframework format changes from v0.19.5 to fix SPM linker errors by removing `type: .static` from all library products and updating to framework-format xcframeworks.

- Removed `type: .static` declarations from `RunAnywhere`, `RunAnywhereONNX`, `RunAnywhereLlamaCPP`, and `RunAnywhereWhisperKit` library products
- Updated checksums for all four binary targets (`RACommonsBinary`, `RABackendLlamaCPPBinary`, `RABackendONNXBinary`, `ONNXRuntimeiOSBinary`) to point to v0.19.5 framework-format xcframeworks
- Removed comment "Static to prevent SPM from embedding binary target stubs as dynamic frameworks" that no longer applies

This fix addresses linker errors where `type: .static` prevented binary target linker flags from being forwarded to consuming apps, causing "Undefined symbol: _rac_*" errors during archiving. The v0.19.5 release attempted to use library-format xcframeworks but this caused issues with remote SPM consumption.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with minimal risk - it reverts problematic changes from v0.19.5
- The changes are straightforward and fix a critical linker issue by reverting to a known working configuration. The commit messages clearly document the rationale, and only Package.swift checksums are updated to match newly released xcframeworks. However, thorough testing on both simulator and device with archiving is recommended to verify the linker errors are resolved.
- No files require special attention - the changes are limited to Package.swift configuration

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Package.swift | Removed `type: .static` from all library products and updated checksums for v0.19.5 xcframeworks to fix linker errors |

</details>



<sub>Last reviewed commit: 4533a99</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->