### PR TITLE
Fix lora [ios changes + fixign some bugs identified in the other PR #414]

### DIFF
--- a/.idea/vcs.xml
+++ b/.idea/vcs.xml
@@ -2,7 +2,5 @@
 <project version="4">
   <component name="VcsDirectoryMappings">
     <mapping directory="" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/sdk/runanywhere-commons/build/android/unified/arm64-v8a/_deps/llamacpp-src" vcs="Git" />
-    <mapping directory="$PROJECT_DIR$/sdk/runanywhere-commons/build/android/unified/arm64-v8a/_deps/nlohmann_json-src" vcs="Git" />
   </component>
 </project>

--- a/Package.swift
+++ b/Package.swift
@@ -222,11 +222,10 @@ func ragProducts() -> [Product] {
 }
 
 /// RAG dependency for the RunAnywhere core target
+/// NOTE: Core already accesses RAG C headers via CRACommons umbrella (rac_rag.h, rac_rag_pipeline.h).
+/// No additional dependency needed — RAGBackend is only used by RAGRuntime.
 func ragCoreDependencies() -> [Target.Dependency] {
-    guard useLocalBinaries || ragRemoteBinaryAvailable else { return [] }
-    return [
-        "RAGBackend",
-    ]
+    return []
 }
 
 /// RAG-related targets (C bridge + Swift runtime)
@@ -246,6 +245,8 @@ func ragTargets() -> [Target] {
             dependencies: [
                 "RunAnywhere",
                 "RAGBackend",
+                "ONNXRuntime",
+                "LlamaCPPRuntime",
             ],
             path: "sdk/runanywhere-swift/Sources/RAGRuntime",
             exclude: ["include"],
@@ -291,12 +292,12 @@ func binaryTargets() -> [Target] {
 
         // Local combined ONNX Runtime xcframework (iOS + macOS)
         // Created by: cd sdk/runanywhere-swift && ./scripts/create-onnxruntime-xcframework.sh
-        // targets.append(
-        //     .binaryTarget(
-        //         name: "ONNXRuntimeBinary",
-        //         path: "sdk/runanywhere-swift/Binaries/onnxruntime.xcframework"
-        //     )
-        // )
+        targets.append(
+            .binaryTarget(
+                name: "ONNXRuntimeBinary",
+                path: "sdk/runanywhere-swift/Binaries/onnxruntime.xcframework"
+            )
+        )
 
         return targets
     } else {

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/lora/LoraAdapterPickerSheet.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/lora/LoraAdapterPickerSheet.kt
@@ -132,6 +132,7 @@ fun LoraAdapterPickerSheet(
                             isDownloading = state.downloadingAdapterId == entry.id,
                             downloadProgress = if (state.downloadingAdapterId == entry.id) state.downloadProgress else 0f,
                             onDownload = { loraViewModel.downloadAdapter(entry) },
+                            onCancelDownload = { loraViewModel.cancelDownload() },
                             onApply = { scale ->
                                 val path = loraViewModel.localPath(entry) ?: return@CatalogAdapterRow
                                 loraViewModel.loadAdapter(path, scale)
@@ -218,6 +219,7 @@ private fun CatalogAdapterRow(
     isDownloading: Boolean,
     downloadProgress: Float,
     onDownload: () -> Unit,
+    onCancelDownload: () -> Unit,
     onApply: (Float) -> Unit,
     onRemove: () -> Unit,
 ) {
@@ -314,6 +316,10 @@ private fun CatalogAdapterRow(
                     "${(downloadProgress * 100).toInt()}%",
                     style = MaterialTheme.typography.bodySmall,
                 )
+                Spacer(modifier = Modifier.width(Dimensions.smallMedium))
+                IconButton(onClick = onCancelDownload, modifier = Modifier.size(24.dp)) {
+                    Icon(Icons.Default.Close, contentDescription = "Cancel download", modifier = Modifier.size(16.dp))
+                }
             }
         } else {
             // Not downloaded — show download button

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/lora/LoraManagerScreen.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/lora/LoraManagerScreen.kt
@@ -15,6 +15,7 @@ import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
 import androidx.compose.material.icons.filled.CloudDownload
 import androidx.compose.material.icons.filled.Delete
 import androidx.compose.material.icons.filled.DeleteForever
@@ -153,6 +154,7 @@ fun LoraManagerScreen(
                         isDownloading = state.downloadingAdapterId == entry.id,
                         downloadProgress = if (state.downloadingAdapterId == entry.id) state.downloadProgress else 0f,
                         onDownload = { loraViewModel.downloadAdapter(entry) },
+                        onCancelDownload = { loraViewModel.cancelDownload() },
                         onDelete = { loraViewModel.deleteAdapter(entry) },
                     )
                 }
@@ -181,6 +183,7 @@ private fun RegisteredAdapterCard(
     isDownloading: Boolean,
     downloadProgress: Float,
     onDownload: () -> Unit,
+    onCancelDownload: () -> Unit,
     onDelete: () -> Unit,
 ) {
     Card(
@@ -272,6 +275,10 @@ private fun RegisteredAdapterCard(
                             "Downloading ${(downloadProgress * 100).toInt()}%",
                             style = MaterialTheme.typography.bodySmall,
                         )
+                        Spacer(modifier = Modifier.width(Dimensions.smallMedium))
+                        IconButton(onClick = onCancelDownload, modifier = Modifier.size(24.dp)) {
+                            Icon(Icons.Default.Close, contentDescription = "Cancel download", modifier = Modifier.size(16.dp))
+                        }
                     }
                 }
                 isDownloaded -> {

--- a/examples/ios/RunAnywhereAI/Package.resolved
+++ b/examples/ios/RunAnywhereAI/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Alamofire/Alamofire.git",
       "state" : {
-        "revision" : "7be73f6c2b5cd90e40798b06ebd5da8f9f79cf88",
-        "version" : "5.11.0"
+        "revision" : "3f99050e75bbc6fe71fc323adabb039756680016",
+        "version" : "5.11.1"
       }
     },
     {

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI.xcodeproj/project.pbxproj
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI.xcodeproj/project.pbxproj
@@ -10,6 +10,7 @@
 		541C59DA2E63772A00DD7839 /* RunAnywhere in Frameworks */ = {isa = PBXBuildFile; productRef = 541C59D92E63772A00DD7839 /* RunAnywhere */; };
 		58ABEDD22ED16DA40058D033 /* RunAnywhereONNX in Frameworks */ = {isa = PBXBuildFile; productRef = 58ABEDD12ED16DA40058D033 /* RunAnywhereONNX */; };
 		58LLAMACPP12ED16DA40058D0 /* RunAnywhereLlamaCPP in Frameworks */ = {isa = PBXBuildFile; productRef = 58LLAMACPP02ED16DA40058D0 /* RunAnywhereLlamaCPP */; };
+		58RAGBKND12ED16DA40058D03 /* RunAnywhereRAG in Frameworks */ = {isa = PBXBuildFile; productRef = 58RAGBKND02ED16DA40058D03 /* RunAnywhereRAG */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -65,6 +66,7 @@
 				58ABEDD22ED16DA40058D033 /* RunAnywhereONNX in Frameworks */,
 				541C59DA2E63772A00DD7839 /* RunAnywhere in Frameworks */,
 				58LLAMACPP12ED16DA40058D0 /* RunAnywhereLlamaCPP in Frameworks */,
+				58RAGBKND12ED16DA40058D03 /* RunAnywhereRAG in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -140,6 +142,7 @@
 				541C59D92E63772A00DD7839 /* RunAnywhere */,
 				58ABEDD12ED16DA40058D033 /* RunAnywhereONNX */,
 				58LLAMACPP02ED16DA40058D0 /* RunAnywhereLlamaCPP */,
+				58RAGBKND02ED16DA40058D03 /* RunAnywhereRAG */,
 			);
 			productName = RunAnywhereAI;
 			productReference = 5480A1F02E2F250200337F2F /* RunAnywhereAI.app */;
@@ -705,6 +708,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 58E021172E52A86000B722EF /* XCLocalSwiftPackageReference "../../.." */;
 			productName = RunAnywhereLlamaCPP;
+		};
+		58RAGBKND02ED16DA40058D03 /* RunAnywhereRAG */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 58E021172E52A86000B722EF /* XCLocalSwiftPackageReference "../../.." */;
+			productName = RunAnywhereRAG;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
@@ -370,6 +370,10 @@ struct RunAnywhereAIApp: App {
 
         logger.info("✅ Diffusion models registered (Apple Stable Diffusion / CoreML only)")
 
+        // Register LoRA adapters into SDK registry (same catalog as Android)
+        await LoRAAdapterCatalog.registerAll()
+        logger.info("✅ LoRA adapters registered (\(LoRAAdapterCatalog.adapters.count))")
+
         logger.info("🎉 All modules and models registered")
     }
 }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/DemoLoRAAdapter.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/DemoLoRAAdapter.swift
@@ -2,119 +2,69 @@
 //  DemoLoRAAdapter.swift
 //  RunAnywhereAI
 //
-//  TODO: [Portal Integration] Remove this entire file once adapters are delivered OTA from portal.
+//  Registers LoRA adapters into the SDK's global LoRA registry at startup.
+//  Uses the SDK's LoraAdapterCatalogEntry — same type and registry that Android uses.
 //
-//  =========================================================================================
-//  LoRA Demo Integration Guide
-//  =========================================================================================
-//
-//  WHAT THIS IS
-//  ------------
-//  This file provides a temporary, hardcoded LoRA adapter catalog so we can verify that the
-//  full LoRA pipeline works end-to-end on iOS: download adapter OTA -> apply to model -> generate.
-//  Once the RunAnywhere portal delivers adapter catalogs via its API, this file should be deleted
-//  and replaced with the portal-provided data.
-//
-//
-//  WHY QWEN 2.5 1.5B WAS CHOSEN
-//  -----------------------------
-//  LoRA adapters are architecture-specific: an adapter trained on Model A cannot be used with
-//  Model B, even if they're the same parameter count. We needed a base model + GGUF LoRA adapter
-//  pair that is publicly available and proven to work with llama.cpp.
-//
-//  - SmolLM2 360M:   No GGUF LoRA adapters exist anywhere (no one has published a fine-tune).
-//  - Qwen 2.5 0.5B:  No matching adapter (smallest ggml-org adapter is for 1.5B).
-//  - LFM2 350M:      No LoRA adapters exist. LFM2.5-1.2B adapters are architecturally incompatible
-//                     with the LFM2-1.2B-Tool model in the app (different model version).
-//  - Qwen 2.5 1.5B:  ggml-org (the llama.cpp team) publishes a tested, GGUF-format "abliterated"
-//                     LoRA adapter (~374MB). This is the smallest proven pair available.
-//
-//  The Qwen 2.5 1.5B base model is registered in RunAnywhereAIApp.swift (~986MB Q4_K_M GGUF).
-//
-//
-//  CONTEXT SIZE & MEMORY (C++ CHANGE)
-//  ----------------------------------
-//  Qwen 2.5 1.5B has 1.5B parameters and a 128K training context. The C++ llama.cpp backend
-//  uses adaptive context sizing based on model size:
-//
-//    >= 7B params  -> 2048 context   (fits ~6GB GPU memory)
-//    >= 3B params  -> 4096 context
-//    >= 1B params  -> 2048 context   (** we added this tier **)
-//    <  1B params  -> 8192 context   (tiny models, plenty of headroom)
-//
-//  Without the 1-3B tier, the 1.5B model got 8192 context -> 4,748 MB compute buffer -> OOM crash.
-//  Even at 4096, applying the F16 LoRA adapter pushed the compute buffer to 2,399 MB -> OOM.
-//  At 2048 context, total runtime memory is ~2.5GB (weights + KV cache + LoRA + compute), which
-//  fits on 6GB+ iPhones (iPhone 14 and newer).
-//
-//  This change lives in: sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
-//  (search for "Small-medium model detected")
-//
-//
-//  LORA SCALE NOTE
-//  ---------------
-//  The demo adapter is F16 (full precision) applied to a Q4_K_M (4-bit quantized) base model.
-//  At scale 1.0, this causes numerical instability -> gibberish output. Scale 0.3 is the tested
-//  sweet spot: coherent output with observable behavior change. The UI slider still allows
-//  adjustment (0.0 - 2.0) for experimentation.
-//
-//
-//  PORTAL INTEGRATION CHECKLIST
-//  ----------------------------
-//  When the portal delivers LoRA adapters OTA, do the following:
-//
-//  1. DELETE this file (DemoLoRAAdapter.swift)
-//  2. DELETE the Qwen 2.5 1.5B model registration in RunAnywhereAIApp.swift
-//     (search for "qwen2.5-1.5b-instruct-q4_k_m" and the TODO above it)
-//  3. In LLMViewModel.swift, REPLACE the demo adapter state & download logic
-//     (search for "TODO: [Portal Integration]") with portal API calls
-//  4. In ChatInterfaceView.swift, UPDATE the "Available for This Model" section
-//     in LoRAManagementSheetView to use portal-provided adapter data
-//     (search for "TODO: [Portal Integration]")
-//  5. The SDK-level LoRA API (RunAnywhere+LoRA.swift, CppBridge+LLM.swift) stays unchanged --
-//     it takes a local file path + scale, which is the same regardless of how the file got there
-//
-//  =========================================================================================
+//  TODO: [Portal Integration] Replace hardcoded adapters with portal-provided catalog.
 
 import Foundation
+import RunAnywhere
 
-// MARK: - Demo LoRA Adapter Registry
+enum LoRAAdapterCatalog {
 
-/// Represents a pre-registered LoRA adapter available for OTA download.
-/// TODO: [Portal Integration] Replace with portal-provided adapter catalog model.
-struct DemoLoRAAdapter: Identifiable, Sendable {
-    let id: String
-    let name: String
-    let description: String
-    let downloadURL: URL
-    let fileName: String
-    let compatibleModelIds: Set<String>
-    let fileSize: Int64
-    let defaultScale: Float
-
-    var fileSizeFormatted: String {
-        ByteCountFormatter.string(fromByteCount: fileSize, countStyle: .file)
+    /// Register all known LoRA adapters into the SDK's C++ registry.
+    /// Call once at startup, after SDK initialization.
+    static func registerAll() async {
+        for entry in adapters {
+            do {
+                try await RunAnywhere.registerLoraAdapter(entry)
+            } catch {
+                print("[LoRA] Failed to register adapter \(entry.id): \(error)")
+            }
+        }
     }
-}
 
-// MARK: - Demo Adapter Catalog
-
-/// TODO: [Portal Integration] Remove once adapters are delivered OTA from portal.
-enum DemoLoRAAdapterCatalog {
-    static let adapters: [DemoLoRAAdapter] = [
-        DemoLoRAAdapter(
-            id: "qwen2.5-1.5b-abliterated-lora",
-            name: "Abliterated (Uncensored)",
-            description: "Removes refusal behavior from Qwen2.5-1.5B. From ggml-org.",
-            downloadURL: URL(string: "https://huggingface.co/ggml-org/LoRA-Qwen2.5-1.5B-Instruct-abliterated-F16-GGUF/resolve/main/LoRA-Qwen2.5-1.5B-Instruct-abliterated-f16.gguf")!,
-            fileName: "LoRA-Qwen2.5-1.5B-Instruct-abliterated-f16.gguf",
-            compatibleModelIds: ["qwen2.5-1.5b-instruct-q4_k_m"],
-            fileSize: 374_000_000,
-            defaultScale: 0.3
-        )
+    /// All hardcoded adapters (matches Android's ModelList.kt)
+    static let adapters: [LoraAdapterCatalogEntry] = [
+        LoraAdapterCatalogEntry(
+            id: "chat-assistant-lora",
+            name: "Chat Assistant",
+            description: "Enhances conversational chat ability",
+            downloadURL: URL(string: "https://huggingface.co/Void2377/Qwen/resolve/main/lora/chat_assistant-lora-Q8_0.gguf")!,
+            filename: "chat_assistant-lora-Q8_0.gguf",
+            compatibleModelIds: ["lfm2-350m-q4_k_m", "lfm2-350m-q8_0"],
+            fileSize: 690_176,
+            defaultScale: 1.0
+        ),
+        LoraAdapterCatalogEntry(
+            id: "summarizer-lora",
+            name: "Summarizer",
+            description: "Specialized for text summarization tasks",
+            downloadURL: URL(string: "https://huggingface.co/Void2377/Qwen/resolve/main/lora/summarizer-lora-Q8_0.gguf")!,
+            filename: "summarizer-lora-Q8_0.gguf",
+            compatibleModelIds: ["lfm2-350m-q4_k_m", "lfm2-350m-q8_0"],
+            fileSize: 690_176,
+            defaultScale: 1.0
+        ),
+        LoraAdapterCatalogEntry(
+            id: "translator-lora",
+            name: "Translator",
+            description: "Improves translation between languages",
+            downloadURL: URL(string: "https://huggingface.co/Void2377/Qwen/resolve/main/lora/translator-lora-Q8_0.gguf")!,
+            filename: "translator-lora-Q8_0.gguf",
+            compatibleModelIds: ["lfm2-350m-q4_k_m", "lfm2-350m-q8_0"],
+            fileSize: 690_176,
+            defaultScale: 1.0
+        ),
+        LoraAdapterCatalogEntry(
+            id: "sentiment-lora",
+            name: "Sentiment Analysis",
+            description: "Fine-tuned for sentiment analysis tasks",
+            downloadURL: URL(string: "https://huggingface.co/Void2377/Qwen/resolve/main/lora/sentiment-lora-Q8_0.gguf")!,
+            filename: "sentiment-lora-Q8_0.gguf",
+            compatibleModelIds: ["lfm2-350m-q4_k_m", "lfm2-350m-q8_0"],
+            fileSize: 690_176,
+            defaultScale: 1.0
+        ),
     ]
-
-    static func adapters(forModelId modelId: String) -> [DemoLoRAAdapter] {
-        adapters.filter { $0.compatibleModelIds.contains(modelId) }
-    }
 }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift
@@ -509,7 +509,7 @@ extension ChatInterfaceView {
 
     var loraAdapterBadge: some View {
         Button {
-            viewModel.refreshAvailableDemoAdapters()
+            Task { await viewModel.refreshAvailableAdapters() }
             showingLoRAManagement = true
         } label: {
             HStack(spacing: 6) {
@@ -528,7 +528,7 @@ extension ChatInterfaceView {
 
     var loraAddButton: some View {
         Button {
-            viewModel.refreshAvailableDemoAdapters()
+            Task { await viewModel.refreshAvailableAdapters() }
             showingLoRAManagement = true
         } label: {
             HStack(spacing: 4) {
@@ -646,14 +646,13 @@ private struct LoRAManagementSheetView: View {
         }
     }
 
-    // MARK: - Available Adapters (OTA Download)
-    // TODO: [Portal Integration] Replace demo adapter section with portal-provided adapter catalog.
+    // MARK: - Available Adapters (from SDK Registry)
 
     @ViewBuilder
     private var availableAdaptersSection: some View {
-        if !viewModel.availableDemoAdapters.isEmpty {
+        if !viewModel.availableAdapters.isEmpty {
             Section {
-                ForEach(viewModel.availableDemoAdapters) { adapter in
+                ForEach(viewModel.availableAdapters, id: \.id) { adapter in
                     availableAdapterRow(adapter)
                 }
             } header: {
@@ -664,7 +663,7 @@ private struct LoRAManagementSheetView: View {
         }
     }
 
-    private func availableAdapterRow(_ adapter: DemoLoRAAdapter) -> some View {
+    private func availableAdapterRow(_ adapter: LoraAdapterCatalogEntry) -> some View {
         let isDownloaded = viewModel.isAdapterDownloaded(adapter)
         let isDownloading = viewModel.isDownloadingAdapter[adapter.id] == true
         let progress = viewModel.adapterDownloadProgress[adapter.id] ?? 0.0
@@ -672,6 +671,7 @@ private struct LoRAManagementSheetView: View {
         let isAlreadyApplied = viewModel.loraAdapters.contains {
             $0.path == viewModel.localPath(for: adapter)
         }
+        let fileSizeText = ByteCountFormatter.string(fromByteCount: adapter.fileSize, countStyle: .file)
 
         return VStack(alignment: .leading, spacing: 10) {
             HStack(alignment: .top) {
@@ -679,10 +679,10 @@ private struct LoRAManagementSheetView: View {
                     Text(adapter.name)
                         .font(.subheadline)
                         .fontWeight(.medium)
-                    Text(adapter.description)
+                    Text(adapter.adapterDescription)
                         .font(.caption)
                         .foregroundColor(.secondary)
-                    Text(adapter.fileSizeFormatted)
+                    Text(fileSizeText)
                         .font(.caption2)
                         .foregroundColor(.secondary)
                 }

--- a/sdk/runanywhere-commons/exports/RACommons.exports
+++ b/sdk/runanywhere-commons/exports/RACommons.exports
@@ -221,6 +221,11 @@ _rac_lora_entry_free
 _rac_lora_entry_array_free
 _rac_lora_entry_copy
 
+# LoRA Registry - Global convenience API
+_rac_get_lora_registry
+_rac_register_lora
+_rac_get_lora_for_model
+
 # LLM Analytics
 _rac_llm_analytics_complete_generation
 _rac_llm_analytics_create

--- a/sdk/runanywhere-commons/include/rac/core/rac_core.h
+++ b/sdk/runanywhere-commons/include/rac/core/rac_core.h
@@ -339,8 +339,29 @@ RAC_API rac_result_t rac_get_model_by_path(const char* local_path, struct rac_mo
 // GLOBAL LORA REGISTRY API
 // =============================================================================
 
+/**
+ * @brief Get the global LoRA adapter registry singleton
+ *
+ * The registry is lazily created on first access and lives for the process lifetime.
+ *
+ * @return Handle to the global registry (never NULL after first successful call)
+ */
 RAC_API struct rac_lora_registry* rac_get_lora_registry(void);
+
+/**
+ * @brief Register a LoRA adapter in the global registry
+ * @param entry Adapter entry to register (deep-copied internally)
+ * @return RAC_SUCCESS or error code
+ */
 RAC_API rac_result_t rac_register_lora(const struct rac_lora_entry* entry);
+
+/**
+ * @brief Query the global registry for adapters compatible with a model
+ * @param model_id Model ID to match
+ * @param out_entries Output: array of matching entries (caller must free with rac_lora_entry_array_free)
+ * @param out_count Output: number of matching entries
+ * @return RAC_SUCCESS or error code
+ */
 RAC_API rac_result_t rac_get_lora_for_model(const char* model_id,
                                              struct rac_lora_entry*** out_entries,
                                              size_t* out_count);

--- a/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_component.h
+++ b/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_component.h
@@ -264,15 +264,15 @@ RAC_API rac_result_t rac_llm_component_get_lora_info(rac_handle_t handle,
                                                       char** out_json);
 
 /**
- * @brief Check if a LoRA adapter is compatible with the currently loaded model
+ * @brief Check if the current backend supports LoRA adapters
  *
- * Validates that the adapter file exists and is potentially loadable.
- * This is a lightweight pre-check before attempting to load.
+ * Verifies that a model is loaded and the active backend exposes LoRA operations.
+ * This is a lightweight pre-check; actual file validation occurs during load.
  *
  * @param handle Component handle
- * @param adapter_path Path to the LoRA adapter GGUF file
+ * @param adapter_path Path to the LoRA adapter GGUF file (must be non-empty)
  * @param out_error Output: error message if incompatible (caller must free with rac_free), NULL if compatible
- * @return RAC_SUCCESS if compatible, error code otherwise
+ * @return RAC_SUCCESS if the backend supports LoRA, error code otherwise
  */
 RAC_API rac_result_t rac_llm_component_check_lora_compat(rac_handle_t handle,
                                                            const char* adapter_path,

--- a/sdk/runanywhere-commons/scripts/build-ios.sh
+++ b/sdk/runanywhere-commons/scripts/build-ios.sh
@@ -356,7 +356,7 @@ create_xcframework() {
 
         # Find the library (try multiple locations)
         local LIB_PATH="${PLATFORM_DIR}/lib${LIB_NAME}.a"
-        
+
         # Try Xcode generator output paths
         if [[ ! -f "${LIB_PATH}" ]]; then
             if [[ "$PLATFORM" == "OS" ]]; then
@@ -365,7 +365,7 @@ create_xcframework() {
                 LIB_PATH="${PLATFORM_DIR}/Release-iphonesimulator/lib${LIB_NAME}.a"
             fi
         fi
-        
+
         # Try backend-specific paths
         [[ ! -f "${LIB_PATH}" ]] && LIB_PATH="${PLATFORM_DIR}/src/backends/${BUILD_BACKEND}/lib${LIB_NAME}.a"
 
@@ -483,7 +483,7 @@ create_backend_xcframework() {
         else
             XCODE_SUBDIR="Release-iphonesimulator"
         fi
-        
+
         for possible_path in \
             "${PLATFORM_DIR}/src/backends/${BACKEND_NAME}/librac_backend_${BACKEND_NAME}.a" \
             "${PLATFORM_DIR}/${XCODE_SUBDIR}/librac_backend_${BACKEND_NAME}.a" \
@@ -551,47 +551,6 @@ create_backend_xcframework() {
             fi
         done
     fi
-
-            
-            elif [[ "$BACKEND_NAME" == "rag" ]]; then
-        # RAG backend depends on:
-        # 1. Sherpa-ONNX
-        # 2. ONNX Runtime (required for Ort* symbols)
-
-        # -------------------------------
-        # Bundle Sherpa-ONNX
-        # -------------------------------
-        local SHERPA_XCFW="${PROJECT_ROOT}/third_party/sherpa-onnx-ios/sherpa-onnx.xcframework"
-        local SHERPA_ARCH
-
-        case $PLATFORM in
-            OS) SHERPA_ARCH="ios-arm64" ;;
-            *)  SHERPA_ARCH="ios-arm64_x86_64-simulator" ;;
-        esac
-
-        for possible in \
-            "${SHERPA_XCFW}/${SHERPA_ARCH}/libsherpa-onnx.a" \
-            "${SHERPA_XCFW}/${SHERPA_ARCH}/sherpa-onnx.framework/sherpa-onnx"; do
-            if [[ -f "$possible" ]]; then
-                LIBS_TO_BUNDLE+=("$possible")
-                break
-            fi
-        done
-
-        # -------------------------------
-        # Bundle ONNX Runtime
-        # -------------------------------
-        local ONNX_XCFW="${PROJECT_ROOT}/third_party/onnxruntime-ios/onnxruntime.xcframework"
-        local ONNX_ARCH="$SHERPA_ARCH"
-
-        for possible in \
-            "${ONNX_XCFW}/${ONNX_ARCH}/libonnxruntime.a" \
-            "${ONNX_XCFW}/${ONNX_ARCH}/onnxruntime.framework/onnxruntime"; do
-            if [[ -f "$possible" ]]; then
-                LIBS_TO_BUNDLE+=("$possible")
-                break
-            fi
-        done
     fi
 
         # Bundle all libraries

--- a/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
@@ -878,20 +878,20 @@ extern "C" rac_result_t rac_llm_component_check_lora_compat(rac_handle_t handle,
 
     rac_handle_t service = rac_lifecycle_get_service(component->lifecycle);
     if (!service) {
-        *out_error = strdup("No model loaded");
+        *out_error = rac_strdup("No model loaded");
         return RAC_ERROR_COMPONENT_NOT_READY;
     }
 
     // Check if the adapter file path is non-empty
     if (strlen(adapter_path) == 0) {
-        *out_error = strdup("Empty adapter path");
+        *out_error = rac_strdup("Empty adapter path");
         return RAC_ERROR_INVALID_ARGUMENT;
     }
 
     // Basic pre-check: verify the backend supports LoRA at all
     auto* llm_service = reinterpret_cast<rac_llm_service_t*>(service);
     if (!llm_service->ops || !llm_service->ops->load_lora) {
-        *out_error = strdup("Backend does not support LoRA adapters");
+        *out_error = rac_strdup("Backend does not support LoRA adapters");
         return RAC_ERROR_NOT_SUPPORTED;
     }
 

--- a/sdk/runanywhere-commons/src/infrastructure/model_management/lora_registry.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/model_management/lora_registry.cpp
@@ -136,6 +136,7 @@ rac_result_t rac_lora_registry_get_for_model(rac_lora_registry_handle_t handle,
     std::vector<rac_lora_entry_t*> matches;
     for (const auto& pair : handle->entries) {
         const rac_lora_entry_t* entry = pair.second;
+        if (!entry->compatible_model_ids) continue;
         for (size_t i = 0; i < entry->compatible_model_count; ++i) {
             if (entry->compatible_model_ids[i] && strcmp(entry->compatible_model_ids[i], model_id) == 0) {
                 matches.push_back(pair.second);

--- a/sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp
+++ b/sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp
@@ -1961,9 +1961,11 @@ static std::string loraEntryToJson(const rac_lora_entry_t* entry) {
     j["file_size"] = entry->file_size;
     j["default_scale"] = entry->default_scale;
     nlohmann::json ids = nlohmann::json::array();
-    for (size_t i = 0; i < entry->compatible_model_count; ++i) {
-        if (entry->compatible_model_ids[i])
-            ids.push_back(entry->compatible_model_ids[i]);
+    if (entry->compatible_model_ids) {
+        for (size_t i = 0; i < entry->compatible_model_count; ++i) {
+            if (entry->compatible_model_ids[i])
+                ids.push_back(entry->compatible_model_ids[i]);
+        }
     }
     j["compatible_model_ids"] = ids;
     return j.dump();

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/foundation/bridge/extensions/CppBridgeLoraRegistry.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/foundation/bridge/extensions/CppBridgeLoraRegistry.kt
@@ -90,7 +90,7 @@ object CppBridgeLoraRegistry {
     }
 
     private fun extractString(json: String, key: String): String? {
-        val regex = Regex(""""$key"\s*:\s*"([^"]*)"""")
+        val regex = Regex(""""$key"\s*:\s*"((?:[^"\\]|\\.)*)"""")
         return regex.find(json)?.groupValues?.get(1)?.takeIf { it.isNotEmpty() }
     }
 
@@ -114,7 +114,7 @@ object CppBridgeLoraRegistry {
         if (depth != 0) return emptyList()
         val arrayContent = json.substring(arrayStart, pos - 1).trim()
         if (arrayContent.isEmpty()) return emptyList()
-        return Regex(""""([^"]*)"""").findAll(arrayContent).map { it.groupValues[1] }.toList()
+        return Regex(""""((?:[^"\\]|\\.)*)"""").findAll(arrayContent).map { it.groupValues[1] }.toList()
     }
 
     private enum class LogLevel { DEBUG, INFO, WARN, ERROR }

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+LoRA.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+LoRA.jvmAndroid.kt
@@ -98,6 +98,7 @@ actual fun RunAnywhere.checkLoraCompatibility(loraPath: String): LoraCompatibili
 // MARK: - LoRA Adapter Catalog
 
 actual fun RunAnywhere.registerLoraAdapter(entry: LoraAdapterCatalogEntry) {
+    if (!isInitialized) throw SDKError.notInitialized("SDK not initialized")
     CppBridgeLoraRegistry.register(
         CppBridgeLoraRegistry.LoraEntry(
             id = entry.id,
@@ -113,10 +114,12 @@ actual fun RunAnywhere.registerLoraAdapter(entry: LoraAdapterCatalogEntry) {
 }
 
 actual fun RunAnywhere.loraAdaptersForModel(modelId: String): List<LoraAdapterCatalogEntry> {
+    if (!isInitialized) return emptyList()
     return CppBridgeLoraRegistry.getForModel(modelId).map { it.toCatalogEntry() }
 }
 
 actual fun RunAnywhere.allRegisteredLoraAdapters(): List<LoraAdapterCatalogEntry> {
+    if (!isInitialized) return emptyList()
     return CppBridgeLoraRegistry.getAll().map { it.toCatalogEntry() }
 }
 

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/CRACommons.h
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/CRACommons.h
@@ -106,6 +106,7 @@
 // Model management
 #include "rac_model_types.h"
 #include "rac_model_registry.h"
+#include "rac_lora_registry.h"
 #include "rac_model_paths.h"
 #include "rac_model_strategy.h"
 #include "rac_model_assignment.h"

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_core.h
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_core.h
@@ -324,6 +324,47 @@ RAC_API rac_result_t rac_register_model(const struct rac_model_info* model);
  */
 RAC_API rac_result_t rac_get_model(const char* model_id, struct rac_model_info** out_model);
 
+/**
+ * Gets model info from the global registry by local path.
+ * Useful when loading models by path instead of model_id.
+ *
+ * @param local_path Local path to search for
+ * @param out_model Output: Model info (owned, must be freed with rac_model_info_free)
+ * @return RAC_SUCCESS on success, RAC_ERROR_NOT_FOUND if not registered
+ */
+RAC_API rac_result_t rac_get_model_by_path(const char* local_path, struct rac_model_info** out_model);
+
+// =============================================================================
+// GLOBAL LORA REGISTRY API
+// =============================================================================
+
+/**
+ * @brief Get the global LoRA adapter registry singleton
+ *
+ * The registry is lazily created on first access and lives for the process lifetime.
+ *
+ * @return Handle to the global registry (never NULL after first successful call)
+ */
+RAC_API struct rac_lora_registry* rac_get_lora_registry(void);
+
+/**
+ * @brief Register a LoRA adapter in the global registry
+ * @param entry Adapter entry to register (deep-copied internally)
+ * @return RAC_SUCCESS or error code
+ */
+RAC_API rac_result_t rac_register_lora(const struct rac_lora_entry* entry);
+
+/**
+ * @brief Query the global registry for adapters compatible with a model
+ * @param model_id Model ID to match
+ * @param out_entries Output: array of matching entries (caller must free with rac_lora_entry_array_free)
+ * @param out_count Output: number of matching entries
+ * @return RAC_SUCCESS or error code
+ */
+RAC_API rac_result_t rac_get_lora_for_model(const char* model_id,
+                                             struct rac_lora_entry*** out_entries,
+                                             size_t* out_count);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_llm_component.h
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_llm_component.h
@@ -263,6 +263,21 @@ RAC_API rac_result_t rac_llm_component_clear_lora(rac_handle_t handle);
 RAC_API rac_result_t rac_llm_component_get_lora_info(rac_handle_t handle,
                                                       char** out_json);
 
+/**
+ * @brief Check if the current backend supports LoRA adapters
+ *
+ * Verifies that a model is loaded and the active backend exposes LoRA operations.
+ * This is a lightweight pre-check; actual file validation occurs during load.
+ *
+ * @param handle Component handle
+ * @param adapter_path Path to the LoRA adapter GGUF file (must be non-empty)
+ * @param out_error Output: error message if incompatible (caller must free with rac_free), NULL if compatible
+ * @return RAC_SUCCESS if the backend supports LoRA, error code otherwise
+ */
+RAC_API rac_result_t rac_llm_component_check_lora_compat(rac_handle_t handle,
+                                                           const char* adapter_path,
+                                                           char** out_error);
+
 // =============================================================================
 // DESTRUCTION
 // =============================================================================

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_lora_registry.h
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_lora_registry.h
@@ -16,8 +16,8 @@
 #ifndef RAC_LORA_REGISTRY_H
 #define RAC_LORA_REGISTRY_H
 
-#include "rac/core/rac_error.h"
-#include "rac/core/rac_types.h"
+#include "rac_error.h"
+#include "rac_types.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -39,8 +39,6 @@ typedef struct rac_lora_entry {
 
 typedef struct rac_lora_registry* rac_lora_registry_handle_t;
 
-// LIFECYCLE
-
 /**
  * @brief Create a new LoRA adapter registry
  * @param out_handle Output: handle to the newly created registry
@@ -53,8 +51,6 @@ RAC_API rac_result_t rac_lora_registry_create(rac_lora_registry_handle_t* out_ha
  * @param handle Registry handle (NULL is a no-op)
  */
 RAC_API void rac_lora_registry_destroy(rac_lora_registry_handle_t handle);
-
-// REGISTRATION
 
 /**
  * @brief Register a LoRA adapter entry in the registry
@@ -76,8 +72,6 @@ RAC_API rac_result_t rac_lora_registry_register(rac_lora_registry_handle_t handl
  */
 RAC_API rac_result_t rac_lora_registry_remove(rac_lora_registry_handle_t handle,
                                                const char* adapter_id);
-
-// QUERIES
 
 /**
  * @brief Get all registered LoRA adapter entries
@@ -113,8 +107,6 @@ RAC_API rac_result_t rac_lora_registry_get_for_model(rac_lora_registry_handle_t 
 RAC_API rac_result_t rac_lora_registry_get(rac_lora_registry_handle_t handle,
                                             const char* adapter_id,
                                             rac_lora_entry_t** out_entry);
-
-// MEMORY
 
 /**
  * @brief Free a single LoRA entry and all its owned strings

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_model_types.h
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_model_types.h
@@ -247,6 +247,9 @@ typedef struct rac_model_info {
     /** Whether model supports thinking/reasoning */
     rac_bool_t supports_thinking;
 
+    /** Whether model supports LoRA adapters */
+    rac_bool_t supports_lora;
+
     /** Tags (NULL-terminated array of strings, can be NULL) */
     char** tags;
     size_t tag_count;

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+LoraRegistry.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+LoraRegistry.swift
@@ -21,19 +21,11 @@ extension CppBridge {
         private let logger = SDKLogger(category: "CppBridge.LoraRegistry")
 
         private init() {
-            var h: rac_lora_registry_handle_t?
-            let result = rac_lora_registry_create(&h)
-            if result == RAC_SUCCESS {
-                handle = h
-                logger.debug("LoRA registry created")
+            handle = rac_get_lora_registry()
+            if handle != nil {
+                logger.debug("LoRA registry acquired (global singleton)")
             } else {
-                logger.error("Failed to create LoRA registry: \(result)")
-            }
-        }
-
-        deinit {
-            if let h = handle {
-                rac_lora_registry_destroy(h)
+                logger.error("Failed to acquire global LoRA registry")
             }
         }
 


### PR DESCRIPTION
## Description

Aligning the ios SDK with the kotlin SDK.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Lint passes locally
- [ ] Added/updated tests for changes

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [x] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Playground:**
- [ ] Tested on target platform
- [ ] Verified no regressions in existing Playground projects
**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels
Please add the appropriate label(s):

**SDKs:**
- [x] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`sdk/runanywhere-kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`sdk/runanywhere-flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`sdk/runanywhere-react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`sdk/runanywhere-web`)
- [ ] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

**Sample Apps:**
- [x] `iOS Sample` - Changes to iOS example app (`examples/ios`)
- [ ] `Android Sample` - Changes to Android example app (`examples/android`)
- [ ] `Flutter Sample` - Changes to Flutter example app (`examples/flutter`)
- [ ] `React Native Sample` - Changes to React Native example app (`examples/react-native`)
- [ ] `Web Sample` - Changes to Web example app (`examples/web`)

## Checklist
- [x] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)

## Screenshots
Attach relevant UI screenshots for changes (if applicable):
- Mobile (Phone)
- Tablet / iPad
- Desktop / Mac

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Aligns iOS SDK with Kotlin SDK by implementing LoRA adapter management, updating iOS app for adapter registration, and enhancing Kotlin SDK for consistent LoRA handling.
> 
>   - **LoRA Adapter Management**:
>     - Introduces `rac_lora_registry.h` for LoRA adapter registry management.
>     - Adds `rac_register_lora()` and `rac_get_lora_for_model()` in `rac_core.h` for global registry access.
>     - Implements `LoraRegistry` actor in `CppBridge+LoraRegistry.swift` for Swift.
>     - Updates `CppBridgeLoraRegistry.kt` and `RunAnywhere+LoRA.jvmAndroid.kt` for Kotlin.
>   - **iOS App Updates**:
>     - Registers LoRA adapters in `RunAnywhereAIApp.swift`.
>     - Replaces hardcoded demo adapters with catalog entries in `DemoLoRAAdapter.swift`.
>   - **Kotlin SDK Updates**:
>     - Adds LoRA adapter registration and retrieval in `CppBridgeLoraRegistry.kt`.
>     - Updates `RunAnywhere+LoRA.jvmAndroid.kt` to use the new registry functions.
>   - **Miscellaneous**:
>     - Removes unused VCS mappings in `.idea/vcs.xml`.
>     - Updates Alamofire version in `Package.resolved`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for a591ec93d708120ac289c47000c40a56a9f3b405. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR aligns the iOS SDK's LoRA implementation with the Kotlin SDK and fixes several bugs identified in PR #414.

**Key changes:**
- Refactored iOS to use SDK's global LoRA registry singleton (matching Android architecture)
- Replaced iOS demo-specific `DemoLoRAAdapter` with SDK's `LoraAdapterCatalogEntry` type for cross-platform consistency
- Added comprehensive API documentation to C++ LoRA registry headers
- Fixed null pointer bug in JNI code that could crash when `compatible_model_ids` is NULL
- Fixed regex in Kotlin bridge to properly handle escaped characters in JSON strings
- Added cancel download functionality in Android UI
- Replaced direct state mutations with thread-safe `update{}` pattern in Android ViewModel

**Android bugs fixed:**
- Null pointer dereference in `runanywhere_commons_jni.cpp` when iterating `compatible_model_ids`
- JSON parsing failure with escaped characters in `CppBridgeLoraRegistry.kt`
- Race conditions from direct `_uiState.value =` assignments replaced with atomic `update{}`

**Architecture improvement:**
The global LoRA registry singleton pattern eliminates per-instance lifecycle management and ensures a single source of truth for LoRA adapters across both platforms.

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge with one logical issue that should be addressed
- Score reflects solid cross-platform alignment work and important bug fixes. The unconditional `destFile.delete()` in `LoraViewModel.kt:211` is a logic issue that could cause data loss if rename fails on a re-download. All other changes are clean architectural improvements and bug fixes.
- Review `LoraViewModel.kt:211` - the destFile deletion logic needs a conditional check

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+LoraRegistry.swift | Refactored to use global LoRA registry singleton instead of creating/destroying per-instance |
| examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/DemoLoRAAdapter.swift | Replaced demo-specific adapter implementation with SDK-based LoraAdapterCatalogEntry to match Android |
| examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift | Updated to use SDK LoraAdapterCatalogEntry type and async refresh from registry |
| examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/lora/LoraViewModel.kt | Replaced direct state mutation with update{} pattern, added cancel download support, added destFile.delete() before rename |
| sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/foundation/bridge/extensions/CppBridgeLoraRegistry.kt | Fixed regex to handle escaped characters in JSON string values |
| sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp | Added null check for compatible_model_ids before iterating to prevent potential crash |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    subgraph "iOS SDK"
        A[CppBridge+LoraRegistry] -->|rac_get_lora_registry| B[Global Registry Singleton]
        C[LLMViewModel] -->|registerLoraAdapter| A
        D[DemoLoRAAdapter] -->|LoraAdapterCatalogEntry| C
    end
    
    subgraph "Android SDK"
        E[CppBridgeLoraRegistry] -->|rac_get_lora_registry| B
        F[LoraViewModel] -->|registerLoraAdapter| E
        G[ModelList] -->|LoraAdapterCatalogEntry| F
    end
    
    subgraph "C++ Commons Layer"
        B -->|register/query| H[rac_lora_registry]
        H -->|thread-safe map| I[In-Memory Store]
        J[rac_llm_component] -->|load/remove| H
    end
    
    style B fill:#90EE90
    style H fill:#FFD700
    style I fill:#87CEEB
```

<sub>Last reviewed commit: a591ec9</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->