### PR TITLE
[Flutter SDK] Add configuration validation for LLM, STT, and TTS (#450)

### DIFF
--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/features/llm/llm_configuration.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/features/llm/llm_configuration.dart
@@ -1,0 +1,48 @@
+import 'package:runanywhere/core/protocols/component/component_configuration.dart';
+import 'package:runanywhere/core/types/model_types.dart';
+import 'package:runanywhere/foundation/error_types/sdk_error.dart';
+
+/// Configuration for the LLM component.
+///
+/// Mirrors the validation contract used by the Swift and Kotlin SDKs so
+/// invalid parameters fail in Dart before crossing the FFI boundary.
+class LLMConfiguration implements ComponentConfiguration {
+  final String? modelId;
+  final InferenceFramework? preferredFramework;
+  final int contextLength;
+  final double temperature;
+  final int maxTokens;
+  final String? systemPrompt;
+  final bool streamingEnabled;
+
+  const LLMConfiguration({
+    this.modelId,
+    this.preferredFramework,
+    this.contextLength = 2048,
+    this.temperature = 0.7,
+    this.maxTokens = 100,
+    this.systemPrompt,
+    this.streamingEnabled = true,
+  });
+
+  @override
+  void validate() {
+    if (contextLength <= 0 || contextLength > 32768) {
+      throw SDKError.validationFailed(
+        'Context length must be between 1 and 32768',
+      );
+    }
+
+    if (!temperature.isFinite || temperature < 0 || temperature > 2.0) {
+      throw SDKError.validationFailed(
+        'Temperature must be between 0 and 2.0',
+      );
+    }
+
+    if (maxTokens <= 0 || maxTokens > contextLength) {
+      throw SDKError.validationFailed(
+        'Max tokens must be between 1 and context length',
+      );
+    }
+  }
+}

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/features/stt/stt_configuration.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/features/stt/stt_configuration.dart
@@ -1,0 +1,46 @@
+import 'package:runanywhere/core/protocols/component/component_configuration.dart';
+import 'package:runanywhere/core/types/model_types.dart';
+import 'package:runanywhere/foundation/error_types/sdk_error.dart';
+
+/// Configuration for the STT component.
+///
+/// Mirrors the validation contract used by the Swift and Kotlin SDKs so
+/// invalid parameters fail in Dart before crossing the FFI boundary.
+class STTConfiguration implements ComponentConfiguration {
+  final String? modelId;
+  final InferenceFramework? preferredFramework;
+  final String language;
+  final int sampleRate;
+  final bool enablePunctuation;
+  final bool enableDiarization;
+  final List<String> vocabularyList;
+  final int maxAlternatives;
+  final bool enableTimestamps;
+
+  const STTConfiguration({
+    this.modelId,
+    this.preferredFramework,
+    this.language = 'en-US',
+    this.sampleRate = 16000,
+    this.enablePunctuation = true,
+    this.enableDiarization = false,
+    this.vocabularyList = const <String>[],
+    this.maxAlternatives = 1,
+    this.enableTimestamps = true,
+  });
+
+  @override
+  void validate() {
+    if (sampleRate <= 0 || sampleRate > 48000) {
+      throw SDKError.validationFailed(
+        'Sample rate must be between 1 and 48000 Hz',
+      );
+    }
+
+    if (maxAlternatives <= 0 || maxAlternatives > 10) {
+      throw SDKError.validationFailed(
+        'Max alternatives must be between 1 and 10',
+      );
+    }
+  }
+}

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/features/tts/system_tts_service.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/features/tts/system_tts_service.dart
@@ -8,48 +8,7 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter_tts/flutter_tts.dart';
-import 'package:runanywhere/core/protocols/component/component_configuration.dart';
-import 'package:runanywhere/foundation/error_types/sdk_error.dart';
-
-/// Configuration for TTS synthesis
-class TTSConfiguration implements ComponentConfiguration {
-  final String voice;
-  final String language;
-  final double speakingRate;
-  final double pitch;
-  final double volume;
-  final String audioFormat;
-
-  const TTSConfiguration({
-    this.voice = 'system',
-    this.language = 'en-US',
-    this.speakingRate = 0.5,
-    this.pitch = 1.0,
-    this.volume = 1.0,
-    this.audioFormat = 'pcm',
-  });
-
-  @override
-  void validate() {
-    if (!speakingRate.isFinite || speakingRate < 0.5 || speakingRate > 2.0) {
-      throw SDKError.validationFailed(
-        'Speaking rate must be between 0.5 and 2.0',
-      );
-    }
-
-    if (!pitch.isFinite || pitch < 0.5 || pitch > 2.0) {
-      throw SDKError.validationFailed(
-        'Pitch must be between 0.5 and 2.0',
-      );
-    }
-
-    if (!volume.isFinite || volume < 0.0 || volume > 1.0) {
-      throw SDKError.validationFailed(
-        'Volume must be between 0.0 and 1.0',
-      );
-    }
-  }
-}
+import 'package:runanywhere/features/tts/tts_configuration.dart';
 
 /// Input for TTS synthesis
 class TTSSynthesisInput {

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/features/tts/system_tts_service.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/features/tts/system_tts_service.dart
@@ -8,9 +8,11 @@ import 'dart:async';
 import 'dart:typed_data';
 
 import 'package:flutter_tts/flutter_tts.dart';
+import 'package:runanywhere/core/protocols/component/component_configuration.dart';
+import 'package:runanywhere/foundation/error_types/sdk_error.dart';
 
 /// Configuration for TTS synthesis
-class TTSConfiguration {
+class TTSConfiguration implements ComponentConfiguration {
   final String voice;
   final String language;
   final double speakingRate;
@@ -26,6 +28,27 @@ class TTSConfiguration {
     this.volume = 1.0,
     this.audioFormat = 'pcm',
   });
+
+  @override
+  void validate() {
+    if (!speakingRate.isFinite || speakingRate < 0.5 || speakingRate > 2.0) {
+      throw SDKError.validationFailed(
+        'Speaking rate must be between 0.5 and 2.0',
+      );
+    }
+
+    if (!pitch.isFinite || pitch < 0.5 || pitch > 2.0) {
+      throw SDKError.validationFailed(
+        'Pitch must be between 0.5 and 2.0',
+      );
+    }
+
+    if (!volume.isFinite || volume < 0.0 || volume > 1.0) {
+      throw SDKError.validationFailed(
+        'Volume must be between 0.0 and 1.0',
+      );
+    }
+  }
 }
 
 /// Input for TTS synthesis

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/features/tts/tts_configuration.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/features/tts/tts_configuration.dart
@@ -1,0 +1,42 @@
+import 'package:runanywhere/core/protocols/component/component_configuration.dart';
+import 'package:runanywhere/foundation/error_types/sdk_error.dart';
+
+/// Configuration for TTS synthesis.
+class TTSConfiguration implements ComponentConfiguration {
+  final String voice;
+  final String language;
+  final double speakingRate;
+  final double pitch;
+  final double volume;
+  final String audioFormat;
+
+  const TTSConfiguration({
+    this.voice = 'system',
+    this.language = 'en-US',
+    this.speakingRate = 0.5,
+    this.pitch = 1.0,
+    this.volume = 1.0,
+    this.audioFormat = 'pcm',
+  });
+
+  @override
+  void validate() {
+    if (!speakingRate.isFinite || speakingRate < 0.5 || speakingRate > 2.0) {
+      throw SDKError.validationFailed(
+        'Speaking rate must be between 0.5 and 2.0',
+      );
+    }
+
+    if (!pitch.isFinite || pitch < 0.5 || pitch > 2.0) {
+      throw SDKError.validationFailed(
+        'Pitch must be between 0.5 and 2.0',
+      );
+    }
+
+    if (!volume.isFinite || volume < 0.0 || volume > 1.0) {
+      throw SDKError.validationFailed(
+        'Volume must be between 0.0 and 1.0',
+      );
+    }
+  }
+}

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
@@ -48,6 +48,7 @@ class DartBridgeLLM {
 
   RacHandle? _handle;
   String? _loadedModelId;
+  int? _loadedContextLength;
   final _logger = SDKLogger('DartBridge.LLM');
 
   /// Active stream subscription for cancellation
@@ -153,6 +154,7 @@ class DartBridgeLLM {
     String modelPath,
     String modelId,
     String modelName,
+    int? contextLength,
   ) async {
     final handle = getHandle();
 
@@ -181,6 +183,7 @@ class DartBridgeLLM {
       }
 
       _loadedModelId = modelId;
+      _loadedContextLength = contextLength;
       _logger.info('LLM model loaded: $modelId');
     } finally {
       calloc.free(pathPtr);
@@ -200,6 +203,7 @@ class DartBridgeLLM {
 
       cleanupFn(_handle!);
       _loadedModelId = null;
+      _loadedContextLength = null;
       _logger.info('LLM model unloaded');
     } catch (e) {
       _logger.error('Failed to unload LLM model: $e');
@@ -386,8 +390,10 @@ class DartBridgeLLM {
     String? systemPrompt,
     bool streamingEnabled = false,
   }) {
+    final contextLength = _loadedContextLength;
+
     LLMConfiguration(
-      contextLength: 32768,
+      contextLength: contextLength ?? 32768,
       maxTokens: maxTokens,
       temperature: temperature,
       systemPrompt: systemPrompt,
@@ -408,6 +414,7 @@ class DartBridgeLLM {
         destroyFn(_handle!);
         _handle = null;
         _loadedModelId = null;
+        _loadedContextLength = null;
         _logger.debug('LLM component destroyed');
       } catch (e) {
         _logger.error('Failed to destroy LLM component: $e');

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
@@ -18,7 +18,7 @@ import 'dart:ffi';
 import 'dart:isolate'; // Keep for non-streaming generation
 
 import 'package:ffi/ffi.dart';
-
+import 'package:runanywhere/features/llm/llm_configuration.dart';
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
 import 'package:runanywhere/native/platform_loader.dart';
@@ -241,6 +241,12 @@ class DartBridgeLLM {
     double temperature = 0.7,
     String? systemPrompt,
   }) async {
+    _validateGenerationParameters(
+      maxTokens: maxTokens,
+      temperature: temperature,
+      systemPrompt: systemPrompt,
+    );
+
     final handle = getHandle();
 
     if (!isLoaded) {
@@ -284,6 +290,13 @@ class DartBridgeLLM {
     double temperature = 0.7,
     String? systemPrompt,
   }) {
+    _validateGenerationParameters(
+      maxTokens: maxTokens,
+      temperature: temperature,
+      systemPrompt: systemPrompt,
+      streamingEnabled: true,
+    );
+
     final handle = getHandle();
 
     if (!isLoaded) {
@@ -365,6 +378,21 @@ class DartBridgeLLM {
       }
       receivePort.close();
     }
+  }
+
+  void _validateGenerationParameters({
+    required int maxTokens,
+    required double temperature,
+    String? systemPrompt,
+    bool streamingEnabled = false,
+  }) {
+    LLMConfiguration(
+      contextLength: 32768,
+      maxTokens: maxTokens,
+      temperature: temperature,
+      systemPrompt: systemPrompt,
+      streamingEnabled: streamingEnabled,
+    ).validate();
   }
 
   // MARK: - Cleanup

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
@@ -19,6 +19,7 @@ import 'dart:isolate'; // Keep for non-streaming generation
 
 import 'package:ffi/ffi.dart';
 import 'package:runanywhere/features/llm/llm_configuration.dart';
+import 'package:runanywhere/foundation/error_types/sdk_error.dart';
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
 import 'package:runanywhere/native/platform_loader.dart';
@@ -245,17 +246,18 @@ class DartBridgeLLM {
     double temperature = 0.7,
     String? systemPrompt,
   }) async {
-    _validateGenerationParameters(
-      maxTokens: maxTokens,
-      temperature: temperature,
-      systemPrompt: systemPrompt,
-    );
-
     final handle = getHandle();
 
     if (!isLoaded) {
       throw StateError('No LLM model loaded. Call loadModel() first.');
     }
+
+    _validateGenerationParameters(
+      contextLength: _requireLoadedContextLength(),
+      maxTokens: maxTokens,
+      temperature: temperature,
+      systemPrompt: systemPrompt,
+    );
 
     // Run FFI call in a separate isolate to avoid heap corruption
     // from C++ background threads (Metal GPU operations)
@@ -294,18 +296,19 @@ class DartBridgeLLM {
     double temperature = 0.7,
     String? systemPrompt,
   }) {
-    _validateGenerationParameters(
-      maxTokens: maxTokens,
-      temperature: temperature,
-      systemPrompt: systemPrompt,
-      streamingEnabled: true,
-    );
-
     final handle = getHandle();
 
     if (!isLoaded) {
       throw StateError('No LLM model loaded. Call loadModel() first.');
     }
+
+    _validateGenerationParameters(
+      contextLength: _requireLoadedContextLength(),
+      maxTokens: maxTokens,
+      temperature: temperature,
+      systemPrompt: systemPrompt,
+      streamingEnabled: true,
+    );
 
     // Create stream controller for emitting tokens to the caller
     final controller = StreamController<String>();
@@ -384,16 +387,26 @@ class DartBridgeLLM {
     }
   }
 
+  int _requireLoadedContextLength() {
+    final contextLength = _loadedContextLength;
+    if (contextLength != null && contextLength > 0) {
+      return contextLength;
+    }
+
+    throw SDKError.validationFailed(
+      'Loaded model is missing context length metadata for maxTokens validation',
+    );
+  }
+
   void _validateGenerationParameters({
+    required int contextLength,
     required int maxTokens,
     required double temperature,
     String? systemPrompt,
     bool streamingEnabled = false,
   }) {
-    final contextLength = _loadedContextLength;
-
     LLMConfiguration(
-      contextLength: contextLength ?? 32768,
+      contextLength: contextLength,
       maxTokens: maxTokens,
       temperature: temperature,
       systemPrompt: systemPrompt,

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_model_registry.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_model_registry.dart
@@ -152,6 +152,7 @@ class DartBridgeModelRegistry {
         modelPtr.ref.localPath =
             pathDart != null ? strdupFn(pathDart) : nullptr;
         modelPtr.ref.downloadSize = model.sizeBytes;
+        modelPtr.ref.contextLength = model.contextLength;
         modelPtr.ref.source = model.source;
 
         final result = saveFn(_registryHandle!, modelPtr);
@@ -197,6 +198,7 @@ class DartBridgeModelRegistry {
         framework: _frameworkToFfi(model.framework),
         source: _sourceToFfi(model.source),
         sizeBytes: model.downloadSize ?? 0,
+        contextLength: model.contextLength ?? 0,
         downloadURL: model.downloadURL?.toString(),
         localPath: model.localPath?.toFilePath(),
         version: null,
@@ -385,6 +387,7 @@ class DartBridgeModelRegistry {
           ? Uri.file(ffiModel.localPath!)
           : null,
       downloadSize: ffiModel.sizeBytes > 0 ? ffiModel.sizeBytes : null,
+      contextLength: ffiModel.contextLength > 0 ? ffiModel.contextLength : null,
       source: _sourceFromFfi(ffiModel.source),
     );
   }
@@ -797,6 +800,7 @@ class DartBridgeModelRegistry {
       framework: struct.ref.framework,
       source: struct.ref.source,
       sizeBytes: struct.ref.downloadSize,
+      contextLength: struct.ref.contextLength,
       downloadURL: struct.ref.downloadUrl != nullptr
           ? struct.ref.downloadUrl.toDartString()
           : null,
@@ -1085,6 +1089,7 @@ class ModelInfo {
   final int framework;
   final int source;
   final int sizeBytes;
+  final int contextLength;
   final String? downloadURL;
   final String? localPath;
   final String? version;
@@ -1097,6 +1102,7 @@ class ModelInfo {
     required this.framework,
     required this.source,
     required this.sizeBytes,
+    required this.contextLength,
     this.downloadURL,
     this.localPath,
     this.version,
@@ -1112,6 +1118,7 @@ class ModelInfo {
         'framework': framework,
         'source': source,
         'sizeBytes': sizeBytes,
+        'contextLength': contextLength,
         if (downloadURL != null) 'downloadURL': downloadURL,
         if (localPath != null) 'localPath': localPath,
         if (version != null) 'version': version,

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_stt.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_stt.dart
@@ -9,7 +9,7 @@ import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
-
+import 'package:runanywhere/features/stt/stt_configuration.dart';
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
 import 'package:runanywhere/native/platform_loader.dart';
@@ -185,6 +185,8 @@ class DartBridgeSTT {
     Uint8List audioData, {
     int sampleRate = 16000,
   }) async {
+    STTConfiguration(sampleRate: sampleRate).validate();
+
     final handle = getHandle();
 
     if (!isLoaded) {

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_tts.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_tts.dart
@@ -9,7 +9,8 @@ import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
-
+import 'package:runanywhere/features/tts/system_tts_service.dart'
+    show TTSConfiguration;
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
 import 'package:runanywhere/native/platform_loader.dart';
@@ -190,6 +191,12 @@ class DartBridgeTTS {
     double pitch = 1.0,
     double volume = 1.0,
   }) async {
+    TTSConfiguration(
+      speakingRate: rate,
+      pitch: pitch,
+      volume: volume,
+    ).validate();
+
     final handle = getHandle();
 
     if (!isLoaded) {

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_tts.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_tts.dart
@@ -9,8 +9,7 @@ import 'dart:isolate';
 import 'dart:typed_data';
 
 import 'package:ffi/ffi.dart';
-import 'package:runanywhere/features/tts/system_tts_service.dart'
-    show TTSConfiguration;
+import 'package:runanywhere/features/tts/tts_configuration.dart';
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
 import 'package:runanywhere/native/platform_loader.dart';

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/public/runanywhere.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/public/runanywhere.dart
@@ -468,7 +468,12 @@ class RunAnywhere {
       // Load model directly via DartBridgeLLM (mirrors Swift CppBridge.LLM pattern)
       // The C++ layer handles finding the right backend via the service registry
       logger.debug('Loading model via C++ bridge: $resolvedPath');
-      await DartBridge.llm.loadModel(resolvedPath, modelId, model.name);
+      await DartBridge.llm.loadModel(
+        resolvedPath,
+        modelId,
+        model.name,
+        model.contextLength,
+      );
 
       // Verify the model loaded successfully
       if (!DartBridge.llm.isLoaded) {
@@ -1812,7 +1817,7 @@ class RunAnywhere {
         latencyMs: latencyMs.round(),
         temperature: opts.temperature,
         maxTokens: opts.maxTokens,
-        contextLength: 8192, // Default context length for LlamaCpp
+        contextLength: modelInfo?.contextLength,
         tokensPerSecond: tokensPerSecond,
         isStreaming: false,
       );
@@ -1993,7 +1998,7 @@ class RunAnywhere {
         latencyMs: latencyMs.round(),
         temperature: opts.temperature,
         maxTokens: opts.maxTokens,
-        contextLength: 8192, // Default context length for LlamaCpp
+        contextLength: modelInfo?.contextLength,
         tokensPerSecond: tokensPerSecond,
         timeToFirstTokenMs: timeToFirstTokenMs,
         isStreaming: true,

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/public/runanywhere.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/public/runanywhere.dart
@@ -686,6 +686,8 @@ class RunAnywhere {
       logger.info(
           'Transcription complete: ${result.text.length} chars, confidence: ${result.confidence}');
       return result.text;
+    } on SDKError {
+      rethrow;
     } catch (e) {
       // Track transcription failure
       TelemetryService.shared.trackError(
@@ -949,6 +951,8 @@ class RunAnywhere {
         sampleRate: result.sampleRate,
         durationMs: result.durationMs,
       );
+    } on SDKError {
+      rethrow;
     } catch (e) {
       // Track synthesis failure
       TelemetryService.shared.trackError(
@@ -1932,12 +1936,17 @@ class RunAnywhere {
     final allTokens = <String>[];
 
     // Start streaming generation via DartBridgeLLM
-    final tokenStream = DartBridge.llm.generateStream(
-      prompt,
-      maxTokens: opts.maxTokens,
-      temperature: opts.temperature,
-      systemPrompt: effectiveSystemPrompt,
-    );
+    late final Stream<String> tokenStream;
+    try {
+      tokenStream = DartBridge.llm.generateStream(
+        prompt,
+        maxTokens: opts.maxTokens,
+        temperature: opts.temperature,
+        systemPrompt: effectiveSystemPrompt,
+      );
+    } on SDKError {
+      rethrow;
+    }
 
     // Forward tokens and collect them, track subscription in bridge for cancellation
     DartBridge.llm.setActiveStreamSubscription(

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/public/runanywhere.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/public/runanywhere.dart
@@ -1844,6 +1844,8 @@ class RunAnywhere {
         tokensPerSecond: tokensPerSecond,
         structuredData: structuredData,
       );
+    } on SDKError {
+      rethrow;
     } catch (e) {
       // Track generation failure
       TelemetryService.shared.trackError(

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/runanywhere.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/runanywhere.dart
@@ -13,6 +13,7 @@ export 'core/types/storage_types.dart';
 // Network layer
 export 'data/network/network.dart';
 export 'features/llm/llm_configuration.dart';
+export 'features/stt/stt_configuration.dart';
 export 'features/vad/vad_configuration.dart';
 export 'foundation/configuration/sdk_constants.dart';
 export 'foundation/error_types/sdk_error.dart';

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/runanywhere.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/runanywhere.dart
@@ -14,7 +14,7 @@ export 'core/types/storage_types.dart';
 export 'data/network/network.dart';
 export 'features/llm/llm_configuration.dart';
 export 'features/stt/stt_configuration.dart';
-export 'features/tts/system_tts_service.dart' show TTSConfiguration;
+export 'features/tts/tts_configuration.dart';
 export 'features/vad/vad_configuration.dart';
 export 'foundation/configuration/sdk_constants.dart';
 export 'foundation/error_types/sdk_error.dart';

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/runanywhere.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/runanywhere.dart
@@ -14,6 +14,7 @@ export 'core/types/storage_types.dart';
 export 'data/network/network.dart';
 export 'features/llm/llm_configuration.dart';
 export 'features/stt/stt_configuration.dart';
+export 'features/tts/system_tts_service.dart' show TTSConfiguration;
 export 'features/vad/vad_configuration.dart';
 export 'foundation/configuration/sdk_constants.dart';
 export 'foundation/error_types/sdk_error.dart';

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/runanywhere.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/runanywhere.dart
@@ -12,6 +12,7 @@ export 'core/types/sdk_component.dart';
 export 'core/types/storage_types.dart';
 // Network layer
 export 'data/network/network.dart';
+export 'features/llm/llm_configuration.dart';
 export 'features/vad/vad_configuration.dart';
 export 'foundation/configuration/sdk_constants.dart';
 export 'foundation/error_types/sdk_error.dart';


### PR DESCRIPTION
## Summary

Fixes #450 by adding the missing Flutter-side configuration validation for LLM, STT, and TTS before invalid values cross the FFI boundary into the native C++ layer.

Flutter already validated VAD, but LLM and STT configuration models were missing and TTS had no `validate()` implementation. This PR brings Flutter behavior closer to Swift/Kotlin parity for these components.

## Problem

Today, invalid Flutter configuration values can reach native code without a Dart-level error.

Examples:
- negative LLM temperature
- zero or invalid max token counts
- invalid STT sample rates
- invalid TTS speaking rate, pitch, or volume

Swift and Kotlin already reject these values earlier. Flutter did not.

## Changes

### Added missing Flutter configuration models
- Added `LLMConfiguration`
- Added `STTConfiguration`

### Added missing validation
- Implemented `validate()` for `TTSConfiguration`

### Enforced validation before native calls
- Validate LLM generation parameters before `generate()` / `generateStream()` hit FFI
- Validate STT settings before transcription
- Validate TTS settings before synthesis

### Exported config types publicly
- Exported LLM/STT/TTS configuration types from the package root

### Preserved validation errors at the public API layer
- Updated `RunAnywhere.generate()` so `SDKError.validationFailed(...)` is rethrown instead of being masked as a generic generation failure

## Files touched

- `sdk/runanywhere-flutter/packages/runanywhere/lib/features/llm/llm_configuration.dart`
- `sdk/runanywhere-flutter/packages/runanywhere/lib/features/stt/stt_configuration.dart`
- `sdk/runanywhere-flutter/packages/runanywhere/lib/features/tts/system_tts_service.dart`
- `sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart`
- `sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_stt.dart`
- `sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_tts.dart`
- `sdk/runanywhere-flutter/packages/runanywhere/lib/public/runanywhere.dart`
- `sdk/runanywhere-flutter/packages/runanywhere/lib/runanywhere.dart`

## Expected behavior after this PR

Invalid values now fail in Dart first with clear validation errors, for example:
- `Temperature must be between 0 and 2.0`
- `Max tokens must be between 1 and context length`
- `Sample rate must be between 1 and 48000 Hz`
- `Speaking rate must be between 0.5 and 2.0`

## Notes

- This keeps the current Flutter public API shape intact and adds validation at the configuration/bridge boundary.
- VAD behavior is unchanged.
- This PR focuses on validation parity and does not add new public runtime features beyond the missing config models.

## Testing

- Verified the patch structure and git diff cleanliness locally
- I was not able to run `dart format`, `dart analyze`, or Flutter tests in this shell because `dart`/`flutter` were not available on `PATH`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added public configuration objects for LLM, STT, and TTS with validation and defaults.
  * Exposed these configurations in the public SDK API.

* **Improvements**
  * Generation and streaming now respect and carry model context-length metadata end-to-end.
  * Runtime parameter validation is applied before operations to catch invalid inputs early.

* **Bug Fixes**
  * Improved error propagation for validation failures during transcription, synthesis, and generation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds Dart-side configuration validation for LLM, STT, and TTS components in the Flutter SDK, bringing it to parity with the Swift and Kotlin SDKs. Invalid parameters (e.g., negative temperature, out-of-range sample rates) now fail with clear `SDKError.validationFailed` messages before crossing the FFI boundary into C++.

- Added `LLMConfiguration` and `STTConfiguration` models implementing `ComponentConfiguration` with `validate()` methods matching Swift/Kotlin ranges
- Added `validate()` implementation to the existing `TTSConfiguration` class (speakingRate, pitch, volume)
- Wired validation calls into `DartBridgeLLM.generate()`, `DartBridgeLLM.generateStream()`, `DartBridgeSTT.transcribe()`, and `DartBridgeTTS.synthesize()` before FFI calls
- Fixed `RunAnywhere.generate()` to rethrow `SDKError` instead of masking it as a generic generation failure
- Exported new configuration types from the package root barrel file
- **Note:** The LLM bridge hardcodes `contextLength: 32768` when validating, which means the `maxTokens <= contextLength` check will always pass for values under 32768 regardless of the actual model's context window — this weakens the intended protection

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge — it adds defensive validation that improves robustness without changing existing behavior for valid inputs.
- The validation ranges match Swift/Kotlin parity exactly. The code is clean and follows the existing VADConfiguration pattern. One concern is the hardcoded contextLength=32768 in LLM validation which weakens the maxTokens upper-bound check, but this is a design limitation rather than a regression — invalid values that previously crossed FFI unchecked will still be caught for clearly invalid ranges (negative, zero, NaN/Infinity). No tests were run due to environment constraints.
- Pay close attention to `dart_bridge_llm.dart` — the hardcoded `contextLength: 32768` in `_validateGenerationParameters` makes the `maxTokens <= contextLength` check effectively a no-op for realistic values.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| sdk/runanywhere-flutter/packages/runanywhere/lib/features/llm/llm_configuration.dart | New LLM configuration model with validate() matching Swift/Kotlin ranges. Validation logic is sound; ranges match peer SDKs. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/features/stt/stt_configuration.dart | New STT configuration model with sampleRate and maxAlternatives validation. Ranges match Swift/Kotlin SDKs exactly. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/features/tts/system_tts_service.dart | Added validate() to existing TTSConfiguration. Validates speakingRate, pitch, and volume with isFinite checks and range bounds matching Swift/Kotlin. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart | Adds validation before generate/generateStream. Hardcodes contextLength to 32768 in _validateGenerationParameters, which weakens the maxTokens upper-bound check. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_stt.dart | Adds STTConfiguration validation before transcription. Clean integration with minimal changes. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_tts.dart | Adds TTSConfiguration validation before synthesis. Correctly maps rate/pitch/volume parameters to TTSConfiguration fields. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/public/runanywhere.dart | Adds `on SDKError { rethrow; }` to prevent validation errors from being masked as generic generation failures. Correct and necessary fix. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/runanywhere.dart | Exports the three new/updated configuration types from the package root. Uses `show TTSConfiguration` to avoid exporting the entire system_tts_service barrel. |

</details>

<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    A[Public API Call] --> B{Which component?}
    B -->|generate / generateStream| C[DartBridgeLLM]
    B -->|transcribe| D[DartBridgeSTT]
    B -->|synthesize| E[DartBridgeTTS]

    C --> F[LLMConfiguration.validate]
    D --> G[STTConfiguration.validate]
    E --> H[TTSConfiguration.validate]

    F -->|Invalid| I[Throw SDKError.validationFailed]
    G -->|Invalid| I
    H -->|Invalid| I

    F -->|Valid| J[FFI Call to C++]
    G -->|Valid| J
    H -->|Valid| J

    I --> K{Caller}
    K -->|RunAnywhere.generate| L["on SDKError { rethrow }"]
    K -->|Other methods| M[Propagates naturally]
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
Line: 383-396

Comment:
**Hardcoded `contextLength` defeats `maxTokens` validation**

The `contextLength` is hardcoded to `32768` (the maximum allowed), which means the `maxTokens <= contextLength` check in `LLMConfiguration.validate()` will never reject any value under 32768. A user could pass `maxTokens: 32768` even though the loaded model may have a much smaller context window (e.g. 2048 or 4096), sending an invalid value across the FFI boundary — exactly what this PR is trying to prevent.

Consider passing the actual model's context length here. Since `DartBridgeLLM` manages the C++ lifecycle, the real context length may be queryable from the native layer, or you could store it when the model is loaded and pass it through to validation.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-flutter/packages/runanywhere/lib/public/runanywhere.dart
Line: 1847-1848

Comment:
**Missing parallel `SDKError` rethrow in `generateStream`, `transcribe`, and `synthesize`**

The `on SDKError { rethrow; }` clause was added here for `generate`, but the sibling `generateStream` method (line ~1930) calls `DartBridge.llm.generateStream()` outside any try-catch. While this works because validation errors propagate naturally (they're thrown synchronously before the stream is returned), it creates an inconsistency in error handling patterns.

More importantly, `transcribe` (line 684) and `synthesize` (line 947) both have a generic `catch (e) { ... rethrow; }` which *does* preserve the `SDKError` via `rethrow`. This means the `generate` method was the only place actively swallowing `SDKError` (via `throw SDKError.generationFailed('$e')`). This fix is correct — just calling it out for completeness that only `generate` had this masking issue.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: 115e330</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->