### PR TITLE
Optimization of lib.lookup function calls

### DIFF
--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
@@ -21,6 +21,7 @@ import 'package:ffi/ffi.dart';
 
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
+import 'package:runanywhere/native/native_functions.dart';
 import 'package:runanywhere/native/platform_loader.dart';
 
 /// LLM component bridge for C++ interop.
@@ -78,13 +79,9 @@ class DartBridgeLLM {
     }
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final create = lib.lookupFunction<Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_llm_component_create');
-
       final handlePtr = calloc<RacHandle>();
       try {
-        final result = create(handlePtr);
+        final result = NativeFunctions.llmCreate(handlePtr);
 
         if (result != RAC_SUCCESS) {
           throw StateError(
@@ -111,11 +108,7 @@ class DartBridgeLLM {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final isLoadedFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_is_loaded');
-
-      return isLoadedFn(_handle!) == RAC_TRUE;
+      return NativeFunctions.llmIsLoaded(_handle!) == RAC_TRUE;
     } catch (e) {
       _logger.debug('isLoaded check failed: $e');
       return false;
@@ -130,11 +123,7 @@ class DartBridgeLLM {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final supportsStreamingFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_supports_streaming');
-
-      return supportsStreamingFn(_handle!) == RAC_TRUE;
+      return NativeFunctions.llmSupportsStreaming(_handle!) == RAC_TRUE;
     } catch (e) {
       return false;
     }
@@ -161,16 +150,7 @@ class DartBridgeLLM {
     final namePtr = modelName.toNativeUtf8();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final loadModelFn = lib.lookupFunction<
-          Int32 Function(
-              RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
-              Pointer<Utf8>)>('rac_llm_component_load_model');
-
-      _logger.debug(
-          'Calling rac_llm_component_load_model with handle: $_handle, path: $modelPath');
-      final result = loadModelFn(handle, pathPtr, idPtr, namePtr);
+      final result = NativeFunctions.llmLoadModel(handle, pathPtr, idPtr, namePtr);
       _logger.debug(
           'rac_llm_component_load_model returned: $result (${RacResultCode.getMessage(result)})');
 
@@ -194,11 +174,7 @@ class DartBridgeLLM {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final cleanupFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_cleanup');
-
-      cleanupFn(_handle!);
+      NativeFunctions.llmCleanup(_handle!);
       _loadedModelId = null;
       _logger.info('LLM model unloaded');
     } catch (e) {
@@ -211,11 +187,7 @@ class DartBridgeLLM {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final cancelFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_cancel');
-
-      cancelFn(_handle!);
+      NativeFunctions.llmCancel(_handle!);
       _logger.debug('LLM generation cancelled');
     } catch (e) {
       _logger.error('Failed to cancel generation: $e');
@@ -373,11 +345,7 @@ class DartBridgeLLM {
   void destroy() {
     if (_handle != null) {
       try {
-        final lib = PlatformLoader.loadCommons();
-        final destroyFn = lib.lookupFunction<Void Function(RacHandle),
-            void Function(RacHandle)>('rac_llm_component_destroy');
-
-        destroyFn(_handle!);
+        NativeFunctions.llmDestroy(_handle!);
         _handle = null;
         _loadedModelId = null;
         _logger.debug('LLM component destroyed');

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
@@ -150,6 +150,7 @@ class DartBridgeLLM {
     final namePtr = modelName.toNativeUtf8();
 
     try {
+      _logger.debug('Calling rac_llm_component_load_model with handle=$handle');
       final result = NativeFunctions.llmLoadModel(handle, pathPtr, idPtr, namePtr);
       _logger.debug(
           'rac_llm_component_load_model returned: $result (${RacResultCode.getMessage(result)})');
@@ -454,7 +455,7 @@ void _streamingIsolateEntry(_StreamingIsolateParams params) {
     // Set systemPrompt if provided
     if (params.systemPrompt != null && params.systemPrompt!.isNotEmpty) {
       systemPromptPtr = params.systemPrompt!.toNativeUtf8();
-      optionsPtr.ref.systemPrompt = systemPromptPtr!;
+      optionsPtr.ref.systemPrompt = systemPromptPtr;
     } else {
       optionsPtr.ref.systemPrompt = nullptr;
     }
@@ -521,7 +522,7 @@ void _streamingIsolateEntry(_StreamingIsolateParams params) {
     calloc.free(promptPtr);
     calloc.free(optionsPtr);
     if (systemPromptPtr != null) {
-      calloc.free(systemPromptPtr!);
+      calloc.free(systemPromptPtr);
     }
     _isolateSendPort = null;
   }
@@ -590,7 +591,7 @@ _IsolateGenerationResult _generateInIsolate(
     // Set systemPrompt if provided
     if (systemPrompt != null && systemPrompt.isNotEmpty) {
       systemPromptPtr = systemPrompt.toNativeUtf8();
-      optionsPtr.ref.systemPrompt = systemPromptPtr!;
+      optionsPtr.ref.systemPrompt = systemPromptPtr;
     } else {
       optionsPtr.ref.systemPrompt = nullptr;
     }
@@ -626,7 +627,7 @@ _IsolateGenerationResult _generateInIsolate(
     calloc.free(optionsPtr);
     calloc.free(resultPtr);
     if (systemPromptPtr != null) {
-      calloc.free(systemPromptPtr!);
+      calloc.free(systemPromptPtr);
     }
   }
 }

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_stt.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_stt.dart
@@ -12,6 +12,7 @@ import 'package:ffi/ffi.dart';
 
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
+import 'package:runanywhere/native/native_functions.dart';
 import 'package:runanywhere/native/platform_loader.dart';
 
 /// STT component bridge for C++ interop.
@@ -48,13 +49,9 @@ class DartBridgeSTT {
     }
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final create = lib.lookupFunction<Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_stt_component_create');
-
       final handlePtr = calloc<RacHandle>();
       try {
-        final result = create(handlePtr);
+        final result = NativeFunctions.sttCreate(handlePtr);
 
         if (result != RAC_SUCCESS) {
           throw StateError(
@@ -81,11 +78,7 @@ class DartBridgeSTT {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final isLoadedFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_stt_component_is_loaded');
-
-      return isLoadedFn(_handle!) == RAC_TRUE;
+      return NativeFunctions.sttIsLoaded(_handle!) == RAC_TRUE;
     } catch (e) {
       _logger.debug('isLoaded check failed: $e');
       return false;
@@ -100,11 +93,7 @@ class DartBridgeSTT {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final supportsStreamingFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_stt_component_supports_streaming');
-
-      return supportsStreamingFn(_handle!) == RAC_TRUE;
+      return NativeFunctions.sttSupportsStreaming(_handle!) == RAC_TRUE;
     } catch (e) {
       return false;
     }
@@ -131,14 +120,7 @@ class DartBridgeSTT {
     final namePtr = modelName.toNativeUtf8();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final loadModelFn = lib.lookupFunction<
-          Int32 Function(
-              RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
-              Pointer<Utf8>)>('rac_stt_component_load_model');
-
-      final result = loadModelFn(handle, pathPtr, idPtr, namePtr);
+      final result = NativeFunctions.sttLoadModel(handle, pathPtr, idPtr, namePtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -160,11 +142,7 @@ class DartBridgeSTT {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final cleanupFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_stt_component_cleanup');
-
-      cleanupFn(_handle!);
+      NativeFunctions.sttCleanup(_handle!);
       _loadedModelId = null;
       _logger.info('STT model unloaded');
     } catch (e) {
@@ -357,11 +335,7 @@ class DartBridgeSTT {
   void destroy() {
     if (_handle != null) {
       try {
-        final lib = PlatformLoader.loadCommons();
-        final destroyFn = lib.lookupFunction<Void Function(RacHandle),
-            void Function(RacHandle)>('rac_stt_component_destroy');
-
-        destroyFn(_handle!);
+        NativeFunctions.sttDestroy(_handle!);
         _handle = null;
         _loadedModelId = null;
         _logger.debug('STT component destroyed');

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_tts.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_tts.dart
@@ -12,6 +12,7 @@ import 'package:ffi/ffi.dart';
 
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
+import 'package:runanywhere/native/native_functions.dart';
 import 'package:runanywhere/native/platform_loader.dart';
 
 /// TTS component bridge for C++ interop.
@@ -48,13 +49,9 @@ class DartBridgeTTS {
     }
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final create = lib.lookupFunction<Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_tts_component_create');
-
       final handlePtr = calloc<RacHandle>();
       try {
-        final result = create(handlePtr);
+        final result = NativeFunctions.ttsCreate(handlePtr);
 
         if (result != RAC_SUCCESS) {
           throw StateError(
@@ -81,11 +78,7 @@ class DartBridgeTTS {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final isLoadedFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_tts_component_is_loaded');
-
-      return isLoadedFn(_handle!) == RAC_TRUE;
+      return NativeFunctions.ttsIsLoaded(_handle!) == RAC_TRUE;
     } catch (e) {
       _logger.debug('isLoaded check failed: $e');
       return false;
@@ -116,14 +109,7 @@ class DartBridgeTTS {
     final namePtr = voiceName.toNativeUtf8();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final loadVoiceFn = lib.lookupFunction<
-          Int32 Function(
-              RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
-              Pointer<Utf8>)>('rac_tts_component_load_voice');
-
-      final result = loadVoiceFn(handle, pathPtr, idPtr, namePtr);
+      final result = NativeFunctions.ttsLoadVoice(handle, pathPtr, idPtr, namePtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -145,11 +131,7 @@ class DartBridgeTTS {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final cleanupFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_tts_component_cleanup');
-
-      cleanupFn(_handle!);
+      NativeFunctions.ttsCleanup(_handle!);
       _loadedVoiceId = null;
       _logger.info('TTS voice unloaded');
     } catch (e) {
@@ -162,11 +144,7 @@ class DartBridgeTTS {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final stopFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_tts_component_stop');
-
-      stopFn(_handle!);
+      NativeFunctions.ttsStop(_handle!);
       _logger.debug('TTS synthesis stopped');
     } catch (e) {
       _logger.error('Failed to stop TTS: $e');
@@ -335,11 +313,7 @@ class DartBridgeTTS {
   void destroy() {
     if (_handle != null) {
       try {
-        final lib = PlatformLoader.loadCommons();
-        final destroyFn = lib.lookupFunction<Void Function(RacHandle),
-            void Function(RacHandle)>('rac_tts_component_destroy');
-
-        destroyFn(_handle!);
+        NativeFunctions.ttsDestroy(_handle!);
         _handle = null;
         _loadedVoiceId = null;
         _logger.debug('TTS component destroyed');

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart
@@ -229,7 +229,7 @@ class DartBridgeVAD {
         handle,
         samplesPtr,
         samples.length,
-        resultPtr.cast<Void>(),
+        resultPtr,
       );
 
       if (status != RAC_SUCCESS) {

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart
@@ -12,6 +12,7 @@ import 'package:ffi/ffi.dart';
 
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
+import 'package:runanywhere/native/native_functions.dart';
 import 'package:runanywhere/native/platform_loader.dart';
 
 /// VAD component bridge for C++ interop.
@@ -54,14 +55,9 @@ class DartBridgeVAD {
     }
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final create = lib.lookupFunction<
-          Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_vad_component_create');
-
       final handlePtr = calloc<RacHandle>();
       try {
-        final result = create(handlePtr);
+        final result = NativeFunctions.vadCreate(handlePtr);
 
         if (result != RAC_SUCCESS) {
           throw StateError(
@@ -88,11 +84,7 @@ class DartBridgeVAD {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final isInitializedFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_is_initialized');
-
-      return isInitializedFn(_handle!) == RAC_TRUE;
+      return NativeFunctions.vadIsInitialized(_handle!) == RAC_TRUE;
     } catch (e) {
       _logger.debug('isInitialized check failed: $e');
       return false;
@@ -104,11 +96,7 @@ class DartBridgeVAD {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final isSpeechActiveFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_is_speech_active');
-
-      return isSpeechActiveFn(_handle!) == RAC_TRUE;
+      return NativeFunctions.vadIsSpeechActive(_handle!) == RAC_TRUE;
     } catch (e) {
       return false;
     }
@@ -119,11 +107,7 @@ class DartBridgeVAD {
     if (_handle == null) return 0.0;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final getThresholdFn = lib.lookupFunction<Float Function(RacHandle),
-          double Function(RacHandle)>('rac_vad_component_get_energy_threshold');
-
-      return getThresholdFn(_handle!);
+      return NativeFunctions.vadGetEnergyThreshold(_handle!);
     } catch (e) {
       return 0.0;
     }
@@ -134,13 +118,7 @@ class DartBridgeVAD {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final setThresholdFn = lib.lookupFunction<
-          Int32 Function(RacHandle, Float),
-          int Function(
-              RacHandle, double)>('rac_vad_component_set_energy_threshold');
-
-      setThresholdFn(_handle!, threshold);
+      NativeFunctions.vadSetEnergyThreshold(_handle!, threshold);
     } catch (e) {
       _logger.error('Failed to set energy threshold: $e');
     }
@@ -155,11 +133,7 @@ class DartBridgeVAD {
     final handle = getHandle();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final initializeFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_initialize');
-
-      final result = initializeFn(handle);
+      final result = NativeFunctions.vadInitialize(handle);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -179,11 +153,7 @@ class DartBridgeVAD {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final startFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_start');
-
-      final result = startFn(_handle!);
+      final result = NativeFunctions.vadStart(_handle!);
       if (result != RAC_SUCCESS) {
         throw StateError(
           'Failed to start VAD: ${RacResultCode.getMessage(result)}',
@@ -201,11 +171,7 @@ class DartBridgeVAD {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final stopFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_stop');
-
-      stopFn(_handle!);
+      NativeFunctions.vadStop(_handle!);
       _logger.debug('VAD stopped');
     } catch (e) {
       _logger.error('Failed to stop VAD: $e');
@@ -217,11 +183,7 @@ class DartBridgeVAD {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final resetFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_reset');
-
-      resetFn(_handle!);
+      NativeFunctions.vadReset(_handle!);
       _logger.debug('VAD reset');
     } catch (e) {
       _logger.error('Failed to reset VAD: $e');
@@ -233,11 +195,7 @@ class DartBridgeVAD {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final cleanupFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_cleanup');
-
-      cleanupFn(_handle!);
+      NativeFunctions.vadCleanup(_handle!);
       _logger.info('VAD cleaned up');
     } catch (e) {
       _logger.error('Failed to cleanup VAD: $e');
@@ -268,14 +226,7 @@ class DartBridgeVAD {
         samplesPtr[i] = samples[i];
       }
 
-      final lib = PlatformLoader.loadCommons();
-      final processFn = lib.lookupFunction<
-          Int32 Function(
-              RacHandle, Pointer<Float>, IntPtr, Pointer<RacVadResultStruct>),
-          int Function(RacHandle, Pointer<Float>, int,
-              Pointer<RacVadResultStruct>)>('rac_vad_component_process');
-
-      final status = processFn(handle, samplesPtr, samples.length, resultPtr);
+      final status = NativeFunctions.vadProcess(handle, samplesPtr, samples.length, resultPtr);
 
       if (status != RAC_SUCCESS) {
         throw StateError(
@@ -315,11 +266,7 @@ class DartBridgeVAD {
   void destroy() {
     if (_handle != null) {
       try {
-        final lib = PlatformLoader.loadCommons();
-        final destroyFn = lib.lookupFunction<Void Function(RacHandle),
-            void Function(RacHandle)>('rac_vad_component_destroy');
-
-        destroyFn(_handle!);
+        NativeFunctions.vadDestroy(_handle!);
         _handle = null;
         _logger.debug('VAD component destroyed');
       } catch (e) {

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart
@@ -13,7 +13,6 @@ import 'package:ffi/ffi.dart';
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
 import 'package:runanywhere/native/native_functions.dart';
-import 'package:runanywhere/native/platform_loader.dart';
 
 /// VAD component bridge for C++ interop.
 ///
@@ -226,7 +225,12 @@ class DartBridgeVAD {
         samplesPtr[i] = samples[i];
       }
 
-      final status = NativeFunctions.vadProcess(handle, samplesPtr, samples.length, resultPtr);
+      final status = NativeFunctions.vadProcess(
+        handle,
+        samplesPtr,
+        samples.length,
+        resultPtr.cast<Void>(),
+      );
 
       if (status != RAC_SUCCESS) {
         throw StateError(

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -66,8 +66,6 @@ class DartBridgeVoiceAgent {
     }
 
     try {
-      final lib = PlatformLoader.loadCommons();
-
       // Use shared component handles (matches Swift approach)
       // This allows the voice agent to use already-loaded models from the
       // individual component bridges (STT, LLM, TTS, VAD)
@@ -110,7 +108,6 @@ class DartBridgeVoiceAgent {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
       final readyPtr = calloc<Int32>();
       try {
         final result = NativeFunctions.voiceAgentIsReady(_handle!, readyPtr);
@@ -128,7 +125,6 @@ class DartBridgeVoiceAgent {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
       final loadedPtr = calloc<Int32>();
       try {
         final result = NativeFunctions.voiceAgentIsSTTLoaded(_handle!, loadedPtr);
@@ -146,7 +142,6 @@ class DartBridgeVoiceAgent {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
       final loadedPtr = calloc<Int32>();
       try {
         final result = NativeFunctions.voiceAgentIsLLMLoaded(_handle!, loadedPtr);
@@ -164,7 +159,6 @@ class DartBridgeVoiceAgent {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
       final loadedPtr = calloc<Int32>();
       try {
         final result = NativeFunctions.voiceAgentIsTTSLoaded(_handle!, loadedPtr);
@@ -466,7 +460,11 @@ class DartBridgeVoiceAgent {
       calloc.free(textPtr);
       // Free the audio data allocated by C++
       if (audioPtr.value != nullptr) {
-        NativeFunctions.racFree(audioPtr.value);
+        try {
+          NativeFunctions.racFree(audioPtr.value);
+        } catch (_) {
+          // `rac_free` may not exist in some native builds.
+        }
       }
       calloc.free(audioPtr);
       calloc.free(audioSizePtr);

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -65,17 +65,16 @@ class DartBridgeVoiceAgent {
       return _handle!;
     }
 
-    try {
-      // Use shared component handles (matches Swift approach)
-      // This allows the voice agent to use already-loaded models from the
-      // individual component bridges (STT, LLM, TTS, VAD)
-      final llmHandle = DartBridgeLLM.shared.getHandle();
-      final sttHandle = DartBridgeSTT.shared.getHandle();
-      final ttsHandle = DartBridgeTTS.shared.getHandle();
-      final vadHandle = DartBridgeVAD.shared.getHandle();
+    // Use shared component handles (matches Swift approach)
+    // This allows the voice agent to use already-loaded models from the
+    // individual component bridges (STT, LLM, TTS, VAD)
+    final llmHandle = DartBridgeLLM.shared.getHandle();
+    final sttHandle = DartBridgeSTT.shared.getHandle();
+    final ttsHandle = DartBridgeTTS.shared.getHandle();
+    final vadHandle = DartBridgeVAD.shared.getHandle();
 
-      _logger.debug(
-          'Creating voice agent with shared handles: LLM=$llmHandle, STT=$sttHandle, TTS=$ttsHandle, VAD=$vadHandle');
+    _logger.debug(
+        'Creating voice agent with shared handles: LLM=$llmHandle, STT=$sttHandle, TTS=$ttsHandle, VAD=$vadHandle');
 
     try {
       final handlePtr = calloc<RacVoiceAgentHandle>();
@@ -127,7 +126,8 @@ class DartBridgeVoiceAgent {
     try {
       final loadedPtr = calloc<Int32>();
       try {
-        final result = NativeFunctions.voiceAgentIsSTTLoaded(_handle!, loadedPtr);
+        final result =
+            NativeFunctions.voiceAgentIsSTTLoaded(_handle!, loadedPtr);
         return result == RAC_SUCCESS && loadedPtr.value == RAC_TRUE;
       } finally {
         calloc.free(loadedPtr);
@@ -144,7 +144,8 @@ class DartBridgeVoiceAgent {
     try {
       final loadedPtr = calloc<Int32>();
       try {
-        final result = NativeFunctions.voiceAgentIsLLMLoaded(_handle!, loadedPtr);
+        final result =
+            NativeFunctions.voiceAgentIsLLMLoaded(_handle!, loadedPtr);
         return result == RAC_SUCCESS && loadedPtr.value == RAC_TRUE;
       } finally {
         calloc.free(loadedPtr);
@@ -161,7 +162,8 @@ class DartBridgeVoiceAgent {
     try {
       final loadedPtr = calloc<Int32>();
       try {
-        final result = NativeFunctions.voiceAgentIsTTSLoaded(_handle!, loadedPtr);
+        final result =
+            NativeFunctions.voiceAgentIsTTSLoaded(_handle!, loadedPtr);
         return result == RAC_SUCCESS && loadedPtr.value == RAC_TRUE;
       } finally {
         calloc.free(loadedPtr);
@@ -181,7 +183,8 @@ class DartBridgeVoiceAgent {
     final idPtr = modelId.toNativeUtf8();
 
     try {
-      final result = NativeFunctions.voiceAgentLoadSTTModel(handle, pathPtr, idPtr);
+      final result =
+          NativeFunctions.voiceAgentLoadSTTModel(handle, pathPtr, idPtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -205,7 +208,8 @@ class DartBridgeVoiceAgent {
     final idPtr = modelId.toNativeUtf8();
 
     try {
-      final result = NativeFunctions.voiceAgentLoadLLMModel(handle, pathPtr, idPtr);
+      final result =
+          NativeFunctions.voiceAgentLoadLLMModel(handle, pathPtr, idPtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -229,7 +233,8 @@ class DartBridgeVoiceAgent {
     final idPtr = voiceId.toNativeUtf8();
 
     try {
-      final result = NativeFunctions.voiceAgentLoadTTSVoice(handle, pathPtr, idPtr);
+      final result =
+          NativeFunctions.voiceAgentLoadTTSVoice(handle, pathPtr, idPtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -254,7 +259,8 @@ class DartBridgeVoiceAgent {
     final handle = await getHandle();
 
     try {
-      final result = NativeFunctions.voiceAgentInitializeWithLoadedModels(handle);
+      final result =
+          NativeFunctions.voiceAgentInitializeWithLoadedModels(handle);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -288,8 +294,7 @@ class DartBridgeVoiceAgent {
     }
 
     // Run the heavy C++ processing in a background isolate
-    return Isolate.run(
-        () => _processVoiceTurnInIsolate(handle, audioData));
+    return Isolate.run(() => _processVoiceTurnInIsolate(handle, audioData));
   }
 
   /// Static helper for processing voice turn in an isolate.
@@ -363,7 +368,9 @@ class DartBridgeVoiceAgent {
     Uint8List audioWavData;
     if (result.synthesizedAudioSize > 0 && result.synthesizedAudio != nullptr) {
       audioWavData = Uint8List.fromList(
-        result.synthesizedAudio.cast<Uint8>().asTypedList(result.synthesizedAudioSize),
+        result.synthesizedAudio
+            .cast<Uint8>()
+            .asTypedList(result.synthesizedAudioSize),
       );
     } else {
       audioWavData = Uint8List(0);
@@ -416,7 +423,8 @@ class DartBridgeVoiceAgent {
     final resultPtr = calloc<Pointer<Utf8>>();
 
     try {
-      final status = NativeFunctions.voiceAgentGenerateResponse(handle, promptPtr, resultPtr);
+      final status = NativeFunctions.voiceAgentGenerateResponse(
+          handle, promptPtr, resultPtr);
 
       if (status != RAC_SUCCESS) {
         throw StateError(
@@ -514,6 +522,7 @@ class DartBridgeVoiceAgent {
 class VoiceTurnResult {
   final String transcription;
   final String response;
+
   /// WAV-formatted audio data ready for playback
   final Uint8List audioWavData;
   final int sttDurationMs;

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -20,6 +20,16 @@ import 'package:runanywhere/native/ffi_types.dart';
 import 'package:runanywhere/native/native_functions.dart';
 import 'package:runanywhere/native/platform_loader.dart';
 
+void _safeRacFree(Pointer<Void> ptr) {
+  if (ptr == nullptr) return;
+
+  try {
+    NativeFunctions.racFree(ptr);
+  } catch (_) {
+    // rac_free may not exist in some native builds
+  }
+}
+
 /// VoiceAgent component bridge for C++ interop.
 ///
 /// Orchestrates LLM, STT, TTS, and VAD components for voice conversations.
@@ -76,10 +86,10 @@ class DartBridgeVoiceAgent {
       // Use shared component handles (matches Swift approach)
       // This allows the voice agent to use already-loaded models from the
       // individual component bridges (STT, LLM, TTS, VAD)
-      final llmHandle = await DartBridgeLLM.shared.getHandle();
-      final sttHandle = await DartBridgeSTT.shared.getHandle();
-      final ttsHandle = await DartBridgeTTS.shared.getHandle();
-      final vadHandle = await DartBridgeVAD.shared.getHandle();
+      final llmHandle = DartBridgeLLM.shared.getHandle();
+      final sttHandle = DartBridgeSTT.shared.getHandle();
+      final ttsHandle = DartBridgeTTS.shared.getHandle();
+      final vadHandle = DartBridgeVAD.shared.getHandle();
 
       _logger.debug(
           'Creating voice agent with shared handles: LLM=$llmHandle, STT=$sttHandle, TTS=$ttsHandle, VAD=$vadHandle');
@@ -409,9 +419,7 @@ class DartBridgeVoiceAgent {
       return resultPtr.value != nullptr ? resultPtr.value.toDartString() : '';
     } finally {
       calloc.free(audioPtr);
-      if (resultPtr.value != nullptr) {
-        NativeFunctions.racFree(resultPtr.value.cast<Void>());
-      }
+      _safeRacFree(resultPtr.value.cast<Void>());
       calloc.free(resultPtr);
     }
   }
@@ -435,9 +443,7 @@ class DartBridgeVoiceAgent {
       return resultPtr.value != nullptr ? resultPtr.value.toDartString() : '';
     } finally {
       calloc.free(promptPtr);
-      if (resultPtr.value != nullptr) {
-        NativeFunctions.racFree(resultPtr.value.cast<Void>());
-      }
+      _safeRacFree(resultPtr.value.cast<Void>());
       calloc.free(resultPtr);
     }
   }
@@ -471,13 +477,7 @@ class DartBridgeVoiceAgent {
     } finally {
       calloc.free(textPtr);
       // Free the audio data allocated by C++
-      if (audioPtr.value != nullptr) {
-        try {
-          NativeFunctions.racFree(audioPtr.value);
-        } catch (_) {
-          // `rac_free` may not exist in some native builds.
-        }
-      }
+      _safeRacFree(audioPtr.value);
       calloc.free(audioPtr);
       calloc.free(audioSizePtr);
     }

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -20,9 +20,6 @@ import 'package:runanywhere/native/ffi_types.dart';
 import 'package:runanywhere/native/native_functions.dart';
 import 'package:runanywhere/native/platform_loader.dart';
 
-/// Voice agent handle type (opaque pointer to rac_voice_agent struct).
-typedef RacVoiceAgentHandle = Pointer<Void>;
-
 /// VoiceAgent component bridge for C++ interop.
 ///
 /// Orchestrates LLM, STT, TTS, and VAD components for voice conversations.
@@ -45,7 +42,8 @@ class DartBridgeVoiceAgent {
 
   // MARK: - State
 
-  RacVoiceAgentHandle? _handle;
+  RacHandle? _handle;
+  Future<RacHandle>? _initFuture;
   final _logger = SDKLogger('DartBridge.VoiceAgent');
 
   /// Event stream controller
@@ -60,10 +58,19 @@ class DartBridgeVoiceAgent {
   ///
   /// Requires LLM, STT, TTS, and VAD components to be available.
   /// Uses shared component handles (matches Swift CppBridge+VoiceAgent.swift).
-  Future<RacVoiceAgentHandle> getHandle() async {
+  Future<RacHandle> getHandle() async {
     if (_handle != null) {
       return _handle!;
     }
+
+    final initFuture = _initFuture;
+    if (initFuture != null) {
+      await initFuture;
+      return _handle!;
+    }
+
+    final completer = Completer<RacHandle>();
+    _initFuture = completer.future;
 
     // Use shared component handles (matches Swift approach)
     // This allows the voice agent to use already-loaded models from the
@@ -77,7 +84,7 @@ class DartBridgeVoiceAgent {
         'Creating voice agent with shared handles: LLM=$llmHandle, STT=$sttHandle, TTS=$ttsHandle, VAD=$vadHandle');
 
     try {
-      final handlePtr = calloc<RacVoiceAgentHandle>();
+      final handlePtr = calloc<RacHandle>();
       try {
         final result = NativeFunctions.voiceAgentCreate(
             llmHandle, sttHandle, ttsHandle, vadHandle, handlePtr);
@@ -90,12 +97,18 @@ class DartBridgeVoiceAgent {
 
         _handle = handlePtr.value;
         _logger.info('Voice agent created with shared component handles');
+        completer.complete(_handle!);
+        _initFuture = null;
         return _handle!;
       } finally {
         calloc.free(handlePtr);
       }
-    } catch (e) {
+    } catch (e, st) {
       _logger.error('Failed to create voice agent handle: $e');
+      if (!completer.isCompleted) {
+        completer.completeError(e, st);
+      }
+      _initFuture = null;
       rethrow;
     }
   }
@@ -300,7 +313,7 @@ class DartBridgeVoiceAgent {
   /// Static helper for processing voice turn in an isolate.
   /// The C++ API expects raw audio bytes (PCM16), not float samples.
   static Future<VoiceTurnResult> _processVoiceTurnInIsolate(
-    RacVoiceAgentHandle handle,
+    RacHandle handle,
     Uint8List audioData,
   ) async {
     // Allocate native memory for audio data (raw PCM16 bytes)
@@ -311,16 +324,8 @@ class DartBridgeVoiceAgent {
       // Efficient bulk copy of audio bytes
       audioPtr.asTypedList(audioData.length).setAll(0, audioData);
 
-      final lib = PlatformLoader.loadCommons();
-      final processFn = lib.lookupFunction<
-              Int32 Function(RacVoiceAgentHandle, Pointer<Void>, IntPtr,
-                  Pointer<RacVoiceAgentResultStruct>),
-              int Function(RacVoiceAgentHandle, Pointer<Void>, int,
-                  Pointer<RacVoiceAgentResultStruct>)>(
-          'rac_voice_agent_process_voice_turn');
-
-      final status =
-          processFn(handle, audioPtr.cast<Void>(), audioData.length, resultPtr);
+      final status = _processVoiceTurnFn(
+          handle, audioPtr.cast<Void>(), audioData.length, resultPtr);
 
       if (status != RAC_SUCCESS) {
         throw StateError(
@@ -329,20 +334,14 @@ class DartBridgeVoiceAgent {
       }
 
       // Parse result while still in isolate (before freeing memory)
-      return _parseVoiceTurnResultStatic(resultPtr.ref, lib);
+      return _parseVoiceTurnResultStatic(resultPtr.ref, _voiceAgentLib);
     } finally {
       // Free audio data
       calloc.free(audioPtr);
 
       // Free result struct - the C++ side allocates strings/audio that need freeing
-      final lib = PlatformLoader.loadCommons();
       try {
-        final freeFn = lib.lookupFunction<
-            Void Function(Pointer<RacVoiceAgentResultStruct>),
-            void Function(Pointer<RacVoiceAgentResultStruct>)>(
-          'rac_voice_agent_result_free',
-        );
-        freeFn(resultPtr);
+        _voiceAgentResultFreeFn?.call(resultPtr);
       } catch (e) {
         // Function may not exist, just free the struct
       }
@@ -600,3 +599,34 @@ final class RacVoiceAgentResultStruct extends Struct {
   @IntPtr()
   external int synthesizedAudioSize; // size_t (size in bytes)
 }
+
+// MARK: - Isolate-scoped FFI caches
+
+// These are intentionally top-level statics so each isolate initializes them
+// once on first use. This keeps symbol lookups out of hot paths while preserving
+// the existing isolate execution model.
+final DynamicLibrary _voiceAgentLib = PlatformLoader.loadCommons();
+
+final int Function(
+  RacHandle,
+  Pointer<Void>,
+  int,
+  Pointer<RacVoiceAgentResultStruct>,
+) _processVoiceTurnFn = _voiceAgentLib.lookupFunction<
+    Int32 Function(RacHandle, Pointer<Void>, IntPtr,
+        Pointer<RacVoiceAgentResultStruct>),
+    int Function(RacHandle, Pointer<Void>, int,
+        Pointer<RacVoiceAgentResultStruct>)>('rac_voice_agent_process_voice_turn');
+
+final void Function(Pointer<RacVoiceAgentResultStruct>)?
+    _voiceAgentResultFreeFn = (() {
+  try {
+    return _voiceAgentLib.lookupFunction<
+        Void Function(Pointer<RacVoiceAgentResultStruct>),
+        void Function(Pointer<RacVoiceAgentResultStruct>)>(
+      'rac_voice_agent_result_free',
+    );
+  } catch (_) {
+    return null;
+  }
+})();

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -72,18 +72,18 @@ class DartBridgeVoiceAgent {
     final completer = Completer<RacHandle>();
     _initFuture = completer.future;
 
-    // Use shared component handles (matches Swift approach)
-    // This allows the voice agent to use already-loaded models from the
-    // individual component bridges (STT, LLM, TTS, VAD)
-    final llmHandle = DartBridgeLLM.shared.getHandle();
-    final sttHandle = DartBridgeSTT.shared.getHandle();
-    final ttsHandle = DartBridgeTTS.shared.getHandle();
-    final vadHandle = DartBridgeVAD.shared.getHandle();
-
-    _logger.debug(
-        'Creating voice agent with shared handles: LLM=$llmHandle, STT=$sttHandle, TTS=$ttsHandle, VAD=$vadHandle');
-
     try {
+      // Use shared component handles (matches Swift approach)
+      // This allows the voice agent to use already-loaded models from the
+      // individual component bridges (STT, LLM, TTS, VAD)
+      final llmHandle = await DartBridgeLLM.shared.getHandle();
+      final sttHandle = await DartBridgeSTT.shared.getHandle();
+      final ttsHandle = await DartBridgeTTS.shared.getHandle();
+      final vadHandle = await DartBridgeVAD.shared.getHandle();
+
+      _logger.debug(
+          'Creating voice agent with shared handles: LLM=$llmHandle, STT=$sttHandle, TTS=$ttsHandle, VAD=$vadHandle');
+
       final handlePtr = calloc<RacHandle>();
       try {
         final result = NativeFunctions.voiceAgentCreate(
@@ -334,7 +334,7 @@ class DartBridgeVoiceAgent {
       }
 
       // Parse result while still in isolate (before freeing memory)
-      return _parseVoiceTurnResultStatic(resultPtr.ref, _voiceAgentLib);
+      return _parseVoiceTurnResultStatic(resultPtr.ref);
     } finally {
       // Free audio data
       calloc.free(audioPtr);
@@ -354,7 +354,6 @@ class DartBridgeVoiceAgent {
   /// using rac_audio_float32_to_wav, so synthesized_audio is WAV data.
   static VoiceTurnResult _parseVoiceTurnResultStatic(
     RacVoiceAgentResultStruct result,
-    DynamicLibrary lib,
   ) {
     final transcription = result.transcription != nullptr
         ? result.transcription.toDartString()
@@ -410,6 +409,9 @@ class DartBridgeVoiceAgent {
       return resultPtr.value != nullptr ? resultPtr.value.toDartString() : '';
     } finally {
       calloc.free(audioPtr);
+      if (resultPtr.value != nullptr) {
+        NativeFunctions.racFree(resultPtr.value.cast<Void>());
+      }
       calloc.free(resultPtr);
     }
   }
@@ -433,6 +435,9 @@ class DartBridgeVoiceAgent {
       return resultPtr.value != nullptr ? resultPtr.value.toDartString() : '';
     } finally {
       calloc.free(promptPtr);
+      if (resultPtr.value != nullptr) {
+        NativeFunctions.racFree(resultPtr.value.cast<Void>());
+      }
       calloc.free(resultPtr);
     }
   }

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -24,7 +24,7 @@ void _safeRacFree(Pointer<Void> ptr) {
   if (ptr == nullptr) return;
 
   try {
-    NativeFunctions.racFree(ptr);
+    NativeFunctions.racFree?.call(ptr);
   } catch (_) {
     // rac_free may not exist in some native builds
   }
@@ -73,10 +73,8 @@ class DartBridgeVoiceAgent {
       return _handle!;
     }
 
-    final initFuture = _initFuture;
-    if (initFuture != null) {
-      await initFuture;
-      return _handle!;
+    if (_initFuture != null) {
+      return _initFuture!;
     }
 
     final completer = Completer<RacHandle>();
@@ -618,10 +616,11 @@ final int Function(
   int,
   Pointer<RacVoiceAgentResultStruct>,
 ) _processVoiceTurnFn = _voiceAgentLib.lookupFunction<
-    Int32 Function(RacHandle, Pointer<Void>, IntPtr,
-        Pointer<RacVoiceAgentResultStruct>),
-    int Function(RacHandle, Pointer<Void>, int,
-        Pointer<RacVoiceAgentResultStruct>)>('rac_voice_agent_process_voice_turn');
+        Int32 Function(RacHandle, Pointer<Void>, IntPtr,
+            Pointer<RacVoiceAgentResultStruct>),
+        int Function(
+            RacHandle, Pointer<Void>, int, Pointer<RacVoiceAgentResultStruct>)>(
+    'rac_voice_agent_process_voice_turn');
 
 final void Function(Pointer<RacVoiceAgentResultStruct>)?
     _voiceAgentResultFreeFn = (() {

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -17,6 +17,7 @@ import 'package:runanywhere/native/dart_bridge_stt.dart';
 import 'package:runanywhere/native/dart_bridge_tts.dart';
 import 'package:runanywhere/native/dart_bridge_vad.dart';
 import 'package:runanywhere/native/ffi_types.dart';
+import 'package:runanywhere/native/native_functions.dart';
 import 'package:runanywhere/native/platform_loader.dart';
 
 /// Voice agent handle type (opaque pointer to rac_voice_agent struct).
@@ -78,16 +79,11 @@ class DartBridgeVoiceAgent {
       _logger.debug(
           'Creating voice agent with shared handles: LLM=$llmHandle, STT=$sttHandle, TTS=$ttsHandle, VAD=$vadHandle');
 
-      final create = lib.lookupFunction<
-          Int32 Function(RacHandle, RacHandle, RacHandle, RacHandle,
-              Pointer<RacVoiceAgentHandle>),
-          int Function(RacHandle, RacHandle, RacHandle, RacHandle,
-              Pointer<RacVoiceAgentHandle>)>('rac_voice_agent_create');
-
+    try {
       final handlePtr = calloc<RacVoiceAgentHandle>();
       try {
-        final result =
-            create(llmHandle, sttHandle, ttsHandle, vadHandle, handlePtr);
+        final result = NativeFunctions.voiceAgentCreate(
+            llmHandle, sttHandle, ttsHandle, vadHandle, handlePtr);
 
         if (result != RAC_SUCCESS) {
           throw StateError(
@@ -115,14 +111,9 @@ class DartBridgeVoiceAgent {
 
     try {
       final lib = PlatformLoader.loadCommons();
-      final isReadyFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
-          int Function(
-              RacVoiceAgentHandle, Pointer<Int32>)>('rac_voice_agent_is_ready');
-
       final readyPtr = calloc<Int32>();
       try {
-        final result = isReadyFn(_handle!, readyPtr);
+        final result = NativeFunctions.voiceAgentIsReady(_handle!, readyPtr);
         return result == RAC_SUCCESS && readyPtr.value == RAC_TRUE;
       } finally {
         calloc.free(readyPtr);
@@ -138,14 +129,9 @@ class DartBridgeVoiceAgent {
 
     try {
       final lib = PlatformLoader.loadCommons();
-      final isLoadedFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
-          int Function(RacVoiceAgentHandle,
-              Pointer<Int32>)>('rac_voice_agent_is_stt_loaded');
-
       final loadedPtr = calloc<Int32>();
       try {
-        final result = isLoadedFn(_handle!, loadedPtr);
+        final result = NativeFunctions.voiceAgentIsSTTLoaded(_handle!, loadedPtr);
         return result == RAC_SUCCESS && loadedPtr.value == RAC_TRUE;
       } finally {
         calloc.free(loadedPtr);
@@ -161,14 +147,9 @@ class DartBridgeVoiceAgent {
 
     try {
       final lib = PlatformLoader.loadCommons();
-      final isLoadedFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
-          int Function(RacVoiceAgentHandle,
-              Pointer<Int32>)>('rac_voice_agent_is_llm_loaded');
-
       final loadedPtr = calloc<Int32>();
       try {
-        final result = isLoadedFn(_handle!, loadedPtr);
+        final result = NativeFunctions.voiceAgentIsLLMLoaded(_handle!, loadedPtr);
         return result == RAC_SUCCESS && loadedPtr.value == RAC_TRUE;
       } finally {
         calloc.free(loadedPtr);
@@ -184,14 +165,9 @@ class DartBridgeVoiceAgent {
 
     try {
       final lib = PlatformLoader.loadCommons();
-      final isLoadedFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
-          int Function(RacVoiceAgentHandle,
-              Pointer<Int32>)>('rac_voice_agent_is_tts_loaded');
-
       final loadedPtr = calloc<Int32>();
       try {
-        final result = isLoadedFn(_handle!, loadedPtr);
+        final result = NativeFunctions.voiceAgentIsTTSLoaded(_handle!, loadedPtr);
         return result == RAC_SUCCESS && loadedPtr.value == RAC_TRUE;
       } finally {
         calloc.free(loadedPtr);
@@ -211,13 +187,7 @@ class DartBridgeVoiceAgent {
     final idPtr = modelId.toNativeUtf8();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final loadFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
-              Pointer<Utf8>)>('rac_voice_agent_load_stt_model');
-
-      final result = loadFn(handle, pathPtr, idPtr);
+      final result = NativeFunctions.voiceAgentLoadSTTModel(handle, pathPtr, idPtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -241,13 +211,7 @@ class DartBridgeVoiceAgent {
     final idPtr = modelId.toNativeUtf8();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final loadFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
-              Pointer<Utf8>)>('rac_voice_agent_load_llm_model');
-
-      final result = loadFn(handle, pathPtr, idPtr);
+      final result = NativeFunctions.voiceAgentLoadLLMModel(handle, pathPtr, idPtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -271,13 +235,7 @@ class DartBridgeVoiceAgent {
     final idPtr = voiceId.toNativeUtf8();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final loadFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
-              Pointer<Utf8>)>('rac_voice_agent_load_tts_voice');
-
-      final result = loadFn(handle, pathPtr, idPtr);
+      final result = NativeFunctions.voiceAgentLoadTTSVoice(handle, pathPtr, idPtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -302,12 +260,7 @@ class DartBridgeVoiceAgent {
     final handle = await getHandle();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final initFn = lib.lookupFunction<Int32 Function(RacVoiceAgentHandle),
-              int Function(RacVoiceAgentHandle)>(
-          'rac_voice_agent_initialize_with_loaded_models');
-
-      final result = initFn(handle);
+      final result = NativeFunctions.voiceAgentInitializeWithLoadedModels(handle);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -446,14 +399,7 @@ class DartBridgeVoiceAgent {
       // Efficient bulk copy of audio bytes
       audioPtr.asTypedList(audioData.length).setAll(0, audioData);
 
-      final lib = PlatformLoader.loadCommons();
-      final transcribeFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Void>, IntPtr,
-              Pointer<Pointer<Utf8>>),
-          int Function(RacVoiceAgentHandle, Pointer<Void>, int,
-              Pointer<Pointer<Utf8>>)>('rac_voice_agent_transcribe');
-
-      final status = transcribeFn(
+      final status = NativeFunctions.voiceAgentTranscribe(
           handle, audioPtr.cast<Void>(), audioData.length, resultPtr);
 
       if (status != RAC_SUCCESS) {
@@ -476,14 +422,7 @@ class DartBridgeVoiceAgent {
     final resultPtr = calloc<Pointer<Utf8>>();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final generateFn = lib.lookupFunction<
-          Int32 Function(
-              RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
-              Pointer<Pointer<Utf8>>)>('rac_voice_agent_generate_response');
-
-      final status = generateFn(handle, promptPtr, resultPtr);
+      final status = NativeFunctions.voiceAgentGenerateResponse(handle, promptPtr, resultPtr);
 
       if (status != RAC_SUCCESS) {
         throw StateError(
@@ -507,17 +446,8 @@ class DartBridgeVoiceAgent {
     final audioSizePtr = calloc<IntPtr>();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final synthesizeFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>,
-              Pointer<Pointer<Void>>, Pointer<IntPtr>),
-          int Function(
-              RacVoiceAgentHandle,
-              Pointer<Utf8>,
-              Pointer<Pointer<Void>>,
-              Pointer<IntPtr>)>('rac_voice_agent_synthesize_speech');
-
-      final status = synthesizeFn(handle, textPtr, audioPtr, audioSizePtr);
+      final status = NativeFunctions.voiceAgentSynthesizeSpeech(
+          handle, textPtr, audioPtr, audioSizePtr);
 
       if (status != RAC_SUCCESS) {
         throw StateError(
@@ -536,14 +466,7 @@ class DartBridgeVoiceAgent {
       calloc.free(textPtr);
       // Free the audio data allocated by C++
       if (audioPtr.value != nullptr) {
-        final lib = PlatformLoader.loadCommons();
-        try {
-          final freeFn = lib.lookupFunction<Void Function(Pointer<Void>),
-              void Function(Pointer<Void>)>('rac_free');
-          freeFn(audioPtr.value);
-        } catch (_) {
-          // rac_free may not exist
-        }
+        NativeFunctions.racFree(audioPtr.value);
       }
       calloc.free(audioPtr);
       calloc.free(audioSizePtr);
@@ -557,11 +480,7 @@ class DartBridgeVoiceAgent {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final cleanupFn = lib.lookupFunction<Int32 Function(RacVoiceAgentHandle),
-          int Function(RacVoiceAgentHandle)>('rac_voice_agent_cleanup');
-
-      cleanupFn(_handle!);
+      NativeFunctions.voiceAgentCleanup(_handle!);
       _logger.info('Voice agent cleaned up');
     } catch (e) {
       _logger.error('Failed to cleanup voice agent: $e');
@@ -572,11 +491,7 @@ class DartBridgeVoiceAgent {
   void destroy() {
     if (_handle != null) {
       try {
-        final lib = PlatformLoader.loadCommons();
-        final destroyFn = lib.lookupFunction<Void Function(RacVoiceAgentHandle),
-            void Function(RacVoiceAgentHandle)>('rac_voice_agent_destroy');
-
-        destroyFn(_handle!);
+        NativeFunctions.voiceAgentDestroy(_handle!);
         _handle = null;
         _logger.debug('Voice agent destroyed');
       } catch (e) {

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
@@ -12,6 +12,7 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:runanywhere/native/ffi_types.dart';
 import 'package:runanywhere/native/platform_loader.dart';
+import 'package:runanywhere/native/dart_bridge_vad.dart' as vad;
 
 /// Cached native function pointers for the RACommons library.
 ///
@@ -26,200 +27,174 @@ abstract class NativeFunctions {
   // LLM Component
   // ---------------------------------------------------------------------------
 
-  static final int Function(Pointer<RacHandle>) llmCreate =
-      _lib.lookupFunction<
-          Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_llm_component_create');
+  static final int Function(Pointer<RacHandle>) llmCreate = _lib.lookupFunction<
+      Int32 Function(Pointer<RacHandle>),
+      int Function(Pointer<RacHandle>)>('rac_llm_component_create');
 
   static final int Function(RacHandle) llmIsLoaded =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_is_loaded');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_llm_component_is_loaded');
 
   static final int Function(RacHandle) llmSupportsStreaming =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_supports_streaming');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_llm_component_supports_streaming');
 
-  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
-          Pointer<Utf8>) llmLoadModel =
+  static final int Function(
+          RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>) llmLoadModel =
       _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+          Int32 Function(
+              RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_llm_component_load_model');
 
   static final int Function(RacHandle) llmCleanup =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_cleanup');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_llm_component_cleanup');
 
   static final int Function(RacHandle) llmCancel =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_cancel');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_llm_component_cancel');
 
   static final void Function(RacHandle) llmDestroy =
-      _lib.lookupFunction<
-          Void Function(RacHandle),
-          void Function(RacHandle)>('rac_llm_component_destroy');
-
+      _lib.lookupFunction<Void Function(RacHandle), void Function(RacHandle)>(
+          'rac_llm_component_destroy');
 
   // ---------------------------------------------------------------------------
   // STT Component
   // ---------------------------------------------------------------------------
 
-  static final int Function(Pointer<RacHandle>) sttCreate =
-      _lib.lookupFunction<
-          Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_stt_component_create');
+  static final int Function(Pointer<RacHandle>) sttCreate = _lib.lookupFunction<
+      Int32 Function(Pointer<RacHandle>),
+      int Function(Pointer<RacHandle>)>('rac_stt_component_create');
 
   static final int Function(RacHandle) sttIsLoaded =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_stt_component_is_loaded');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_stt_component_is_loaded');
 
   static final int Function(RacHandle) sttSupportsStreaming =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_stt_component_supports_streaming');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_stt_component_supports_streaming');
 
-  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
-          Pointer<Utf8>) sttLoadModel =
+  static final int Function(
+          RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>) sttLoadModel =
       _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+          Int32 Function(
+              RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_stt_component_load_model');
 
   static final int Function(RacHandle) sttCleanup =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_stt_component_cleanup');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_stt_component_cleanup');
 
   static final void Function(Pointer<RacSttResultStruct>) sttResultFree =
       _lib.lookupFunction<Void Function(Pointer<RacSttResultStruct>),
           void Function(Pointer<RacSttResultStruct>)>('rac_stt_result_free');
 
   static final void Function(RacHandle) sttDestroy =
-      _lib.lookupFunction<
-          Void Function(RacHandle),
-          void Function(RacHandle)>('rac_stt_component_destroy');
-
+      _lib.lookupFunction<Void Function(RacHandle), void Function(RacHandle)>(
+          'rac_stt_component_destroy');
 
   // ---------------------------------------------------------------------------
   // TTS Component
   // ---------------------------------------------------------------------------
 
-  static final int Function(Pointer<RacHandle>) ttsCreate =
-      _lib.lookupFunction<
-          Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_tts_component_create');
+  static final int Function(Pointer<RacHandle>) ttsCreate = _lib.lookupFunction<
+      Int32 Function(Pointer<RacHandle>),
+      int Function(Pointer<RacHandle>)>('rac_tts_component_create');
 
   static final int Function(RacHandle) ttsIsLoaded =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_tts_component_is_loaded');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_tts_component_is_loaded');
 
-  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
-          Pointer<Utf8>) ttsLoadVoice =
+  static final int Function(
+          RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>) ttsLoadVoice =
       _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+          Int32 Function(
+              RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_tts_component_load_voice');
 
   static final int Function(RacHandle) ttsCleanup =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_tts_component_cleanup');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_tts_component_cleanup');
 
   static final int Function(RacHandle) ttsStop =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_tts_component_stop');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_tts_component_stop');
 
   static final void Function(RacHandle) ttsDestroy =
-      _lib.lookupFunction<
-          Void Function(RacHandle),
-          void Function(RacHandle)>('rac_tts_component_destroy');
-
+      _lib.lookupFunction<Void Function(RacHandle), void Function(RacHandle)>(
+          'rac_tts_component_destroy');
 
   // ---------------------------------------------------------------------------
   // VAD Component
   // ---------------------------------------------------------------------------
 
-  static final int Function(Pointer<RacHandle>) vadCreate =
-      _lib.lookupFunction<
-          Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_vad_component_create');
+  static final int Function(Pointer<RacHandle>) vadCreate = _lib.lookupFunction<
+      Int32 Function(Pointer<RacHandle>),
+      int Function(Pointer<RacHandle>)>('rac_vad_component_create');
 
   static final int Function(RacHandle) vadIsInitialized =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_is_initialized');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_vad_component_is_initialized');
 
   static final int Function(RacHandle) vadIsSpeechActive =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_is_speech_active');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_vad_component_is_speech_active');
 
-  static final double Function(RacHandle) vadGetEnergyThreshold =
-      _lib.lookupFunction<
-          Float Function(RacHandle),
-          double Function(RacHandle)>('rac_vad_component_get_energy_threshold');
+  static final double Function(RacHandle) vadGetEnergyThreshold = _lib
+      .lookupFunction<Float Function(RacHandle), double Function(RacHandle)>(
+          'rac_vad_component_get_energy_threshold');
 
   static final int Function(RacHandle, double) vadSetEnergyThreshold =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Float),
-          int Function(RacHandle, double)>('rac_vad_component_set_energy_threshold');
+          int Function(
+              RacHandle, double)>('rac_vad_component_set_energy_threshold');
 
   static final int Function(RacHandle) vadInitialize =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_initialize');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_vad_component_initialize');
 
   static final int Function(RacHandle) vadStart =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_start');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_vad_component_start');
 
   static final int Function(RacHandle) vadStop =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_stop');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_vad_component_stop');
 
   static final int Function(RacHandle) vadReset =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_reset');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_vad_component_reset');
 
   static final int Function(RacHandle) vadCleanup =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_cleanup');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_vad_component_cleanup');
 
   static final int Function(
-  RacHandle,
-  Pointer<Float>,
-  int,
-  Pointer<RacVadResultStruct>,
-) vadProcess =
-    _lib.lookupFunction<
-        Int32 Function(
-          RacHandle,
-          Pointer<Float>,
-          IntPtr,
-          Pointer<RacVadResultStruct>,
-        ),
-        int Function(
-          RacHandle,
-          Pointer<Float>,
-          int,
-          Pointer<RacVadResultStruct>,
-        )>('rac_vad_component_process');
+    RacHandle,
+    Pointer<Float>,
+    int,
+    Pointer<vad.RacVadResultStruct>,
+  ) vadProcess = _lib.lookupFunction<
+      Int32 Function(
+        RacHandle,
+        Pointer<Float>,
+        IntPtr,
+        Pointer<vad.RacVadResultStruct>,
+      ),
+      int Function(
+        RacHandle,
+        Pointer<Float>,
+        int,
+        Pointer<vad.RacVadResultStruct>,
+      )>('rac_vad_component_process');
 
   static final void Function(RacHandle) vadDestroy =
-      _lib.lookupFunction<
-          Void Function(RacHandle),
-          void Function(RacHandle)>('rac_vad_component_destroy');
+      _lib.lookupFunction<Void Function(RacHandle), void Function(RacHandle)>(
+          'rac_vad_component_destroy');
 
   // ---------------------------------------------------------------------------
   // VoiceAgent Component
@@ -231,102 +206,102 @@ abstract class NativeFunctions {
     RacHandle,
     RacHandle,
     Pointer<RacHandle>,
-  ) voiceAgentCreate =
-      _lib.lookupFunction<
-          Int32 Function(
-            RacHandle,
-            RacHandle,
-            RacHandle,
-            RacHandle,
-            Pointer<RacHandle>,
-          ),
-          int Function(
-            RacHandle,
-            RacHandle,
-            RacHandle,
-            RacHandle,
-            Pointer<RacHandle>,
-          )>('rac_voice_agent_create');
+  ) voiceAgentCreate = _lib.lookupFunction<
+      Int32 Function(
+        RacHandle,
+        RacHandle,
+        RacHandle,
+        RacHandle,
+        Pointer<RacHandle>,
+      ),
+      int Function(
+        RacHandle,
+        RacHandle,
+        RacHandle,
+        RacHandle,
+        Pointer<RacHandle>,
+      )>('rac_voice_agent_create');
 
   static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsReady =
       _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
           int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_ready');
 
   static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsSTTLoaded =
-      _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
-          int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_stt_loaded');
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Int32>),
+          int Function(
+              RacHandle, Pointer<Int32>)>('rac_voice_agent_is_stt_loaded');
 
   static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsLLMLoaded =
-      _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
-          int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_llm_loaded');
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Int32>),
+          int Function(
+              RacHandle, Pointer<Int32>)>('rac_voice_agent_is_llm_loaded');
 
   static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsTTSLoaded =
-      _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
-          int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_tts_loaded');
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Int32>),
+          int Function(
+              RacHandle, Pointer<Int32>)>('rac_voice_agent_is_tts_loaded');
 
-  static final int Function(
-          RacHandle, Pointer<Utf8>, Pointer<Utf8>)
+  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadSTTModel = _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_stt_model');
 
-  static final int Function(
-          RacHandle, Pointer<Utf8>, Pointer<Utf8>)
+  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadLLMModel = _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_llm_model');
 
-  static final int Function(
-          RacHandle, Pointer<Utf8>, Pointer<Utf8>)
+  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadTTSVoice = _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_tts_voice');
 
-  static final int Function(RacHandle)
-      voiceAgentInitializeWithLoadedModels = _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_voice_agent_initialize_with_loaded_models');
+  static final int Function(RacHandle) voiceAgentInitializeWithLoadedModels =
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_voice_agent_initialize_with_loaded_models');
 
-  static final int Function(RacHandle, Pointer<Void>, int,
-          Pointer<Pointer<Utf8>>) voiceAgentTranscribe =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Void>, IntPtr,
-              Pointer<Pointer<Utf8>>),
+  static final int Function(
+          RacHandle, Pointer<Void>, int, Pointer<Pointer<Utf8>>)
+      voiceAgentTranscribe = _lib.lookupFunction<
+          Int32 Function(
+              RacHandle, Pointer<Void>, IntPtr, Pointer<Pointer<Utf8>>),
           int Function(RacHandle, Pointer<Void>, int,
               Pointer<Pointer<Utf8>>)>('rac_voice_agent_transcribe');
 
-  static final int Function(
-          RacHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>)
+  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>)
       voiceAgentGenerateResponse = _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Utf8>,
-              Pointer<Pointer<Utf8>>),
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>),
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Pointer<Utf8>>)>('rac_voice_agent_generate_response');
 
-  static final int Function(RacHandle, Pointer<Utf8>,
-          Pointer<Pointer<Void>>, Pointer<IntPtr>) voiceAgentSynthesizeSpeech =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Utf8>,
-              Pointer<Pointer<Void>>, Pointer<IntPtr>),
-          int Function(RacHandle, Pointer<Utf8>,
-              Pointer<Pointer<Void>>, Pointer<IntPtr>)>('rac_voice_agent_synthesize_speech');
+  static final int Function(
+          RacHandle, Pointer<Utf8>, Pointer<Pointer<Void>>, Pointer<IntPtr>)
+      voiceAgentSynthesizeSpeech = _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Pointer<Void>>,
+              Pointer<IntPtr>),
+          int Function(RacHandle, Pointer<Utf8>, Pointer<Pointer<Void>>,
+              Pointer<IntPtr>)>('rac_voice_agent_synthesize_speech');
 
   static final int Function(RacHandle) voiceAgentCleanup =
-      _lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_voice_agent_cleanup');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_voice_agent_cleanup');
 
   static final void Function(RacHandle) voiceAgentDestroy =
-      _lib.lookupFunction<Void Function(RacHandle),
-          void Function(RacHandle)>('rac_voice_agent_destroy');
+      _lib.lookupFunction<Void Function(RacHandle), void Function(RacHandle)>(
+          'rac_voice_agent_destroy');
 
   static final void Function(Pointer<Void>)? racFree = (() {
-  try {
-    return _lib.lookupFunction<Void Function(Pointer<Void>),
-        void Function(Pointer<Void>)>('rac_free');
-  } catch (_) {
-    return null;
-  }
-})();
+    try {
+      return _lib.lookupFunction<Void Function(Pointer<Void>),
+          void Function(Pointer<Void>)>('rac_free');
+    } catch (_) {
+      return null;
+    }
+  })();
+}

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
@@ -20,45 +20,45 @@ import 'package:runanywhere/native/platform_loader.dart';
 /// final result = NativeFunctions.llmIsLoaded(_handle!);
 /// ```
 abstract class NativeFunctions {
-  static late final _lib = PlatformLoader.loadCommons();
+  static final _lib = PlatformLoader.loadCommons();
 
   // ---------------------------------------------------------------------------
   // LLM Component
   // ---------------------------------------------------------------------------
 
-  static late final int Function(Pointer<RacHandle>) llmCreate =
+  static final int Function(Pointer<RacHandle>) llmCreate =
       _lib.lookupFunction<
           Int32 Function(Pointer<RacHandle>),
           int Function(Pointer<RacHandle>)>('rac_llm_component_create');
 
-  static late final int Function(RacHandle) llmIsLoaded =
+  static final int Function(RacHandle) llmIsLoaded =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_llm_component_is_loaded');
 
-  static late final int Function(RacHandle) llmSupportsStreaming =
+  static final int Function(RacHandle) llmSupportsStreaming =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_llm_component_supports_streaming');
 
-  static late final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
           Pointer<Utf8>) llmLoadModel =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_llm_component_load_model');
 
-  static late final int Function(RacHandle) llmCleanup =
+  static final int Function(RacHandle) llmCleanup =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_llm_component_cleanup');
 
-  static late final int Function(RacHandle) llmCancel =
+  static final int Function(RacHandle) llmCancel =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_llm_component_cancel');
 
-  static late final int Function(
+  static final int Function(
     RacHandle,
     Pointer<Utf8>,
     Pointer<RacLlmOptionsStruct>,
@@ -69,7 +69,7 @@ abstract class NativeFunctions {
       int Function(RacHandle, Pointer<Utf8>, Pointer<RacLlmOptionsStruct>,
           Pointer<RacLlmResultStruct>)>('rac_llm_component_generate');
 
-  static late final int Function(
+  static final int Function(
     RacHandle,
     Pointer<Utf8>,
     Pointer<RacLlmOptionsStruct>,
@@ -97,7 +97,7 @@ abstract class NativeFunctions {
         Pointer<Void>,
       )>('rac_llm_component_generate_stream');
 
-  static late final void Function(RacHandle) llmDestroy =
+  static final void Function(RacHandle) llmDestroy =
       _lib.lookupFunction<
           Void Function(RacHandle),
           void Function(RacHandle)>('rac_llm_component_destroy');
@@ -107,60 +107,60 @@ abstract class NativeFunctions {
   // STT Component
   // ---------------------------------------------------------------------------
 
-  static late final int Function(Pointer<RacHandle>) sttCreate =
+  static final int Function(Pointer<RacHandle>) sttCreate =
       _lib.lookupFunction<
           Int32 Function(Pointer<RacHandle>),
           int Function(Pointer<RacHandle>)>('rac_stt_component_create');
 
-  static late final int Function(RacHandle) sttIsLoaded =
+  static final int Function(RacHandle) sttIsLoaded =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_stt_component_is_loaded');
 
-  static late final int Function(RacHandle) sttSupportsStreaming =
+  static final int Function(RacHandle) sttSupportsStreaming =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_stt_component_supports_streaming');
 
-  static late final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
           Pointer<Utf8>) sttLoadModel =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_stt_component_load_model');
 
-  static late final int Function(RacHandle) sttCleanup =
+  static final int Function(RacHandle) sttCleanup =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_stt_component_cleanup');
 
-  static late final int Function(
+  static final int Function(
     RacHandle,
     Pointer<Void>,
     int,
-    Pointer<Void>,
-    Pointer<Void>,
+    Pointer<RacSttOptionsStruct>,
+    Pointer<RacSttResultStruct>,
   ) sttTranscribe = _lib.lookupFunction<
       Int32 Function(
         RacHandle,
         Pointer<Void>,
         IntPtr,
-        Pointer<Void>,
-        Pointer<Void>,
+        Pointer<RacSttOptionsStruct>,
+        Pointer<RacSttResultStruct>,
       ),
       int Function(
         RacHandle,
         Pointer<Void>,
         int,
-        Pointer<Void>,
-        Pointer<Void>,
+        Pointer<RacSttOptionsStruct>,
+        Pointer<RacSttResultStruct>,
       )>('rac_stt_component_transcribe');
 
-  static late final void Function(Pointer<Void>) sttResultFree =
-      _lib.lookupFunction<Void Function(Pointer<Void>),
-          void Function(Pointer<Void>)>('rac_stt_result_free');
+  static final void Function(Pointer<RacSttResultStruct>) sttResultFree =
+      _lib.lookupFunction<Void Function(Pointer<RacSttResultStruct>),
+          void Function(Pointer<RacSttResultStruct>)>('rac_stt_result_free');
 
-  static late final void Function(RacHandle) sttDestroy =
+  static final void Function(RacHandle) sttDestroy =
       _lib.lookupFunction<
           Void Function(RacHandle),
           void Function(RacHandle)>('rac_stt_component_destroy');
@@ -170,53 +170,53 @@ abstract class NativeFunctions {
   // TTS Component
   // ---------------------------------------------------------------------------
 
-  static late final int Function(Pointer<RacHandle>) ttsCreate =
+  static final int Function(Pointer<RacHandle>) ttsCreate =
       _lib.lookupFunction<
           Int32 Function(Pointer<RacHandle>),
           int Function(Pointer<RacHandle>)>('rac_tts_component_create');
 
-  static late final int Function(RacHandle) ttsIsLoaded =
+  static final int Function(RacHandle) ttsIsLoaded =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_tts_component_is_loaded');
 
-  static late final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
           Pointer<Utf8>) ttsLoadVoice =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_tts_component_load_voice');
 
-  static late final int Function(RacHandle) ttsCleanup =
+  static final int Function(RacHandle) ttsCleanup =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_tts_component_cleanup');
 
-  static late final int Function(RacHandle) ttsStop =
+  static final int Function(RacHandle) ttsStop =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_tts_component_stop');
 
-  static late final int Function(
+  static final int Function(
     RacHandle,
     Pointer<Utf8>,
-    Pointer<Void>,
-    Pointer<Void>,
+    Pointer<RacTtsOptionsStruct>,
+    Pointer<RacTtsResultStruct>,
   ) ttsSynthesize = _lib.lookupFunction<
       Int32 Function(
         RacHandle,
         Pointer<Utf8>,
-        Pointer<Void>,
-        Pointer<Void>,
+        Pointer<RacTtsOptionsStruct>,
+        Pointer<RacTtsResultStruct>,
       ),
       int Function(
         RacHandle,
         Pointer<Utf8>,
-        Pointer<Void>,
-        Pointer<Void>,
+        Pointer<RacTtsOptionsStruct>,
+        Pointer<RacTtsResultStruct>,
       )>('rac_tts_component_synthesize');
 
-  static late final void Function(RacHandle) ttsDestroy =
+  static final void Function(RacHandle) ttsDestroy =
       _lib.lookupFunction<
           Void Function(RacHandle),
           void Function(RacHandle)>('rac_tts_component_destroy');
@@ -226,64 +226,64 @@ abstract class NativeFunctions {
   // VAD Component
   // ---------------------------------------------------------------------------
 
-  static late final int Function(Pointer<RacHandle>) vadCreate =
+  static final int Function(Pointer<RacHandle>) vadCreate =
       _lib.lookupFunction<
           Int32 Function(Pointer<RacHandle>),
           int Function(Pointer<RacHandle>)>('rac_vad_component_create');
 
-  static late final int Function(RacHandle) vadIsInitialized =
+  static final int Function(RacHandle) vadIsInitialized =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_is_initialized');
 
-  static late final int Function(RacHandle) vadIsSpeechActive =
+  static final int Function(RacHandle) vadIsSpeechActive =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_is_speech_active');
 
-  static late final double Function(RacHandle) vadGetEnergyThreshold =
+  static final double Function(RacHandle) vadGetEnergyThreshold =
       _lib.lookupFunction<
           Float Function(RacHandle),
           double Function(RacHandle)>('rac_vad_component_get_energy_threshold');
 
-  static late final int Function(RacHandle, double) vadSetEnergyThreshold =
+  static final int Function(RacHandle, double) vadSetEnergyThreshold =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Float),
           int Function(RacHandle, double)>('rac_vad_component_set_energy_threshold');
 
-  static late final int Function(RacHandle) vadInitialize =
+  static final int Function(RacHandle) vadInitialize =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_initialize');
 
-  static late final int Function(RacHandle) vadStart =
+  static final int Function(RacHandle) vadStart =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_start');
 
-  static late final int Function(RacHandle) vadStop =
+  static final int Function(RacHandle) vadStop =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_stop');
 
-  static late final int Function(RacHandle) vadReset =
+  static final int Function(RacHandle) vadReset =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_reset');
 
-  static late final int Function(RacHandle) vadCleanup =
+  static final int Function(RacHandle) vadCleanup =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_cleanup');
 
-  static late final int Function(RacHandle, Pointer<Float>, int, Pointer<Void>)
+  static final int Function(RacHandle, Pointer<Float>, int, Pointer<Void>)
       vadProcess =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Float>, IntPtr, Pointer<Void>),
           int Function(
               RacHandle, Pointer<Float>, int, Pointer<Void>)>('rac_vad_component_process');
 
-  static late final void Function(RacHandle) vadDestroy =
+  static final void Function(RacHandle) vadDestroy =
       _lib.lookupFunction<
           Void Function(RacHandle),
           void Function(RacHandle)>('rac_vad_component_destroy');
@@ -292,7 +292,7 @@ abstract class NativeFunctions {
   // VoiceAgent Component
   // ---------------------------------------------------------------------------
 
-  static late final int Function(
+  static final int Function(
     RacHandle,
     RacHandle,
     RacHandle,
@@ -315,60 +315,60 @@ abstract class NativeFunctions {
             Pointer<RacHandle>,
           )>('rac_voice_agent_create');
 
-  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsReady =
+  static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsReady =
       _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
           int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_ready');
 
-  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsSTTLoaded =
+  static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsSTTLoaded =
       _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
           int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_stt_loaded');
 
-  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsLLMLoaded =
+  static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsLLMLoaded =
       _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
           int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_llm_loaded');
 
-  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsTTSLoaded =
+  static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsTTSLoaded =
       _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
           int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_tts_loaded');
 
-  static late final int Function(
+  static final int Function(
           RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadSTTModel = _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_stt_model');
 
-  static late final int Function(
+  static final int Function(
           RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadLLMModel = _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_llm_model');
 
-  static late final int Function(
+  static final int Function(
           RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadTTSVoice = _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_tts_voice');
 
-  static late final int Function(RacHandle)
+  static final int Function(RacHandle)
       voiceAgentInitializeWithLoadedModels = _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_voice_agent_initialize_with_loaded_models');
 
-  static late final int Function(RacHandle, Pointer<Void>, int, Pointer<Void>)
+  static final int Function(RacHandle, Pointer<Void>, int, Pointer<Void>)
       voiceAgentProcessVoiceTurn =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Void>, IntPtr, Pointer<Void>),
           int Function(
               RacHandle, Pointer<Void>, int, Pointer<Void>)>('rac_voice_agent_process_voice_turn');
 
-  static late final void Function(Pointer<Void>) voiceAgentResultFree =
+  static final void Function(Pointer<Void>) voiceAgentResultFree =
       _lib.lookupFunction<Void Function(Pointer<Void>),
           void Function(Pointer<Void>)>('rac_voice_agent_result_free');
 
-  static late final int Function(RacHandle, Pointer<Void>, int,
+  static final int Function(RacHandle, Pointer<Void>, int,
           Pointer<Pointer<Utf8>>) voiceAgentTranscribe =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Void>, IntPtr,
@@ -376,7 +376,7 @@ abstract class NativeFunctions {
           int Function(RacHandle, Pointer<Void>, int,
               Pointer<Pointer<Utf8>>)>('rac_voice_agent_transcribe');
 
-  static late final int Function(
+  static final int Function(
           RacHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>)
       voiceAgentGenerateResponse = _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>,
@@ -384,7 +384,7 @@ abstract class NativeFunctions {
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Pointer<Utf8>>)>('rac_voice_agent_generate_response');
 
-  static late final int Function(RacHandle, Pointer<Utf8>,
+  static final int Function(RacHandle, Pointer<Utf8>,
           Pointer<Pointer<Void>>, Pointer<IntPtr>) voiceAgentSynthesizeSpeech =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>,
@@ -392,15 +392,129 @@ abstract class NativeFunctions {
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Pointer<Void>>, Pointer<IntPtr>)>('rac_voice_agent_synthesize_speech');
 
-  static late final int Function(RacHandle) voiceAgentCleanup =
+  static final int Function(RacHandle) voiceAgentCleanup =
       _lib.lookupFunction<Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_voice_agent_cleanup');
 
-  static late final void Function(RacHandle) voiceAgentDestroy =
+  static final void Function(RacHandle) voiceAgentDestroy =
       _lib.lookupFunction<Void Function(RacHandle),
           void Function(RacHandle)>('rac_voice_agent_destroy');
 
-  static late final void Function(Pointer<Void>) racFree =
+  static final void Function(Pointer<Void>) racFree =
       _lib.lookupFunction<Void Function(Pointer<Void>),
           void Function(Pointer<Void>)>('rac_free');
+}
+
+// =============================================================================
+// FFI Structs
+// =============================================================================
+//
+// These are the native struct layouts used by a subset of component functions.
+// They are defined here (instead of `ffi_types.dart`) so that `NativeFunctions`
+// exposes correctly typed pointers without requiring other library imports.
+
+/// FFI struct for STT options (matches `rac_stt_options_t`).
+final class RacSttOptionsStruct extends Struct {
+  /// Language code (e.g., "en")
+  external Pointer<Utf8> language;
+
+  /// Whether to auto-detect language
+  @Int32()
+  external int detectLanguage;
+
+  /// Whether to add punctuation
+  @Int32()
+  external int enablePunctuation;
+
+  /// Whether to enable speaker diarization
+  @Int32()
+  external int enableDiarization;
+
+  /// Maximum number of speakers for diarization
+  @Int32()
+  external int maxSpeakers;
+
+  /// Whether to include word timestamps
+  @Int32()
+  external int enableTimestamps;
+
+  /// Audio format of input data (`rac_audio_format_enum_t`)
+  @Int32()
+  external int audioFormat;
+
+  /// Sample rate of input audio in Hz
+  @Int32()
+  external int sampleRate;
+}
+
+/// FFI struct for STT result (matches `rac_stt_result_t`).
+final class RacSttResultStruct extends Struct {
+  external Pointer<Utf8> text;
+
+  @Double()
+  external double confidence;
+
+  @Int32()
+  external int durationMs;
+
+  external Pointer<Utf8> language;
+}
+
+/// FFI struct for TTS options (matches `rac_tts_options_t`).
+final class RacTtsOptionsStruct extends Struct {
+  /// Voice to use for synthesis (can be NULL for default)
+  external Pointer<Utf8> voice;
+
+  /// Language for synthesis (BCP-47 format, e.g., "en-US")
+  external Pointer<Utf8> language;
+
+  /// Speech rate (0.0 to 2.0, 1.0 is normal)
+  @Float()
+  external double rate;
+
+  /// Speech pitch (0.0 to 2.0, 1.0 is normal)
+  @Float()
+  external double pitch;
+
+  /// Speech volume (0.0 to 1.0)
+  @Float()
+  external double volume;
+
+  /// Audio format for output (`rac_audio_format_enum_t`)
+  @Int32()
+  external int audioFormat;
+
+  /// Sample rate for output audio in Hz
+  @Int32()
+  external int sampleRate;
+
+  /// Whether to use SSML markup (`rac_bool_t`)
+  @Int32()
+  external int useSsml;
+}
+
+/// FFI struct for TTS result (matches `rac_tts_result_t`).
+final class RacTtsResultStruct extends Struct {
+  /// Audio data (PCM float samples)
+  external Pointer<Void> audioData;
+
+  /// Size of audio data in bytes (size_t)
+  @IntPtr()
+  external int audioSize;
+
+  /// Audio format (`rac_audio_format_enum_t`)
+  @Int32()
+  external int audioFormat;
+
+  /// Sample rate in Hz
+  @Int32()
+  external int sampleRate;
+
+  /// Duration in milliseconds
+  @Int64()
+  external int durationMs;
+
+  /// Processing time in milliseconds
+  @Int64()
+  external int processingTimeMs;
 }

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
@@ -58,45 +58,6 @@ abstract class NativeFunctions {
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_llm_component_cancel');
 
-  static final int Function(
-    RacHandle,
-    Pointer<Utf8>,
-    Pointer<RacLlmOptionsStruct>,
-    Pointer<RacLlmResultStruct>,
-  ) llmGenerate = _lib.lookupFunction<
-      Int32 Function(RacHandle, Pointer<Utf8>, Pointer<RacLlmOptionsStruct>,
-          Pointer<RacLlmResultStruct>),
-      int Function(RacHandle, Pointer<Utf8>, Pointer<RacLlmOptionsStruct>,
-          Pointer<RacLlmResultStruct>)>('rac_llm_component_generate');
-
-  static final int Function(
-    RacHandle,
-    Pointer<Utf8>,
-    Pointer<RacLlmOptionsStruct>,
-    Pointer<NativeFunction<Int32 Function(Pointer<Utf8>, Pointer<Void>)>>,
-    Pointer<NativeFunction<Void Function(Pointer<RacLlmResultStruct>, Pointer<Void>)>>,
-    Pointer<NativeFunction<Void Function(Int32, Pointer<Utf8>, Pointer<Void>)>>,
-    Pointer<Void>,
-  ) llmGenerateStream = _lib.lookupFunction<
-      Int32 Function(
-        RacHandle,
-        Pointer<Utf8>,
-        Pointer<RacLlmOptionsStruct>,
-        Pointer<NativeFunction<Int32 Function(Pointer<Utf8>, Pointer<Void>)>>,
-        Pointer<NativeFunction<Void Function(Pointer<RacLlmResultStruct>, Pointer<Void>)>>,
-        Pointer<NativeFunction<Void Function(Int32, Pointer<Utf8>, Pointer<Void>)>>,
-        Pointer<Void>,
-      ),
-      int Function(
-        RacHandle,
-        Pointer<Utf8>,
-        Pointer<RacLlmOptionsStruct>,
-        Pointer<NativeFunction<Int32 Function(Pointer<Utf8>, Pointer<Void>)>>,
-        Pointer<NativeFunction<Void Function(Pointer<RacLlmResultStruct>, Pointer<Void>)>>,
-        Pointer<NativeFunction<Void Function(Int32, Pointer<Utf8>, Pointer<Void>)>>,
-        Pointer<Void>,
-      )>('rac_llm_component_generate_stream');
-
   static final void Function(RacHandle) llmDestroy =
       _lib.lookupFunction<
           Void Function(RacHandle),
@@ -133,28 +94,6 @@ abstract class NativeFunctions {
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_stt_component_cleanup');
-
-  static final int Function(
-    RacHandle,
-    Pointer<Void>,
-    int,
-    Pointer<RacSttOptionsStruct>,
-    Pointer<RacSttResultStruct>,
-  ) sttTranscribe = _lib.lookupFunction<
-      Int32 Function(
-        RacHandle,
-        Pointer<Void>,
-        IntPtr,
-        Pointer<RacSttOptionsStruct>,
-        Pointer<RacSttResultStruct>,
-      ),
-      int Function(
-        RacHandle,
-        Pointer<Void>,
-        int,
-        Pointer<RacSttOptionsStruct>,
-        Pointer<RacSttResultStruct>,
-      )>('rac_stt_component_transcribe');
 
   static final void Function(Pointer<RacSttResultStruct>) sttResultFree =
       _lib.lookupFunction<Void Function(Pointer<RacSttResultStruct>),
@@ -196,25 +135,6 @@ abstract class NativeFunctions {
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_tts_component_stop');
-
-  static final int Function(
-    RacHandle,
-    Pointer<Utf8>,
-    Pointer<RacTtsOptionsStruct>,
-    Pointer<RacTtsResultStruct>,
-  ) ttsSynthesize = _lib.lookupFunction<
-      Int32 Function(
-        RacHandle,
-        Pointer<Utf8>,
-        Pointer<RacTtsOptionsStruct>,
-        Pointer<RacTtsResultStruct>,
-      ),
-      int Function(
-        RacHandle,
-        Pointer<Utf8>,
-        Pointer<RacTtsOptionsStruct>,
-        Pointer<RacTtsResultStruct>,
-      )>('rac_tts_component_synthesize');
 
   static final void Function(RacHandle) ttsDestroy =
       _lib.lookupFunction<
@@ -357,17 +277,6 @@ abstract class NativeFunctions {
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_voice_agent_initialize_with_loaded_models');
 
-  static final int Function(RacHandle, Pointer<Void>, int, Pointer<Void>)
-      voiceAgentProcessVoiceTurn =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Void>, IntPtr, Pointer<Void>),
-          int Function(
-              RacHandle, Pointer<Void>, int, Pointer<Void>)>('rac_voice_agent_process_voice_turn');
-
-  static final void Function(Pointer<Void>) voiceAgentResultFree =
-      _lib.lookupFunction<Void Function(Pointer<Void>),
-          void Function(Pointer<Void>)>('rac_voice_agent_result_free');
-
   static final int Function(RacHandle, Pointer<Void>, int,
           Pointer<Pointer<Utf8>>) voiceAgentTranscribe =
       _lib.lookupFunction<
@@ -403,118 +312,4 @@ abstract class NativeFunctions {
   static final void Function(Pointer<Void>) racFree =
       _lib.lookupFunction<Void Function(Pointer<Void>),
           void Function(Pointer<Void>)>('rac_free');
-}
-
-// =============================================================================
-// FFI Structs
-// =============================================================================
-//
-// These are the native struct layouts used by a subset of component functions.
-// They are defined here (instead of `ffi_types.dart`) so that `NativeFunctions`
-// exposes correctly typed pointers without requiring other library imports.
-
-/// FFI struct for STT options (matches `rac_stt_options_t`).
-final class RacSttOptionsStruct extends Struct {
-  /// Language code (e.g., "en")
-  external Pointer<Utf8> language;
-
-  /// Whether to auto-detect language
-  @Int32()
-  external int detectLanguage;
-
-  /// Whether to add punctuation
-  @Int32()
-  external int enablePunctuation;
-
-  /// Whether to enable speaker diarization
-  @Int32()
-  external int enableDiarization;
-
-  /// Maximum number of speakers for diarization
-  @Int32()
-  external int maxSpeakers;
-
-  /// Whether to include word timestamps
-  @Int32()
-  external int enableTimestamps;
-
-  /// Audio format of input data (`rac_audio_format_enum_t`)
-  @Int32()
-  external int audioFormat;
-
-  /// Sample rate of input audio in Hz
-  @Int32()
-  external int sampleRate;
-}
-
-/// FFI struct for STT result (matches `rac_stt_result_t`).
-final class RacSttResultStruct extends Struct {
-  external Pointer<Utf8> text;
-
-  @Double()
-  external double confidence;
-
-  @Int32()
-  external int durationMs;
-
-  external Pointer<Utf8> language;
-}
-
-/// FFI struct for TTS options (matches `rac_tts_options_t`).
-final class RacTtsOptionsStruct extends Struct {
-  /// Voice to use for synthesis (can be NULL for default)
-  external Pointer<Utf8> voice;
-
-  /// Language for synthesis (BCP-47 format, e.g., "en-US")
-  external Pointer<Utf8> language;
-
-  /// Speech rate (0.0 to 2.0, 1.0 is normal)
-  @Float()
-  external double rate;
-
-  /// Speech pitch (0.0 to 2.0, 1.0 is normal)
-  @Float()
-  external double pitch;
-
-  /// Speech volume (0.0 to 1.0)
-  @Float()
-  external double volume;
-
-  /// Audio format for output (`rac_audio_format_enum_t`)
-  @Int32()
-  external int audioFormat;
-
-  /// Sample rate for output audio in Hz
-  @Int32()
-  external int sampleRate;
-
-  /// Whether to use SSML markup (`rac_bool_t`)
-  @Int32()
-  external int useSsml;
-}
-
-/// FFI struct for TTS result (matches `rac_tts_result_t`).
-final class RacTtsResultStruct extends Struct {
-  /// Audio data (PCM float samples)
-  external Pointer<Void> audioData;
-
-  /// Size of audio data in bytes (size_t)
-  @IntPtr()
-  external int audioSize;
-
-  /// Audio format (`rac_audio_format_enum_t`)
-  @Int32()
-  external int audioFormat;
-
-  /// Sample rate in Hz
-  @Int32()
-  external int sampleRate;
-
-  /// Duration in milliseconds
-  @Int64()
-  external int durationMs;
-
-  /// Processing time in milliseconds
-  @Int64()
-  external int processingTimeMs;
 }

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
@@ -196,12 +196,25 @@ abstract class NativeFunctions {
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_cleanup');
 
-  static final int Function(RacHandle, Pointer<Float>, int, Pointer<Void>)
-      vadProcess =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Float>, IntPtr, Pointer<Void>),
-          int Function(
-              RacHandle, Pointer<Float>, int, Pointer<Void>)>('rac_vad_component_process');
+  static final int Function(
+  RacHandle,
+  Pointer<Float>,
+  int,
+  Pointer<RacVadResultStruct>,
+) vadProcess =
+    _lib.lookupFunction<
+        Int32 Function(
+          RacHandle,
+          Pointer<Float>,
+          IntPtr,
+          Pointer<RacVadResultStruct>,
+        ),
+        int Function(
+          RacHandle,
+          Pointer<Float>,
+          int,
+          Pointer<RacVadResultStruct>,
+        )>('rac_vad_component_process');
 
   static final void Function(RacHandle) vadDestroy =
       _lib.lookupFunction<
@@ -309,7 +322,11 @@ abstract class NativeFunctions {
       _lib.lookupFunction<Void Function(RacHandle),
           void Function(RacHandle)>('rac_voice_agent_destroy');
 
-  static final void Function(Pointer<Void>) racFree =
-      _lib.lookupFunction<Void Function(Pointer<Void>),
-          void Function(Pointer<Void>)>('rac_free');
-}
+  static final void Function(Pointer<Void>)? racFree = (() {
+  try {
+    return _lib.lookupFunction<Void Function(Pointer<Void>),
+        void Function(Pointer<Void>)>('rac_free');
+  } catch (_) {
+    return null;
+  }
+})();

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
@@ -1,0 +1,380 @@
+/// NativeFunctions
+///
+/// Cached FFI function lookup registry.
+///
+/// All [DynamicLibrary.lookupFunction] calls are performed once at first access
+/// via lazy static fields. Subsequent calls return the cached function pointer,
+/// avoiding repeated symbol-table searches (dlsym) on every invocation.
+library native_functions;
+
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+import 'package:runanywhere/native/ffi_types.dart';
+import 'package:runanywhere/native/platform_loader.dart';
+
+/// Cached native function pointers for the RACommons library.
+///
+/// Usage:
+/// ```dart
+/// final result = NativeFunctions.llmIsLoaded(_handle!);
+/// ```
+abstract class NativeFunctions {
+  static late final _lib = PlatformLoader.loadCommons();
+
+  // ---------------------------------------------------------------------------
+  // LLM Component
+  // ---------------------------------------------------------------------------
+
+  static late final int Function(Pointer<RacHandle>) llmCreate =
+      _lib.lookupFunction<
+          Int32 Function(Pointer<RacHandle>),
+          int Function(Pointer<RacHandle>)>('rac_llm_component_create');
+
+  static late final int Function(RacHandle) llmIsLoaded =
+      _lib.lookupFunction<RacLlmComponentIsLoadedNative,
+          RacLlmComponentIsLoadedDart>('rac_llm_component_is_loaded');
+
+  static late final int Function(RacHandle) llmSupportsStreaming =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_llm_component_supports_streaming');
+
+  static late final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+          Pointer<Utf8>) llmLoadModel =
+      _lib.lookupFunction<RacLlmComponentLoadModelNative,
+          RacLlmComponentLoadModelDart>('rac_llm_component_load_model');
+
+  static late final int Function(RacHandle) llmCleanup =
+      _lib.lookupFunction<RacLlmComponentCleanupNative,
+          RacLlmComponentCleanupDart>('rac_llm_component_cleanup');
+
+  static late final int Function(RacHandle) llmCancel =
+      _lib.lookupFunction<RacLlmComponentCancelNative,
+          RacLlmComponentCancelDart>('rac_llm_component_cancel');
+
+  static late final int Function(
+    RacHandle,
+    Pointer<Utf8>,
+    Pointer<RacLlmOptionsStruct>,
+    Pointer<RacLlmResultStruct>,
+  ) llmGenerate = _lib.lookupFunction<
+      Int32 Function(RacHandle, Pointer<Utf8>, Pointer<RacLlmOptionsStruct>,
+          Pointer<RacLlmResultStruct>),
+      int Function(RacHandle, Pointer<Utf8>, Pointer<RacLlmOptionsStruct>,
+          Pointer<RacLlmResultStruct>)>('rac_llm_component_generate');
+
+  static late final int Function(
+    RacHandle,
+    Pointer<Utf8>,
+    Pointer<RacLlmOptionsStruct>,
+    Pointer<NativeFunction<Int32 Function(Pointer<Utf8>, Pointer<Void>)>>,
+    Pointer<NativeFunction<Void Function(Pointer<RacLlmResultStruct>, Pointer<Void>)>>,
+    Pointer<NativeFunction<Void Function(Int32, Pointer<Utf8>, Pointer<Void>)>>,
+    Pointer<Void>,
+  ) llmGenerateStream = _lib.lookupFunction<
+      Int32 Function(
+        RacHandle,
+        Pointer<Utf8>,
+        Pointer<RacLlmOptionsStruct>,
+        Pointer<NativeFunction<Int32 Function(Pointer<Utf8>, Pointer<Void>)>>,
+        Pointer<NativeFunction<Void Function(Pointer<RacLlmResultStruct>, Pointer<Void>)>>,
+        Pointer<NativeFunction<Void Function(Int32, Pointer<Utf8>, Pointer<Void>)>>,
+        Pointer<Void>,
+      ),
+      int Function(
+        RacHandle,
+        Pointer<Utf8>,
+        Pointer<RacLlmOptionsStruct>,
+        Pointer<NativeFunction<Int32 Function(Pointer<Utf8>, Pointer<Void>)>>,
+        Pointer<NativeFunction<Void Function(Pointer<RacLlmResultStruct>, Pointer<Void>)>>,
+        Pointer<NativeFunction<Void Function(Int32, Pointer<Utf8>, Pointer<Void>)>>,
+        Pointer<Void>,
+      )>('rac_llm_component_generate_stream');
+
+  static late final void Function(RacHandle) llmDestroy =
+      _lib.lookupFunction<RacLlmComponentDestroyNative,
+          RacLlmComponentDestroyDart>('rac_llm_component_destroy');
+
+
+  // ---------------------------------------------------------------------------
+  // STT Component
+  // ---------------------------------------------------------------------------
+
+  static late final int Function(Pointer<RacHandle>) sttCreate =
+      _lib.lookupFunction<
+          Int32 Function(Pointer<RacHandle>),
+          int Function(Pointer<RacHandle>)>('rac_stt_component_create');
+
+  static late final int Function(RacHandle) sttIsLoaded =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_stt_component_is_loaded');
+
+  static late final int Function(RacHandle) sttSupportsStreaming =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_stt_component_supports_streaming');
+
+  static late final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+          Pointer<Utf8>) sttLoadModel =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+              Pointer<Utf8>)>('rac_stt_component_load_model');
+
+  static late final int Function(RacHandle) sttCleanup =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_stt_component_cleanup');
+
+  static late final int Function(
+    RacHandle,
+    Pointer<Void>,
+    int,
+    Pointer<RacSttOptionsStruct>,
+    Pointer<RacSttResultStruct>,
+  ) sttTranscribe = _lib.lookupFunction<
+      Int32 Function(RacHandle, Pointer<Void>, IntPtr,
+          Pointer<RacSttOptionsStruct>, Pointer<RacSttResultStruct>),
+      int Function(RacHandle, Pointer<Void>, int, Pointer<RacSttOptionsStruct>,
+          Pointer<RacSttResultStruct>)>('rac_stt_component_transcribe');
+
+  static late final void Function(Pointer<Void>) sttResultFree =
+      _lib.lookupFunction<Void Function(Pointer<Void>),
+          void Function(Pointer<Void>)>('rac_stt_result_free');
+
+  static late final void Function(RacHandle) sttDestroy =
+      _lib.lookupFunction<
+          Void Function(RacHandle),
+          void Function(RacHandle)>('rac_stt_component_destroy');
+
+
+  // ---------------------------------------------------------------------------
+  // TTS Component
+  // ---------------------------------------------------------------------------
+
+  static late final int Function(Pointer<RacHandle>) ttsCreate =
+      _lib.lookupFunction<
+          Int32 Function(Pointer<RacHandle>),
+          int Function(Pointer<RacHandle>)>('rac_tts_component_create');
+
+  static late final int Function(RacHandle) ttsIsLoaded =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_tts_component_is_loaded');
+
+  static late final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+          Pointer<Utf8>) ttsLoadVoice =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+              Pointer<Utf8>)>('rac_tts_component_load_voice');
+
+  static late final int Function(RacHandle) ttsCleanup =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_tts_component_cleanup');
+
+  static late final int Function(RacHandle) ttsStop =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_tts_component_stop');
+
+  static late final int Function(
+    RacHandle,
+    Pointer<Utf8>,
+    Pointer<RacTtsOptionsStruct>,
+    Pointer<RacTtsResultStruct>,
+  ) ttsSynthesize = _lib.lookupFunction<
+      Int32 Function(RacHandle, Pointer<Utf8>, Pointer<RacTtsOptionsStruct>,
+          Pointer<RacTtsResultStruct>),
+      int Function(RacHandle, Pointer<Utf8>, Pointer<RacTtsOptionsStruct>,
+          Pointer<RacTtsResultStruct>)>('rac_tts_component_synthesize');
+
+  static late final void Function(RacHandle) ttsDestroy =
+      _lib.lookupFunction<
+          Void Function(RacHandle),
+          void Function(RacHandle)>('rac_tts_component_destroy');
+
+
+  // ---------------------------------------------------------------------------
+  // VAD Component
+  // ---------------------------------------------------------------------------
+
+  static late final int Function(Pointer<RacHandle>) vadCreate =
+      _lib.lookupFunction<
+          Int32 Function(Pointer<RacHandle>),
+          int Function(Pointer<RacHandle>)>('rac_vad_component_create');
+
+  static late final int Function(RacHandle) vadIsInitialized =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_vad_component_is_initialized');
+
+  static late final int Function(RacHandle) vadIsSpeechActive =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_vad_component_is_speech_active');
+
+  static late final double Function(RacHandle) vadGetEnergyThreshold =
+      _lib.lookupFunction<
+          Float Function(RacHandle),
+          double Function(RacHandle)>('rac_vad_component_get_energy_threshold');
+
+  static late final int Function(RacHandle, double) vadSetEnergyThreshold =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Float),
+          int Function(RacHandle, double)>('rac_vad_component_set_energy_threshold');
+
+  static late final int Function(RacHandle) vadInitialize =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_vad_component_initialize');
+
+  static late final int Function(RacHandle) vadStart =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_vad_component_start');
+
+  static late final int Function(RacHandle) vadStop =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_vad_component_stop');
+
+  static late final int Function(RacHandle) vadReset =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_vad_component_reset');
+
+  static late final int Function(RacHandle) vadCleanup =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_vad_component_cleanup');
+
+  static late final int Function(RacHandle, Pointer<Float>, int,
+          Pointer<RacVadResultStruct>) vadProcess =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Float>, IntPtr,
+              Pointer<RacVadResultStruct>),
+          int Function(RacHandle, Pointer<Float>, int,
+              Pointer<RacVadResultStruct>)>('rac_vad_component_process');
+
+  static late final void Function(RacHandle) vadDestroy =
+      _lib.lookupFunction<
+          Void Function(RacHandle),
+          void Function(RacHandle)>('rac_vad_component_destroy');
+
+  // ---------------------------------------------------------------------------
+  // VoiceAgent Component
+  // ---------------------------------------------------------------------------
+
+  static late final int Function(RacHandle, RacHandle, RacHandle, RacHandle,
+          Pointer<RacVoiceAgentHandle>) voiceAgentCreate =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, RacHandle, RacHandle, RacHandle,
+              Pointer<RacVoiceAgentHandle>),
+          int Function(RacHandle, RacHandle, RacHandle, RacHandle,
+              Pointer<RacVoiceAgentHandle>)>('rac_voice_agent_create');
+
+  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
+      voiceAgentIsReady = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
+          int Function(
+              RacVoiceAgentHandle, Pointer<Int32>)>('rac_voice_agent_is_ready');
+
+  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
+      voiceAgentIsSTTLoaded = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
+          int Function(RacVoiceAgentHandle,
+              Pointer<Int32>)>('rac_voice_agent_is_stt_loaded');
+
+  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
+      voiceAgentIsLLMLoaded = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
+          int Function(RacVoiceAgentHandle,
+              Pointer<Int32>)>('rac_voice_agent_is_llm_loaded');
+
+  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
+      voiceAgentIsTTSLoaded = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
+          int Function(RacVoiceAgentHandle,
+              Pointer<Int32>)>('rac_voice_agent_is_tts_loaded');
+
+  static late final int Function(
+          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>)
+      voiceAgentLoadSTTModel = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+              Pointer<Utf8>)>('rac_voice_agent_load_stt_model');
+
+  static late final int Function(
+          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>)
+      voiceAgentLoadLLMModel = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+              Pointer<Utf8>)>('rac_voice_agent_load_llm_model');
+
+  static late final int Function(
+          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>)
+      voiceAgentLoadTTSVoice = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+              Pointer<Utf8>)>('rac_voice_agent_load_tts_voice');
+
+  static late final int Function(RacVoiceAgentHandle)
+      voiceAgentInitializeWithLoadedModels = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle),
+          int Function(
+              RacVoiceAgentHandle)>('rac_voice_agent_initialize_with_loaded_models');
+
+  static late final int Function(RacVoiceAgentHandle, Pointer<Void>, int,
+          Pointer<RacVoiceAgentResultStruct>) voiceAgentProcessVoiceTurn =
+      _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Void>, IntPtr,
+              Pointer<RacVoiceAgentResultStruct>),
+          int Function(RacVoiceAgentHandle, Pointer<Void>, int,
+              Pointer<RacVoiceAgentResultStruct>)>('rac_voice_agent_process_voice_turn');
+
+  static late final void Function(Pointer<RacVoiceAgentResultStruct>)
+      voiceAgentResultFree = _lib.lookupFunction<
+          Void Function(Pointer<RacVoiceAgentResultStruct>),
+          void Function(
+              Pointer<RacVoiceAgentResultStruct>)>('rac_voice_agent_result_free');
+
+  static late final int Function(RacVoiceAgentHandle, Pointer<Void>, int,
+          Pointer<Pointer<Utf8>>) voiceAgentTranscribe =
+      _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Void>, IntPtr,
+              Pointer<Pointer<Utf8>>),
+          int Function(RacVoiceAgentHandle, Pointer<Void>, int,
+              Pointer<Pointer<Utf8>>)>('rac_voice_agent_transcribe');
+
+  static late final int Function(
+          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>)
+      voiceAgentGenerateResponse = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>,
+              Pointer<Pointer<Utf8>>),
+          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+              Pointer<Pointer<Utf8>>)>('rac_voice_agent_generate_response');
+
+  static late final int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          Pointer<Pointer<Void>>, Pointer<IntPtr>) voiceAgentSynthesizeSpeech =
+      _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>,
+              Pointer<Pointer<Void>>, Pointer<IntPtr>),
+          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+              Pointer<Pointer<Void>>, Pointer<IntPtr>)>('rac_voice_agent_synthesize_speech');
+
+  static late final int Function(RacVoiceAgentHandle) voiceAgentCleanup =
+      _lib.lookupFunction<Int32 Function(RacVoiceAgentHandle),
+          int Function(RacVoiceAgentHandle)>('rac_voice_agent_cleanup');
+
+  static late final void Function(RacVoiceAgentHandle) voiceAgentDestroy =
+      _lib.lookupFunction<Void Function(RacVoiceAgentHandle),
+          void Function(RacVoiceAgentHandle)>('rac_voice_agent_destroy');
+
+  static late final void Function(Pointer<Void>) racFree =
+      _lib.lookupFunction<Void Function(Pointer<Void>),
+          void Function(Pointer<Void>)>('rac_free');
+}

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
@@ -32,8 +32,9 @@ abstract class NativeFunctions {
           int Function(Pointer<RacHandle>)>('rac_llm_component_create');
 
   static late final int Function(RacHandle) llmIsLoaded =
-      _lib.lookupFunction<RacLlmComponentIsLoadedNative,
-          RacLlmComponentIsLoadedDart>('rac_llm_component_is_loaded');
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_llm_component_is_loaded');
 
   static late final int Function(RacHandle) llmSupportsStreaming =
       _lib.lookupFunction<
@@ -42,16 +43,20 @@ abstract class NativeFunctions {
 
   static late final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
           Pointer<Utf8>) llmLoadModel =
-      _lib.lookupFunction<RacLlmComponentLoadModelNative,
-          RacLlmComponentLoadModelDart>('rac_llm_component_load_model');
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+              Pointer<Utf8>)>('rac_llm_component_load_model');
 
   static late final int Function(RacHandle) llmCleanup =
-      _lib.lookupFunction<RacLlmComponentCleanupNative,
-          RacLlmComponentCleanupDart>('rac_llm_component_cleanup');
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_llm_component_cleanup');
 
   static late final int Function(RacHandle) llmCancel =
-      _lib.lookupFunction<RacLlmComponentCancelNative,
-          RacLlmComponentCancelDart>('rac_llm_component_cancel');
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_llm_component_cancel');
 
   static late final int Function(
     RacHandle,
@@ -93,8 +98,9 @@ abstract class NativeFunctions {
       )>('rac_llm_component_generate_stream');
 
   static late final void Function(RacHandle) llmDestroy =
-      _lib.lookupFunction<RacLlmComponentDestroyNative,
-          RacLlmComponentDestroyDart>('rac_llm_component_destroy');
+      _lib.lookupFunction<
+          Void Function(RacHandle),
+          void Function(RacHandle)>('rac_llm_component_destroy');
 
 
   // ---------------------------------------------------------------------------
@@ -132,13 +138,23 @@ abstract class NativeFunctions {
     RacHandle,
     Pointer<Void>,
     int,
-    Pointer<RacSttOptionsStruct>,
-    Pointer<RacSttResultStruct>,
+    Pointer<Void>,
+    Pointer<Void>,
   ) sttTranscribe = _lib.lookupFunction<
-      Int32 Function(RacHandle, Pointer<Void>, IntPtr,
-          Pointer<RacSttOptionsStruct>, Pointer<RacSttResultStruct>),
-      int Function(RacHandle, Pointer<Void>, int, Pointer<RacSttOptionsStruct>,
-          Pointer<RacSttResultStruct>)>('rac_stt_component_transcribe');
+      Int32 Function(
+        RacHandle,
+        Pointer<Void>,
+        IntPtr,
+        Pointer<Void>,
+        Pointer<Void>,
+      ),
+      int Function(
+        RacHandle,
+        Pointer<Void>,
+        int,
+        Pointer<Void>,
+        Pointer<Void>,
+      )>('rac_stt_component_transcribe');
 
   static late final void Function(Pointer<Void>) sttResultFree =
       _lib.lookupFunction<Void Function(Pointer<Void>),
@@ -184,13 +200,21 @@ abstract class NativeFunctions {
   static late final int Function(
     RacHandle,
     Pointer<Utf8>,
-    Pointer<RacTtsOptionsStruct>,
-    Pointer<RacTtsResultStruct>,
+    Pointer<Void>,
+    Pointer<Void>,
   ) ttsSynthesize = _lib.lookupFunction<
-      Int32 Function(RacHandle, Pointer<Utf8>, Pointer<RacTtsOptionsStruct>,
-          Pointer<RacTtsResultStruct>),
-      int Function(RacHandle, Pointer<Utf8>, Pointer<RacTtsOptionsStruct>,
-          Pointer<RacTtsResultStruct>)>('rac_tts_component_synthesize');
+      Int32 Function(
+        RacHandle,
+        Pointer<Utf8>,
+        Pointer<Void>,
+        Pointer<Void>,
+      ),
+      int Function(
+        RacHandle,
+        Pointer<Utf8>,
+        Pointer<Void>,
+        Pointer<Void>,
+      )>('rac_tts_component_synthesize');
 
   static late final void Function(RacHandle) ttsDestroy =
       _lib.lookupFunction<
@@ -252,13 +276,12 @@ abstract class NativeFunctions {
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_cleanup');
 
-  static late final int Function(RacHandle, Pointer<Float>, int,
-          Pointer<RacVadResultStruct>) vadProcess =
+  static late final int Function(RacHandle, Pointer<Float>, int, Pointer<Void>)
+      vadProcess =
       _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Float>, IntPtr,
-              Pointer<RacVadResultStruct>),
-          int Function(RacHandle, Pointer<Float>, int,
-              Pointer<RacVadResultStruct>)>('rac_vad_component_process');
+          Int32 Function(RacHandle, Pointer<Float>, IntPtr, Pointer<Void>),
+          int Function(
+              RacHandle, Pointer<Float>, int, Pointer<Void>)>('rac_vad_component_process');
 
   static late final void Function(RacHandle) vadDestroy =
       _lib.lookupFunction<
@@ -269,110 +292,113 @@ abstract class NativeFunctions {
   // VoiceAgent Component
   // ---------------------------------------------------------------------------
 
-  static late final int Function(RacHandle, RacHandle, RacHandle, RacHandle,
-          Pointer<RacVoiceAgentHandle>) voiceAgentCreate =
+  static late final int Function(
+    RacHandle,
+    RacHandle,
+    RacHandle,
+    RacHandle,
+    Pointer<RacHandle>,
+  ) voiceAgentCreate =
       _lib.lookupFunction<
-          Int32 Function(RacHandle, RacHandle, RacHandle, RacHandle,
-              Pointer<RacVoiceAgentHandle>),
-          int Function(RacHandle, RacHandle, RacHandle, RacHandle,
-              Pointer<RacVoiceAgentHandle>)>('rac_voice_agent_create');
-
-  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
-      voiceAgentIsReady = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
+          Int32 Function(
+            RacHandle,
+            RacHandle,
+            RacHandle,
+            RacHandle,
+            Pointer<RacHandle>,
+          ),
           int Function(
-              RacVoiceAgentHandle, Pointer<Int32>)>('rac_voice_agent_is_ready');
+            RacHandle,
+            RacHandle,
+            RacHandle,
+            RacHandle,
+            Pointer<RacHandle>,
+          )>('rac_voice_agent_create');
 
-  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
-      voiceAgentIsSTTLoaded = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
-          int Function(RacVoiceAgentHandle,
-              Pointer<Int32>)>('rac_voice_agent_is_stt_loaded');
+  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsReady =
+      _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
+          int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_ready');
 
-  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
-      voiceAgentIsLLMLoaded = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
-          int Function(RacVoiceAgentHandle,
-              Pointer<Int32>)>('rac_voice_agent_is_llm_loaded');
+  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsSTTLoaded =
+      _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
+          int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_stt_loaded');
 
-  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
-      voiceAgentIsTTSLoaded = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
-          int Function(RacVoiceAgentHandle,
-              Pointer<Int32>)>('rac_voice_agent_is_tts_loaded');
+  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsLLMLoaded =
+      _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
+          int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_llm_loaded');
+
+  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsTTSLoaded =
+      _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
+          int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_tts_loaded');
 
   static late final int Function(
-          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>)
+          RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadSTTModel = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_stt_model');
 
   static late final int Function(
-          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>)
+          RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadLLMModel = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_llm_model');
 
   static late final int Function(
-          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>)
+          RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadTTSVoice = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_tts_voice');
 
-  static late final int Function(RacVoiceAgentHandle)
+  static late final int Function(RacHandle)
       voiceAgentInitializeWithLoadedModels = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle),
-          int Function(
-              RacVoiceAgentHandle)>('rac_voice_agent_initialize_with_loaded_models');
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_voice_agent_initialize_with_loaded_models');
 
-  static late final int Function(RacVoiceAgentHandle, Pointer<Void>, int,
-          Pointer<RacVoiceAgentResultStruct>) voiceAgentProcessVoiceTurn =
+  static late final int Function(RacHandle, Pointer<Void>, int, Pointer<Void>)
+      voiceAgentProcessVoiceTurn =
       _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Void>, IntPtr,
-              Pointer<RacVoiceAgentResultStruct>),
-          int Function(RacVoiceAgentHandle, Pointer<Void>, int,
-              Pointer<RacVoiceAgentResultStruct>)>('rac_voice_agent_process_voice_turn');
+          Int32 Function(RacHandle, Pointer<Void>, IntPtr, Pointer<Void>),
+          int Function(
+              RacHandle, Pointer<Void>, int, Pointer<Void>)>('rac_voice_agent_process_voice_turn');
 
-  static late final void Function(Pointer<RacVoiceAgentResultStruct>)
-      voiceAgentResultFree = _lib.lookupFunction<
-          Void Function(Pointer<RacVoiceAgentResultStruct>),
-          void Function(
-              Pointer<RacVoiceAgentResultStruct>)>('rac_voice_agent_result_free');
+  static late final void Function(Pointer<Void>) voiceAgentResultFree =
+      _lib.lookupFunction<Void Function(Pointer<Void>),
+          void Function(Pointer<Void>)>('rac_voice_agent_result_free');
 
-  static late final int Function(RacVoiceAgentHandle, Pointer<Void>, int,
+  static late final int Function(RacHandle, Pointer<Void>, int,
           Pointer<Pointer<Utf8>>) voiceAgentTranscribe =
       _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Void>, IntPtr,
+          Int32 Function(RacHandle, Pointer<Void>, IntPtr,
               Pointer<Pointer<Utf8>>),
-          int Function(RacVoiceAgentHandle, Pointer<Void>, int,
+          int Function(RacHandle, Pointer<Void>, int,
               Pointer<Pointer<Utf8>>)>('rac_voice_agent_transcribe');
 
   static late final int Function(
-          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>)
+          RacHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>)
       voiceAgentGenerateResponse = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          Int32 Function(RacHandle, Pointer<Utf8>,
               Pointer<Pointer<Utf8>>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          int Function(RacHandle, Pointer<Utf8>,
               Pointer<Pointer<Utf8>>)>('rac_voice_agent_generate_response');
 
-  static late final int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+  static late final int Function(RacHandle, Pointer<Utf8>,
           Pointer<Pointer<Void>>, Pointer<IntPtr>) voiceAgentSynthesizeSpeech =
       _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          Int32 Function(RacHandle, Pointer<Utf8>,
               Pointer<Pointer<Void>>, Pointer<IntPtr>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          int Function(RacHandle, Pointer<Utf8>,
               Pointer<Pointer<Void>>, Pointer<IntPtr>)>('rac_voice_agent_synthesize_speech');
 
-  static late final int Function(RacVoiceAgentHandle) voiceAgentCleanup =
-      _lib.lookupFunction<Int32 Function(RacVoiceAgentHandle),
-          int Function(RacVoiceAgentHandle)>('rac_voice_agent_cleanup');
+  static late final int Function(RacHandle) voiceAgentCleanup =
+      _lib.lookupFunction<Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_voice_agent_cleanup');
 
-  static late final void Function(RacVoiceAgentHandle) voiceAgentDestroy =
-      _lib.lookupFunction<Void Function(RacVoiceAgentHandle),
-          void Function(RacVoiceAgentHandle)>('rac_voice_agent_destroy');
+  static late final void Function(RacHandle) voiceAgentDestroy =
+      _lib.lookupFunction<Void Function(RacHandle),
+          void Function(RacHandle)>('rac_voice_agent_destroy');
 
   static late final void Function(Pointer<Void>) racFree =
       _lib.lookupFunction<Void Function(Pointer<Void>),


### PR DESCRIPTION
Created native_functions.dart - a single abstract class NativeFunctions with static late final fields for every FFI function across LLM, STT, TTS, VAD, and VoiceAgent. Each field calls lookupFunction exactly once on first access, then caches the result. All five bridge files were updated to call NativeFunctions.* instead of doing inline lookups.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized native interop into a single, cached bindings layer covering LLM, STT, TTS, VAD, and VoiceAgent — stream/isolates and runtime behavior preserved while improving reliability and consistency of audio/AI features.

* **Chores**
  * Minor public handle-related adjustment for voice-agent management; no material changes to end-user behavior or public APIs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralises all FFI symbol lookups into a new `NativeFunctions` abstract class with `static final` cached fields, eliminating repeated `lib.lookupFunction` / `PlatformLoader.loadCommons()` calls across the five bridge files. The isolate-bound functions (`processVoiceTurn`, `transcribe`, `synthesize`) are intentionally kept as file-level top-level statics so each `Isolate.run()` gets its own initialised copy. The PR also adds a `_safeRacFree` helper, a `Completer`-based double-init guard in `getHandle()`, and fixes pre-existing memory leaks in `transcribeAudio` and `generateResponse`.

Key points:
- The refactor is largely sound; all previously flagged type-mismatch, nullable-call, and unused-variable issues appear to have been resolved.
- **Circular import**: `native_functions.dart` imports `dart_bridge_vad.dart` (for `RacVadResultStruct`) while `dart_bridge_vad.dart` imports `native_functions.dart`. Moving `RacVadResultStruct` to `ffi_types.dart` would break the cycle cleanly.
- `NativeFunctions.sttResultFree` is declared but never called — the STT isolate still uses its own inline lookup, leaving this entry as dead code.

<h3>Confidence Score: 4/5</h3>

- PR is close to merge-ready; one targeted fix (circular import) is recommended before landing.
- All critical issues flagged in earlier review rounds have been addressed — type mismatches, nullable invocations, unused `lib` variables, and the race condition in `getHandle()` are resolved. The two remaining items are architectural (circular import) and cosmetic (dead `sttResultFree` declaration), neither of which causes a runtime failure today. The circular import is the only item worth resolving before merge.
- sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart — circular import with dart_bridge_vad.dart needs to be resolved.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart | New file centralising all FFI lookups as cached static fields. Contains a circular import with dart_bridge_vad.dart (imported for RacVadResultStruct) and an unused sttResultFree declaration. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart | Migrated most lookups to NativeFunctions.*; added Completer-based _initFuture guard to getHandle(); introduced _safeRacFree helper for rac_free memory management; isolate path uses file-level statics to stay per-isolate safe. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart | Straightforward migration of all main-isolate lookups to NativeFunctions.*; removed redundant lib local variables; isolate paths unchanged. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_stt.dart | Main-isolate lookups migrated to NativeFunctions.*; transcription isolate retains inline lookups, consistent with the per-isolate caching pattern. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_tts.dart | Main-isolate lookups migrated to NativeFunctions.*; synthesis isolate retains inline lookups. No issues found. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart | All lookups migrated to NativeFunctions.*; platform_loader import correctly removed; participates in a circular import with native_functions.dart due to RacVadResultStruct being defined here. |

</details>



<h3>Flowchart</h3>

```mermaid
%%{init: {'theme': 'neutral'}}%%
flowchart TD
    LLM[dart_bridge_llm.dart] -->|NativeFunctions.*| NF
    STT[dart_bridge_stt.dart] -->|NativeFunctions.*| NF
    TTS[dart_bridge_tts.dart] -->|NativeFunctions.*| NF
    VAD[dart_bridge_vad.dart] -->|NativeFunctions.*| NF
    VA[dart_bridge_voice_agent.dart] -->|NativeFunctions.*| NF
    NF[NativeFunctions\nstatic final cached fields] -->|PlatformLoader.loadCommons| LIB[(_lib: DynamicLibrary)]
    LIB -->|lookupFunction once| SYM[(Native Symbols\nrac_llm_* / rac_stt_*\nrac_tts_* / rac_vad_*\nrac_voice_agent_*)]

    NF -->|import for RacVadResultStruct ⚠️| VAD

    VA -->|Isolate.run| ISO[Background Isolate]
    ISO -->|_processVoiceTurnFn\nfile-level static| IL[(_voiceAgentLib\nper-isolate DynamicLibrary)]
    IL -->|lookupFunction once per isolate| SYM2[(rac_voice_agent_process_voice_turn\nrac_voice_agent_result_free)]
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart`, line 68-104 ([link](https://github.com/runanywhereai/runanywhere-sdks/blob/92b8dac5a2dff9fb93005877b7a2e73bcea68901/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart#L68-L104)) 

   **Broken try/catch nesting — compile error**

   The refactor introduced a malformed `try` block. Line 68 opens a `try {` but it has no matching `catch` or `finally` clause — this is a syntax error in Dart and will fail to compile.

   The original code had a single `try/catch` wrapping the entire handle creation logic. During the refactoring, the `lookupFunction` call was removed and replaced with `NativeFunctions.voiceAgentCreate(...)`, but a new `try {` was inserted at line 82 while the original outer `try {` at line 68 was left dangling without its `catch`.

   The fix is to remove the extra `try` on line 82 so the original `try`/`catch` structure is restored:

   

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
   Line: 68-104

   Comment:
   **Broken try/catch nesting — compile error**

   The refactor introduced a malformed `try` block. Line 68 opens a `try {` but it has no matching `catch` or `finally` clause — this is a syntax error in Dart and will fail to compile.

   The original code had a single `try/catch` wrapping the entire handle creation logic. During the refactoring, the `lookupFunction` call was removed and replaced with `NativeFunctions.voiceAgentCreate(...)`, but a new `try {` was inserted at line 82 while the original outer `try {` at line 68 was left dangling without its `catch`.

   The fix is to remove the extra `try` on line 82 so the original `try`/`catch` structure is restored:

   

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart`, line 1007 ([link](https://github.com/runanywhereai/runanywhere-sdks/blob/6265177ab6d56bf064343c6cd6a0d4f773bf8dda/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart#L1007)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Circular import between `native_functions.dart` and `dart_bridge_vad.dart`**

   `native_functions.dart` imports `dart_bridge_vad.dart` as `vad` in order to reference `vad.RacVadResultStruct` in the `vadProcess` signature. At the same time, `dart_bridge_vad.dart` imports `native_functions.dart`. This creates a mutual dependency between the two files.

   Dart's import resolver handles library cycles without an infinite loop, but circular imports are a recognised code smell and can cause subtle issues in some toolchain configurations (e.g. tree-shaking, static analysis). More concretely, placing a `Struct` subclass in the bridge file rather than the shared types file (`ffi_types.dart`) was always the root cause: `RacVadResultStruct` belongs alongside the other FFI structs so that `native_functions.dart` can import it without creating a cycle.

   The clean fix is to move `RacVadResultStruct` (and any other result/options structs that are still in bridge files) to `ffi_types.dart`, then update the import in `native_functions.dart`:

   ```dart
   // native_functions.dart – replace:
   import 'package:runanywhere/native/dart_bridge_vad.dart' as vad;

   // with:
   // (no extra import needed – RacVadResultStruct is already in ffi_types.dart)
   ```

   And replace `vad.RacVadResultStruct` with `RacVadResultStruct` everywhere in `native_functions.dart`.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
   Line: 1007

   Comment:
   **Circular import between `native_functions.dart` and `dart_bridge_vad.dart`**

   `native_functions.dart` imports `dart_bridge_vad.dart` as `vad` in order to reference `vad.RacVadResultStruct` in the `vadProcess` signature. At the same time, `dart_bridge_vad.dart` imports `native_functions.dart`. This creates a mutual dependency between the two files.

   Dart's import resolver handles library cycles without an infinite loop, but circular imports are a recognised code smell and can cause subtle issues in some toolchain configurations (e.g. tree-shaking, static analysis). More concretely, placing a `Struct` subclass in the bridge file rather than the shared types file (`ffi_types.dart`) was always the root cause: `RacVadResultStruct` belongs alongside the other FFI structs so that `native_functions.dart` can import it without creating a cycle.

   The clean fix is to move `RacVadResultStruct` (and any other result/options structs that are still in bridge files) to `ffi_types.dart`, then update the import in `native_functions.dart`:

   ```dart
   // native_functions.dart – replace:
   import 'package:runanywhere/native/dart_bridge_vad.dart' as vad;

   // with:
   // (no extra import needed – RacVadResultStruct is already in ffi_types.dart)
   ```

   And replace `vad.RacVadResultStruct` with `RacVadResultStruct` everywhere in `native_functions.dart`.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
Line: 1007

Comment:
**Circular import between `native_functions.dart` and `dart_bridge_vad.dart`**

`native_functions.dart` imports `dart_bridge_vad.dart` as `vad` in order to reference `vad.RacVadResultStruct` in the `vadProcess` signature. At the same time, `dart_bridge_vad.dart` imports `native_functions.dart`. This creates a mutual dependency between the two files.

Dart's import resolver handles library cycles without an infinite loop, but circular imports are a recognised code smell and can cause subtle issues in some toolchain configurations (e.g. tree-shaking, static analysis). More concretely, placing a `Struct` subclass in the bridge file rather than the shared types file (`ffi_types.dart`) was always the root cause: `RacVadResultStruct` belongs alongside the other FFI structs so that `native_functions.dart` can import it without creating a cycle.

The clean fix is to move `RacVadResultStruct` (and any other result/options structs that are still in bridge files) to `ffi_types.dart`, then update the import in `native_functions.dart`:

```dart
// native_functions.dart – replace:
import 'package:runanywhere/native/dart_bridge_vad.dart' as vad;

// with:
// (no extra import needed – RacVadResultStruct is already in ffi_types.dart)
```

And replace `vad.RacVadResultStruct` with `RacVadResultStruct` everywhere in `native_functions.dart`.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
Line: 1082-1084

Comment:
**`sttResultFree` declared but never called — dead code**

`NativeFunctions.sttResultFree` looks up `rac_stt_result_free`, but no call site in the updated bridge files actually uses it. The STT transcription isolate (`_transcribeInIsolate` in `dart_bridge_stt.dart`) still performs its own inline `lookupFunction` call for both `rac_stt_component_transcribe` and `rac_stt_result_free`, meaning this cached entry is unused.

Because `static final` fields in Dart are lazily initialised, the symbol lookup won't fire unless `NativeFunctions.sttResultFree` is accessed, so there is no runtime cost today. However, the declaration creates a misleading impression that the STT bridge uses the centralised cache for result freeing, which may confuse future maintainers. Either wire up the call sites in the STT isolate to use this field (keeping the refactor consistent), or remove the declaration until it is needed.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (8): Last reviewed commit: ["FFI Fix: Resolve type conflicts and fix ..."](https://github.com/runanywhereai/runanywhere-sdks/commit/6265177ab6d56bf064343c6cd6a0d4f773bf8dda) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=25320228)</sub>

<!-- /greptile_comment -->