### PR TITLE
Complete RAG Flutter implementation (full state)

### DIFF
--- a/examples/flutter/RunAnywhereAI/lib/app/runanywhere_ai_app.dart
+++ b/examples/flutter/RunAnywhereAI/lib/app/runanywhere_ai_app.dart
@@ -10,8 +10,8 @@ import 'package:runanywhere_ai/core/design_system/app_spacing.dart';
 import 'package:runanywhere_ai/core/services/model_manager.dart';
 import 'package:runanywhere_ai/core/utilities/constants.dart';
 import 'package:runanywhere_ai/core/utilities/keychain_helper.dart';
+import 'package:runanywhere/public/extensions/rag_module.dart';
 import 'package:runanywhere_llamacpp/runanywhere_llamacpp.dart';
-import 'package:runanywhere_onnx/runanywhere_onnx.dart';
 
 /// RunAnywhereAIApp (mirroring iOS RunAnywhereAIApp.swift)
 ///
@@ -140,11 +140,8 @@ class _RunAnywhereAIAppState extends State<RunAnywhereAIApp> {
   Future<void> _registerModulesAndModels() async {
     debugPrint('📦 Registering modules with their models...');
 
-    // LlamaCPP module with LLM models
-    // Using explicit IDs ensures models are recognized after download across app restarts
+    // --- LLAMACPP MODULE ---
     await LlamaCpp.register();
-
-    // Yield after heavy backend registration
     await Future<void>.delayed(Duration.zero);
 
     LlamaCpp.addModel(
@@ -190,8 +187,6 @@ class _RunAnywhereAIAppState extends State<RunAnywhereAIApp> {
       memoryRequirement: 400000000,
     );
 
-    // Tool Calling Optimized Models
-    // LFM2-1.2B-Tool - Designed for concise and precise tool calling (Liquid AI)
     LlamaCpp.addModel(
       id: 'lfm2-1.2b-tool-q4_k_m',
       name: 'LiquidAI LFM2 1.2B Tool Q4_K_M',
@@ -206,16 +201,10 @@ class _RunAnywhereAIAppState extends State<RunAnywhereAIApp> {
           'https://huggingface.co/LiquidAI/LFM2-1.2B-Tool-GGUF/resolve/main/LFM2-1.2B-Tool-Q8_0.gguf',
       memoryRequirement: 1400000000,
     );
-    debugPrint('✅ LlamaCPP module registered with LLM models (including tool-calling optimized models)');
-
-    // Yield between module registrations
+    debugPrint('✅ LlamaCPP module registered');
     await Future<void>.delayed(Duration.zero);
 
-    // Register VLM (Vision Language) models
-    // VLM models require 2 files: main model + mmproj (vision projector)
-    // Bundled as tar.gz archives for easy download/extraction
-
-    // SmolVLM 500M - Ultra-lightweight VLM for mobile (~500MB total)
+    // --- VLM MODULE ---
     RunAnywhere.registerModel(
       id: 'smolvlm-500m-instruct-q8_0',
       name: 'SmolVLM 500M Instruct',
@@ -229,57 +218,81 @@ class _RunAnywhereAIAppState extends State<RunAnywhereAIApp> {
       memoryRequirement: 600000000,
     );
     debugPrint('✅ VLM models registered');
-
-    // Yield between module registrations
     await Future<void>.delayed(Duration.zero);
 
-    // Diffusion (image generation) is not registered here. CoreML diffusion is supported
-    // only in the Swift SDK and Swift example app; Flutter/RN do not register diffusion.
-
-    // ONNX module with STT and TTS models
-    // Using tar.gz format hosted on RunanywhereAI/sherpa-onnx for fast native extraction
-    // Using explicit IDs ensures models are recognized after download across app restarts
-    await Onnx.register();
-
-    // Yield after heavy backend registration
-    await Future<void>.delayed(Duration.zero);
-
+    // --- ONNX MODULE (STT/TTS via Core SDK) ---
     // STT Models (Sherpa-ONNX Whisper)
-    Onnx.addModel(
+    RunAnywhere.registerModel(
       id: 'sherpa-onnx-whisper-tiny.en',
       name: 'Sherpa Whisper Tiny (ONNX)',
-      url:
-          'https://github.com/RunanywhereAI/sherpa-onnx/releases/download/runanywhere-models-v1/sherpa-onnx-whisper-tiny.en.tar.gz',
+      url: Uri.parse('https://github.com/RunanywhereAI/sherpa-onnx/releases/download/runanywhere-models-v1/sherpa-onnx-whisper-tiny.en.tar.gz'),
+      framework: InferenceFramework.onnx,
       modality: ModelCategory.speechRecognition,
       memoryRequirement: 75000000,
     );
-    Onnx.addModel(
+
+    RunAnywhere.registerModel(
       id: 'sherpa-onnx-whisper-small.en',
       name: 'Sherpa Whisper Small (ONNX)',
-      url:
-          'https://github.com/RunanywhereAI/sherpa-onnx/releases/download/runanywhere-models-v1/sherpa-onnx-whisper-small.en.tar.gz',
+      url: Uri.parse('https://github.com/RunanywhereAI/sherpa-onnx/releases/download/runanywhere-models-v1/sherpa-onnx-whisper-small.en.tar.gz'),
+      framework: InferenceFramework.onnx,
       modality: ModelCategory.speechRecognition,
       memoryRequirement: 250000000,
     );
 
     // TTS Models (Piper VITS)
-    Onnx.addModel(
+    RunAnywhere.registerModel(
       id: 'vits-piper-en_US-lessac-medium',
       name: 'Piper TTS (US English - Medium)',
-      url:
-          'https://github.com/RunanywhereAI/sherpa-onnx/releases/download/runanywhere-models-v1/vits-piper-en_US-lessac-medium.tar.gz',
+      url: Uri.parse('https://github.com/RunanywhereAI/sherpa-onnx/releases/download/runanywhere-models-v1/vits-piper-en_US-lessac-medium.tar.gz'),
+      framework: InferenceFramework.onnx,
       modality: ModelCategory.speechSynthesis,
       memoryRequirement: 65000000,
     );
-    Onnx.addModel(
+
+    RunAnywhere.registerModel(
       id: 'vits-piper-en_GB-alba-medium',
       name: 'Piper TTS (British English)',
-      url:
-          'https://github.com/RunanywhereAI/sherpa-onnx/releases/download/runanywhere-models-v1/vits-piper-en_GB-alba-medium.tar.gz',
+      url: Uri.parse('https://github.com/RunanywhereAI/sherpa-onnx/releases/download/runanywhere-models-v1/vits-piper-en_GB-alba-medium.tar.gz'),
+      framework: InferenceFramework.onnx,
       modality: ModelCategory.speechSynthesis,
       memoryRequirement: 65000000,
     );
-    debugPrint('✅ ONNX module registered with STT/TTS models');
+    debugPrint('✅ STT/TTS models registered via Core SDK');
+    await Future<void>.delayed(Duration.zero);
+
+    // --- RAG EMBEDDINGS ---
+    RunAnywhere.registerMultiFileModel(
+      id: 'all-minilm-l6-v2',
+      name: 'All MiniLM L6 v2 (Embedding)',
+      files: [
+        ModelFileDescriptor(
+          relativePath: 'model.onnx',
+          destinationPath: 'model.onnx',
+          url: Uri.parse(
+              'https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/main/onnx/model.onnx'),
+        ),
+        ModelFileDescriptor(
+          relativePath: 'vocab.txt',
+          destinationPath: 'vocab.txt',
+          url: Uri.parse(
+              'https://huggingface.co/Xenova/all-MiniLM-L6-v2/resolve/main/vocab.txt'),
+        ),
+      ],
+      framework: InferenceFramework.onnx,
+      modality: ModelCategory.embedding,
+      memoryRequirement: 25500000,
+    );
+    debugPrint('✅ ONNX Embedding models registered');
+    await Future<void>.delayed(Duration.zero);
+
+    // --- RAG BACKEND ---
+    try {
+      await RAGModule.register();
+      debugPrint('✅ RAG backend registered');
+    } catch (e) {
+      debugPrint('⚠️ RAG backend not available (RAG features disabled): $e');
+    }
 
     debugPrint('🎉 All modules and models registered');
   }

--- a/examples/flutter/RunAnywhereAI/lib/features/chat/chat_interface_view.dart
+++ b/examples/flutter/RunAnywhereAI/lib/features/chat/chat_interface_view.dart
@@ -16,6 +16,7 @@ import 'package:runanywhere_ai/features/models/model_selection_sheet.dart';
 import 'package:runanywhere_ai/features/models/model_status_components.dart';
 import 'package:runanywhere_ai/features/models/model_types.dart';
 import 'package:runanywhere_ai/features/settings/tool_settings_view_model.dart';
+import 'package:runanywhere_ai/features/rag/rag_demo_view.dart';
 import 'package:runanywhere_ai/features/structured_output/structured_output_view.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 
@@ -454,6 +455,17 @@ class _ChatInterfaceViewState extends State<ChatInterfaceView> {
       appBar: AppBar(
         title: const Text('Chat'),
       actions: [
+          IconButton(
+            icon: const Icon(Icons.article_outlined),
+            onPressed: () {
+              Navigator.of(context).push<void>(
+                MaterialPageRoute<void>(
+                  builder: (context) => const RagDemoView(),
+                ),
+              );
+            },
+            tooltip: 'Document Q&A',
+          ),
           IconButton(
             icon: const Icon(Icons.data_object),
             onPressed: () {

--- a/examples/flutter/RunAnywhereAI/lib/features/models/model_list_view_model.dart
+++ b/examples/flutter/RunAnywhereAI/lib/features/models/model_list_view_model.dart
@@ -106,6 +106,8 @@ class ModelListViewModel extends ChangeNotifier {
         return ModelCategory.imageGeneration;
       case sdk.ModelCategory.audio:
         return ModelCategory.audio;
+      case sdk.ModelCategory.embedding:
+        return ModelCategory.embedding;
     }
   }
 

--- a/examples/flutter/RunAnywhereAI/lib/features/models/model_selection_sheet.dart
+++ b/examples/flutter/RunAnywhereAI/lib/features/models/model_selection_sheet.dart
@@ -507,8 +507,15 @@ class _ModelSelectionSheetState extends State<ModelSelectionSheet> {
     });
 
     try {
-      // Update view model selection state
-      await _viewModel.selectModel(model);
+      // RAG contexts record the selection only — do NOT pre-load into memory.
+      // The RAG pipeline loads models on demand when the document is ingested.
+      final isRagContext = widget.context == ModelSelectionContext.ragEmbedding ||
+          widget.context == ModelSelectionContext.ragLLM;
+
+      if (!isRagContext) {
+        // Update view model selection state (loads the model into memory)
+        await _viewModel.selectModel(model);
+      }
 
       // Call the callback - this is where the actual model loading happens
       // The callback knows the correct context and how to load the model

--- a/examples/flutter/RunAnywhereAI/lib/features/models/model_status_components.dart
+++ b/examples/flutter/RunAnywhereAI/lib/features/models/model_status_components.dart
@@ -251,6 +251,10 @@ class ModelRequiredOverlay extends StatelessWidget {
         return Icons.mic;
       case ModelSelectionContext.vlm:
         return Icons.center_focus_strong;
+      case ModelSelectionContext.ragEmbedding:
+        return Icons.data_object;
+      case ModelSelectionContext.ragLLM:
+        return Icons.question_answer_outlined;
     }
   }
 
@@ -266,6 +270,10 @@ class ModelRequiredOverlay extends StatelessWidget {
         return 'Voice Assistant';
       case ModelSelectionContext.vlm:
         return 'Vision Language Model';
+      case ModelSelectionContext.ragEmbedding:
+        return 'Document RAG';
+      case ModelSelectionContext.ragLLM:
+        return 'Document RAG';
     }
   }
 
@@ -281,6 +289,10 @@ class ModelRequiredOverlay extends StatelessWidget {
         return 'Voice assistant requires multiple models. Let\'s set them up together.';
       case ModelSelectionContext.vlm:
         return 'Select a vision-language model to analyze images. Point your camera or pick a photo to get AI descriptions.';
+      case ModelSelectionContext.ragEmbedding:
+        return 'Select an embedding model to encode document chunks for retrieval.';
+      case ModelSelectionContext.ragLLM:
+        return 'Select a language model to generate answers from retrieved document context.';
     }
   }
 }

--- a/examples/flutter/RunAnywhereAI/lib/features/models/model_types.dart
+++ b/examples/flutter/RunAnywhereAI/lib/features/models/model_types.dart
@@ -124,7 +124,9 @@ enum ModelSelectionContext {
   stt,
   tts,
   voice,
-  vlm;
+  vlm,
+  ragEmbedding,
+  ragLLM;
 
   String get title {
     switch (this) {
@@ -138,6 +140,10 @@ enum ModelSelectionContext {
         return 'Select Model';
       case ModelSelectionContext.vlm:
         return 'Select VLM Model';
+      case ModelSelectionContext.ragEmbedding:
+        return 'Select Embedding Model';
+      case ModelSelectionContext.ragLLM:
+        return 'Select LLM Model';
     }
   }
 
@@ -158,6 +164,10 @@ enum ModelSelectionContext {
         };
       case ModelSelectionContext.vlm:
         return {ModelCategory.vision, ModelCategory.multimodal};
+      case ModelSelectionContext.ragEmbedding:
+        return {ModelCategory.embedding};
+      case ModelSelectionContext.ragLLM:
+        return {ModelCategory.language};
     }
   }
 }

--- a/examples/flutter/RunAnywhereAI/lib/features/rag/document_service.dart
+++ b/examples/flutter/RunAnywhereAI/lib/features/rag/document_service.dart
@@ -1,0 +1,79 @@
+// Document Service
+//
+// Utility for extracting plain text from PDF and JSON files.
+// Used to prepare document content for RAG ingestion.
+
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:syncfusion_flutter_pdf/pdf.dart';
+
+// MARK: - DocumentService
+
+/// Extracts plain text from PDF and JSON files.
+///
+/// Supports:
+/// - PDF — All page text concatenated with newlines (via syncfusion_flutter_pdf).
+/// - JSON — Raw UTF-8 file content returned as-is.
+class DocumentService {
+  // Private constructor — static-only class.
+  DocumentService._();
+
+  /// Extract plain text from a file at [filePath].
+  ///
+  /// Determines the document type from the file extension.
+  ///
+  /// Throws [UnsupportedError] for unsupported file extensions.
+  /// Throws [Exception] if the file cannot be read or parsed.
+  static Future<String> extractText(String filePath) async {
+    final extension = filePath.split('.').last.toLowerCase();
+
+    switch (extension) {
+      case 'pdf':
+        return _extractPDFText(filePath);
+      case 'json':
+        return _extractJSONText(filePath);
+      default:
+        throw UnsupportedError(
+          'Unsupported document format: .$extension. Only PDF and JSON files are supported.',
+        );
+    }
+  }
+
+  // MARK: - Private Helpers
+
+  static Future<String> _extractPDFText(String filePath) async {
+    final file = File(filePath);
+    final bytes = await file.readAsBytes();
+
+    final document = PdfDocument(inputBytes: bytes);
+    final extractor = PdfTextExtractor(document);
+
+    final buffer = StringBuffer();
+    final pageCount = document.pages.count;
+
+    for (var i = 0; i < pageCount; i++) {
+      final pageText = extractor.extractText(startPageIndex: i, endPageIndex: i);
+      if (pageText.trim().isNotEmpty) {
+        if (buffer.isNotEmpty) buffer.write('\n');
+        buffer.write(pageText);
+      }
+    }
+
+    document.dispose();
+
+    final result = buffer.toString();
+    if (result.isEmpty) {
+      throw Exception(
+        'Failed to extract text from PDF. The file may be corrupted or image-only.',
+      );
+    }
+
+    return result;
+  }
+
+  static Future<String> _extractJSONText(String filePath) async {
+    final file = File(filePath);
+    return file.readAsString(encoding: utf8);
+  }
+}

--- a/examples/flutter/RunAnywhereAI/lib/features/rag/rag_demo_view.dart
+++ b/examples/flutter/RunAnywhereAI/lib/features/rag/rag_demo_view.dart
@@ -1,0 +1,859 @@
+// RAG Demo View
+//
+// Full-screen RAG document Q&A UI.
+// Mirrors iOS DocumentRAGView.swift adapted for Material Design.
+// Allows model selection, document ingestion, chat Q&A with expandable
+// retrieved chunks and timing metrics.
+
+import 'dart:async';
+import 'dart:io';
+
+import 'package:file_picker/file_picker.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:runanywhere/public/types/rag_types.dart';
+
+import 'package:runanywhere_ai/core/design_system/app_colors.dart';
+import 'package:runanywhere_ai/core/design_system/app_spacing.dart';
+import 'package:runanywhere_ai/core/design_system/typography.dart';
+import 'package:runanywhere_ai/features/models/model_selection_sheet.dart';
+import 'package:runanywhere_ai/features/models/model_types.dart';
+import 'package:runanywhere_ai/features/rag/rag_view_model.dart';
+
+/// RagDemoView — Full-page RAG document Q&A screen.
+///
+/// Entry point: pushed from Chat tab AppBar via Navigator.push.
+/// Manages its own [RAGViewModel] lifecycle.
+class RagDemoView extends StatefulWidget {
+  const RagDemoView({super.key});
+
+  @override
+  State<RagDemoView> createState() => _RagDemoViewState();
+}
+
+class _RagDemoViewState extends State<RagDemoView> {
+  final RAGViewModel _viewModel = RAGViewModel();
+  final ScrollController _scrollController = ScrollController();
+  final TextEditingController _questionController = TextEditingController();
+
+  ModelInfo? _selectedEmbeddingModel;
+  ModelInfo? _selectedLLMModel;
+
+  // MARK: - Computed
+
+  bool get _areModelsReady =>
+      _selectedEmbeddingModel?.localPath != null &&
+      _selectedLLMModel?.localPath != null;
+
+  // MARK: - Lifecycle
+
+  @override
+  void initState() {
+    super.initState();
+    _viewModel.addListener(_onViewModelChanged);
+  }
+
+  @override
+  void dispose() {
+    _viewModel.removeListener(_onViewModelChanged);
+    _viewModel.dispose();
+    _scrollController.dispose();
+    _questionController.dispose();
+    super.dispose();
+  }
+
+  void _onViewModelChanged() {
+    // Sync question controller with view model (for external clears)
+    if (_viewModel.currentQuestion != _questionController.text) {
+      // Only sync when viewModel clears the field (askQuestion resets it)
+      if (_viewModel.currentQuestion.isEmpty) {
+        _questionController.clear();
+      }
+    }
+    // Auto-scroll on new messages
+    _scrollToBottom();
+  }
+
+  // MARK: - Path Resolution (mirrors iOS exactly)
+
+  /// Resolve the actual embedding model file path.
+  ///
+  /// Multi-file models store localPath as a directory containing model.onnx.
+  String _resolveEmbeddingFilePath(String localPath) {
+    if (Directory(localPath).existsSync()) {
+      return '$localPath/model.onnx';
+    }
+    return localPath;
+  }
+
+  /// Resolve the actual LLM model file path.
+  ///
+  /// Single-file LlamaCpp models live inside a directory — find the first .gguf file.
+  String _resolveLLMFilePath(String localPath) {
+    if (!Directory(localPath).existsSync()) {
+      return localPath;
+    }
+    final dir = Directory(localPath);
+    final ggufFile = dir
+        .listSync()
+        .whereType<File>()
+        .firstWhere(
+          (f) => f.path.toLowerCase().endsWith('.gguf'),
+          orElse: () => File(localPath),
+        );
+    return ggufFile.path;
+  }
+
+  /// Resolve the vocab.txt path for the embedding model.
+  ///
+  /// For multi-file models (directory) vocab.txt is inside the directory.
+  /// For single-file models vocab.txt is a sibling file.
+  String? _resolveVocabPath(ModelInfo embeddingModel) {
+    final localPath = embeddingModel.localPath;
+    if (localPath == null) return null;
+
+    if (Directory(localPath).existsSync()) {
+      return '$localPath/vocab.txt';
+    }
+    // Single-file: sibling vocab.txt
+    final parent = File(localPath).parent.path;
+    return '$parent/vocab.txt';
+  }
+
+  /// Build a [RAGConfiguration] from selected models with resolved paths.
+  RAGConfiguration? _buildRagConfig() {
+    final embeddingPath = _selectedEmbeddingModel?.localPath;
+    final llmPath = _selectedLLMModel?.localPath;
+    if (embeddingPath == null || llmPath == null) return null;
+
+    final vocabPath = _resolveVocabPath(_selectedEmbeddingModel!);
+    final embeddingConfigJson =
+        vocabPath != null ? '{"vocab_path":"$vocabPath"}' : null;
+
+    return RAGConfiguration(
+      embeddingModelPath: _resolveEmbeddingFilePath(embeddingPath),
+      llmModelPath: _resolveLLMFilePath(llmPath),
+      embeddingConfigJSON: embeddingConfigJson,
+    );
+  }
+
+  // MARK: - Actions
+
+  void _showEmbeddingModelSheet() {
+    unawaited(showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => ModelSelectionSheet(
+        context: ModelSelectionContext.ragEmbedding,
+        onModelSelected: (model) async {
+          // RAG model selection does NOT pre-load into memory — just record selection
+          setState(() {
+            _selectedEmbeddingModel = model;
+          });
+        },
+      ),
+    ));
+  }
+
+  void _showLLMModelSheet() {
+    unawaited(showModalBottomSheet<void>(
+      context: context,
+      isScrollControlled: true,
+      useSafeArea: true,
+      builder: (_) => ModelSelectionSheet(
+        context: ModelSelectionContext.ragLLM,
+        onModelSelected: (model) async {
+          // RAG model selection does NOT pre-load into memory — just record selection
+          setState(() {
+            _selectedLLMModel = model;
+          });
+        },
+      ),
+    ));
+  }
+
+  Future<void> _pickDocument() async {
+    try {
+      final result = await FilePicker.platform.pickFiles(
+        type: FileType.custom,
+        allowedExtensions: ['pdf', 'json'],
+      );
+      if (result == null || result.files.isEmpty) return;
+      final filePath = result.files.first.path;
+      if (filePath == null) return;
+
+      final ragConfig = _buildRagConfig();
+      if (ragConfig == null) return;
+
+      await _viewModel.loadDocument(filePath, ragConfig);
+    } catch (e) {
+      _viewModel.error = 'Failed to pick file: $e';
+    }
+  }
+
+  Future<void> _changeDocument() async {
+    await _viewModel.clearDocument();
+    await _pickDocument();
+  }
+
+  void _sendQuestion() {
+    if (!_viewModel.canAskQuestion) return;
+    unawaited(_viewModel.askQuestion());
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        unawaited(_scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: AppLayout.animationFast,
+          curve: Curves.easeOut,
+        ));
+      }
+    });
+  }
+
+  // MARK: - Build
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Document Q&A'),
+      ),
+      body: ListenableBuilder(
+        listenable: _viewModel,
+        builder: (context, _) {
+          return Column(
+            children: [
+              _buildModelSetupSection(),
+              const Divider(height: 1),
+              _buildDocumentStatusBar(),
+              const Divider(height: 1),
+              if (_viewModel.error != null) _buildErrorBanner(),
+              Expanded(child: _buildMessagesArea()),
+              _buildInputBar(),
+            ],
+          );
+        },
+      ),
+    );
+  }
+
+  // MARK: - Model Setup Section
+
+  Widget _buildModelSetupSection() {
+    return Container(
+      color: AppColors.backgroundPrimary(context),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.large,
+        vertical: AppSpacing.mediumLarge,
+      ),
+      child: Column(
+        children: [
+          _buildModelPickerRow(
+            label: 'Embedding Model',
+            icon: Icons.psychology_outlined,
+            model: _selectedEmbeddingModel,
+            onTap: _showEmbeddingModelSheet,
+          ),
+          const SizedBox(height: AppSpacing.smallMedium),
+          _buildModelPickerRow(
+            label: 'LLM Model',
+            icon: Icons.chat_bubble_outline,
+            model: _selectedLLMModel,
+            onTap: _showLLMModelSheet,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildModelPickerRow({
+    required String label,
+    required IconData icon,
+    required ModelInfo? model,
+    required VoidCallback onTap,
+  }) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(AppSpacing.cornerRadiusRegular),
+      child: Padding(
+        padding: const EdgeInsets.symmetric(vertical: AppSpacing.xSmall),
+        child: Row(
+          children: [
+            Icon(
+              icon,
+              size: AppSpacing.iconRegular,
+              color: AppColors.textSecondary(context),
+            ),
+            const SizedBox(width: AppSpacing.mediumLarge),
+            Text(
+              label,
+              style: AppTypography.subheadline(context).copyWith(
+                color: AppColors.textSecondary(context),
+              ),
+            ),
+            const Spacer(),
+            if (model != null) ...[
+              Flexible(
+                child: Text(
+                  model.name,
+                  style: AppTypography.subheadline(context).copyWith(
+                    fontWeight: FontWeight.w500,
+                  ),
+                  overflow: TextOverflow.ellipsis,
+                  maxLines: 1,
+                ),
+              ),
+              const SizedBox(width: AppSpacing.xSmall),
+              const Icon(
+                Icons.check_circle,
+                size: AppSpacing.iconRegular,
+                color: AppColors.primaryGreen,
+              ),
+            ] else ...[
+              Text(
+                'Not selected',
+                style: AppTypography.subheadline(context).copyWith(
+                  color: AppColors.primaryAccent,
+                ),
+              ),
+              const SizedBox(width: AppSpacing.xSmall),
+              Icon(
+                Icons.chevron_right,
+                size: AppSpacing.iconRegular,
+                color: AppColors.textSecondary(context),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  // MARK: - Document Status Bar
+
+  Widget _buildDocumentStatusBar() {
+    if (_viewModel.isLoadingDocument) {
+      return _buildLoadingStatus();
+    }
+    if (_viewModel.isDocumentLoaded && _viewModel.documentName != null) {
+      return _buildLoadedStatus(_viewModel.documentName!);
+    }
+    return _buildNoDocumentStatus();
+  }
+
+  Widget _buildNoDocumentStatus() {
+    return Container(
+      color: AppColors.backgroundPrimary(context),
+      padding: const EdgeInsets.all(AppSpacing.large),
+      child: Center(
+        child: ElevatedButton.icon(
+          onPressed: _areModelsReady ? _pickDocument : null,
+          icon: const Icon(Icons.add_to_photos_outlined),
+          label: const Text('Select Document'),
+          style: ElevatedButton.styleFrom(
+            padding: const EdgeInsets.symmetric(
+              horizontal: AppSpacing.xLarge,
+              vertical: AppSpacing.mediumLarge,
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildLoadingStatus() {
+    return Container(
+      color: AppColors.backgroundPrimary(context),
+      padding: const EdgeInsets.all(AppSpacing.large),
+      child: Row(
+        mainAxisAlignment: MainAxisAlignment.center,
+        children: [
+          const SizedBox(
+            width: 18,
+            height: 18,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          const SizedBox(width: AppSpacing.mediumLarge),
+          Text(
+            'Loading document...',
+            style: AppTypography.subheadline(context).copyWith(
+              color: AppColors.textSecondary(context),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildLoadedStatus(String documentName) {
+    return Container(
+      color: AppColors.backgroundPrimary(context),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.large,
+        vertical: AppSpacing.mediumLarge,
+      ),
+      child: Row(
+        children: [
+          const Icon(
+            Icons.check_circle,
+            color: AppColors.primaryGreen,
+            size: AppSpacing.iconRegular + 4,
+          ),
+          const SizedBox(width: AppSpacing.mediumLarge),
+          Expanded(
+            child: Text(
+              documentName,
+              style: AppTypography.subheadline(context).copyWith(
+                fontWeight: FontWeight.w500,
+              ),
+              overflow: TextOverflow.ellipsis,
+              maxLines: 1,
+            ),
+          ),
+          TextButton(
+            onPressed: _changeDocument,
+            child: Text(
+              'Change',
+              style: AppTypography.caption(context).copyWith(
+                color: AppColors.primaryAccent,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // MARK: - Error Banner
+
+  Widget _buildErrorBanner() {
+    return Container(
+      margin: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.large,
+        vertical: AppSpacing.smallMedium,
+      ),
+      padding: const EdgeInsets.symmetric(
+        horizontal: AppSpacing.mediumLarge,
+        vertical: AppSpacing.smallMedium,
+      ),
+      decoration: BoxDecoration(
+        color: AppColors.primaryRed.withValues(alpha: 0.1),
+        borderRadius:
+            BorderRadius.circular(AppSpacing.cornerRadiusRegular),
+      ),
+      child: Row(
+        children: [
+          const Icon(
+            Icons.warning_amber_rounded,
+            color: AppColors.primaryRed,
+            size: AppSpacing.iconRegular,
+          ),
+          const SizedBox(width: AppSpacing.mediumLarge),
+          Expanded(
+            child: Text(
+              _viewModel.error!,
+              style: AppTypography.caption(context).copyWith(
+                color: AppColors.primaryRed,
+              ),
+              maxLines: 2,
+              overflow: TextOverflow.ellipsis,
+            ),
+          ),
+          IconButton(
+            icon: const Icon(Icons.close, size: AppSpacing.iconRegular),
+            onPressed: () => _viewModel.error = null,
+            color: AppColors.textSecondary(context),
+            padding: EdgeInsets.zero,
+            constraints: const BoxConstraints(),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // MARK: - Messages Area
+
+  Widget _buildMessagesArea() {
+    final messages = _viewModel.messages;
+
+    if (messages.isEmpty) {
+      return _buildEmptyState();
+    }
+
+    return GestureDetector(
+      onTap: () => FocusScope.of(context).unfocus(),
+      behavior: HitTestBehavior.opaque,
+      child: ListView.builder(
+        controller: _scrollController,
+        padding: const EdgeInsets.symmetric(
+          horizontal: AppSpacing.large,
+          vertical: AppSpacing.large,
+        ),
+        itemCount: messages.length + (_viewModel.isQuerying ? 1 : 0),
+        itemBuilder: (context, index) {
+          if (index == messages.length && _viewModel.isQuerying) {
+            return _buildQueryingIndicator();
+          }
+          return _RAGMessageBubble(message: messages[index]);
+        },
+      ),
+    );
+  }
+
+  Widget _buildEmptyState() {
+    final String title;
+    final String subtitle;
+    if (_viewModel.isDocumentLoaded) {
+      title = 'Document loaded';
+      subtitle = 'Ask a question below to get started';
+    } else if (!_areModelsReady) {
+      title = 'Select models to get started';
+      subtitle =
+          'Choose an embedding model and an LLM model above, then pick a document';
+    } else {
+      title = 'No document selected';
+      subtitle = 'Pick a PDF or JSON document to start asking questions';
+    }
+
+    return Center(
+      child: Padding(
+        padding: const EdgeInsets.all(AppSpacing.xxxLarge),
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.find_in_page_outlined,
+              size: AppSpacing.iconXXLarge,
+              color: AppColors.textSecondary(context),
+            ),
+            const SizedBox(height: AppSpacing.large),
+            Text(
+              title,
+              style: AppTypography.headline(context),
+              textAlign: TextAlign.center,
+            ),
+            const SizedBox(height: AppSpacing.smallMedium),
+            Text(
+              subtitle,
+              style: AppTypography.subheadline(context).copyWith(
+                color: AppColors.textSecondary(context),
+              ),
+              textAlign: TextAlign.center,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildQueryingIndicator() {
+    return Padding(
+      padding: const EdgeInsets.only(bottom: AppSpacing.large),
+      child: Row(
+        children: [
+          const SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(strokeWidth: 2),
+          ),
+          const SizedBox(width: AppSpacing.smallMedium),
+          Text(
+            'Searching document...',
+            style: AppTypography.caption(context).copyWith(
+              color: AppColors.textSecondary(context),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  // MARK: - Input Bar
+
+  Widget _buildInputBar() {
+    final canSend = _viewModel.canAskQuestion;
+    final isQuerying = _viewModel.isQuerying;
+    final isDocumentLoaded = _viewModel.isDocumentLoaded;
+
+    return Container(
+      padding: const EdgeInsets.all(AppSpacing.large),
+      decoration: BoxDecoration(
+        color: AppColors.backgroundPrimary(context),
+        boxShadow: [
+          BoxShadow(
+            color: AppColors.shadowLight,
+            blurRadius: AppSpacing.shadowLarge,
+            offset: const Offset(0, -2),
+          ),
+        ],
+      ),
+      child: SafeArea(
+        child: Row(
+          children: [
+            Expanded(
+              child: TextField(
+                controller: _questionController,
+                maxLines: 4,
+                minLines: 1,
+                enabled: isDocumentLoaded && !isQuerying,
+                textInputAction: TextInputAction.send,
+                decoration: InputDecoration(
+                  hintText: 'Ask a question...',
+                  border: OutlineInputBorder(
+                    borderRadius:
+                        BorderRadius.circular(AppSpacing.cornerRadiusBubble),
+                  ),
+                  contentPadding: const EdgeInsets.symmetric(
+                    horizontal: AppSpacing.large,
+                    vertical: AppSpacing.mediumLarge,
+                  ),
+                ),
+                onChanged: (value) => _viewModel.currentQuestion = value,
+                onSubmitted: (_) => _sendQuestion(),
+              ),
+            ),
+            const SizedBox(width: AppSpacing.smallMedium),
+            IconButton.filled(
+              onPressed: canSend ? _sendQuestion : null,
+              icon: isQuerying
+                  ? const SizedBox(
+                      width: 20,
+                      height: 20,
+                      child: CircularProgressIndicator(
+                        color: Colors.white,
+                        strokeWidth: 2,
+                      ),
+                    )
+                  : const Icon(Icons.arrow_upward),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+// MARK: - RAG Message Bubble
+
+/// Chat bubble widget for a single RAG conversation message.
+///
+/// User messages: right-aligned blue gradient bubble.
+/// Assistant messages: left-aligned gray bubble with timing metrics and
+/// expandable retrieved-chunks section.
+class _RAGMessageBubble extends StatefulWidget {
+  final RAGMessage message;
+
+  const _RAGMessageBubble({required this.message});
+
+  @override
+  State<_RAGMessageBubble> createState() => _RAGMessageBubbleState();
+}
+
+class _RAGMessageBubbleState extends State<_RAGMessageBubble> {
+  bool _showChunks = false;
+
+  bool get _isUser => widget.message.role == RAGMessageRole.user;
+
+  @override
+  Widget build(BuildContext context) {
+    return Align(
+      alignment: _isUser ? Alignment.centerRight : Alignment.centerLeft,
+      child: Container(
+        margin: const EdgeInsets.only(bottom: AppSpacing.mediumLarge),
+        constraints: BoxConstraints(
+          maxWidth: MediaQuery.of(context).size.width * 0.78,
+        ),
+        child: Column(
+          crossAxisAlignment:
+              _isUser ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+          children: [
+            // Main bubble
+            Container(
+              padding: const EdgeInsets.symmetric(
+                horizontal: AppSpacing.mediumLarge,
+                vertical: AppSpacing.smallMedium,
+              ),
+              decoration: BoxDecoration(
+                gradient: _isUser
+                    ? LinearGradient(
+                        begin: Alignment.topLeft,
+                        end: Alignment.bottomRight,
+                        colors: [
+                          AppColors.userBubbleGradientStart,
+                          AppColors.userBubbleGradientEnd,
+                        ],
+                      )
+                    : null,
+                color: _isUser ? null : AppColors.backgroundGray5(context),
+                borderRadius:
+                    BorderRadius.circular(AppSpacing.cornerRadiusBubble),
+                boxShadow: [
+                  BoxShadow(
+                    color: AppColors.shadowLight,
+                    blurRadius: AppSpacing.shadowSmall,
+                    offset: const Offset(0, 1),
+                  ),
+                ],
+              ),
+              child: _isUser
+                  ? Text(
+                      widget.message.text,
+                      style: AppTypography.body(context).copyWith(
+                        color: AppColors.textWhite,
+                      ),
+                    )
+                  : MarkdownBody(
+                      data: widget.message.text,
+                      styleSheet: MarkdownStyleSheet(
+                        p: AppTypography.body(context),
+                        code: AppTypography.monospaced.copyWith(
+                          backgroundColor:
+                              AppColors.backgroundGray6(context),
+                        ),
+                      ),
+                    ),
+            ),
+
+            // Timing metrics (assistant only, always visible when result available)
+            if (!_isUser && widget.message.result != null)
+              _buildTimingMetrics(context, widget.message.result!),
+
+            // Expandable chunks section (assistant only)
+            if (!_isUser &&
+                widget.message.result != null &&
+                widget.message.result!.retrievedChunks.isNotEmpty)
+              _buildChunksSection(context, widget.message.result!),
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildTimingMetrics(BuildContext context, RAGResult result) {
+    final retrievalMs = result.retrievalTimeMs.round();
+    final generationS = (result.generationTimeMs / 1000).toStringAsFixed(1);
+    final totalS = (result.totalTimeMs / 1000).toStringAsFixed(1);
+
+    return Padding(
+      padding: const EdgeInsets.only(top: AppSpacing.xSmall),
+      child: Text(
+        'Retrieved: ${retrievalMs}ms  Generated: ${generationS}s  Total: ${totalS}s',
+        style: AppTypography.caption(context).copyWith(
+          color: AppColors.textSecondary(context),
+        ),
+      ),
+    );
+  }
+
+  Widget _buildChunksSection(BuildContext context, RAGResult result) {
+    final count = result.retrievedChunks.length;
+
+    return Padding(
+      padding: const EdgeInsets.only(top: AppSpacing.smallMedium),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Toggle button
+          GestureDetector(
+            onTap: () => setState(() => _showChunks = !_showChunks),
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Icon(
+                  Icons.format_quote,
+                  size: AppSpacing.iconRegular,
+                  color: AppColors.primaryAccent,
+                ),
+                const SizedBox(width: AppSpacing.xSmall),
+                Text(
+                  _showChunks ? 'Hide chunks' : 'Show $count chunk${count == 1 ? '' : 's'}',
+                  style: AppTypography.caption(context).copyWith(
+                    color: AppColors.primaryAccent,
+                  ),
+                ),
+                Icon(
+                  _showChunks
+                      ? Icons.keyboard_arrow_up
+                      : Icons.keyboard_arrow_down,
+                  size: AppSpacing.iconRegular,
+                  color: AppColors.primaryAccent,
+                ),
+              ],
+            ),
+          ),
+
+          // Expanded chunk list
+          if (_showChunks) ...[
+            const SizedBox(height: AppSpacing.xSmall),
+            ...result.retrievedChunks.map(
+              (chunk) => _buildChunkCard(context, chunk),
+            ),
+          ],
+        ],
+      ),
+    );
+  }
+
+  Widget _buildChunkCard(BuildContext context, RAGSearchResult chunk) {
+    const maxSnippetLength = 200;
+    final snippet = chunk.text.length > maxSnippetLength
+        ? '${chunk.text.substring(0, maxSnippetLength)}...'
+        : chunk.text;
+    final scorePercent =
+        (chunk.similarityScore * 100).toStringAsFixed(1);
+
+    return Container(
+      margin: const EdgeInsets.only(top: AppSpacing.xSmall),
+      padding: const EdgeInsets.all(AppSpacing.smallMedium),
+      decoration: BoxDecoration(
+        color: AppColors.backgroundGray6(context),
+        borderRadius:
+            BorderRadius.circular(AppSpacing.cornerRadiusRegular),
+        border: Border.all(
+          color: AppColors.borderMedium,
+        ),
+      ),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          // Similarity score badge
+          Row(
+            mainAxisAlignment: MainAxisAlignment.end,
+            children: [
+              Container(
+                padding: const EdgeInsets.symmetric(
+                  horizontal: AppSpacing.small,
+                  vertical: AppSpacing.xxSmall,
+                ),
+                decoration: BoxDecoration(
+                  color: AppColors.badgeBlue,
+                  borderRadius: BorderRadius.circular(
+                      AppSpacing.cornerRadiusSmall),
+                ),
+                child: Text(
+                  '$scorePercent%',
+                  style: AppTypography.caption2(context).copyWith(
+                    color: AppColors.primaryBlue,
+                    fontWeight: FontWeight.w600,
+                  ),
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(height: AppSpacing.xxSmall),
+          // Chunk text snippet
+          Text(
+            snippet,
+            style: AppTypography.caption(context).copyWith(
+              color: AppColors.textSecondary(context),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/examples/flutter/RunAnywhereAI/lib/features/rag/rag_view_model.dart
+++ b/examples/flutter/RunAnywhereAI/lib/features/rag/rag_view_model.dart
@@ -1,0 +1,171 @@
+// RAG View Model
+//
+// ViewModel for the RAG feature. Orchestrates document loading,
+// text extraction, SDK pipeline lifecycle, and query flow.
+// Mirrors iOS RAGViewModel.swift adapted for Flutter ChangeNotifier pattern.
+
+import 'dart:io';
+
+import 'package:flutter/foundation.dart';
+import 'package:runanywhere/public/extensions/runanywhere_rag.dart';
+import 'package:runanywhere/public/types/rag_types.dart';
+
+import 'package:runanywhere_ai/features/rag/document_service.dart';
+
+// MARK: - Message Role
+
+enum RAGMessageRole { user, assistant }
+
+// MARK: - RAG Message
+
+/// A single message in the RAG conversation.
+///
+/// User messages contain only text. Assistant messages also carry
+/// the [RAGResult] for displaying retrieved chunks and timing info.
+class RAGMessage {
+  final RAGMessageRole role;
+  final String text;
+
+  /// The RAG result associated with this assistant message.
+  /// Null for user messages and error messages.
+  final RAGResult? result;
+
+  const RAGMessage({
+    required this.role,
+    required this.text,
+    this.result,
+  });
+}
+
+// MARK: - RAG View Model
+
+/// ViewModel managing the full RAG pipeline lifecycle, document state, and query flow.
+///
+/// Mirrors iOS RAGViewModel.swift. Exposes observable state via ChangeNotifier
+/// for use with Flutter's ListenableBuilder / ChangeNotifierProvider.
+class RAGViewModel extends ChangeNotifier {
+  // MARK: - Document State
+
+  String? _documentName;
+  String? get documentName => _documentName;
+
+  bool _isDocumentLoaded = false;
+  bool get isDocumentLoaded => _isDocumentLoaded;
+
+  bool _isLoadingDocument = false;
+  bool get isLoadingDocument => _isLoadingDocument;
+
+  // MARK: - Query State
+
+  List<RAGMessage> _messages = [];
+  List<RAGMessage> get messages => List.unmodifiable(_messages);
+
+  bool _isQuerying = false;
+  bool get isQuerying => _isQuerying;
+
+  /// Settable from the view layer to surface file-picker failures.
+  String? _error;
+  String? get error => _error;
+  set error(String? value) {
+    _error = value;
+    notifyListeners();
+  }
+
+  // MARK: - Input
+
+  String _currentQuestion = '';
+  String get currentQuestion => _currentQuestion;
+  set currentQuestion(String value) {
+    _currentQuestion = value;
+    notifyListeners();
+  }
+
+  // MARK: - Last Result
+
+  RAGResult? _lastResult;
+  RAGResult? get lastResult => _lastResult;
+
+  // MARK: - Computed Properties
+
+  bool get canAskQuestion =>
+      _isDocumentLoaded &&
+      !_isQuerying &&
+      _currentQuestion.trim().isNotEmpty;
+
+  // MARK: - Public Methods
+
+  /// Load a document: extract text, create RAG pipeline, ingest text.
+  ///
+  /// [filePath] - Absolute path to the document (PDF or JSON).
+  /// [config] - RAG pipeline configuration with model paths and tuning parameters.
+  Future<void> loadDocument(String filePath, RAGConfiguration config) async {
+    _isLoadingDocument = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      final extractedText = await DocumentService.extractText(filePath);
+
+      await RunAnywhereRAG.ragCreatePipeline(config);
+      await RunAnywhereRAG.ragIngest(extractedText);
+
+      _documentName = File(filePath).uri.pathSegments.last;
+      _isDocumentLoaded = true;
+    } catch (e) {
+      _error = e.toString();
+    } finally {
+      _isLoadingDocument = false;
+      notifyListeners();
+    }
+  }
+
+  /// Query the loaded document with the current question.
+  ///
+  /// Appends the user question and the assistant answer to [messages].
+  /// Guards against empty questions and unloaded documents.
+  Future<void> askQuestion() async {
+    final question = _currentQuestion.trim();
+    if (question.isEmpty) return;
+    if (!_isDocumentLoaded) return;
+
+    _messages = [..._messages, RAGMessage(role: RAGMessageRole.user, text: question)];
+    _currentQuestion = '';
+    _isQuerying = true;
+    _error = null;
+    notifyListeners();
+
+    try {
+      final result = await RunAnywhereRAG.ragQuery(question);
+
+      _messages = [
+        ..._messages,
+        RAGMessage(role: RAGMessageRole.assistant, text: result.answer, result: result),
+      ];
+      _lastResult = result;
+    } catch (e) {
+      _error = e.toString();
+      _messages = [
+        ..._messages,
+        RAGMessage(role: RAGMessageRole.assistant, text: 'Error: $e'),
+      ];
+    } finally {
+      _isQuerying = false;
+      notifyListeners();
+    }
+  }
+
+  /// Clear the loaded document and destroy the RAG pipeline.
+  ///
+  /// Resets all document and conversation state.
+  Future<void> clearDocument() async {
+    await RunAnywhereRAG.ragDestroyPipeline();
+
+    _documentName = null;
+    _isDocumentLoaded = false;
+    _messages = [];
+    _error = null;
+    _currentQuestion = '';
+    _lastResult = null;
+    notifyListeners();
+  }
+}

--- a/examples/flutter/RunAnywhereAI/pubspec.yaml
+++ b/examples/flutter/RunAnywhereAI/pubspec.yaml
@@ -13,9 +13,7 @@ dependencies:
   # RunAnywhere SDK - Core
   runanywhere:
     path: ../../../sdk/runanywhere-flutter/packages/runanywhere
-  # RunAnywhere SDK - ONNX Backend (STT, TTS, VAD, LLM)
-  runanywhere_onnx:
-    path: ../../../sdk/runanywhere-flutter/packages/runanywhere_onnx
+    
   # RunAnywhere SDK - LlamaCpp Backend (LLM)
   runanywhere_llamacpp:
     path: ../../../sdk/runanywhere-flutter/packages/runanywhere_llamacpp
@@ -45,6 +43,10 @@ dependencies:
   image_picker: ^1.0.0
   # Image manipulation (BGRA to RGB pixel conversion)
   image: ^4.0.0
+  # File picker for PDF/JSON document selection (RAG)
+  file_picker: ^8.0.0
+  # PDF text extraction (RAG)
+  syncfusion_flutter_pdf: ^27.1.48
 
 dev_dependencies:
   flutter_test:

--- a/sdk/runanywhere-flutter/packages/runanywhere/android/binary_config.gradle
+++ b/sdk/runanywhere-flutter/packages/runanywhere/android/binary_config.gradle
@@ -17,24 +17,28 @@ ext {
     // Version Configuration (MUST match Swift Package.swift and Kotlin build.gradle.kts)
     // =============================================================================
     commonsVersion = "0.1.6"
+    coreVersion = "0.1.6"
 
     // =============================================================================
     // Remote binary URLs
     // RACommons from runanywhere-sdks (NOT runanywhere-binaries)
+    // RABackendRAG from runanywhere-sdks
     // =============================================================================
     commonsGitHubOrg = "RunanywhereAI"
     commonsRepo = "runanywhere-sdks"
     commonsBaseUrl = "https://github.com/${commonsGitHubOrg}/${commonsRepo}/releases/download"
+    binariesBaseUrl = "https://github.com/${commonsGitHubOrg}/${commonsRepo}/releases/download"
 
-    // Android native libraries package
+    // Android native libraries packages
     commonsAndroidUrl = "${commonsBaseUrl}/commons-v${commonsVersion}/RACommons-android-v${commonsVersion}.zip"
+    ragAndroidUrl = "${binariesBaseUrl}/commons-v${coreVersion}/RABackendRAG-android-v${coreVersion}.zip"
 
     // Helper method to check if we should download
     shouldDownloadAndroidLibs = { ->
         return !testLocal
     }
 
-    // Helper method to check if local libs exist
+    // Helper method to check if local RACommons libs exist
     checkLocalLibsExist = { ->
         def jniLibsDir = project.file('src/main/jniLibs')
         def arm64Dir = new File(jniLibsDir, 'arm64-v8a')
@@ -46,5 +50,19 @@ ext {
         // Check for RACommons library
         def commonsLib = new File(arm64Dir, 'librac_commons.so')
         return commonsLib.exists()
+    }
+
+    // Helper method to check if local RAG libs exist
+    checkLocalRagLibsExist = { ->
+        def jniLibsDir = project.file('src/main/jniLibs')
+        def arm64Dir = new File(jniLibsDir, 'arm64-v8a')
+
+        if (!arm64Dir.exists() || !arm64Dir.isDirectory()) {
+            return false
+        }
+
+        // Check for RAG backend library
+        def ragLib = new File(arm64Dir, 'librac_backend_rag.so')
+        return ragLib.exists()
     }
 }

--- a/sdk/runanywhere-flutter/packages/runanywhere/android/build.gradle
+++ b/sdk/runanywhere-flutter/packages/runanywhere/android/build.gradle
@@ -1,7 +1,8 @@
 // RunAnywhere Core SDK - Android
 //
-// This plugin bundles RACommons native libraries (.so files) for Android.
+// This plugin bundles RACommons and RABackendRAG native libraries (.so files) for Android.
 // RACommons provides the core infrastructure for on-device AI capabilities.
+// RABackendRAG provides the RAG pipeline for document ingestion and querying.
 //
 // Binary Configuration:
 //   Edit binary_config.gradle to toggle between local and remote binaries:
@@ -96,7 +97,7 @@ def calculateChecksum(File file) {
 }
 
 // =============================================================================
-// Binary Download Task (runs when testLocal = false)
+// Binary Download Task: RACommons (runs when testLocal = false)
 // =============================================================================
 task downloadNativeLibs {
     group = 'runanywhere'
@@ -180,5 +181,91 @@ task downloadNativeLibs {
     }
 }
 
-// Run downloadNativeLibs before preBuild
+// =============================================================================
+// Binary Download Task: RABackendRAG (runs when testLocal = false)
+// =============================================================================
+task downloadRagNativeLibs {
+    group = 'runanywhere'
+    description = 'Download RABackendRAG native libraries from GitHub releases'
+
+    doLast {
+        if (shouldDownloadAndroidLibs()) {
+            println "📦 Remote mode: Downloading RABackendRAG Android native libraries..."
+
+            def jniLibsDir = file('build/jniLibs')
+            jniLibsDir.mkdirs()
+
+            // Ensure build directory exists
+            buildDir.mkdirs()
+
+            def downloadUrl = ragAndroidUrl
+            def zipFile = file("${buildDir}/rag-android.zip")
+
+            println "Downloading from: ${downloadUrl}"
+
+            // Download the zip file
+            ant.get(src: downloadUrl, dest: zipFile)
+
+            println "✅ Downloaded successfully"
+
+            // Extract to temp directory first
+            def tempDir = file("${buildDir}/rag-temp")
+            if (tempDir.exists()) {
+                delete(tempDir)
+            }
+            tempDir.mkdirs()
+
+            copy {
+                from zipTree(zipFile)
+                into tempDir
+            }
+
+            // Common libs that should NOT be duplicated (they're in the core SDK via downloadNativeLibs)
+            def commonLibs = ['libc++_shared.so', 'librac_commons.so', 'librac_commons_jni.so']
+
+            // Copy .so files from jniLibs structure (excluding common libs)
+            tempDir.eachFileRecurse { file ->
+                if (file.isDirectory() && file.name in ['arm64-v8a', 'armeabi-v7a', 'x86_64', 'x86']) {
+                    def targetAbiDir = new File(jniLibsDir, file.name)
+                    targetAbiDir.mkdirs()
+                    file.eachFile { soFile ->
+                        if (soFile.name.endsWith('.so') && !(soFile.name in commonLibs)) {
+                            copy {
+                                from soFile
+                                into targetAbiDir
+                            }
+                            println "  ✓ ${file.name}/${soFile.name}"
+                        }
+                    }
+                }
+            }
+
+            // Clean up
+            zipFile.delete()
+            if (tempDir.exists()) {
+                delete(tempDir)
+            }
+
+            println "✅ RABackendRAG native libraries downloaded successfully"
+        } else {
+            println "🔧 Local mode: Using RAG native libraries from src/main/jniLibs/"
+
+            if (!checkLocalRagLibsExist()) {
+                throw new GradleException("""
+                    ⚠️  RAG native libraries not found in src/main/jniLibs/!
+                    For local mode, please build and copy the libraries:
+                      1. cd runanywhere-commons && ./scripts/build-android.sh --rag
+                      2. Copy the .so files to packages/runanywhere/android/src/main/jniLibs/
+                    Or switch to remote mode by editing binary_config.gradle:
+                      testLocal = false
+                """)
+            } else {
+                println "✅ Using local RAG native libraries"
+            }
+        }
+    }
+}
+
+// Run downloadNativeLibs and downloadRagNativeLibs before preBuild
 preBuild.dependsOn downloadNativeLibs
+preBuild.dependsOn downloadRagNativeLibs

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/core/types/model_types.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/core/types/model_types.dart
@@ -59,7 +59,8 @@ enum ModelCategory {
   vision('vision', 'Vision Model'),
   imageGeneration('image-generation', 'Image Generation'),
   multimodal('multimodal', 'Multimodal'),
-  audio('audio', 'Audio Processing');
+  audio('audio', 'Audio Processing'),
+  embedding('embedding', 'Embedding Model');
 
   final String rawValue;
   final String displayName;
@@ -219,22 +220,32 @@ class ExpectedModelFiles {
       Object.hash(requiredPatterns.length, optionalPatterns.length);
 }
 
-/// Describes a file that needs to be downloaded as part of a multi-file model
+/// Describes a file that needs to be downloaded as part of a multi-file model.
+///
+/// Matches Swift ModelFileDescriptor from Public/Extensions/Models/ModelTypes.swift.
 class ModelFileDescriptor {
   final String relativePath;
   final String destinationPath;
   final bool isRequired;
 
+  /// The individual download URL for this file.
+  ///
+  /// When set, the download service fetches this specific URL instead of deriving
+  /// the URL from the parent model's downloadURL.
+  final Uri? url;
+
   const ModelFileDescriptor({
     required this.relativePath,
     required this.destinationPath,
     this.isRequired = true,
+    this.url,
   });
 
   Map<String, dynamic> toJson() => {
         'relativePath': relativePath,
         'destinationPath': destinationPath,
         'isRequired': isRequired,
+        if (url != null) 'url': url.toString(),
       };
 
   factory ModelFileDescriptor.fromJson(Map<String, dynamic> json) {
@@ -242,6 +253,7 @@ class ModelFileDescriptor {
       relativePath: json['relativePath'] as String,
       destinationPath: json['destinationPath'] as String,
       isRequired: json['isRequired'] as bool? ?? true,
+      url: json['url'] != null ? Uri.parse(json['url'] as String) : null,
     );
   }
 }

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/infrastructure/events/event_publisher.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/infrastructure/events/event_publisher.dart
@@ -96,6 +96,9 @@ class EventPublisher {
       case EventCategory.vad:
         _trackVADEvent(event);
         break;
+      case EventCategory.rag:
+        // RAG events are logged locally but not sent to telemetry
+        break;
       case EventCategory.network:
       case EventCategory.error:
         // These are logged but not sent to telemetry

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_model_registry.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_model_registry.dart
@@ -234,6 +234,8 @@ class DartBridgeModelRegistry {
         return 5; // RAC_MODEL_CATEGORY_MULTIMODAL
       case public_types.ModelCategory.audio:
         return 6; // RAC_MODEL_CATEGORY_AUDIO
+      case public_types.ModelCategory.embedding:
+        return 7; // RAC_MODEL_CATEGORY_EMBEDDING
     }
   }
 
@@ -311,6 +313,8 @@ class DartBridgeModelRegistry {
         return public_types.ModelCategory.multimodal;
       case 6:
         return public_types.ModelCategory.audio;
+      case 7:
+        return public_types.ModelCategory.embedding;
       default:
         return public_types.ModelCategory.language;
     }

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_rag.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_rag.dart
@@ -1,0 +1,391 @@
+/// DartBridge+RAG
+///
+/// RAG pipeline bridge - manages C++ RAG pipeline lifecycle.
+/// Mirrors Swift's CppBridge+RAG.swift pattern exactly.
+///
+/// This is a thin wrapper around C++ RAG pipeline functions.
+/// All business logic is in C++ - Dart only manages the pipeline handle.
+///
+/// MEMORY SAFETY:
+/// String pointers are freed in finally blocks.
+/// Query results are copied to Dart objects before rac_rag_result_free is called.
+library dart_bridge_rag;
+
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+
+import 'package:runanywhere/foundation/logging/sdk_logger.dart';
+import 'package:runanywhere/native/ffi_types.dart';
+import 'package:runanywhere/native/platform_loader.dart';
+
+/// RAG pipeline bridge for C++ interop.
+///
+/// Provides access to the C++ RAG pipeline.
+/// Handles pipeline lifecycle, document management, and query operations.
+///
+/// Matches Swift's CppBridge.RAG actor pattern.
+///
+/// Usage:
+/// ```dart
+/// DartBridgeRAG.registerBackend();
+/// final rag = DartBridgeRAG.shared;
+/// rag.createPipeline(config: myConfig);
+/// rag.addDocument('My document text');
+/// final result = rag.query(queryStruct);
+/// ```
+class DartBridgeRAG {
+  // MARK: - Singleton
+
+  /// Shared instance
+  static final DartBridgeRAG shared = DartBridgeRAG._();
+
+  DartBridgeRAG._();
+
+  // MARK: - State (matches Swift CppBridge.RAG exactly)
+
+  Pointer<Void>? _pipeline; // rac_rag_pipeline_t* (opaque)
+  final _logger = SDKLogger('DartBridge.RAG');
+
+  // MARK: - Pipeline Lifecycle
+
+  /// Create the RAG pipeline with configuration.
+  ///
+  /// [config] - Pointer to a populated RacRagConfigStruct.
+  ///
+  /// Throws if pipeline creation fails.
+  void createPipeline({required Pointer<RacRagConfigStruct> config}) {
+    final pipelinePtr = calloc<Pointer<Void>>();
+    try {
+      final lib = PlatformLoader.loadCommons();
+      final createFn = lib.lookupFunction<RacRagPipelineCreateNative,
+          RacRagPipelineCreateDart>('rac_rag_pipeline_create');
+
+      final result = createFn(config, pipelinePtr);
+      if (result != RAC_SUCCESS || pipelinePtr.value == nullptr) {
+        throw StateError(
+          'Failed to create RAG pipeline: ${RacResultCode.getMessage(result)}',
+        );
+      }
+
+      _pipeline = pipelinePtr.value;
+      _logger.debug('RAG pipeline created');
+    } finally {
+      calloc.free(pipelinePtr);
+    }
+  }
+
+  /// Check if the pipeline has been created.
+  bool get isCreated => _pipeline != null;
+
+  /// Destroy the pipeline and release native resources.
+  void destroy() {
+    final pipeline = _pipeline;
+    if (pipeline == null) return;
+
+    try {
+      final lib = PlatformLoader.loadCommons();
+      final destroyFn = lib.lookupFunction<RacRagPipelineDestroyNative,
+          RacRagPipelineDestroyDart>('rac_rag_pipeline_destroy');
+
+      destroyFn(pipeline);
+      _pipeline = null;
+      _logger.debug('RAG pipeline destroyed');
+    } catch (e) {
+      _logger.error('Failed to destroy RAG pipeline: $e');
+    }
+  }
+
+  // MARK: - Document Management
+
+  /// Add a document to the RAG pipeline.
+  ///
+  /// The document will be split into chunks, embedded, and indexed.
+  ///
+  /// [text] - Document text content.
+  /// [metadataJSON] - Optional JSON metadata string.
+  ///
+  /// Throws if pipeline is not created or document addition fails.
+  void addDocument(String text, {String? metadataJSON}) {
+    final pipeline = _pipeline;
+    if (pipeline == null) {
+      throw StateError('RAG pipeline not created. Call createPipeline() first.');
+    }
+
+    final textPtr = text.toNativeUtf8();
+    final metaPtr = metadataJSON?.toNativeUtf8();
+
+    try {
+      final lib = PlatformLoader.loadCommons();
+      final addDocFn = lib.lookupFunction<RacRagAddDocumentNative,
+          RacRagAddDocumentDart>('rac_rag_add_document');
+
+      final result = addDocFn(
+        pipeline,
+        textPtr,
+        metaPtr ?? nullptr,
+      );
+
+      if (result != RAC_SUCCESS) {
+        throw StateError(
+          'Failed to add document to RAG pipeline: ${RacResultCode.getMessage(result)}',
+        );
+      }
+    } finally {
+      calloc.free(textPtr);
+      if (metaPtr != null) calloc.free(metaPtr);
+    }
+  }
+
+  /// Clear all documents from the pipeline.
+  ///
+  /// Throws if pipeline is not created or clear operation fails.
+  void clearDocuments() {
+    final pipeline = _pipeline;
+    if (pipeline == null) {
+      throw StateError('RAG pipeline not created. Call createPipeline() first.');
+    }
+
+    final lib = PlatformLoader.loadCommons();
+    final clearFn = lib.lookupFunction<RacRagClearDocumentsNative,
+        RacRagClearDocumentsDart>('rac_rag_clear_documents');
+
+    final result = clearFn(pipeline);
+    if (result != RAC_SUCCESS) {
+      throw StateError(
+        'Failed to clear RAG documents: ${RacResultCode.getMessage(result)}',
+      );
+    }
+  }
+
+  /// Get the number of indexed document chunks.
+  ///
+  /// Returns 0 if pipeline is not created.
+  int get documentCount {
+    final pipeline = _pipeline;
+    if (pipeline == null) return 0;
+
+    try {
+      final lib = PlatformLoader.loadCommons();
+      final countFn = lib.lookupFunction<RacRagGetDocumentCountNative,
+          RacRagGetDocumentCountDart>('rac_rag_get_document_count');
+
+      return countFn(pipeline);
+    } catch (e) {
+      _logger.debug('documentCount check failed: $e');
+      return 0;
+    }
+  }
+
+  // MARK: - Query
+
+  /// Query the RAG pipeline.
+  ///
+  /// Retrieves relevant chunks and generates an answer.
+  /// C memory is freed before returning — result is copied into a Dart object.
+  ///
+  /// [question] - User question string.
+  /// [systemPrompt] - Optional system prompt override.
+  /// [maxTokens] - Max tokens to generate (default 512).
+  /// [temperature] - Sampling temperature (default 0.7).
+  /// [topP] - Nucleus sampling (default 0.9).
+  /// [topK] - Top-k sampling (default 40).
+  ///
+  /// Throws if pipeline is not created or query fails.
+  RAGBridgeResult query(
+    String question, {
+    String? systemPrompt,
+    int maxTokens = 512,
+    double temperature = 0.7,
+    double topP = 0.9,
+    int topK = 40,
+  }) {
+    final pipeline = _pipeline;
+    if (pipeline == null) {
+      throw StateError('RAG pipeline not created. Call createPipeline() first.');
+    }
+
+    final questionPtr = question.toNativeUtf8();
+    final systemPromptPtr = systemPrompt?.toNativeUtf8();
+    final queryPtr = calloc<RacRagQueryStruct>();
+    final resultPtr = calloc<RacRagResultStruct>();
+
+    final lib = PlatformLoader.loadCommons();
+    final queryFn =
+        lib.lookupFunction<RacRagQueryNative, RacRagQueryDart>('rac_rag_query');
+    final freeFn = lib.lookupFunction<RacRagResultFreeNative,
+        RacRagResultFreeDart>('rac_rag_result_free');
+
+    var queryExecuted = false;
+
+    try {
+      // Populate query struct
+      queryPtr.ref.question = questionPtr;
+      queryPtr.ref.systemPrompt = systemPromptPtr ?? nullptr;
+      queryPtr.ref.maxTokens = maxTokens;
+      queryPtr.ref.temperature = temperature;
+      queryPtr.ref.topP = topP;
+      queryPtr.ref.topK = topK;
+
+      final status = queryFn(pipeline, queryPtr, resultPtr);
+      queryExecuted = true;
+      if (status != RAC_SUCCESS) {
+        throw StateError(
+          'RAG query failed: ${RacResultCode.getMessage(status)}',
+        );
+      }
+
+      // Copy result data to Dart objects BEFORE freeing
+      final dartResult = RAGBridgeResult._fromStruct(resultPtr.ref);
+
+      return dartResult;
+    } finally {
+      // Free C result memory if query was executed (even if _fromStruct throws)
+      if (queryExecuted) {
+        freeFn(resultPtr);
+      }
+
+      calloc.free(questionPtr);
+      if (systemPromptPtr != null) calloc.free(systemPromptPtr);
+      calloc.free(queryPtr);
+      calloc.free(resultPtr);
+    }
+  }
+
+  // MARK: - Backend Registration
+
+  /// Register the RAG backend module.
+  ///
+  /// Must be called before using any RAG functionality.
+  /// Returns RAC_SUCCESS (0) on success, error code otherwise.
+  static int registerBackend() {
+    try {
+      final lib = PlatformLoader.loadCommons();
+      final registerFn = lib.lookupFunction<RacBackendRagRegisterNative,
+          RacBackendRagRegisterDart>('rac_backend_rag_register');
+
+      return registerFn();
+    } catch (e) {
+      // Graceful degradation if RAG backend is not available
+      return RacResultCode.errorModuleNotFound;
+    }
+  }
+
+  /// Unregister the RAG backend module.
+  ///
+  /// Returns RAC_SUCCESS (0) on success, error code otherwise.
+  static int unregisterBackend() {
+    try {
+      final lib = PlatformLoader.loadCommons();
+      final unregisterFn = lib.lookupFunction<RacBackendRagUnregisterNative,
+          RacBackendRagUnregisterDart>('rac_backend_rag_unregister');
+
+      return unregisterFn();
+    } catch (e) {
+      // Graceful degradation if RAG backend is not available
+      return RacResultCode.errorModuleNotFound;
+    }
+  }
+}
+
+// =============================================================================
+// Dart-side Result Objects (safe copies of C memory)
+// =============================================================================
+
+/// A single retrieved chunk from vector search.
+///
+/// Safe Dart copy of rac_search_result_t — C memory has already been freed.
+class RAGBridgeSearchResult {
+  /// Chunk ID
+  final String chunkId;
+
+  /// Chunk text content
+  final String text;
+
+  /// Cosine similarity score (0.0–1.0)
+  final double similarityScore;
+
+  /// JSON metadata (may be empty)
+  final String metadataJson;
+
+  const RAGBridgeSearchResult({
+    required this.chunkId,
+    required this.text,
+    required this.similarityScore,
+    required this.metadataJson,
+  });
+
+  /// Copy fields from a native RacSearchResultStruct.
+  factory RAGBridgeSearchResult._fromStruct(RacSearchResultStruct s) {
+    return RAGBridgeSearchResult(
+      chunkId: s.chunkId != nullptr ? s.chunkId.toDartString() : '',
+      text: s.text != nullptr ? s.text.toDartString() : '',
+      similarityScore: s.similarityScore,
+      metadataJson: s.metadataJson != nullptr ? s.metadataJson.toDartString() : '',
+    );
+  }
+
+  @override
+  String toString() =>
+      'RAGBridgeSearchResult(chunkId: $chunkId, score: $similarityScore)';
+}
+
+/// The result of a RAG query.
+///
+/// Safe Dart copy of rac_rag_result_t — C memory has already been freed.
+class RAGBridgeResult {
+  /// Generated answer text
+  final String answer;
+
+  /// Retrieved chunks used as context
+  final List<RAGBridgeSearchResult> retrievedChunks;
+
+  /// Full context text sent to the LLM
+  final String contextUsed;
+
+  /// Time taken for retrieval phase (ms)
+  final double retrievalTimeMs;
+
+  /// Time taken for LLM generation (ms)
+  final double generationTimeMs;
+
+  /// Total query time (ms)
+  final double totalTimeMs;
+
+  const RAGBridgeResult({
+    required this.answer,
+    required this.retrievedChunks,
+    required this.contextUsed,
+    required this.retrievalTimeMs,
+    required this.generationTimeMs,
+    required this.totalTimeMs,
+  });
+
+  /// Copy fields from a native RacRagResultStruct.
+  ///
+  /// Call this BEFORE freeing the C result with rac_rag_result_free.
+  factory RAGBridgeResult._fromStruct(RacRagResultStruct s) {
+    final chunks = <RAGBridgeSearchResult>[];
+
+    if (s.retrievedChunks != nullptr && s.numChunks > 0) {
+      for (var i = 0; i < s.numChunks; i++) {
+        final chunkRef = (s.retrievedChunks + i).ref;
+        chunks.add(RAGBridgeSearchResult._fromStruct(chunkRef));
+      }
+    }
+
+    return RAGBridgeResult(
+      answer: s.answer != nullptr ? s.answer.toDartString() : '',
+      retrievedChunks: chunks,
+      contextUsed: s.contextUsed != nullptr ? s.contextUsed.toDartString() : '',
+      retrievalTimeMs: s.retrievalTimeMs,
+      generationTimeMs: s.generationTimeMs,
+      totalTimeMs: s.totalTimeMs,
+    );
+  }
+
+  @override
+  String toString() =>
+      'RAGBridgeResult(answer: ${answer.substring(0, answer.length.clamp(0, 50))}..., '
+      'chunks: ${retrievedChunks.length}, totalTimeMs: $totalTimeMs)';
+}

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/ffi_types.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/ffi_types.dart
@@ -1228,6 +1228,184 @@ final class RacStructuredOutputValidationStruct extends Struct {
 }
 
 // =============================================================================
+// RAG Pipeline API Types (from rac_rag_pipeline.h and rac_rag.h)
+// =============================================================================
+
+/// RAG pipeline configuration struct matching rac_rag_config_t
+base class RacRagConfigStruct extends Struct {
+  /// Path to embedding model (ONNX)
+  external Pointer<Utf8> embeddingModelPath;
+
+  /// Path to LLM model (GGUF)
+  external Pointer<Utf8> llmModelPath;
+
+  /// Embedding dimension (default 384 for all-MiniLM-L6-v2)
+  @IntPtr()
+  external int embeddingDimension;
+
+  /// Number of top chunks to retrieve (default 3)
+  @IntPtr()
+  external int topK;
+
+  /// Minimum similarity threshold 0.0-1.0 (default 0.7)
+  @Float()
+  external double similarityThreshold;
+
+  /// Maximum tokens for context (default 2048)
+  @IntPtr()
+  external int maxContextTokens;
+
+  /// Tokens per chunk when splitting documents (default 512)
+  @IntPtr()
+  external int chunkSize;
+
+  /// Overlap tokens between chunks (default 50)
+  @IntPtr()
+  external int chunkOverlap;
+
+  /// Prompt template with {context} and {query} placeholders
+  external Pointer<Utf8> promptTemplate;
+
+  /// Configuration JSON for embedding model (optional)
+  external Pointer<Utf8> embeddingConfigJson;
+
+  /// Configuration JSON for LLM model (optional)
+  external Pointer<Utf8> llmConfigJson;
+}
+
+/// RAG query parameters struct matching rac_rag_query_t
+base class RacRagQueryStruct extends Struct {
+  /// User question
+  external Pointer<Utf8> question;
+
+  /// Optional system prompt override
+  external Pointer<Utf8> systemPrompt;
+
+  /// Max tokens to generate (default 512)
+  @Int32()
+  external int maxTokens;
+
+  /// Sampling temperature (default 0.7)
+  @Float()
+  external double temperature;
+
+  /// Nucleus sampling (default 0.9)
+  @Float()
+  external double topP;
+
+  /// Top-k sampling (default 40)
+  @Int32()
+  external int topK;
+}
+
+/// Search result from vector retrieval matching rac_search_result_t
+base class RacSearchResultStruct extends Struct {
+  /// Chunk ID (caller must free)
+  external Pointer<Utf8> chunkId;
+
+  /// Chunk text (caller must free)
+  external Pointer<Utf8> text;
+
+  /// Cosine similarity (0.0-1.0)
+  @Float()
+  external double similarityScore;
+
+  /// Metadata JSON (caller must free)
+  external Pointer<Utf8> metadataJson;
+}
+
+/// RAG result with answer and context matching rac_rag_result_t
+base class RacRagResultStruct extends Struct {
+  /// Generated answer (caller must free via rac_rag_result_free)
+  external Pointer<Utf8> answer;
+
+  /// Retrieved chunks (caller must free via rac_rag_result_free)
+  external Pointer<RacSearchResultStruct> retrievedChunks;
+
+  /// Number of chunks retrieved
+  @IntPtr()
+  external int numChunks;
+
+  /// Full context sent to LLM (caller must free via rac_rag_result_free)
+  external Pointer<Utf8> contextUsed;
+
+  /// Time for retrieval phase (ms)
+  @Double()
+  external double retrievalTimeMs;
+
+  /// Time for LLM generation (ms)
+  @Double()
+  external double generationTimeMs;
+
+  /// Total query time (ms)
+  @Double()
+  external double totalTimeMs;
+}
+
+// RAG Pipeline Lifecycle
+// rac_result_t rac_rag_pipeline_create(const rac_rag_config_t* config, rac_rag_pipeline_t** out_pipeline)
+typedef RacRagPipelineCreateNative = Int32 Function(
+  Pointer<RacRagConfigStruct> config,
+  Pointer<Pointer<Void>> outPipeline,
+);
+typedef RacRagPipelineCreateDart = int Function(
+  Pointer<RacRagConfigStruct> config,
+  Pointer<Pointer<Void>> outPipeline,
+);
+
+// void rac_rag_pipeline_destroy(rac_rag_pipeline_t* pipeline)
+typedef RacRagPipelineDestroyNative = Void Function(Pointer<Void> pipeline);
+typedef RacRagPipelineDestroyDart = void Function(Pointer<Void> pipeline);
+
+// RAG Document Management
+// rac_result_t rac_rag_add_document(rac_rag_pipeline_t* pipeline, const char* document_text, const char* metadata_json)
+typedef RacRagAddDocumentNative = Int32 Function(
+  Pointer<Void> pipeline,
+  Pointer<Utf8> documentText,
+  Pointer<Utf8> metadataJson,
+);
+typedef RacRagAddDocumentDart = int Function(
+  Pointer<Void> pipeline,
+  Pointer<Utf8> documentText,
+  Pointer<Utf8> metadataJson,
+);
+
+// rac_result_t rac_rag_clear_documents(rac_rag_pipeline_t* pipeline)
+typedef RacRagClearDocumentsNative = Int32 Function(Pointer<Void> pipeline);
+typedef RacRagClearDocumentsDart = int Function(Pointer<Void> pipeline);
+
+// size_t rac_rag_get_document_count(rac_rag_pipeline_t* pipeline)
+typedef RacRagGetDocumentCountNative = IntPtr Function(Pointer<Void> pipeline);
+typedef RacRagGetDocumentCountDart = int Function(Pointer<Void> pipeline);
+
+// RAG Query
+// rac_result_t rac_rag_query(rac_rag_pipeline_t* pipeline, const rac_rag_query_t* query, rac_rag_result_t* out_result)
+typedef RacRagQueryNative = Int32 Function(
+  Pointer<Void> pipeline,
+  Pointer<RacRagQueryStruct> query,
+  Pointer<RacRagResultStruct> outResult,
+);
+typedef RacRagQueryDart = int Function(
+  Pointer<Void> pipeline,
+  Pointer<RacRagQueryStruct> query,
+  Pointer<RacRagResultStruct> outResult,
+);
+
+// void rac_rag_result_free(rac_rag_result_t* result)
+typedef RacRagResultFreeNative = Void Function(
+    Pointer<RacRagResultStruct> result);
+typedef RacRagResultFreeDart = void Function(Pointer<RacRagResultStruct> result);
+
+// RAG Backend Registration
+// rac_result_t rac_backend_rag_register(void)
+typedef RacBackendRagRegisterNative = Int32 Function();
+typedef RacBackendRagRegisterDart = int Function();
+
+// rac_result_t rac_backend_rag_unregister(void)
+typedef RacBackendRagUnregisterNative = Int32 Function();
+typedef RacBackendRagUnregisterDart = int Function();
+
+// =============================================================================
 // Backward Compatibility Aliases
 // =============================================================================
 

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/type_conversions/model_types_cpp_bridge.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/type_conversions/model_types_cpp_bridge.dart
@@ -21,6 +21,7 @@ abstract class RacModelCategory {
   static const int imageGeneration = 4;
   static const int multimodal = 5;
   static const int audio = 6;
+  static const int embedding = 7;
   static const int unknown = 99;
 }
 
@@ -100,6 +101,8 @@ extension ModelCategoryCppBridge on ModelCategory {
         return RacModelCategory.multimodal;
       case ModelCategory.audio:
         return RacModelCategory.audio;
+      case ModelCategory.embedding:
+        return RacModelCategory.embedding;
     }
   }
 
@@ -120,8 +123,10 @@ extension ModelCategoryCppBridge on ModelCategory {
         return ModelCategory.multimodal;
       case RacModelCategory.audio:
         return ModelCategory.audio;
+      case RacModelCategory.embedding:
+        return ModelCategory.embedding;
       default:
-        return ModelCategory.audio; // Default fallback
+        return ModelCategory.language; // Default fallback
     }
   }
 }

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/public/events/event_bus.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/public/events/event_bus.dart
@@ -21,6 +21,7 @@ class EventBus {
   final _voiceController = StreamController<SDKVoiceEvent>.broadcast();
   final _storageController = StreamController<SDKStorageEvent>.broadcast();
   final _deviceController = StreamController<SDKDeviceEvent>.broadcast();
+  final _ragController = StreamController<SDKRAGEvent>.broadcast();
   final _allEventsController = StreamController<SDKEvent>.broadcast();
 
   /// Public streams for subscribing to events
@@ -40,6 +41,8 @@ class EventBus {
   Stream<SDKStorageEvent> get storageEvents => _storageController.stream;
 
   Stream<SDKDeviceEvent> get deviceEvents => _deviceController.stream;
+
+  Stream<SDKRAGEvent> get ragEvents => _ragController.stream;
 
   Stream<SDKEvent> get allEvents => _allEventsController.stream;
 
@@ -61,6 +64,8 @@ class EventBus {
       _storageController.add(event);
     } else if (event is SDKDeviceEvent) {
       _deviceController.add(event);
+    } else if (event is SDKRAGEvent) {
+      _ragController.add(event);
     }
   }
 
@@ -73,6 +78,7 @@ class EventBus {
     await _voiceController.close();
     await _storageController.close();
     await _deviceController.close();
+    await _ragController.close();
     await _allEventsController.close();
   }
 }

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/public/extensions/rag_module.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/public/extensions/rag_module.dart
@@ -1,0 +1,132 @@
+/// RAG backend module for RunAnywhere Flutter SDK.
+///
+/// This module registers the RAG (Retrieval-Augmented Generation) backend
+/// with the RunAnywhere plugin system via the module lifecycle.
+///
+/// ## Architecture
+///
+/// The C++ backend (RABackendRAG) handles all business logic:
+/// - RAG pipeline creation and management
+/// - Document embedding and vector indexing
+/// - Query retrieval and LLM answer generation
+///
+/// This Dart module just:
+/// 1. Calls `rac_backend_rag_register()` to register the backend
+/// 2. The core SDK handles RAG operations via `DartBridgeRAG`
+///
+/// ## Quick Start
+///
+/// ```dart
+/// import 'package:runanywhere/public/extensions/rag_module.dart';
+///
+/// // Register the module (matches Swift: RAGModule.register())
+/// await RAGModule.register();
+///
+/// // Use DartBridgeRAG for pipeline operations
+/// DartBridgeRAG.shared.createPipeline(config: myConfig);
+/// ```
+library rag_module;
+
+import 'package:runanywhere/core/module/runanywhere_module.dart';
+import 'package:runanywhere/core/types/model_types.dart';
+import 'package:runanywhere/core/types/sdk_component.dart';
+import 'package:runanywhere/foundation/error_types/sdk_error.dart';
+import 'package:runanywhere/foundation/logging/sdk_logger.dart';
+import 'package:runanywhere/native/dart_bridge_rag.dart';
+import 'package:runanywhere/native/ffi_types.dart';
+
+/// RAG module for Retrieval-Augmented Generation.
+///
+/// Registers the C++ RAG backend with the RunAnywhere service registry.
+/// RAG uses ONNX for embeddings and delegates LLM generation to the
+/// already-registered LlamaCpp backend.
+///
+/// Matches the Swift RAGModule pattern from the iOS SDK.
+class RAGModule implements RunAnywhereModule {
+  // ============================================================================
+  // Singleton Pattern (matches LlamaCpp pattern exactly)
+  // ============================================================================
+
+  static final RAGModule _instance = RAGModule._internal();
+  static RAGModule get module => _instance;
+  RAGModule._internal();
+
+  // ============================================================================
+  // RunAnywhereModule Conformance
+  // ============================================================================
+
+  @override
+  String get moduleId => 'rag';
+
+  @override
+  String get moduleName => 'RAG';
+
+  @override
+  Set<SDKComponent> get capabilities => {SDKComponent.llm};
+
+  @override
+  int get defaultPriority => 100;
+
+  @override
+  InferenceFramework get inferenceFramework => InferenceFramework.onnx;
+
+  // ============================================================================
+  // Registration State
+  // ============================================================================
+
+  static bool _isRegistered = false;
+  static final _logger = SDKLogger('RAGModule');
+
+  // ============================================================================
+  // Registration (matches LlamaCpp.register() pattern)
+  // ============================================================================
+
+  /// Register the RAG backend with the C++ service registry.
+  ///
+  /// Calls `rac_backend_rag_register()` to register the RAG service provider.
+  ///
+  /// Safe to call multiple times — subsequent calls are no-ops.
+  static Future<void> register() async {
+    if (_isRegistered) {
+      _logger.debug('RAGModule already registered');
+      return;
+    }
+
+    _logger.info('Registering RAG backend with C++ registry...');
+
+    try {
+      final result = DartBridgeRAG.registerBackend();
+      _logger.info(
+        'rac_backend_rag_register() returned: $result (${RacResultCode.getMessage(result)})',
+      );
+
+      if (result != RacResultCode.success &&
+          result != RacResultCode.errorModuleAlreadyRegistered) {
+        _logger.error('RAG backend registration FAILED with code: $result');
+        throw SDKError.frameworkNotAvailable(
+          'RAG backend registration failed with code: $result (${RacResultCode.getMessage(result)})',
+        );
+      }
+
+      _isRegistered = true;
+      _logger.info('RAG backend registered successfully');
+    } catch (e) {
+      _logger.error('RAG backend not available: $e');
+      rethrow;
+    }
+  }
+
+  /// Unregister the RAG backend from the C++ service registry.
+  static void unregister() {
+    if (!_isRegistered) {
+      return;
+    }
+
+    DartBridgeRAG.unregisterBackend();
+    _isRegistered = false;
+    _logger.info('RAG backend unregistered');
+  }
+
+  /// Whether the RAG backend is currently registered.
+  static bool get isRegistered => _isRegistered;
+}

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/public/extensions/runanywhere_frameworks.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/public/extensions/runanywhere_frameworks.dart
@@ -70,10 +70,7 @@ extension RunAnywhereFrameworks on RunAnywhere {
       break;
 
     case SDKComponent.embedding:
-      relevantCategories = {
-        ModelCategory.language,
-        ModelCategory.multimodal
-      };
+      relevantCategories = {ModelCategory.embedding};
       break;
 
     case SDKComponent.vlm:

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/public/extensions/runanywhere_rag.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/public/extensions/runanywhere_rag.dart
@@ -1,0 +1,240 @@
+/// RunAnywhere + RAG
+///
+/// Public API for Retrieval-Augmented Generation (RAG) pipeline operations.
+/// Mirrors Swift's RunAnywhere+RAG.swift extension pattern.
+///
+/// Developer-facing API surface for RAG. All methods wrap DartBridgeRAG calls
+/// with initialization guards, event publishing, and typed error conversion.
+library runanywhere_rag;
+
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+
+import 'package:runanywhere/foundation/error_types/sdk_error.dart';
+import 'package:runanywhere/native/dart_bridge_rag.dart';
+import 'package:runanywhere/native/ffi_types.dart';
+import 'package:runanywhere/public/events/event_bus.dart';
+import 'package:runanywhere/public/events/sdk_event.dart';
+import 'package:runanywhere/public/extensions/rag_module.dart';
+import 'package:runanywhere/public/runanywhere.dart';
+import 'package:runanywhere/public/types/rag_types.dart';
+
+// =============================================================================
+// RAG Extension Methods
+// =============================================================================
+
+/// Extension providing static RAG pipeline methods on RunAnywhere.
+///
+/// All methods check SDK initialization before proceeding, publish lifecycle
+/// events to EventBus, and convert bridge errors to typed SDKError exceptions.
+///
+/// Usage:
+/// ```dart
+/// await RunAnywhereRAG.ragCreatePipeline(config);
+/// await RunAnywhereRAG.ragIngest(text);
+/// final result = await RunAnywhereRAG.ragQuery(question);
+/// await RunAnywhereRAG.ragDestroyPipeline();
+/// ```
+extension RunAnywhereRAG on RunAnywhere {
+  // MARK: - Pipeline Lifecycle
+
+  /// Create the RAG pipeline with the given configuration.
+  ///
+  /// Marshals [config] to a native [RacRagConfigStruct] via FFI, calls
+  /// [DartBridgeRAG.createPipeline], then publishes [SDKRAGEvent.pipelineCreated].
+  ///
+  /// Throws [SDKError.notInitialized] if SDK is not initialized.
+  /// Throws [SDKError.invalidState] if pipeline creation fails.
+  static Future<void> ragCreatePipeline(RAGConfiguration config) async {
+    if (!RunAnywhere.isSDKInitialized) {
+      throw SDKError.notInitialized();
+    }
+
+    if (!RAGModule.isRegistered) {
+      throw SDKError.invalidState(
+        'RAG backend not registered. Call RAGModule.register() first.',
+      );
+    }
+
+    final embeddingModelPathPtr = config.embeddingModelPath.toNativeUtf8();
+    final llmModelPathPtr = config.llmModelPath.toNativeUtf8();
+    final promptTemplatePtr = config.promptTemplate?.toNativeUtf8();
+    final embeddingConfigJsonPtr = config.embeddingConfigJSON?.toNativeUtf8();
+    final llmConfigJsonPtr = config.llmConfigJSON?.toNativeUtf8();
+    final configPtr = calloc<RacRagConfigStruct>();
+
+    try {
+      configPtr.ref.embeddingModelPath = embeddingModelPathPtr;
+      configPtr.ref.llmModelPath = llmModelPathPtr;
+      configPtr.ref.embeddingDimension = config.embeddingDimension;
+      configPtr.ref.topK = config.topK;
+      configPtr.ref.similarityThreshold = config.similarityThreshold;
+      configPtr.ref.maxContextTokens = config.maxContextTokens;
+      configPtr.ref.chunkSize = config.chunkSize;
+      configPtr.ref.chunkOverlap = config.chunkOverlap;
+      configPtr.ref.promptTemplate = promptTemplatePtr ?? nullptr;
+      configPtr.ref.embeddingConfigJson = embeddingConfigJsonPtr ?? nullptr;
+      configPtr.ref.llmConfigJson = llmConfigJsonPtr ?? nullptr;
+
+      DartBridgeRAG.shared.createPipeline(config: configPtr);
+
+      EventBus.shared.publish(SDKRAGEvent.pipelineCreated());
+    } catch (e) {
+      EventBus.shared.publish(SDKRAGEvent.error(message: e.toString()));
+      throw SDKError.invalidState('RAG pipeline creation failed: $e');
+    } finally {
+      calloc.free(embeddingModelPathPtr);
+      calloc.free(llmModelPathPtr);
+      if (promptTemplatePtr != null) calloc.free(promptTemplatePtr);
+      if (embeddingConfigJsonPtr != null) calloc.free(embeddingConfigJsonPtr);
+      if (llmConfigJsonPtr != null) calloc.free(llmConfigJsonPtr);
+      calloc.free(configPtr);
+    }
+  }
+
+  /// Destroy the RAG pipeline and release native resources.
+  ///
+  /// Publishes [SDKRAGEvent.pipelineDestroyed] after destruction.
+  ///
+  /// Throws [SDKError.notInitialized] if SDK is not initialized.
+  static Future<void> ragDestroyPipeline() async {
+    if (!RunAnywhere.isSDKInitialized) {
+      throw SDKError.notInitialized();
+    }
+
+    DartBridgeRAG.shared.destroy();
+    EventBus.shared.publish(SDKRAGEvent.pipelineDestroyed());
+  }
+
+  // MARK: - Document Management
+
+  /// Ingest a document into the RAG pipeline.
+  ///
+  /// Splits [text] into chunks, embeds them, and indexes them for retrieval.
+  /// Publishes [SDKRAGEvent.ingestionStarted] before and
+  /// [SDKRAGEvent.ingestionComplete] after the operation.
+  ///
+  /// [text] - Document text content to ingest.
+  /// [metadataJSON] - Optional JSON metadata string to associate with the document.
+  ///
+  /// Throws [SDKError.notInitialized] if SDK is not initialized.
+  /// Throws [SDKError.invalidState] if ingestion fails.
+  static Future<void> ragIngest(String text, {String? metadataJSON}) async {
+    if (!RunAnywhere.isSDKInitialized) {
+      throw SDKError.notInitialized();
+    }
+
+    EventBus.shared.publish(
+      SDKRAGEvent.ingestionStarted(documentLength: text.length),
+    );
+
+    final stopwatch = Stopwatch()..start();
+
+    try {
+      DartBridgeRAG.shared.addDocument(text, metadataJSON: metadataJSON);
+
+      stopwatch.stop();
+
+      final chunkCount = DartBridgeRAG.shared.documentCount;
+
+      EventBus.shared.publish(
+        SDKRAGEvent.ingestionComplete(
+          chunkCount: chunkCount,
+          durationMs: stopwatch.elapsedMilliseconds.toDouble(),
+        ),
+      );
+    } catch (e) {
+      stopwatch.stop();
+      EventBus.shared.publish(SDKRAGEvent.error(message: e.toString()));
+      throw SDKError.invalidState('RAG ingestion failed: $e');
+    }
+  }
+
+  /// Clear all documents from the RAG pipeline.
+  ///
+  /// Throws [SDKError.notInitialized] if SDK is not initialized.
+  /// Throws [SDKError.invalidState] if clearing fails.
+  static Future<void> ragClearDocuments() async {
+    if (!RunAnywhere.isSDKInitialized) {
+      throw SDKError.notInitialized();
+    }
+
+    try {
+      DartBridgeRAG.shared.clearDocuments();
+    } catch (e) {
+      throw SDKError.invalidState('RAG clear documents failed: $e');
+    }
+  }
+
+  // MARK: - Retrieval
+
+  /// Get the number of indexed document chunks in the pipeline.
+  ///
+  /// Returns 0 if the pipeline has not been created.
+  ///
+  /// Throws [SDKError.notInitialized] if SDK is not initialized.
+  static Future<int> ragDocumentCount() async {
+    if (!RunAnywhere.isSDKInitialized) {
+      throw SDKError.notInitialized();
+    }
+
+    return DartBridgeRAG.shared.documentCount;
+  }
+
+  // MARK: - Query
+
+  /// Query the RAG pipeline with a natural language question.
+  ///
+  /// Retrieves relevant document chunks and generates an AI answer.
+  /// Publishes [SDKRAGEvent.queryStarted] before and
+  /// [SDKRAGEvent.queryComplete] after the operation.
+  ///
+  /// [question] - The user's natural language question.
+  /// [options] - Optional query parameters (system prompt, token limits, etc.).
+  ///
+  /// Returns a [RAGResult] with the generated answer, retrieved chunks, and timing.
+  ///
+  /// Throws [SDKError.notInitialized] if SDK is not initialized.
+  /// Throws [SDKError.generationFailed] if the query fails.
+  static Future<RAGResult> ragQuery(
+    String question, {
+    RAGQueryOptions? options,
+  }) async {
+    if (!RunAnywhere.isSDKInitialized) {
+      throw SDKError.notInitialized();
+    }
+
+    EventBus.shared.publish(
+      SDKRAGEvent.queryStarted(questionLength: question.length),
+    );
+
+    try {
+      final bridgeResult = DartBridgeRAG.shared.query(
+        question,
+        systemPrompt: options?.systemPrompt,
+        maxTokens: options?.maxTokens ?? 512,
+        temperature: options?.temperature ?? 0.7,
+        topP: options?.topP ?? 0.9,
+        topK: options?.topK ?? 40,
+      );
+
+      final result = RAGResult.fromBridge(bridgeResult);
+
+      EventBus.shared.publish(
+        SDKRAGEvent.queryComplete(
+          answerLength: result.answer.length,
+          chunksRetrieved: result.retrievedChunks.length,
+          retrievalTimeMs: result.retrievalTimeMs,
+          generationTimeMs: result.generationTimeMs,
+          totalTimeMs: result.totalTimeMs,
+        ),
+      );
+
+      return result;
+    } catch (e) {
+      EventBus.shared.publish(SDKRAGEvent.error(message: e.toString()));
+      throw SDKError.generationFailed('RAG query failed: $e');
+    }
+  }
+}

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/public/types/rag_types.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/public/types/rag_types.dart
@@ -1,0 +1,215 @@
+/// RAG (Retrieval-Augmented Generation) Types
+///
+/// Public types for RAG pipeline configuration, query options, and results.
+/// Mirrors iOS RAGTypes.swift adapted for Flutter/Dart.
+library rag_types;
+
+import 'package:runanywhere/native/dart_bridge_rag.dart';
+
+// MARK: - RAGConfiguration
+
+/// Configuration for the RAG pipeline.
+///
+/// Specifies model paths, chunking parameters, and generation settings.
+/// Mirrors iOS `RAGConfiguration` exactly.
+class RAGConfiguration {
+  /// Path to the ONNX embedding model file (required).
+  final String embeddingModelPath;
+
+  /// Path to the GGUF LLM model file (required).
+  final String llmModelPath;
+
+  /// Embedding vector dimension (default: 384).
+  final int embeddingDimension;
+
+  /// Number of top chunks to retrieve (default: 3).
+  final int topK;
+
+  /// Minimum cosine similarity threshold for retrieval (default: 0.3).
+  final double similarityThreshold;
+
+  /// Maximum context tokens to send to the LLM (default: 2048).
+  final int maxContextTokens;
+
+  /// Document chunk size in tokens (default: 512).
+  final int chunkSize;
+
+  /// Overlap between consecutive chunks in tokens (default: 50).
+  final int chunkOverlap;
+
+  /// Optional custom prompt template for the LLM.
+  final String? promptTemplate;
+
+  /// Optional JSON configuration for the embedding model.
+  final String? embeddingConfigJSON;
+
+  /// Optional JSON configuration for the LLM.
+  final String? llmConfigJSON;
+
+  const RAGConfiguration({
+    required this.embeddingModelPath,
+    required this.llmModelPath,
+    this.embeddingDimension = 384,
+    this.topK = 3,
+    this.similarityThreshold = 0.3,
+    this.maxContextTokens = 2048,
+    this.chunkSize = 512,
+    this.chunkOverlap = 50,
+    this.promptTemplate,
+    this.embeddingConfigJSON,
+    this.llmConfigJSON,
+  });
+
+  @override
+  String toString() {
+    return 'RAGConfiguration(embeddingModel: $embeddingModelPath, '
+        'llmModel: $llmModelPath, topK: $topK)';
+  }
+}
+
+// MARK: - RAGQueryOptions
+
+/// Options for a RAG query.
+///
+/// Specifies the question and generation parameters.
+/// Mirrors iOS `RAGQueryOptions` exactly.
+class RAGQueryOptions {
+  /// The user's question (required).
+  final String question;
+
+  /// Optional system prompt override.
+  final String? systemPrompt;
+
+  /// Maximum tokens to generate (default: 512).
+  final int maxTokens;
+
+  /// Sampling temperature (default: 0.7).
+  final double temperature;
+
+  /// Nucleus sampling probability (default: 0.9).
+  final double topP;
+
+  /// Top-k sampling (default: 40).
+  final int topK;
+
+  const RAGQueryOptions({
+    required this.question,
+    this.systemPrompt,
+    this.maxTokens = 512,
+    this.temperature = 0.7,
+    this.topP = 0.9,
+    this.topK = 40,
+  });
+
+  @override
+  String toString() {
+    return 'RAGQueryOptions(question: "${question.length > 50 ? question.substring(0, 50) : question}...", '
+        'maxTokens: $maxTokens, temperature: $temperature)';
+  }
+}
+
+// MARK: - RAGSearchResult
+
+/// A single retrieved chunk from vector search.
+///
+/// Represents a document chunk that was retrieved as relevant context.
+/// Mirrors iOS `RAGSearchResult` exactly.
+class RAGSearchResult {
+  /// Unique identifier for this chunk.
+  final String chunkId;
+
+  /// Text content of the chunk.
+  final String text;
+
+  /// Cosine similarity score (0.0–1.0).
+  final double similarityScore;
+
+  /// Optional JSON metadata associated with the chunk.
+  /// Empty strings from the bridge are converted to null.
+  final String? metadataJSON;
+
+  const RAGSearchResult({
+    required this.chunkId,
+    required this.text,
+    required this.similarityScore,
+    this.metadataJSON,
+  });
+
+  /// Create from a bridge search result.
+  ///
+  /// Converts empty metadataJson strings to null.
+  factory RAGSearchResult.fromBridge(RAGBridgeSearchResult bridge) {
+    return RAGSearchResult(
+      chunkId: bridge.chunkId,
+      text: bridge.text,
+      similarityScore: bridge.similarityScore,
+      metadataJSON: bridge.metadataJson.isEmpty ? null : bridge.metadataJson,
+    );
+  }
+
+  @override
+  String toString() {
+    return 'RAGSearchResult(chunkId: $chunkId, score: $similarityScore)';
+  }
+}
+
+// MARK: - RAGResult
+
+/// The result of a RAG query.
+///
+/// Contains the generated answer, retrieved chunks, and timing metrics.
+/// Mirrors iOS `RAGResult` exactly.
+class RAGResult {
+  /// The generated answer text.
+  final String answer;
+
+  /// The document chunks retrieved and used as context.
+  final List<RAGSearchResult> retrievedChunks;
+
+  /// The full context text sent to the LLM.
+  /// Null if context was empty.
+  final String? contextUsed;
+
+  /// Time taken for the retrieval phase in milliseconds.
+  final double retrievalTimeMs;
+
+  /// Time taken for LLM generation in milliseconds.
+  final double generationTimeMs;
+
+  /// Total query time in milliseconds.
+  final double totalTimeMs;
+
+  const RAGResult({
+    required this.answer,
+    required this.retrievedChunks,
+    this.contextUsed,
+    required this.retrievalTimeMs,
+    required this.generationTimeMs,
+    required this.totalTimeMs,
+  });
+
+  /// Create from a bridge result.
+  ///
+  /// Converts the bridge's [RAGBridgeResult] to public [RAGResult],
+  /// mapping each chunk through [RAGSearchResult.fromBridge].
+  /// Empty contextUsed strings are converted to null.
+  factory RAGResult.fromBridge(RAGBridgeResult bridge) {
+    return RAGResult(
+      answer: bridge.answer,
+      retrievedChunks: bridge.retrievedChunks
+          .map(RAGSearchResult.fromBridge)
+          .toList(growable: false),
+      contextUsed: bridge.contextUsed.isEmpty ? null : bridge.contextUsed,
+      retrievalTimeMs: bridge.retrievalTimeMs,
+      generationTimeMs: bridge.generationTimeMs,
+      totalTimeMs: bridge.totalTimeMs,
+    );
+  }
+
+  @override
+  String toString() {
+    final preview = answer.length > 50 ? answer.substring(0, 50) : answer;
+    return 'RAGResult(answer: "$preview...", chunks: ${retrievedChunks.length}, '
+        'totalTimeMs: $totalTimeMs)';
+  }
+}

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/public/types/types.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/public/types/types.dart
@@ -10,5 +10,6 @@ export 'generation_types.dart';
 export 'message_types.dart';
 export 'structured_output_types.dart';
 export 'tool_calling_types.dart';
+export 'rag_types.dart';
 export 'vlm_types.dart';
 export 'voice_agent_types.dart';


### PR DESCRIPTION
RAG Flutter SDK.

->there are a bunch of UI/UX issues with this like button not loading, the round spinny download thing not being proper etc, but the rag pipeline works.

-> also onnx and rag when built together were giving duplicate symbol errors as rag requires onnx, so currently they are both using the rag bundled onnx only, A future task that should be done soon is to include onnx in core as well, and perhaps add a conditional. I'm a bit unsure on the how pubspec works(apparently conditionals are not allowed, so should look into this.) Not a big problem tho, just have to change how the backend flags passed end up being used.


Did run into some hiccups while doing the reset hard, and im **pretty sure**, that this is good, but a sanity test would still be good. 

@shubhammalhotra28 @Siddhesh2377 
 
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Implements RAG (Retrieval-Augmented Generation) in Flutter SDK with new models, event handling, and build support for iOS and Android.
> 
>   - **RAG Implementation**:
>     - Introduces `RAGModule` in `rag_module.dart` to register RAG backend.
>     - Adds `RAGConfiguration`, `RAGQueryOptions`, `RAGSearchResult`, and `RAGResult` in `rag_types.dart`.
>     - Implements RAG pipeline methods in `runanywhere_rag.dart`.
>   - **Event Handling**:
>     - Adds `SDKRAGEvent` and related classes in `sdk_event.dart` for RAG lifecycle events.
>     - Updates `EventBus` in `event_bus.dart` to handle `SDKRAGEvent`.
>   - **Build and Setup**:
>     - Updates `build-flutter.sh` to include RAG backend in build process.
>     - Modifies `binary_config.gradle` and `build.gradle` for RAG support.
>   - **Model Management**:
>     - Adds support for multi-file models in `runanywhere.dart`.
>     - Registers RAG models using `registerMultiFileModel()`.
>   - **Miscellaneous**:
>     - Updates `runanywhere_frameworks.dart` to include RAG in framework discovery.
>     - Adjusts `model_types_cpp_bridge.dart` for new model categories.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for 8a5d7e30e69a3ed32f7b6472551261f7dc373935. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added Retrieval-Augmented Generation (RAG) support enabling users to ingest documents (PDF/JSON) and ask questions with context-aware answers.
  * Added embedding model category and multi-file model registration for enhanced AI capabilities.
  * Introduced document Q&A interface with model selection, document upload, and query execution.

* **Changes**
  * Migrated model registration to unified RunAnywhere API.
  * Updated dependencies: added file picker and PDF support libraries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR delivers the complete Flutter RAG (Retrieval-Augmented Generation) implementation across the SDK and example app, wiring together a new `DartBridgeRAG` C++ FFI layer, a public `RunAnywhereRAG` API extension, a `RAGModule` registration system, a multi-file model download path for ONNX embedding models, and a full-screen `RagDemoView` UI with document picking, ingestion, Q&A chat, and expandable retrieved-chunk display.

**Key changes:**
- New `dart_bridge_rag.dart` / `ffi_types.dart` — thin FFI wrapper over `rac_rag_pipeline_*` and `rac_rag_query` C functions with correct memory safety (strings freed in `finally`, C results copied before `rac_rag_result_free`).
- New `RunAnywhereRAG` extension and `RAGModule` — mirrors iOS SDK patterns for registration, event publishing, and typed error conversion.
- `download_service.dart` — new branch for `MultiFileArtifact` that downloads each file individually (e.g. `model.onnx` + `vocab.txt`), but **required files with a `null` URL are silently skipped** rather than throwing an error, which could leave a model directory incomplete.
- `rag_view_model.dart` — `clearDocument()` does **not** wrap `ragDestroyPipeline()` in a try/catch, so an exception during destroy leaves `isDocumentLoaded = true` while the pipeline is gone; `_changeDocument()` in the view has the same gap.
- `ffi_types.dart` — `@Float()` annotations on `similarityThreshold`, `temperature`, and `topP` in the RAG structs should be verified against the C header types; if the C side uses `double` (64-bit), struct layout will be silently corrupted for every field that follows.
- iOS podspec — the old `exit 0` fast-path (which would have prevented RAG from ever being downloaded) is correctly replaced with a per-framework soft-skip pattern.
- Build scripts (`build-android.sh`, `build-flutter.sh`) — backend selection cleanly refactored to support arbitrary comma-separated combinations including `rag`; previously RAG was unconditionally compiled.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge without addressing the silent required-file skip, the clearDocument exception handling gap, and confirming FFI float/double alignment against the C headers.
- Three issues need resolution before merging: (1) the multi-file download silently skips required files when url==null, which can produce a corrupt model directory and a hard-to-debug native crash; (2) clearDocument() leaves the ViewModel in an inconsistent loaded state when ragDestroyPipeline throws; (3) @Float() annotations on RAG struct fields may corrupt C struct layout if the C side uses double. The PR author has also flagged known UI/UX issues and the onnx/rag duplicate-symbol problem, which reinforces that a sanity test pass is needed.
- `download_service.dart` (required-file skip bug), `rag_view_model.dart` and `rag_demo_view.dart` (exception safety), and `ffi_types.dart` (float vs double FFI annotations) need the most attention before merging.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-flutter/packages/runanywhere/lib/infrastructure/download/download_service.dart | New multi-file model download path added for embedding models; contains a logic bug where required files with no URL are silently skipped, and the per-file progress calculation produces inaccurate values. |
| examples/flutter/RunAnywhereAI/lib/features/rag/rag_view_model.dart | New RAG ViewModel; `clearDocument()` does not wrap `ragDestroyPipeline()` in a try/catch, so exceptions leave the ViewModel in an inconsistent loaded state. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/ffi_types.dart | New RAG FFI struct definitions added; `@Float()` annotations on `similarityThreshold`, `temperature`, and `topP` may mismatch C `double` types, risking struct layout corruption. |
| examples/flutter/RunAnywhereAI/lib/features/rag/rag_demo_view.dart | New full-screen RAG UI; `_changeDocument` does not catch exceptions thrown by `clearDocument`, silently swallowing errors; otherwise well-structured with good path resolution helpers. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_rag.dart | New RAG C++ bridge; memory safety looks correct — strings freed in finally blocks, C result copied to Dart before `rac_rag_result_free`; graceful degradation on missing backend. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/public/extensions/runanywhere_rag.dart | New public RAG API extension; correctly marshals config to FFI, publishes lifecycle events, and converts bridge errors to typed SDKErrors. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/public/extensions/rag_module.dart | New RAGModule registration entry point; idempotent registration with correct guard; `inferenceFramework` is ONNX though RAG also uses LlamaCPP (minor mislabeling, not a runtime bug). |
| sdk/runanywhere-flutter/packages/runanywhere/ios/runanywhere.podspec | Adds RABackendRAG.xcframework download alongside RACommons; correctly replaces the old `exit 0` with a soft-skip pattern so both frameworks are handled independently. |
| sdk/runanywhere-commons/scripts/build-android.sh | Backend selection refactored from a large case statement to a loop-based parser; RAG backend flag added; logic is cleaner and handles arbitrary combinations correctly. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/public/types/rag_types.dart | New public RAG types (RAGConfiguration, RAGQueryOptions, RAGSearchResult, RAGResult); clean mirror of iOS types with correct bridge conversion logic. |
| examples/flutter/RunAnywhereAI/lib/features/rag/document_service.dart | New DocumentService for PDF/JSON text extraction; correctly disposes the PdfDocument and throws on empty extraction; only PDF and JSON supported. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/public/runanywhere.dart | Adds `registerMultiFileModel` static method; correctly builds a `MultiFileArtifact` and saves to the C++ registry. |
| sdk/runanywhere-flutter/packages/runanywhere/android/build.gradle | New `downloadRagNativeLibs` task added; correctly deduplicates shared libraries against the core SDK; local-mode check is present. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant RagDemoView
    participant RAGViewModel
    participant RunAnywhereRAG
    participant DartBridgeRAG
    participant DocumentService
    participant CppRAGBackend as "C++ RAG Backend"

    Note over RagDemoView: App startup
    RagDemoView->>RAGViewModel: addListener()

    Note over User: Select models and document
    User->>RagDemoView: Pick embedding model
    User->>RagDemoView: Pick LLM model
    User->>RagDemoView: Pick PDF/JSON file

    RagDemoView->>RAGViewModel: loadDocument(filePath, ragConfig)
    RAGViewModel->>DocumentService: extractText(filePath)
    DocumentService-->>RAGViewModel: plainText

    RAGViewModel->>RunAnywhereRAG: ragCreatePipeline(config)
    RunAnywhereRAG->>DartBridgeRAG: createPipeline(configPtr)
    DartBridgeRAG->>CppRAGBackend: rac_rag_pipeline_create()
    CppRAGBackend-->>DartBridgeRAG: pipeline handle
    DartBridgeRAG-->>RunAnywhereRAG: OK

    RAGViewModel->>RunAnywhereRAG: ragIngest(text)
    RunAnywhereRAG->>DartBridgeRAG: addDocument(text)
    DartBridgeRAG->>CppRAGBackend: rac_rag_add_document() chunking and embedding
    CppRAGBackend-->>DartBridgeRAG: OK
    RAGViewModel-->>RagDemoView: notifyListeners isDocumentLoaded=true

    Note over User: Ask a question
    User->>RagDemoView: Submit question
    RagDemoView->>RAGViewModel: askQuestion()
    RAGViewModel->>RunAnywhereRAG: ragQuery(question)
    RunAnywhereRAG->>DartBridgeRAG: query(question)
    DartBridgeRAG->>CppRAGBackend: rac_rag_query() retrieve and generate
    CppRAGBackend-->>DartBridgeRAG: RacRagResultStruct
    DartBridgeRAG-->>RunAnywhereRAG: RAGBridgeResult C mem freed
    RunAnywhereRAG-->>RAGViewModel: RAGResult
    RAGViewModel-->>RagDemoView: notifyListeners messages updated
    RagDemoView-->>User: Show answer with chunks and timing

    Note over User: Change document
    User->>RagDemoView: Tap Change
    RagDemoView->>RAGViewModel: clearDocument()
    RAGViewModel->>RunAnywhereRAG: ragDestroyPipeline()
    RunAnywhereRAG->>DartBridgeRAG: destroy()
    DartBridgeRAG->>CppRAGBackend: rac_rag_pipeline_destroy()
    RAGViewModel-->>RagDemoView: notifyListeners reset state
```

<sub>Last reviewed commit: 8a5d7e3</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->