### PR TITLE
Dev

### DIFF
--- a/sdk/runanywhere-commons/src/backends/rag/llamacpp_generator.h
+++ b/sdk/runanywhere-commons/src/backends/rag/llamacpp_generator.h
@@ -50,10 +50,17 @@ public:
         const std::string& prompt,
         const GenerationOptions& options
     ) override;
-    
+
     bool is_ready() const noexcept override;
     const char* name() const noexcept override;
     int context_size() const noexcept override;
+
+    // Adaptive query loop methods
+    bool inject_system_prompt(const std::string& prompt) override;
+    bool append_context(const std::string& text) override;
+    float probe_confidence(const std::string& context, const std::string& query) override;
+    GenerationResult generate_from_context(const std::string& query, const GenerationOptions& options = GenerationOptions{}) override;
+    void clear_context() override;
 
 private:
     class Impl;

--- a/sdk/runanywhere-commons/src/backends/rag/rac_rag_pipeline.cpp
+++ b/sdk/runanywhere-commons/src/backends/rag/rac_rag_pipeline.cpp
@@ -69,7 +69,7 @@ rac_result_t rac_rag_pipeline_create(
         RAGBackendConfig backend_config;
         backend_config.embedding_dimension = config->embedding_dimension > 0 
             ? config->embedding_dimension : 384;
-        backend_config.top_k = config->top_k > 0 ? config->top_k : 3;
+        backend_config.top_k = config->top_k > 0 ? config->top_k : 10;
         backend_config.similarity_threshold = config->similarity_threshold;
         backend_config.max_context_tokens = config->max_context_tokens > 0 
             ? config->max_context_tokens : 2048;

--- a/sdk/runanywhere-commons/src/backends/rag/rag_backend.h
+++ b/sdk/runanywhere-commons/src/backends/rag/rag_backend.h
@@ -25,7 +25,7 @@ namespace rag {
  */
 struct RAGBackendConfig {
     size_t embedding_dimension = 384;
-    size_t top_k = 3;
+    size_t top_k = 10; //Need to get Golden document
     float similarity_threshold = 0.15f;
     size_t max_context_tokens = 2048;
     size_t chunk_size = 512;
@@ -35,12 +35,18 @@ struct RAGBackendConfig {
 
 /**
  * @brief RAG backend coordinating vector store, embeddings, and generation
- * 
+ *
  * Uses strategy pattern with pluggable embedding and generation providers.
  * Thread-safe for all operations.
  */
 class __attribute__((visibility("default"))) RAGBackend {
 public:
+    // Adaptive query loop constants
+    static constexpr float kConfidenceThreshold = 0.8f;
+
+    // Decides whether or not "weak" sentences are kept 
+    static constexpr bool kKeepPartialContext = true;
+
     /**
      * @brief Construct RAG backend with configuration
      * 
@@ -145,7 +151,8 @@ private:
         const std::shared_ptr<IEmbeddingProvider>& embedding_provider,
         size_t embedding_dimension,
         float similarity_threshold,
-        bool initialized
+        bool initialized,
+        const DocumentChunker* chunker
     ) const;
 
     RAGBackendConfig config_;

--- a/sdk/runanywhere-commons/src/backends/rag/rag_chunker.cpp
+++ b/sdk/runanywhere-commons/src/backends/rag/rag_chunker.cpp
@@ -29,6 +29,29 @@ size_t DocumentChunker::estimate_tokens(const std::string& text) const {
     return text.length() / config_.chars_per_token;
 }
 
+// used for focus mode in RAG(not final yet, will minmax this further, but this is a working version)
+std::vector<std::string> DocumentChunker::split_into_sentences(const std::string& text) const {
+    if (text.empty()) return {};
+
+    auto boundaries = find_sentence_boundaries(text);
+    std::vector<std::string> sentences;
+    sentences.reserve(boundaries.size() - 1);
+
+    for (size_t i = 0; i + 1 < boundaries.size(); ++i) {
+        std::string sentence = text.substr(boundaries[i], boundaries[i + 1] - boundaries[i]);
+        // Trim whitespace
+        size_t first = sentence.find_first_not_of(" \t\n\r");
+        size_t last = sentence.find_last_not_of(" \t\n\r");
+        if (first != std::string::npos && last != std::string::npos) {
+            sentence = sentence.substr(first, last - first + 1);
+        }
+        if (!sentence.empty()) {
+            sentences.push_back(std::move(sentence));
+        }
+    }
+    return sentences;
+}
+
 std::vector<size_t> DocumentChunker::find_sentence_boundaries(const std::string& text) const {
     std::vector<size_t> boundaries;
     boundaries.push_back(0); // Start of document

--- a/sdk/runanywhere-commons/src/backends/rag/rag_chunker.h
+++ b/sdk/runanywhere-commons/src/backends/rag/rag_chunker.h
@@ -52,6 +52,17 @@ public:
      */
     size_t estimate_tokens(const std::string& text) const;
 
+    /**
+     * @brief Split text into individual sentences
+     *
+     * Uses the same sentence boundary detection as chunk_document().
+     * Sentences are trimmed of whitespace. Empty sentences are excluded.
+     *
+     * @param text Input text to split
+     * @return Vector of sentence strings
+     */
+    std::vector<std::string> split_into_sentences(const std::string& text) const;
+
 private:
     ChunkerConfig config_;
 

--- a/sdk/runanywhere-commons/src/backends/rag/vector_store_usearch.cpp
+++ b/sdk/runanywhere-commons/src/backends/rag/vector_store_usearch.cpp
@@ -54,11 +54,11 @@ public:
         usearch_config.expansion_add = config.expansion_add;
         usearch_config.expansion_search = config.expansion_search;
 
-        // Create metric for cosine similarity with F32 vectors
+        // Create metric for cosine similarity. Using i8 instead of float to save on RAM(quality isnt affected much)
         metric_punned_t metric(
             static_cast<std::size_t>(config.dimension),
             metric_kind_t::cos_k,
-            scalar_kind_t::f32_k
+            scalar_kind_t::i8_k
         );
 
         // Create index
@@ -71,7 +71,7 @@ public:
 
         // Reserve capacity
         index_.reserve(config.max_elements);
-        LOGI("Created vector store: dim=%zu, max=%zu, connectivity=%zu",
+        LOGI("Created vector store: dim=%zu, max=%zu, connectivity=%zu, quantization=i8",
              config.dimension, config.max_elements, config.connectivity);
     }
 

--- a/sdk/runanywhere-commons/src/backends/rag/vector_store_usearch.h
+++ b/sdk/runanywhere-commons/src/backends/rag/vector_store_usearch.h
@@ -48,8 +48,8 @@ struct VectorStoreConfig {
     size_t dimension = 384;              // Embedding dimension
     size_t max_elements = 100000;        // Max capacity
     size_t connectivity = 16;            // HNSW connectivity (M)
-    size_t expansion_add = 128;          // Construction search depth
-    size_t expansion_search = 64;        // Query search depth
+    size_t expansion_add = 40;           // Construction search depth ( even a smaller one should be good enough)
+    size_t expansion_search = 20;        // Query search depth( even a smaller one should be good enough)
 };
 
 /**


### PR DESCRIPTION
## Description
Brief description of the changes made.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Playground:**
- [ ] Tested on target platform
- [ ] Verified no regressions in existing Playground projects
**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`sdk/runanywhere-kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`sdk/runanywhere-flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`sdk/runanywhere-react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`sdk/runanywhere-web`)
- [ ] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

**Sample Apps:**
- [ ] `iOS Sample` - Changes to iOS example app (`examples/ios`)
- [ ] `Android Sample` - Changes to Android example app (`examples/android`)
- [ ] `Flutter Sample` - Changes to Flutter example app (`examples/flutter`)
- [ ] `React Native Sample` - Changes to React Native example app (`examples/react-native`)
- [ ] `Web Sample` - Changes to Web example app (`examples/web`)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)

## Screenshots
Attach relevant UI screenshots for changes (if applicable):
- Mobile (Phone)
- Tablet / iPad
- Desktop / Mac

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance RAG backend with adaptive text generation, sentence-level chunking, and optimized vector store for improved performance and accuracy.
> 
>   - **Text Generation**:
>     - Add `probe_confidence()`, `inject_system_prompt()`, `append_context()`, `generate_from_context()`, and `clear_context()` methods to `LlamaCppTextGeneration` in `llamacpp_backend.cpp` and `LlamaCppGenerator` in `llamacpp_generator.cpp`.
>     - Implement adaptive query loop in `RAGBackend` in `rag_backend.cpp` using new text generation methods.
>   - **Document Handling**:
>     - Add `split_into_sentences()` to `DocumentChunker` in `rag_chunker.cpp` for sentence-level chunking.
>     - Update `RAGBackend` in `rag_backend.cpp` to use sentence-level chunking for more focused search results.
>   - **Vector Store**:
>     - Use `i8` quantization in `VectorStoreUSearch` in `vector_store_usearch.cpp` for reduced memory usage.
>     - Adjust search threshold logic in `vector_store_usearch.cpp` to ensure top-K results are returned.
>   - **Miscellaneous**:
>     - Update `RAGBackendConfig` in `rag_backend.h` to increase `top_k` default to 10.
>     - Add logging improvements across multiple files for better debugging and performance tracking.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=RunanywhereAI%2Frunanywhere-sdks&utm_source=github&utm_medium=referral)<sup> for 9e4f2df9c5728e546d2abb037e6ab6fb718f3139. You can [customize](https://app.ellipsis.dev/RunanywhereAI/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced RAG system with adaptive context management and confidence scoring for improved answer generation accuracy.
  * Sentence-level search refinement to retrieve more precise context from documents.
  * Confidence-based context selection to maintain higher-quality information in responses.

* **Performance Improvements**
  * Optimized vector storage with improved quantization and reduced search parameters for faster retrieval.
  * Increased default search retrieval count from 3 to 10 for better candidate selection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

Implements adaptive RAG optimization with sentence-level retrieval and confidence-based context accumulation. The system now retrieves parent chunks, splits them into sentences, embeds sentences individually, then incrementally adds sentences to KV cache until confidence threshold is reached via logit probing.

**Key changes:**
- Sentence-level retrieval: Embeds and scores individual sentences from parent chunks instead of using full chunks
- Adaptive confidence loop: Progressively adds sentences to KV cache and probes model confidence after each addition using Yes/No token logits
- KV cache management: New methods (`inject_system_prompt`, `append_context`, `probe_confidence`, `generate_from_context`, `clear_context`) for stateful generation
- Vector store optimizations: Changed quantization from f32 to i8 (RAM savings) and reduced HNSW parameters by ~70% (expansion_add: 128→40, expansion_search: 64→20)
- Configuration changes: Increased default `top_k` from 3 to 10

**Critical issues:**
- `rag_backend.cpp:401` - Missing error handling: `append_context()` return value not checked, loop continues even if context append fails
- Quantization and HNSW changes need verification to ensure retrieval quality meets requirements
- WIP comment in `rag_chunker.cpp` suggests incomplete implementation

**Performance implications:**
- Sentence-level embedding creates significant computational overhead (embedding every sentence across 5 parent chunks)
- Confidence probing runs inference after each sentence addition
- Trade-off: more precise context vs. increased latency

<h3>Confidence Score: 3/5</h3>

- Significant architectural changes with quality/performance trade-offs that need verification before production deployment
- Score reflects: (1) critical missing error handling in adaptive loop that could cause incorrect behavior when context fills up, (2) unverified quality impact of quantization and HNSW parameter reductions, (3) WIP comments indicating incomplete implementation, (4) significant performance implications of sentence-level embedding that need measurement. The core implementation is sound but needs testing and refinement before production use.
- Pay close attention to `vector_store_usearch.cpp/h` (quantization/HNSW changes affect retrieval quality) and `rag_backend.cpp` (missing error handling in adaptive loop)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-commons/src/backends/rag/rag_backend.cpp | Implements adaptive RAG with sentence-level retrieval and confidence probing. Missing error handling for append_context() failures in adaptive loop. |
| sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp | Implements KV cache management methods (probe_confidence, inject_system_prompt, append_context, generate_from_context). Complex but well-structured with proper cleanup. |
| sdk/runanywhere-commons/src/backends/rag/rag_chunker.cpp | Added split_into_sentences() method. Contains WIP comment indicating incomplete implementation. |
| sdk/runanywhere-commons/src/backends/rag/vector_store_usearch.cpp | Changed quantization from f32 to i8 and reduced HNSW parameters. Significant quality/performance trade-off that needs verification. |
| sdk/runanywhere-commons/src/backends/rag/vector_store_usearch.h | Reduced HNSW search parameters significantly (expansion_add: 128→40, expansion_search: 64→20). May reduce recall quality. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant User
    participant RAGBackend
    participant VectorStore
    participant Embedder
    participant Generator
    participant KVCache

    User->>RAGBackend: query(text)
    RAGBackend->>Generator: clear_context()
    Generator->>KVCache: Clear all state
    RAGBackend->>Generator: inject_system_prompt(ICL)
    Generator->>KVCache: Add ICL prompt at pos 0

    RAGBackend->>Embedder: embed(query)
    Embedder-->>RAGBackend: query_embedding
    RAGBackend->>VectorStore: search(query_embedding, top_k=5)
    Note over VectorStore: Retrieve 5 parent chunks
    VectorStore-->>RAGBackend: parent_chunks[5]

    loop For each parent chunk
        RAGBackend->>RAGBackend: split_into_sentences()
        loop For each sentence
            RAGBackend->>Embedder: embed(sentence)
            Embedder-->>RAGBackend: sentence_embedding
            RAGBackend->>RAGBackend: score = cosine_similarity()
        end
    end

    RAGBackend->>RAGBackend: sort sentences by similarity
    Note over RAGBackend: Keep top 10 sentences

    loop Until confidence > 0.8 OR all sentences added
        RAGBackend->>Generator: append_context(sentence)
        Generator->>KVCache: Append sentence tokens
        RAGBackend->>Generator: probe_confidence("", query)
        Generator->>KVCache: Add probe tokens temporarily
        Generator->>Generator: Extract Yes/No logits
        Generator->>Generator: Compute softmax confidence
        Generator->>KVCache: Remove probe tokens
        Generator-->>RAGBackend: confidence_score
        
        alt confidence > 0.8
            Note over RAGBackend: Threshold reached, stop
        end
    end

    RAGBackend->>Generator: generate_from_context(query_suffix)
    Generator->>KVCache: Add query tokens
    loop Token generation
        Generator->>Generator: Sample next token
        Generator->>KVCache: Append token
    end
    Generator-->>RAGBackend: generated_text

    RAGBackend-->>User: result + metadata
```

<sub>Last reviewed commit: 9e4f2df</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->