### PR TITLE
Introduce Centralized Typed Error Model Across SDKs

### DIFF
--- a/sdk/runanywhere-commons/CMakeLists.txt
+++ b/sdk/runanywhere-commons/CMakeLists.txt
@@ -197,6 +197,7 @@ set(RAC_CORE_SOURCES
     src/core/sdk_state.cpp
     src/core/rac_structured_error.cpp
     src/core/capabilities/lifecycle_manager.cpp
+    src/core/rac_error_model.cpp
 )
 
 # Infrastructure sources - registry, model management, network, telemetry

--- a/sdk/runanywhere-commons/include/rac/core/rac_error_model.h
+++ b/sdk/runanywhere-commons/include/rac/core/rac_error_model.h
@@ -1,0 +1,36 @@
+#ifndef RAC_ERROR_MODEL_H
+#define RAC_ERROR_MODEL_H
+
+#include "rac/core/rac_error.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Structured error model for RunAnywhere SDKs
+ *
+ * This wraps existing rac_result_t codes into a typed,
+ * structured error representation for cross-SDK consistency.
+ */
+typedef struct {
+    rac_result_t code;      /**< Numeric error code */
+    const char* message;    /**< Human-readable error message */
+    const char* category;   /**< Error category (e.g., Model, Network, Validation) */
+} rac_error_model_t;
+
+/**
+ * @brief Create structured error model from error code
+ */
+rac_error_model_t rac_make_error_model(rac_result_t code);
+
+/**
+ * @brief Get error category string from error code
+ */
+const char* rac_error_category(rac_result_t code);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // RAC_ERROR_MODEL_H

--- a/sdk/runanywhere-commons/src/core/rac_error_model.cpp
+++ b/sdk/runanywhere-commons/src/core/rac_error_model.cpp
@@ -1,0 +1,44 @@
+#include "rac/core/rac_error_model.h"
+#include "rac/core/rac_error.h"
+
+#include <string.h>
+
+// ------------------------------------------------------------
+// Internal Helper: Determine Category from Error Code Range
+// ------------------------------------------------------------
+const char* rac_error_category(rac_result_t code) {
+    if (code >= -109 && code <= -100) return "Initialization";
+    if (code >= -129 && code <= -110) return "Model";
+    if (code >= -149 && code <= -130) return "Generation";
+    if (code >= -179 && code <= -150) return "Network";
+    if (code >= -219 && code <= -180) return "Storage";
+    if (code >= -229 && code <= -220) return "Hardware";
+    if (code >= -249 && code <= -230) return "ComponentState";
+    if (code >= -279 && code <= -250) return "Validation";
+    if (code >= -299 && code <= -280) return "Audio";
+    if (code >= -319 && code <= -300) return "LanguageVoice";
+    if (code >= -329 && code <= -320) return "Authentication";
+    if (code >= -349 && code <= -330) return "Security";
+    if (code >= -369 && code <= -350) return "Extraction";
+    if (code >= -379 && code <= -370) return "Calibration";
+    if (code >= -499 && code <= -400) return "ModuleService";
+    if (code >= -599 && code <= -500) return "PlatformAdapter";
+    if (code >= -699 && code <= -600) return "Backend";
+    if (code >= -799 && code <= -700) return "Event";
+    if (code >= -899 && code <= -800) return "Other";
+
+    if (code == RAC_SUCCESS) return "Success";
+
+    return "Unknown";
+}
+
+// ------------------------------------------------------------
+// Public API: Create Structured Error Model
+// ------------------------------------------------------------
+rac_error_model_t rac_make_error_model(rac_result_t code) {
+    rac_error_model_t model;
+    model.code = code;
+    model.message = rac_error_message(code);
+    model.category = rac_error_category(code);
+    return model;
+}

