### PR TITLE
fix(ci): correct Android release packaging for x86_64 emulators

### DIFF
--- a/.github/workflows/commons-release.yml
+++ b/.github/workflows/commons-release.yml
@@ -391,12 +391,29 @@ jobs:
           fi
 
           mkdir -p android-combined/jniLibs
-          for dir in dist/android-artifacts/racommons-android-*/jniLibs/*/; do
-            if [ -d "$dir" ]; then
-              abi=$(basename "$dir")
-              mkdir -p "android-combined/jniLibs/${abi}"
-              cp -r "${dir}"* "android-combined/jniLibs/${abi}/" 2>/dev/null || true
-              echo "Copied libs for ${abi}: $(ls android-combined/jniLibs/${abi}/ 2>/dev/null | wc -l) files"
+          # Collect .so files from all build output subdirectories (jni/, commons/, onnx/, llamacpp/, rag/)
+          # Each artifact was built for a single ABI via the matrix strategy
+          for artifact_dir in dist/android-artifacts/racommons-android-*/; do
+            if [ ! -d "$artifact_dir" ]; then
+              continue
+            fi
+            for sub in jni commons onnx llamacpp rag; do
+              for abi_dir in "${artifact_dir}${sub}"/*/; do
+                if [ -d "$abi_dir" ]; then
+                  abi=$(basename "$abi_dir")
+                  mkdir -p "android-combined/jniLibs/${abi}"
+                  cp -n "${abi_dir}"*.so "android-combined/jniLibs/${abi}/" 2>/dev/null || true
+                fi
+              done
+            done
+          done
+          # Log what was collected per ABI
+          for abi_dir in android-combined/jniLibs/*/; do
+            if [ -d "$abi_dir" ]; then
+              abi=$(basename "$abi_dir")
+              count=$(ls "$abi_dir"/*.so 2>/dev/null | wc -l)
+              echo "Collected ${abi}: ${count} .so files"
+              ls -la "$abi_dir" 2>/dev/null
             fi
           done
 

--- a/sdk/runanywhere-commons/scripts/build-android.sh
+++ b/sdk/runanywhere-commons/scripts/build-android.sh
@@ -195,7 +195,7 @@ fi
 # =============================================================================
 
 BACKENDS="${1:-all}"
-ABIS="${2:-arm64-v8a}"
+ABIS="${2:-arm64-v8a,armeabi-v7a,x86_64}"
 
 # Use version from VERSIONS file (loaded via load-versions.sh)
 # ANDROID_MIN_SDK is the canonical name from VERSIONS file


### PR DESCRIPTION
## Summary
- Fixes the glob pattern in `commons-release.yml` publish step that was looking for a non-existent `jniLibs/` directory instead of the actual build output directories (`jni/`, `commons/`, `onnx/`, `llamacpp/`, `rag/`)
- This caused ARM64 `libc++_shared.so` to be placed in the `x86_64/` folder of `RACommons-android-v0.1.6.zip`, crashing Flutter apps on x86_64 emulators
- Uses `cp -n` (no-clobber) to prevent cross-architecture overwrites when the same `.so` exists in multiple subdirectories

Fixes #425

## Test plan
- [ ] Trigger a `commons-release` workflow run (dry run) and verify CI logs show correct per-ABI `.so` file counts
- [ ] Download the resulting `RACommons-android-v{VERSION}.zip` and verify `x86_64/libc++_shared.so` is actually x86_64 (`readelf -h` should show `EM_X86_64`)
- [ ] Run a Flutter app on an x86_64 emulator with the new release ZIP
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes Android release packaging in `commons-release.yml` by correcting directory paths and preventing cross-architecture file overwrites.
> 
>   - **Behavior**:
>     - Fixes glob pattern in `commons-release.yml` to correctly target `jni/`, `commons/`, `onnx/`, `llamacpp/`, `rag/` directories instead of non-existent `jniLibs/`.
>     - Uses `cp -n` to prevent overwriting `.so` files across different architectures.
>   - **Impact**:
>     - Corrects placement of ARM64 `libc++_shared.so` in `x86_64/` folder, preventing crashes on x86_64 emulators.
>   - **Testing**:
>     - Verify correct `.so` file counts in CI logs.
>     - Ensure `x86_64/libc++_shared.so` is x86_64 using `readelf -h`.
>     - Test Flutter app on x86_64 emulator with new release ZIP.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for a6fa2c827d15df146e6406acf8d32e3a39f2d121. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved the release workflow's Android native library collection with more robust error handling, non-destructive copying, multi-ABI support, and per-ABI verification logging for more reliable releases.
  * Updated Android build defaults to include multiple ABIs by default, enabling broader device compatibility when using the fallback settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Fixed the Android release packaging by correcting the glob pattern to match the actual build output directory structure. The previous code looked for a non-existent `jniLibs/` directory, causing it to fail silently and resulting in ARM64 libraries being placed in the `x86_64/` folder. The fix iterates through the correct subdirectories (`jni/`, `commons/`, `onnx/`, `llamacpp/`, `rag/`) and uses `cp -n` (no-clobber) to prevent architecture contamination when the same `.so` file exists across multiple ABIs.

**Key Changes:**
- Replaced single-level glob pattern with nested loops to traverse artifact subdirectories
- Added explicit iteration over `jni`, `commons`, `onnx`, `llamacpp`, `rag` subdirectories
- Used `cp -n` flag to prevent overwrites and ensure correct per-ABI `.so` files
- Enhanced logging to show per-ABI `.so` file counts and file listings

<h3>Confidence Score: 4/5</h3>

- Safe to merge with low risk - fixes a critical packaging bug that caused x86_64 emulator crashes
- The fix correctly addresses the root cause by matching the actual build output structure. The use of `cp -n` prevents overwrites, and improved logging aids verification. Score of 4 (not 5) due to the complexity of the nested loops and the need for thorough testing with actual CI runs to verify all ABIs are packaged correctly.
- No files require special attention - the single workflow file change is well-scoped and addresses the stated issue

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| .github/workflows/commons-release.yml | Fixed Android packaging to collect `.so` files from correct build output directories (`jni/`, `commons/`, `onnx/`, `llamacpp/`, `rag/`) instead of non-existent `jniLibs/`, and added `cp -n` to prevent cross-architecture overwrites |

</details>



<sub>Last reviewed commit: a6fa2c8</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->