### PR TITLE
Add qwen 3/3.5 series support

### DIFF
--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
@@ -267,6 +267,64 @@ struct RunAnywhereAIApp: App {
             )
         }
 
+        // Qwen3 models
+        if let qwen3_06bURL = URL(string: "https://huggingface.co/unsloth/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q4_K_M.gguf") {
+            RunAnywhere.registerModel(
+                id: "qwen3-0.6b-q4_k_m",
+                name: "Qwen3 0.6B Q4_K_M",
+                url: qwen3_06bURL,
+                framework: .llamaCpp,
+                memoryRequirement: 500_000_000
+            )
+        }
+        if let qwen3_17bURL = URL(string: "https://huggingface.co/unsloth/Qwen3-1.7B-GGUF/resolve/main/Qwen3-1.7B-Q4_K_M.gguf") {
+            RunAnywhere.registerModel(
+                id: "qwen3-1.7b-q4_k_m",
+                name: "Qwen3 1.7B Q4_K_M",
+                url: qwen3_17bURL,
+                framework: .llamaCpp,
+                memoryRequirement: 1_200_000_000
+            )
+        }
+        if let qwen3_4bURL = URL(string: "https://huggingface.co/unsloth/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q4_K_M.gguf") {
+            RunAnywhere.registerModel(
+                id: "qwen3-4b-q4_k_m",
+                name: "Qwen3 4B Q4_K_M",
+                url: qwen3_4bURL,
+                framework: .llamaCpp,
+                memoryRequirement: 2_800_000_000
+            )
+        }
+
+        // Qwen3.5 models
+        if let qwen35_08bURL = URL(string: "https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf") {
+            RunAnywhere.registerModel(
+                id: "qwen3.5-0.8b-q4_k_m",
+                name: "Qwen3.5 0.8B Q4_K_M",
+                url: qwen35_08bURL,
+                framework: .llamaCpp,
+                memoryRequirement: 600_000_000
+            )
+        }
+        if let qwen35_2bURL = URL(string: "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf") {
+            RunAnywhere.registerModel(
+                id: "qwen3.5-2b-q4_k_m",
+                name: "Qwen3.5 2B Q4_K_M",
+                url: qwen35_2bURL,
+                framework: .llamaCpp,
+                memoryRequirement: 1_500_000_000
+            )
+        }
+        if let qwen35_4bURL = URL(string: "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf") {
+            RunAnywhere.registerModel(
+                id: "qwen3.5-4b-q4_k_m",
+                name: "Qwen3.5 4B Q4_K_M",
+                url: qwen35_4bURL,
+                framework: .llamaCpp,
+                memoryRequirement: 2_800_000_000
+            )
+        }
+
         logger.info("✅ LLM models registered (including tool-calling optimized models)")
 
         // Register VLM (Vision Language) models

--- a/sdk/runanywhere-commons/VERSIONS
+++ b/sdk/runanywhere-commons/VERSIONS
@@ -72,9 +72,9 @@ SHERPA_ONNX_VERSION_LINUX=1.12.23
 # =============================================================================
 # llama.cpp (LLM inference)
 # =============================================================================
-# b8011 - latest stable release (Feb 2026), includes GGML_WEBGPU backend
+# b8201 - latest stable release (Feb 2026), includes GGML_WEBGPU backend
 # NOTE: Bumped from b7650 to enable WebGPU acceleration for WASM builds
-LLAMACPP_VERSION=b8011
+LLAMACPP_VERSION=b8201
 
 # =============================================================================
 # nlohmann/json

--- a/sdk/runanywhere-commons/src/backends/llamacpp/CMakeLists.txt
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/CMakeLists.txt
@@ -153,6 +153,8 @@ if(RAC_VLM_USE_MTMD)
         ${llamacpp_SOURCE_DIR}/tools/mtmd/models/whisper-enc.cpp
         ${llamacpp_SOURCE_DIR}/tools/mtmd/models/kimik25.cpp
         ${llamacpp_SOURCE_DIR}/tools/mtmd/models/mobilenetv5.cpp