--- a/sdk/runanywhere-commons/src/core/rac_error_model.cpp
+++ b/sdk/runanywhere-commons/src/core/rac_error_model.cpp
@@ -21,6 +21,7 @@ const char* rac_error_category(rac_result_t code) {
     if (code >= -349 && code <= -330) return "Security";
     if (code >= -369 && code <= -350) return "Extraction";
     if (code >= -379 && code <= -370) return "Calibration";
+    if (code >= -389 && code <= -380) return "Cancellation";
     if (code >= -499 && code <= -400) return "ModuleService";
     if (code >= -599 && code <= -500) return "PlatformAdapter";
     if (code >= -699 && code <= -600) return "Backend";

--- a/sdk/runanywhere-commons/src/core/rac_logger.cpp
+++ b/sdk/runanywhere-commons/src/core/rac_logger.cpp
@@ -13,6 +13,7 @@
 #include <cstring>
 #include <mutex>
 
+#include "rac/core/rac_error_model.h"
 #include "rac/core/rac_platform_adapter.h"
 
 // =============================================================================
@@ -154,7 +155,10 @@ void log_to_stderr(rac_log_level_t level, const char* category, const char* mess
             fprintf(stream, ", func=%s", metadata->function);
         }
         if (metadata->error_code != 0) {
-            fprintf(stream, ", error_code=%d", metadata->error_code);
+            rac_error_model_t err = rac_make_error_model((rac_result_t)metadata->error_code);
+            fprintf(stream, ", error_code=%d", err.code);
+            fprintf(stream, ", error_category=%s", err.category);
+            fprintf(stream, ", error_message=%s", err.message);
         }
         if (metadata->model_id) {
             fprintf(stream, ", model=%s", metadata->model_id);


### PR DESCRIPTION
## Summary
Introduced a structured typed error model (`rac_error_model_t`) to standardize error handling across SDK layers.

## Changes
- Added `rac_error_model.h` and `rac_error_model.cpp`
- Implemented centralized error category mapping
- Wrapped existing `rac_result_t` codes into structured model
- Integrated typed error model into logger for enriched error reporting
- Updated CMake configuration

## Result
- Centralized, typed, and extensible error handling
- Consistent error categories across SDK modules
- Improved debugging and telemetry support

Closes #423
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Introduces a centralized structured error model for consistent error handling and reporting across SDKs, enhancing debugging and telemetry support.
> 
>   - **Behavior**:
>     - Introduces `rac_error_model_t` in `rac_error_model.h` and `rac_error_model.cpp` for structured error handling.
>     - Maps existing `rac_result_t` codes to error categories in `rac_error_model.cpp`.
>     - Enhances `log_to_stderr()` in `rac_logger.cpp` to use `rac_error_model_t` for detailed error logging.
>   - **Build Configuration**:
>     - Updates `CMakeLists.txt` to include `rac_error_model.cpp` in the build process.
>   - **Result**:
>     - Centralized and consistent error handling across SDKs.
>     - Improved error reporting and telemetry support.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for 7261465db6d3d63ec8d45bbd4aee889da8e0a4e6. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Introduced structured error reporting: errors now surface as a compact model containing code, category and human-readable message to aid diagnosis.
  * Enhanced logging: stderr output shows the error code, its categorized type and descriptive message instead of only a raw numeric code, improving clarity during troubleshooting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR introduces a centralized typed error model (`rac_error_model_t`) that enhances error handling across SDKs by wrapping existing `rac_result_t` codes with structured metadata (category and human-readable messages).

**Key Changes:**
- Added `rac_error_model.h` defining the structured error model with code, message, and category fields
- Implemented `rac_error_category()` to map error codes to semantic categories based on ranges
- Enhanced logger to output error category and message alongside error codes for better debugging
- Updated build configuration to include new error model source file

**Issues Found:**
- Missing category mapping for cancellation error range (-380 to -389), causing `RAC_ERROR_CANCELLED` to return "Unknown"
- Minor code quality issues: unused header include and missing EOF newline

The implementation correctly integrates with existing error infrastructure and provides a clean API for structured error reporting.

<h3>Confidence Score: 4/5</h3>

- Safe to merge after fixing the missing cancellation range mapping
- The PR provides a solid foundation for structured error handling with clean API design and proper integration. One logical error (missing cancellation range) needs correction to ensure all error codes map correctly to categories. The implementation is well-structured and follows existing patterns.
- Pay close attention to `sdk/runanywhere-commons/src/core/rac_error_model.cpp` to ensure the cancellation range is added

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-commons/include/rac/core/rac_error_model.h | Introduces `rac_error_model_t` struct and API for structured error handling; clean interface design, missing newline at EOF |
| sdk/runanywhere-commons/src/core/rac_error_model.cpp | Implements error category mapping; missing cancellation range (-380 to -389), includes unused `<string.h>` header |
| sdk/runanywhere-commons/src/core/rac_logger.cpp | Enhanced stderr logging to include error category and message; clean integration with new error model |
| sdk/runanywhere-commons/CMakeLists.txt | Added `rac_error_model.cpp` to build sources; correct placement in RAC_CORE_SOURCES |

</details>



<sub>Last reviewed commit: 7261465</sub>

<!-- greptile_other_comments_section -->

<sub>(3/5) Reply to the agent's comments like "Can you suggest a fix for this @greptileai?" or ask follow-up questions!</sub>

<!-- /greptile_comment -->