+        ${llamacpp_SOURCE_DIR}/tools/mtmd/models/paddleocr.cpp
+        ${llamacpp_SOURCE_DIR}/tools/mtmd/models/nemotron-v2-vl.cpp
     )
 endif()
 

--- a/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
@@ -371,7 +371,7 @@ bool LlamaCppTextGeneration::unload_model_internal() {
     // Clear LoRA adapters from context before freeing
     // (adapter memory is freed automatically with the model per llama.cpp API)
     if (context_ && !lora_adapters_.empty()) {
-        llama_clear_adapter_lora(context_);
+        llama_set_adapters_lora(context_, nullptr, 0, nullptr);
     }
     lora_adapters_.clear();
 
@@ -828,13 +828,32 @@ bool LlamaCppTextGeneration::recreate_context() {
 }
 
 bool LlamaCppTextGeneration::apply_lora_adapters() {
+    if (lora_adapters_.empty()) {
+        // Clear all adapters from context
+        llama_set_adapters_lora(context_, nullptr, 0, nullptr);
+        return true;
+    }
+
+    std::vector<llama_adapter_lora*> adapters;
+    std::vector<float> scales;
+    adapters.reserve(lora_adapters_.size());
+    scales.reserve(lora_adapters_.size());
+
     for (auto& entry : lora_adapters_) {
-        int32_t result = llama_set_adapter_lora(context_, entry.adapter, entry.scale);
-        if (result != 0) {
-            LOGE("Failed to apply LoRA adapter: %s (error=%d)", entry.path.c_str(), result);
+        adapters.push_back(entry.adapter);
+        scales.push_back(entry.scale);
+    }
+
+    int32_t result = llama_set_adapters_lora(context_, adapters.data(), adapters.size(), scales.data());
+    if (result != 0) {
+        LOGE("Failed to apply LoRA adapters (error=%d)", result);
+        for (auto& entry : lora_adapters_) {
             entry.applied = false;
-            return false;
         }
+        return false;
+    }
+
+    for (auto& entry : lora_adapters_) {
         entry.applied = true;
         LOGI("Applied LoRA adapter: %s (scale=%.2f)", entry.path.c_str(), entry.scale);
     }
@@ -911,16 +930,15 @@ bool LlamaCppTextGeneration::remove_lora_adapter(const std::string& adapter_path
         return false;
     }
 
-    // Remove from context
-    int32_t result = llama_rm_adapter_lora(context_, it->adapter);
-    if (result != 0) {
-        LOGE("Failed to remove LoRA adapter from context: %s (error=%d)", adapter_path.c_str(), result);
-        return false;
-    }
-
     // Remove from tracking (adapter memory is freed automatically with the model
     // per llama.cpp API — llama_adapter_lora_free is deprecated since b8011)
     lora_adapters_.erase(it);
+
+    // Re-apply remaining adapters (or clear if none left)
+    if (!apply_lora_adapters()) {
+        LOGE("Failed to re-apply remaining LoRA adapters after removal");
+        return false;
+    }
 
     // Clear KV cache after adapter changes
     llama_memory_clear(llama_get_memory(context_), true);
@@ -937,7 +955,7 @@ void LlamaCppTextGeneration::clear_lora_adapters() {
     }
 
     if (context_) {
-        llama_clear_adapter_lora(context_);
+        llama_set_adapters_lora(context_, nullptr, 0, nullptr);
         llama_memory_clear(llama_get_memory(context_), true);
     }
 

--- a/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.h
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.h
@@ -163,7 +163,7 @@ class LlamaCppTextGeneration {
     nlohmann::json model_config_;
 
     int context_size_ = 0;
-    int max_default_context_ = 8192;
+    int max_default_context_ = 1024;
 
     std::vector<LoraAdapterEntry> lora_adapters_;
 


### PR DESCRIPTION
Have added support for qwen 3 and 3.5 models.
@sanchitmonga22 ive just ran the 0.6B model, but with the reduced context size, even the bigger models should work. Could test it out but I didnt have the storage on my device rn.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for two new model implementations: PaddleOCR for optical character recognition and Nemotron V2 VL for vision-language tasks.

* **Bug Fixes**
  * Resolved duplicate model registrations for Qwen3 family models that were being registered twice.

* **Chores**
  * Updated backend library to the latest stable release version.
  * Optimized default context size configuration for improved memory efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds registration of six Qwen3 and Qwen3.5 GGUF models (0.6B–4B, Q4_K_M quantization via unsloth on HuggingFace) to the iOS example app, and bumps the llama.cpp dependency from `b8011` to `b8201`. The version bump requires migrating the LoRA adapter API from per-adapter calls (`llama_set_adapter_lora` / `llama_rm_adapter_lora` / `llama_clear_adapter_lora`) to the new batch API (`llama_set_adapters_lora`), which is handled correctly in `llamacpp_backend.cpp`. Two new mtmd VLM source files (`paddleocr.cpp`, `nemotron-v2-vl.cpp`) are also added to `CMakeLists.txt` as required by the updated llama.cpp version.

Key concerns:

- **Global context size regression**: `max_default_context_` in `llamacpp_backend.h` is reduced from `8192` to `1024` — a global change that will silently cap the context window for *all* registered models (not just Qwen3), making the LLM practically unusable for any non-trivial conversation. This should be addressed with a per-model configuration rather than a global default.
- **Model ID dot characters**: Qwen3.5 model IDs (e.g. `"qwen3.5-0.8b-q4_k_m"`) contain a literal `.` which may cause issues if IDs are used in file-system paths or URL routing; the Qwen3 IDs correctly use only hyphens.
- The LoRA refactoring is well-structured — the new batch apply/remove pattern (erase then re-apply remaining) is cleaner and correctly handles the empty-adapter case.

<h3>Confidence Score: 2/5</h3>

- Not safe to merge as-is — the global context size reduction to 1024 tokens will silently degrade all existing models.
- The LoRA API migration and version bump are correct, but reducing max_default_context_ from 8192 to 1024 globally is a significant functional regression for all existing models in the app. This was clearly motivated by wanting Qwen3 to fit in memory, but the fix needs to be scoped per-model rather than applied globally.
- sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.h — the max_default_context_ change needs to be reverted or made per-model.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.h | Reduces max_default_context_ from 8192 to 1024 — a global change that silently degrades context for all registered models, not just Qwen3. |
| sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp | Migrates LoRA adapter API from per-adapter calls (llama_set_adapter_lora / llama_rm_adapter_lora / llama_clear_adapter_lora) to the batch API (llama_set_adapters_lora) required by llama.cpp b8201. Logic is correct and the remove-then-reapply pattern is sound. |
| examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift | Registers six new Qwen3/Qwen3.5 GGUF models via unsloth HuggingFace repos; Qwen3.5 IDs contain dots which may cause issues if IDs are used in file paths or URL segments. |
| sdk/runanywhere-commons/VERSIONS | Bumps LLAMACPP_VERSION from b8011 to b8201; straightforward version pin update needed for the new batch LoRA API. |
| sdk/runanywhere-commons/src/backends/llamacpp/CMakeLists.txt | Adds paddleocr.cpp and nemotron-v2-vl.cpp to the RAC_VLM_USE_MTMD source list, required by the b8201 llama.cpp bump; no issues found. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[apply_lora_adapters called] --> B{lora_adapters_ empty?}
    B -- Yes --> C["llama_set_adapters_lora(ctx, nullptr, 0, nullptr)"]
    C --> D[return true]
    B -- No --> E[Build adapters and scales vectors]
    E --> F["llama_set_adapters_lora(ctx, adapters, size, scales)"]
    F --> G{result == 0?}
    G -- No --> H[Mark all entries applied=false]
    H --> I[return false]
    G -- Yes --> J[Mark all entries applied=true]
    J --> K[return true]

    L[remove_lora_adapter called] --> M{adapter found?}
    M -- No --> N[return false]
    M -- Yes --> O[lora_adapters_.erase]
    O --> P[apply_lora_adapters re-apply or clear]
    P --> Q{success?}
    Q -- No --> R[return false]
    Q -- Yes --> S[llama_memory_clear KV cache]
    S --> T[return true]
```

<sub>Last reviewed commit: 6526e86</sub>

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->