### PR TITLE
fix(android): correct RAM detection and model deletion (#455)

### DIFF
--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/benchmarks/services/BenchmarkRunner.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/benchmarks/services/BenchmarkRunner.kt
@@ -147,6 +147,7 @@ class BenchmarkRunner {
         for ((index, item) in workItems.withIndex()) {
             coroutineContext.ensureActive()
 
+            // Report which benchmark is about to run (progress reflects completed items)
             onProgress(
                 BenchmarkProgressUpdate(
                     completedCount = index,
@@ -185,16 +186,17 @@ class BenchmarkRunner {
                     metrics = metrics,
                 ),
             )
-        }
 
-        onProgress(
-            BenchmarkProgressUpdate(
-                completedCount = total,
-                totalCount = total,
-                currentScenario = "Done",
-                currentModel = "",
-            ),
-        )
+            // Report progress AFTER the benchmark completes so UI reflects actual progress
+            onProgress(
+                BenchmarkProgressUpdate(
+                    completedCount = index + 1,
+                    totalCount = total,
+                    currentScenario = if (index + 1 < total) workItems[index + 1].scenario.name else "Done",
+                    currentModel = if (index + 1 < total) workItems[index + 1].model.name else "",
+                ),
+            )
+        }
 
         return BenchmarkRunResult(
             results = results,

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/benchmarks/viewmodel/BenchmarkViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/benchmarks/viewmodel/BenchmarkViewModel.kt
@@ -19,6 +19,7 @@ import com.runanywhere.runanywhereai.presentation.benchmarks.utilities.Benchmark
 import com.runanywhere.runanywhereai.presentation.benchmarks.utilities.BenchmarkReportFormatter
 import com.runanywhere.runanywhereai.presentation.benchmarks.utilities.SyntheticInputGenerator
 import com.runanywhere.sdk.models.DeviceInfo
+import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -26,6 +27,7 @@ import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
 import java.io.File
 
 // -- UI State --
@@ -105,17 +107,22 @@ class BenchmarkViewModel(application: Application) : AndroidViewModel(applicatio
             var run = BenchmarkRun(deviceInfo = deviceInfo)
 
             try {
-                val runResult = runner.runBenchmarks(
-                    categories = _uiState.value.selectedCategories,
-                ) { update ->
-                    _uiState.update { state ->
-                        state.copy(
-                            progress = update.progress,
-                            completedCount = update.completedCount,
-                            totalCount = update.totalCount,
-                            currentScenario = update.currentScenario,
-                            currentModel = update.currentModel,
-                        )
+                // Run benchmarks off the main thread to prevent ANR.
+                // MutableStateFlow.update is thread-safe so progress callbacks are fine from Default.
+                val selectedCats = _uiState.value.selectedCategories
+                val runResult = withContext(Dispatchers.Default) {
+                    runner.runBenchmarks(
+                        categories = selectedCats,
+                    ) { update ->
+                        _uiState.update { state ->
+                            state.copy(
+                                progress = update.progress,
+                                completedCount = update.completedCount,
+                                totalCount = update.totalCount,
+                                currentScenario = update.currentScenario,
+                                currentModel = update.currentModel,
+                            )
+                        }
                     }
                 }
 

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/benchmarks/views/BenchmarkProgressDialog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/benchmarks/views/BenchmarkProgressDialog.kt
@@ -59,12 +59,22 @@ fun BenchmarkProgressDialog(
 
             Spacer(modifier = Modifier.height(AppSpacing.xxLarge))
 
-            LinearProgressIndicator(
-                progress = { progress },
-                modifier = Modifier.fillMaxWidth(),
-                color = AppColors.primaryAccent,
-                trackColor = AppColors.primaryAccent.copy(alpha = 0.12f),
-            )
+            if (progress > 0f) {
+                // Determinate: show actual progress once first benchmark completes
+                LinearProgressIndicator(
+                    progress = { progress },
+                    modifier = Modifier.fillMaxWidth(),
+                    color = AppColors.primaryAccent,
+                    trackColor = AppColors.primaryAccent.copy(alpha = 0.12f),
+                )
+            } else {
+                // Indeterminate: animate while first benchmark is running
+                LinearProgressIndicator(
+                    modifier = Modifier.fillMaxWidth(),
+                    color = AppColors.primaryAccent,
+                    trackColor = AppColors.primaryAccent.copy(alpha = 0.12f),
+                )
+            }
 
             Spacer(modifier = Modifier.height(AppSpacing.xxLarge))
 

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionBottomSheet.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionBottomSheet.kt
@@ -21,6 +21,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.outlined.CheckCircle
+import androidx.compose.material.icons.outlined.Close
 import androidx.compose.material.icons.outlined.Download
 import androidx.compose.material.icons.outlined.Memory
 import androidx.compose.material.icons.outlined.PhoneAndroid
@@ -199,12 +200,12 @@ fun ModelSelectionBottomSheet(
                         val isBuiltIn = model.framework == InferenceFramework.FOUNDATION_MODELS ||
                             model.framework == InferenceFramework.SYSTEM_TTS
                         val isReady = isBuiltIn || model.isDownloaded
-                        val isThisModelDownloading = uiState.isLoadingModel && uiState.selectedModelId == model.id
+                        val isThisModelDownloading = model.id in uiState.downloadingModelIds
                         ModelCard(
                             model = toAIModel(model, deviceMemoryMB),
                             isReady = isReady,
                             isLoading = isThisModelDownloading,
-                            downloadProgress = if (isThisModelDownloading) uiState.loadingProgress else null,
+                            downloadProgress = uiState.downloadProgressMap[model.id],
                             onCardClick = {
                                 if (isReady) {
                                     scope.launch {
@@ -225,8 +226,11 @@ fun ModelSelectionBottomSheet(
                                 }
                             },
                             onDownloadClick = {
-                                if (!isReady) viewModel.startDownload(model.id)
+                                if (!isReady && !isThisModelDownloading) viewModel.startDownload(model.id)
                             },
+                            onCancelClick = if (isThisModelDownloading) {
+                                { viewModel.cancelDownload(model.id) }
+                            } else null,
                         )
                         if (index < sortedModels.lastIndex) Spacer(modifier = Modifier.height(8.dp))
                     }
@@ -494,6 +498,7 @@ private fun ModelCard(
     downloadProgress: String? = null,
     onCardClick: () -> Unit,
     onDownloadClick: () -> Unit,
+    onCancelClick: (() -> Unit)? = null,
 ) {
     Surface(
         modifier = Modifier
@@ -593,10 +598,12 @@ private fun ModelCard(
                 )
             } else {
                 if (isLoading) {
-                    CircularProgressIndicator(
-                        modifier = Modifier.size(20.dp),
-                        color = AppColors.primaryAccent,
-                        strokeWidth = 2.dp,
+                    Badge(
+                        text = "Cancel",
+                        textColor = AppColors.primaryRed,
+                        backgroundColor = AppColors.primaryRed.copy(alpha = 0.10f),
+                        icon = Icons.Outlined.Close,
+                        onClick = onCancelClick,
                     )
                 } else {
                     Badge(

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionBottomSheet.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionBottomSheet.kt
@@ -26,6 +26,7 @@ import androidx.compose.material.icons.outlined.Memory
 import androidx.compose.material.icons.outlined.PhoneAndroid
 import androidx.compose.material.icons.outlined.Psychology
 import androidx.compose.material.icons.outlined.SdStorage
+import androidx.compose.material.icons.outlined.Warning
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.HorizontalDivider
@@ -70,6 +71,20 @@ private data class DeviceStatus(
     val hasNeuralEngine: Boolean,
 )
 
+/**
+ * Memory compatibility level for a model relative to device RAM.
+ */
+private enum class MemoryCompatibility {
+    /** Model memory requirement is ≤50% of device RAM — runs comfortably */
+    RECOMMENDED,
+    /** Model memory requirement is ≤80% of device RAM — runs but may be tight */
+    COMPATIBLE,
+    /** Model memory requirement exceeds 80% of device RAM — likely too large */
+    TOO_LARGE,
+    /** Unknown — no memory info available */
+    UNKNOWN,
+}
+
 /** Display model for model list row. */
 private data class AIModel(
     val name: String,
@@ -79,6 +94,7 @@ private data class AIModel(
     val size: String,
     val isDownloaded: Boolean,
     val supportsLora: Boolean = false,
+    val memoryCompatibility: MemoryCompatibility = MemoryCompatibility.UNKNOWN,
 )
 
 /**
@@ -104,6 +120,7 @@ fun ModelSelectionBottomSheet(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val deviceStatus = uiState.deviceInfo?.let { toDeviceStatus(it) }
         ?: DeviceStatus(model = "—", chip = "—", memory = "—", hasNeuralEngine = false)
+    val deviceMemoryMB = uiState.deviceInfo?.totalMemoryMB
 
     ModalBottomSheet(
         onDismissRequest = onDismiss,
@@ -184,7 +201,7 @@ fun ModelSelectionBottomSheet(
                         val isReady = isBuiltIn || model.isDownloaded
                         val isThisModelDownloading = uiState.isLoadingModel && uiState.selectedModelId == model.id
                         ModelCard(
-                            model = toAIModel(model),
+                            model = toAIModel(model, deviceMemoryMB),
                             isReady = isReady,
                             isLoading = isThisModelDownloading,
                             downloadProgress = if (isThisModelDownloading) uiState.loadingProgress else null,
@@ -239,7 +256,7 @@ private fun toDeviceStatus(info: DeviceInfo): DeviceStatus =
         hasNeuralEngine = false,
     )
 
-private fun toAIModel(m: ModelInfo): AIModel {
+private fun toAIModel(m: ModelInfo, deviceMemoryMB: Long? = null): AIModel {
     val formatStr = when (m.framework) {
         InferenceFramework.LLAMA_CPP -> "Fast"
         InferenceFramework.ONNX -> "ONNX"
@@ -249,6 +266,10 @@ private fun toAIModel(m: ModelInfo): AIModel {
     }
     val formatColor = if (m.framework == InferenceFramework.ONNX) AppColors.primaryPurple else AppColors.primaryAccent
     val sizeStr = if (m.downloadSize != null && m.downloadSize!! > 0) formatBytes(m.downloadSize!!) else "—"
+
+    // Compute memory compatibility from downloadSize (which stores memoryRequirement)
+    val compatibility = computeMemoryCompatibility(m.downloadSize, deviceMemoryMB)
+
     return AIModel(
         name = m.name,
         logoResId = getModelLogoResId(m),
@@ -257,7 +278,24 @@ private fun toAIModel(m: ModelInfo): AIModel {
         size = sizeStr,
         isDownloaded = m.isDownloaded || m.framework == InferenceFramework.FOUNDATION_MODELS || m.framework == InferenceFramework.SYSTEM_TTS,
         supportsLora = m.supportsLora,
+        memoryCompatibility = compatibility,
     )
+}
+
+private fun computeMemoryCompatibility(
+    memoryRequirementBytes: Long?,
+    deviceMemoryMB: Long?,
+): MemoryCompatibility {
+    if (memoryRequirementBytes == null || memoryRequirementBytes <= 0 || deviceMemoryMB == null || deviceMemoryMB <= 0) {
+        return MemoryCompatibility.UNKNOWN
+    }
+    val deviceMemoryBytes = deviceMemoryMB * 1024 * 1024
+    val ratio = memoryRequirementBytes.toDouble() / deviceMemoryBytes
+    return when {
+        ratio <= 0.50 -> MemoryCompatibility.RECOMMENDED
+        ratio <= 0.80 -> MemoryCompatibility.COMPATIBLE
+        else -> MemoryCompatibility.TOO_LARGE
+    }
 }
 
 /** Drawable resource ID for model logo (matches iOS ModelInfo+Logo). */
@@ -521,6 +559,27 @@ private fun ModelCard(
                     textColor = AppColors.primaryPurple,
                     backgroundColor = AppColors.loraBadgeBg,
                 )
+            }
+
+            when (model.memoryCompatibility) {
+                MemoryCompatibility.RECOMMENDED -> {
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Badge(
+                        text = "Fits",
+                        textColor = AppColors.primaryGreen,
+                        backgroundColor = AppColors.primaryGreen.copy(alpha = 0.10f),
+                    )
+                }
+                MemoryCompatibility.TOO_LARGE -> {
+                    Spacer(modifier = Modifier.width(4.dp))
+                    Badge(
+                        text = "Large",
+                        textColor = AppColors.primaryRed,
+                        backgroundColor = AppColors.primaryRed.copy(alpha = 0.10f),
+                        icon = Icons.Outlined.Warning,
+                    )
+                }
+                else -> { /* COMPATIBLE and UNKNOWN: no extra badge */ }
             }
 
             Spacer(modifier = Modifier.width(8.dp))

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionBottomSheet.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionBottomSheet.kt
@@ -271,7 +271,9 @@ private fun toAIModel(m: ModelInfo, deviceMemoryMB: Long? = null): AIModel {
     val formatColor = if (m.framework == InferenceFramework.ONNX) AppColors.primaryPurple else AppColors.primaryAccent
     val sizeStr = if (m.downloadSize != null && m.downloadSize!! > 0) formatBytes(m.downloadSize!!) else "—"
 
-    // Compute memory compatibility from downloadSize (which stores memoryRequirement)
+    // Compute memory compatibility using downloadSize as an approximation of runtime memory.
+    // Note: downloadSize may not equal runtime memory for all models (e.g., GGUF quantized models
+    // may use less RAM than their file size), but it's the best heuristic available.
     val compatibility = computeMemoryCompatibility(m.downloadSize, deviceMemoryMB)
 
     return AIModel(

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionViewModel.kt
@@ -83,6 +83,10 @@ class ModelSelectionViewModel(
                                 )
                             }
                         }
+                        ModelEvent.ModelEventType.DELETED -> {
+                            Timber.d("🗑️ Model deleted: ${event.modelId}")
+                            loadModelsAndFrameworks() // Refresh models list
+                        }
                         else -> {}
                     }
                 }

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionViewModel.kt
@@ -31,7 +31,6 @@ import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.catch
 import kotlinx.coroutines.flow.filterIsInstance
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -269,16 +268,6 @@ class ModelSelectionViewModel(
 
                 // Call SDK download API - it returns a Flow<DownloadProgress>
                 RunAnywhere.downloadModel(modelId)
-                    .catch { e ->
-                        Timber.e("❌ Download stream error: ${e.message}")
-                        _uiState.update {
-                            it.copy(
-                                downloadingModelIds = it.downloadingModelIds - modelId,
-                                downloadProgressMap = it.downloadProgressMap - modelId,
-                                error = e.message ?: "Download failed",
-                            )
-                        }
-                    }
                     .collect { progress ->
                         val percent = (progress.progress * 100).toInt()
                         _uiState.update {
@@ -302,6 +291,8 @@ class ModelSelectionViewModel(
                         downloadProgressMap = it.downloadProgressMap - modelId,
                     )
                 }
+            } catch (e: kotlinx.coroutines.CancellationException) {
+                throw e
             } catch (e: Exception) {
                 Timber.e(e, "❌ Download failed for $modelId: ${e.message}")
                 _uiState.update {

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionViewModel.kt
@@ -18,6 +18,7 @@ import com.runanywhere.sdk.public.extensions.currentLLMModelId
 import com.runanywhere.sdk.public.extensions.currentSTTModelId
 import com.runanywhere.sdk.public.extensions.currentTTSVoiceId
 import com.runanywhere.sdk.public.extensions.currentVLMModelId
+import com.runanywhere.sdk.public.extensions.cancelDownload
 import com.runanywhere.sdk.public.extensions.downloadModel
 import com.runanywhere.sdk.public.extensions.isVLMModelLoaded
 import com.runanywhere.sdk.public.extensions.loadLLMModel
@@ -25,6 +26,7 @@ import com.runanywhere.sdk.public.extensions.loadSTTModel
 import com.runanywhere.sdk.public.extensions.loadTTSVoice
 import com.runanywhere.sdk.public.extensions.loadVLMModel
 import com.runanywhere.sdk.public.extensions.unloadVLMModel
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -45,6 +47,9 @@ class ModelSelectionViewModel(
 ) : ViewModel() {
     private val _uiState = MutableStateFlow(ModelSelectionUiState(context = context))
     val uiState: StateFlow<ModelSelectionUiState> = _uiState.asStateFlow()
+
+    /** Active download jobs keyed by model ID, for cancellation support. */
+    private val downloadJobs = mutableMapOf<String, Job>()
 
     init {
         loadDeviceInfo()
@@ -244,18 +249,21 @@ class ModelSelectionViewModel(
     }
 
     /**
-     * Download model with progress
+     * Download model with progress.
+     * Supports concurrent downloads — each model is tracked independently.
      */
     fun startDownload(modelId: String) {
-        viewModelScope.launch {
+        // Don't start a duplicate download
+        if (downloadJobs[modelId]?.isActive == true) return
+
+        val job = viewModelScope.launch {
             try {
                 Timber.d("⬇️ Starting download for model: $modelId")
 
                 _uiState.update {
                     it.copy(
-                        selectedModelId = modelId,
-                        isLoadingModel = true,
-                        loadingProgress = "Starting download...",
+                        downloadingModelIds = it.downloadingModelIds + modelId,
+                        downloadProgressMap = it.downloadProgressMap + (modelId to "Starting download..."),
                     )
                 }
 
@@ -265,18 +273,18 @@ class ModelSelectionViewModel(
                         Timber.e("❌ Download stream error: ${e.message}")
                         _uiState.update {
                             it.copy(
-                                isLoadingModel = false,
-                                selectedModelId = null,
-                                loadingProgress = "",
+                                downloadingModelIds = it.downloadingModelIds - modelId,
+                                downloadProgressMap = it.downloadProgressMap - modelId,
                                 error = e.message ?: "Download failed",
                             )
                         }
                     }
                     .collect { progress ->
                         val percent = (progress.progress * 100).toInt()
-                        Timber.d("📥 Download progress: $percent%")
                         _uiState.update {
-                            it.copy(loadingProgress = "Downloading... $percent%")
+                            it.copy(
+                                downloadProgressMap = it.downloadProgressMap + (modelId to "Downloading... $percent%"),
+                            )
                         }
                     }
 
@@ -290,21 +298,48 @@ class ModelSelectionViewModel(
 
                 _uiState.update {
                     it.copy(
-                        isLoadingModel = false,
-                        selectedModelId = null,
-                        loadingProgress = "",
+                        downloadingModelIds = it.downloadingModelIds - modelId,
+                        downloadProgressMap = it.downloadProgressMap - modelId,
                     )
                 }
             } catch (e: Exception) {
                 Timber.e(e, "❌ Download failed for $modelId: ${e.message}")
                 _uiState.update {
                     it.copy(
-                        isLoadingModel = false,
-                        selectedModelId = null,
-                        loadingProgress = "",
+                        downloadingModelIds = it.downloadingModelIds - modelId,
+                        downloadProgressMap = it.downloadProgressMap - modelId,
                         error = e.message ?: "Download failed",
                     )
                 }
+            } finally {
+                downloadJobs.remove(modelId)
+            }
+        }
+        downloadJobs[modelId] = job
+    }
+
+    /**
+     * Cancel an ongoing download.
+     */
+    fun cancelDownload(modelId: String) {
+        viewModelScope.launch {
+            Timber.d("🚫 Cancelling download for model: $modelId")
+            // Cancel the coroutine job (stops Flow collection)
+            downloadJobs[modelId]?.cancel()
+            downloadJobs.remove(modelId)
+
+            // Tell SDK to cancel the actual download thread
+            try {
+                RunAnywhere.cancelDownload(modelId)
+            } catch (e: Exception) {
+                Timber.w("Cancel download SDK call failed (may already be done): ${e.message}")
+            }
+
+            _uiState.update {
+                it.copy(
+                    downloadingModelIds = it.downloadingModelIds - modelId,
+                    downloadProgressMap = it.downloadProgressMap - modelId,
+                )
             }
         }
     }
@@ -431,5 +466,9 @@ data class ModelSelectionUiState(
     val isLoading: Boolean = true,
     val isLoadingModel: Boolean = false,
     val loadingProgress: String = "",
+    /** Set of model IDs currently being downloaded. */
+    val downloadingModelIds: Set<String> = emptySet(),
+    /** Per-model download progress strings (e.g., "Downloading... 45%"). */
+    val downloadProgressMap: Map<String, String> = emptyMap(),
     val error: String? = null,
 )

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsScreen.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsScreen.kt
@@ -70,12 +70,6 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel()) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     var showDeleteConfirmDialog by remember { mutableStateOf<StoredModelInfo?>(null) }
-    var showErrorMessage by remember { mutableStateOf<String?>(null) }
-
-    // Show error messages from ViewModel
-    LaunchedEffect(uiState.errorMessage) {
-        uiState.errorMessage?.let { showErrorMessage = it }
-    }
 
     // Refresh storage data when the screen appears
     // This ensures downloaded models and storage metrics are up-to-date
@@ -445,20 +439,14 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel()) {
         )
     }
 
-    // Error Dialog
-    showErrorMessage?.let { message ->
+    // Error Dialog — driven directly from ViewModel state (single source of truth)
+    uiState.errorMessage?.let { message ->
         AlertDialog(
-            onDismissRequest = {
-                showErrorMessage = null
-                viewModel.clearError()
-            },
+            onDismissRequest = { viewModel.clearError() },
             title = { Text("Error") },
             text = { Text(message) },
             confirmButton = {
-                TextButton(onClick = {
-                    showErrorMessage = null
-                    viewModel.clearError()
-                }) {
+                TextButton(onClick = { viewModel.clearError() }) {
                     Text("OK")
                 }
             },

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsScreen.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsScreen.kt
@@ -448,11 +448,17 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel()) {
     // Error Dialog
     showErrorMessage?.let { message ->
         AlertDialog(
-            onDismissRequest = { showErrorMessage = null },
+            onDismissRequest = {
+                showErrorMessage = null
+                viewModel.clearError()
+            },
             title = { Text("Error") },
             text = { Text(message) },
             confirmButton = {
-                TextButton(onClick = { showErrorMessage = null }) {
+                TextButton(onClick = {
+                    showErrorMessage = null
+                    viewModel.clearError()
+                }) {
                     Text("OK")
                 }
             },

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsScreen.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsScreen.kt
@@ -70,6 +70,12 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel()) {
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val context = LocalContext.current
     var showDeleteConfirmDialog by remember { mutableStateOf<StoredModelInfo?>(null) }
+    var showErrorMessage by remember { mutableStateOf<String?>(null) }
+
+    // Show error messages from ViewModel
+    LaunchedEffect(uiState.errorMessage) {
+        uiState.errorMessage?.let { showErrorMessage = it }
+    }
 
     // Refresh storage data when the screen appears
     // This ensures downloaded models and storage metrics are up-to-date
@@ -434,6 +440,20 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel()) {
             dismissButton = {
                 TextButton(onClick = { showDeleteConfirmDialog = null }) {
                     Text("Cancel")
+                }
+            },
+        )
+    }
+
+    // Error Dialog
+    showErrorMessage?.let { message ->
+        AlertDialog(
+            onDismissRequest = { showErrorMessage = null },
+            title = { Text("Error") },
+            text = { Text(message) },
+            confirmButton = {
+                TextButton(onClick = { showErrorMessage = null }) {
+                    Text("OK")
                 }
             },
         )

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsViewModel.kt
@@ -70,6 +70,12 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
     private val _uiState = MutableStateFlow(SettingsUiState())
     val uiState: StateFlow<SettingsUiState> = _uiState.asStateFlow()
 
+    /**
+     * Track model IDs that have been deleted in this session.
+     * Used to filter out stale entries from the C++ registry that may lag behind.
+     */
+    private val deletedModelIds = mutableSetOf<String>()
+
     private val encryptedPrefs by lazy {
         val masterKey = MasterKey.Builder(application)
             .setKeyScheme(MasterKey.KeyScheme.AES256_GCM)
@@ -251,15 +257,17 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 // Use SDK's storageInfo()
                 val storageInfo = RunAnywhere.storageInfo()
 
-                // Map stored models to UI model
+                // Map stored models to UI model, filtering out models deleted in this session
                 val storedModels =
-                    storageInfo.storedModels.map { model ->
-                        StoredModelInfo(
-                            id = model.id,
-                            name = model.name,
-                            size = model.size,
-                        )
-                    }
+                    storageInfo.storedModels
+                        .filter { it.id !in deletedModelIds }
+                        .map { model ->
+                            StoredModelInfo(
+                                id = model.id,
+                                name = model.name,
+                                size = model.size,
+                            )
+                        }
 
                 Timber.d("Storage info received:")
                 Timber.d("  - Total space: ${storageInfo.deviceStorage.totalSpace}")
@@ -304,14 +312,28 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         viewModelScope.launch {
             try {
                 Timber.d("Deleting model: $modelId")
+
+                // Track this deletion so loadStorageData() filters it out even if C++ is stale
+                deletedModelIds.add(modelId)
+
+                // Optimistic UI update: remove model from list immediately
+                _uiState.update { state ->
+                    state.copy(
+                        downloadedModels = state.downloadedModels.filter { it.id != modelId },
+                    )
+                }
+
                 // Use SDK's deleteModel extension function
                 RunAnywhere.deleteModel(modelId)
                 Timber.d("Model deleted successfully: $modelId")
 
-                // Refresh storage data after deletion
+                // Refresh storage data to sync sizes
                 loadStorageData()
             } catch (e: Exception) {
                 Timber.e(e, "Failed to delete model: $modelId")
+                // Rollback: remove from deleted set and reload
+                deletedModelIds.remove(modelId)
+                loadStorageData()
                 _uiState.update {
                     it.copy(errorMessage = "Failed to delete model: ${e.message}")
                 }

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsViewModel.kt
@@ -615,4 +615,11 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
         val state = _uiState.value
         return state.isApiKeyConfigured && state.isBaseURLConfigured
     }
+
+    /**
+     * Clear the error message so the same error can trigger the dialog again.
+     */
+    fun clearError() {
+        _uiState.update { it.copy(errorMessage = null) }
+    }
 }

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsViewModel.kt
@@ -229,6 +229,9 @@ class SettingsViewModel(application: Application) : AndroidViewModel(application
                 .collect { event ->
                     when (event.eventType) {
                         ModelEvent.ModelEventType.DOWNLOAD_COMPLETED -> {
+                            // Reconcile: if the model was previously deleted and re-downloaded
+                            // in the same session, remove it from the filter set so it reappears.
+                            event.modelId?.let { deletedModelIds.remove(it) }
                             Timber.d("📥 Model download completed: ${event.modelId}, refreshing storage...")
                             loadStorageData()
                         }

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/models/DeviceInfo.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/models/DeviceInfo.kt
@@ -54,9 +54,10 @@ private fun collectAndroidDeviceInfo(): DeviceInfo {
                 "unknown"
             }
 
-        val runtime = Runtime.getRuntime()
-        val totalMemory = runtime.maxMemory()
-        val processorCount = runtime.availableProcessors()
+        val processorCount = Runtime.getRuntime().availableProcessors()
+
+        // Get actual physical RAM via ActivityManager (not Runtime.maxMemory() which is JVM heap limit)
+        val totalMemory = getAndroidPhysicalMemory() ?: Runtime.getRuntime().maxMemory()
 
         DeviceInfo(
             deviceId = generateDeviceId(),
@@ -108,6 +109,37 @@ private fun collectJvmDeviceInfo(): DeviceInfo {
         totalMemory = totalMemory,
         processorCount = processorCount,
     )
+}
+
+/**
+ * Get actual physical RAM on Android via ActivityManager reflection.
+ * Runtime.maxMemory() returns the JVM heap limit (~256-512MB), not physical RAM.
+ * ActivityManager.MemoryInfo.totalMem returns the real physical memory.
+ */
+private fun getAndroidPhysicalMemory(): Long? {
+    return try {
+        // Get the application context via ActivityThread reflection
+        val activityThreadClass = Class.forName("android.app.ActivityThread")
+        val currentAppMethod = activityThreadClass.getMethod("currentApplication")
+        val context = currentAppMethod.invoke(null) ?: return null
+
+        // Get ActivityManager service
+        val contextClass = Class.forName("android.content.Context")
+        val getSystemServiceMethod = contextClass.getMethod("getSystemService", String::class.java)
+        val activityManager = getSystemServiceMethod.invoke(context, "activity") ?: return null
+
+        // Create MemoryInfo and call getMemoryInfo
+        val memInfoClass = Class.forName("android.app.ActivityManager\$MemoryInfo")
+        val memInfo = memInfoClass.getDeclaredConstructor().newInstance()
+        val getMemInfoMethod = activityManager.javaClass.getMethod("getMemoryInfo", memInfoClass)
+        getMemInfoMethod.invoke(activityManager, memInfo)
+
+        // Read totalMem field
+        val totalMemField = memInfoClass.getField("totalMem")
+        totalMemField.getLong(memInfo)
+    } catch (e: Exception) {
+        null
+    }
 }
 
 /**

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
@@ -552,10 +552,10 @@ actual fun RunAnywhere.downloadModel(modelId: String): Flow<DownloadProgress> {
                 }
 
                 // All files downloaded — update registry with directory path
-                //     Guard: if model was deleted during download, don't resurrect it
-                val stillRegistered = synchronized(modelCacheLock) {
-                    registeredModels.any { it.id == modelId }
-                }
+                //     Guard: if model was deleted during download, don't resurrect it.
+                //     Check the C++ registry (cleared by deleteModel via remove()) rather than
+                //     registeredModels (which only clears localPath but keeps the entry).
+                val stillRegistered = CppBridgeModelRegistry.get(modelId) != null
                 if (!stillRegistered) {
                     downloadLogger.warn("Model '$modelId' was deleted during download, discarding result")
                     modelDir.deleteRecursively()
@@ -791,10 +791,10 @@ actual fun RunAnywhere.downloadModel(modelId: String): Flow<DownloadProgress> {
                 }
 
             // 13. Update model in C++ registry with local path
-            //     Guard: if model was deleted during download, don't resurrect it
-            val stillRegistered = synchronized(modelCacheLock) {
-                registeredModels.any { it.id == modelId }
-            }
+            //     Guard: if model was deleted during download, don't resurrect it.
+            //     Check the C++ registry (cleared by deleteModel via remove()) rather than
+            //     registeredModels (which only clears localPath but keeps the entry).
+            val stillRegistered = CppBridgeModelRegistry.get(modelId) != null
             if (!stillRegistered) {
                 downloadLogger.warn("Model '$modelId' was deleted during download, discarding result")
                 File(finalModelPath).let { f -> if (f.exists()) f.deleteRecursively() }
@@ -1318,7 +1318,11 @@ actual suspend fun RunAnywhere.deleteAllModels() {
 
     val downloadedModels = CppBridgeModelRegistry.getDownloaded()
     for (model in downloadedModels) {
-        deleteModel(model.modelId)
+        try {
+            deleteModel(model.modelId)
+        } catch (e: Exception) {
+            downloadLogger.warn("deleteAllModels: failed to delete ${model.modelId}: ${e.message}")
+        }
     }
 }
 

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
@@ -1343,8 +1343,10 @@ actual suspend fun RunAnywhere.loadLLMModel(modelId: String) {
         model.localPath
             ?: throw SDKError.model("Model '$modelId' is not downloaded")
 
-    // Pass modelPath, modelId, and modelName separately for correct telemetry
-    val result = CppBridgeLLM.loadModel(localPath, modelId, model.name)
+    // Run on IO to prevent ANR — JNI model loading can take hundreds of ms
+    val result = withContext(Dispatchers.IO) {
+        CppBridgeLLM.loadModel(localPath, modelId, model.name)
+    }
     if (result != 0) {
         throw SDKError.llm("Failed to load LLM model '$modelId' (error code: $result)")
     }

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
@@ -519,6 +519,14 @@ actual fun RunAnywhere.downloadModel(modelId: String): Flow<DownloadProgress> {
                     totalBytesDownloaded,
                 )
 
+                // Publish to Kotlin EventBus so other ViewModels refresh their model lists
+                EventBus.publish(
+                    ModelEvent(
+                        eventType = ModelEvent.ModelEventType.DOWNLOAD_COMPLETED,
+                        modelId = modelId,
+                    )
+                )
+
                 trySend(
                     DownloadProgress(
                         modelId = modelId,
@@ -730,6 +738,14 @@ actual fun RunAnywhere.downloadModel(modelId: String): Flow<DownloadProgress> {
             // 14. Emit completion events
             val downloadDurationMs = System.currentTimeMillis() - downloadStartTime
             CppBridgeEvents.emitDownloadCompleted(modelId, downloadDurationMs.toDouble(), result.fileSize)
+
+            // Publish to Kotlin EventBus so other ViewModels refresh their model lists
+            EventBus.publish(
+                ModelEvent(
+                    eventType = ModelEvent.ModelEventType.DOWNLOAD_COMPLETED,
+                    modelId = modelId,
+                )
+            )
 
             trySend(
                 DownloadProgress(
@@ -1066,6 +1082,14 @@ private suspend fun downloadEmbeddingModelFiles(
     }
     CppBridgeModelRegistry.updateDownloadStatus(modelId, dirPath)
     CppBridgeEvents.emitDownloadCompleted(modelId, 0.0, 0)
+
+    // Publish to Kotlin EventBus so other ViewModels refresh their model lists
+    EventBus.publish(
+        ModelEvent(
+            eventType = ModelEvent.ModelEventType.DOWNLOAD_COMPLETED,
+            modelId = modelId,
+        )
+    )
 
     logger.info("Embedding model ready at: $dirPath")
 }

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
@@ -17,6 +17,8 @@ import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeModelRegistry
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeSTT
 import com.runanywhere.sdk.foundation.errors.SDKError
 import com.runanywhere.sdk.public.RunAnywhere
+import com.runanywhere.sdk.public.events.EventBus
+import com.runanywhere.sdk.public.events.ModelEvent
 import com.runanywhere.sdk.public.extensions.Models.DownloadProgress
 import com.runanywhere.sdk.public.extensions.Models.DownloadState
 import com.runanywhere.sdk.public.extensions.Models.ModelCategory
@@ -1141,14 +1143,58 @@ actual suspend fun RunAnywhere.deleteModel(modelId: String) {
     if (!isInitialized) {
         throw SDKError.notInitialized("SDK not initialized")
     }
+
+    // 1. Get model info to find the local path for file deletion
+    val model = CppBridgeModelRegistry.get(modelId)
+    val localPath = model?.localPath
+
+    // 2. Delete actual files from disk (matches iOS SimplifiedFileManager.deleteModel)
+    if (localPath != null) {
+        val modelFile = File(localPath)
+        if (modelFile.exists()) {
+            if (modelFile.isDirectory) {
+                modelFile.deleteRecursively()
+            } else {
+                modelFile.delete()
+            }
+        }
+    }
+
+    // 3. Remove from C++ registry entirely.
+    //    The model will be re-registered (without localPath) on next app start via ModelList.setupModels().
     CppBridgeModelRegistry.remove(modelId)
+
+    // 4. Clear localPath in the Kotlin in-memory cache so availableModels() reflects deletion.
+    //    Without this, the registeredModels cache still has localPath set, and since it takes
+    //    precedence over bridge models in the merge, the model would still appear as downloaded.
+    synchronized(modelCacheLock) {
+        val index = registeredModels.indexOfFirst { it.id == modelId }
+        if (index >= 0) {
+            registeredModels[index] = registeredModels[index].copy(localPath = null)
+        }
+    }
+
+    // 5. Emit deletion event to C++ analytics
+    CppBridgeEvents.emitModelDeleted(modelId)
+
+    // 6. Publish to Kotlin EventBus so UI subscribers (e.g., SettingsViewModel) get notified
+    EventBus.publish(
+        ModelEvent(
+            eventType = ModelEvent.ModelEventType.DELETED,
+            modelId = modelId,
+        )
+    )
 }
 
 actual suspend fun RunAnywhere.deleteAllModels() {
     if (!isInitialized) {
         throw SDKError.notInitialized("SDK not initialized")
     }
-    // Would need to parse and delete each - simplified
+
+    val downloadedModels = CppBridgeModelRegistry.getDownloaded()
+    for (model in downloadedModels) {
+        deleteModel(model.modelId)
+    }
 }
 
 actual suspend fun RunAnywhere.refreshModelRegistry() {

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
@@ -189,6 +189,52 @@ private fun getAllBridgeModels(): List<CppBridgeModelRegistry.ModelInfo> {
 private var hasScannedForDownloads = false
 private val scanLock = Any()
 
+// ============================================================================
+// MULTIPLEXING DOWNLOAD LISTENER
+// Routes CppBridgeDownload callbacks to per-model handlers for concurrent downloads.
+// ============================================================================
+
+private val activeDownloadHandlers = java.util.concurrent.ConcurrentHashMap<String, CppBridgeDownload.DownloadListener>()
+/** Maps downloadId → modelId for routing progress callbacks (which only have downloadId). */
+private val downloadIdToModelId = java.util.concurrent.ConcurrentHashMap<String, String>()
+
+private val multiplexingListener = object : CppBridgeDownload.DownloadListener {
+    override fun onDownloadStarted(downloadId: String, modelId: String, url: String) {
+        downloadIdToModelId[downloadId] = modelId
+        activeDownloadHandlers[modelId]?.onDownloadStarted(downloadId, modelId, url)
+    }
+    override fun onDownloadProgress(downloadId: String, downloadedBytes: Long, totalBytes: Long, progress: Int) {
+        val modelId = downloadIdToModelId[downloadId]
+        if (modelId != null) {
+            activeDownloadHandlers[modelId]?.onDownloadProgress(downloadId, downloadedBytes, totalBytes, progress)
+        }
+    }
+    override fun onDownloadCompleted(downloadId: String, modelId: String, filePath: String, fileSize: Long) {
+        activeDownloadHandlers[modelId]?.onDownloadCompleted(downloadId, modelId, filePath, fileSize)
+        downloadIdToModelId.remove(downloadId)
+    }
+    override fun onDownloadFailed(downloadId: String, modelId: String, error: Int, errorMessage: String) {
+        activeDownloadHandlers[modelId]?.onDownloadFailed(downloadId, modelId, error, errorMessage)
+        downloadIdToModelId.remove(downloadId)
+    }
+    override fun onDownloadPaused(downloadId: String) {
+        val modelId = downloadIdToModelId[downloadId]
+        if (modelId != null) activeDownloadHandlers[modelId]?.onDownloadPaused(downloadId)
+    }
+    override fun onDownloadResumed(downloadId: String) {
+        val modelId = downloadIdToModelId[downloadId]
+        if (modelId != null) activeDownloadHandlers[modelId]?.onDownloadResumed(downloadId)
+    }
+    override fun onDownloadCancelled(downloadId: String) {
+        val modelId = downloadIdToModelId[downloadId]
+        if (modelId != null) activeDownloadHandlers[modelId]?.onDownloadCancelled(downloadId)
+        downloadIdToModelId.remove(downloadId)
+    }
+}
+
+@Volatile
+private var isMultiplexingListenerInstalled = false
+
 actual suspend fun RunAnywhere.availableModels(): List<ModelInfo> {
     if (!isInitialized) {
         throw SDKError.notInitialized("SDK not initialized")
@@ -676,8 +722,12 @@ actual fun RunAnywhere.downloadModel(modelId: String): Flow<DownloadProgress> {
                 }
             }
 
-        // Register listener BEFORE starting download
-        CppBridgeDownload.downloadListener = downloadListener
+        // Register per-model handler with the multiplexing listener
+        activeDownloadHandlers[modelId] = downloadListener
+        if (!isMultiplexingListenerInstalled) {
+            CppBridgeDownload.downloadListener = multiplexingListener
+            isMultiplexingListenerInstalled = true
+        }
 
         try {
             // 8. Start the actual download (runs asynchronously on thread pool)
@@ -787,8 +837,8 @@ actual fun RunAnywhere.downloadModel(modelId: String): Flow<DownloadProgress> {
             // Close with exception so collectors receive the error
             close(e)
         } finally {
-            // Clean up listener
-            CppBridgeDownload.downloadListener = null
+            // Remove this model's handler (other downloads keep theirs)
+            activeDownloadHandlers.remove(modelId)
         }
 
         awaitClose {

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
@@ -1145,6 +1145,14 @@ private suspend fun downloadEmbeddingModelFiles(
 
     val dirPath = embeddingDir.absolutePath
 
+    // Guard: if model was deleted during download, don't resurrect it.
+    val stillRegistered = CppBridgeModelRegistry.get(modelId) != null
+    if (!stillRegistered) {
+        logger.warn("Model '$modelId' was deleted during embedding download, discarding result")
+        withContext(Dispatchers.IO) { embeddingDir.deleteRecursively() }
+        return
+    }
+
     // Update in-memory cache with local path
     synchronized(modelCacheLock) {
         val idx = registeredModels.indexOfFirst { it.id == modelId }
@@ -1223,9 +1231,18 @@ actual suspend fun RunAnywhere.cancelDownload(modelId: String) {
     if (!isInitialized) {
         throw SDKError.notInitialized("SDK not initialized")
     }
-    // Actually cancel the download thread via CppBridgeDownload
-    // This cancels the future, cleans up temp files, and notifies listeners
-    CppBridgeDownload.cancelDownload(modelId)
+    // CppBridgeDownload.cancelDownload() expects a downloadId (UUID), not a modelId.
+    // Reverse-lookup the downloadId from the modelId mapping.
+    val downloadId = downloadIdToModelId.entries.firstOrNull { it.value == modelId }?.key
+    if (downloadId != null) {
+        CppBridgeDownload.cancelDownload(downloadId)
+        // Clean up tracking maps
+        downloadIdToModelId.remove(downloadId)
+        activeDownloadHandlers.remove(modelId)
+    } else {
+        // Fallback: try modelId directly (some paths may use modelId as downloadId)
+        CppBridgeDownload.cancelDownload(modelId)
+    }
 }
 
 actual suspend fun RunAnywhere.isModelDownloaded(modelId: String): Boolean {

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
@@ -12,6 +12,8 @@ import com.runanywhere.sdk.foundation.SDKLogger
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeDownload
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeEvents
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeLLM
+import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeTTS
+import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeVLM
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeModelPaths
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeModelRegistry
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeSTT
@@ -1189,11 +1191,29 @@ actual suspend fun RunAnywhere.deleteModel(modelId: String) {
         throw SDKError.notInitialized("SDK not initialized")
     }
 
-    // 1. Get model info to find the local path for file deletion
+    // 1. Unload the model if it is currently loaded (LLM, TTS, STT, or VLM)
+    if (CppBridgeLLM.getLoadedModelId() == modelId) {
+        CppBridgeLLM.unload()
+        EventBus.publish(ModelEvent(eventType = ModelEvent.ModelEventType.UNLOADED, modelId = modelId))
+    }
+    if (CppBridgeTTS.getLoadedModelId() == modelId) {
+        CppBridgeTTS.unload()
+        EventBus.publish(ModelEvent(eventType = ModelEvent.ModelEventType.UNLOADED, modelId = modelId))
+    }
+    if (CppBridgeSTT.getLoadedModelId() == modelId) {
+        CppBridgeSTT.unload()
+        EventBus.publish(ModelEvent(eventType = ModelEvent.ModelEventType.UNLOADED, modelId = modelId))
+    }
+    if (CppBridgeVLM.getLoadedModelId() == modelId) {
+        CppBridgeVLM.unload()
+        EventBus.publish(ModelEvent(eventType = ModelEvent.ModelEventType.UNLOADED, modelId = modelId))
+    }
+
+    // 2. Get model info to find the local path for file deletion
     val model = CppBridgeModelRegistry.get(modelId)
     val localPath = model?.localPath
 
-    // 2. Delete actual files from disk (matches iOS SimplifiedFileManager.deleteModel)
+    // 3. Delete actual files from disk (matches iOS SimplifiedFileManager.deleteModel)
     if (localPath != null) {
         val modelFile = File(localPath)
         if (modelFile.exists()) {

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
@@ -1338,7 +1338,7 @@ actual suspend fun RunAnywhere.deleteAllModels() {
         try {
             deleteModel(model.modelId)
         } catch (e: Exception) {
-            downloadLogger.warn("deleteAllModels: failed to delete ${model.modelId}: ${e.message}")
+            modelsLogger.warn("deleteAllModels: failed to delete ${model.modelId}: ${e.message}")
         }
     }
 }

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
@@ -504,6 +504,16 @@ actual fun RunAnywhere.downloadModel(modelId: String): Flow<DownloadProgress> {
                 }
 
                 // All files downloaded — update registry with directory path
+                //     Guard: if model was deleted during download, don't resurrect it
+                val stillRegistered = synchronized(modelCacheLock) {
+                    registeredModels.any { it.id == modelId }
+                }
+                if (!stillRegistered) {
+                    downloadLogger.warn("Model '$modelId' was deleted during download, discarding result")
+                    modelDir.deleteRecursively()
+                    close()
+                    return@callbackFlow
+                }
                 val finalPath = modelDir.absolutePath
                 val updatedModelInfo = modelInfo.copy(localPath = finalPath)
                 addToModelCache(updatedModelInfo)
@@ -729,6 +739,16 @@ actual fun RunAnywhere.downloadModel(modelId: String): Flow<DownloadProgress> {
                 }
 
             // 13. Update model in C++ registry with local path
+            //     Guard: if model was deleted during download, don't resurrect it
+            val stillRegistered = synchronized(modelCacheLock) {
+                registeredModels.any { it.id == modelId }
+            }
+            if (!stillRegistered) {
+                downloadLogger.warn("Model '$modelId' was deleted during download, discarding result")
+                File(finalModelPath).let { f -> if (f.exists()) f.deleteRecursively() }
+                close()
+                return@callbackFlow
+            }
             val updatedModelInfo = modelInfo.copy(localPath = finalModelPath)
             addToModelCache(updatedModelInfo)
             CppBridgeModelRegistry.updateDownloadStatus(modelId, finalModelPath)
@@ -1151,8 +1171,9 @@ actual suspend fun RunAnywhere.cancelDownload(modelId: String) {
     if (!isInitialized) {
         throw SDKError.notInitialized("SDK not initialized")
     }
-    // Update C++ registry to mark download cancelled
-    CppBridgeModelRegistry.updateDownloadStatus(modelId, null)
+    // Actually cancel the download thread via CppBridgeDownload
+    // This cancels the future, cleans up temp files, and notifies listeners
+    CppBridgeDownload.cancelDownload(modelId)
 }
 
 actual suspend fun RunAnywhere.isModelDownloaded(modelId: String): Boolean {
@@ -1198,10 +1219,20 @@ actual suspend fun RunAnywhere.deleteModel(modelId: String) {
         }
     }
 
-    // 5. Emit deletion event to C++ analytics
+    // 5. Clean up multi-file descriptor cache
+    synchronized(multiFileCacheLock) {
+        multiFileModelCache.remove(modelId)
+    }
+
+    // 6. Reset scan flag so deleted models aren't resurrected from stale scan state
+    synchronized(scanLock) {
+        hasScannedForDownloads = false
+    }
+
+    // 7. Emit deletion event to C++ analytics
     CppBridgeEvents.emitModelDeleted(modelId)
 
-    // 6. Publish to Kotlin EventBus so UI subscribers (e.g., SettingsViewModel) get notified
+    // 8. Publish to Kotlin EventBus so UI subscribers (e.g., SettingsViewModel) get notified
     EventBus.publish(
         ModelEvent(
             eventType = ModelEvent.ModelEventType.DELETED,
@@ -1247,13 +1278,19 @@ actual suspend fun RunAnywhere.loadLLMModel(modelId: String) {
     if (result != 0) {
         throw SDKError.llm("Failed to load LLM model '$modelId' (error code: $result)")
     }
+
+    EventBus.publish(ModelEvent(eventType = ModelEvent.ModelEventType.LOADED, modelId = modelId))
 }
 
 actual suspend fun RunAnywhere.unloadLLMModel() {
     if (!isInitialized) {
         throw SDKError.notInitialized("SDK not initialized")
     }
+    val modelId = CppBridgeLLM.getLoadedModelId()
     CppBridgeLLM.unload()
+    if (modelId != null) {
+        EventBus.publish(ModelEvent(eventType = ModelEvent.ModelEventType.UNLOADED, modelId = modelId))
+    }
 }
 
 actual suspend fun RunAnywhere.isLLMModelLoaded(): Boolean {
@@ -1316,6 +1353,8 @@ actual suspend fun RunAnywhere.loadSTTModel(modelId: String) {
     if (result != 0) {
         throw SDKError.stt("Failed to load STT model '$modelId' (error code: $result). Ensure the model is extracted and contains encoder.onnx, decoder.onnx, tokens.txt.")
     }
+
+    EventBus.publish(ModelEvent(eventType = ModelEvent.ModelEventType.LOADED, modelId = modelId))
 }
 
 // ============================================================================

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+TTS.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+TTS.jvmAndroid.kt
@@ -13,6 +13,8 @@ import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeModelRegistry
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeTTS
 import com.runanywhere.sdk.foundation.errors.SDKError
 import com.runanywhere.sdk.public.RunAnywhere
+import com.runanywhere.sdk.public.events.EventBus
+import com.runanywhere.sdk.public.events.ModelEvent
 import com.runanywhere.sdk.public.extensions.TTS.TTSOptions
 import com.runanywhere.sdk.public.extensions.TTS.TTSOutput
 import com.runanywhere.sdk.public.extensions.TTS.TTSSpeakResult
@@ -43,13 +45,18 @@ actual suspend fun RunAnywhere.loadTTSVoice(voiceId: String) {
         throw SDKError.tts("Failed to load TTS voice '$voiceId' (error code: $result)")
     }
     ttsLogger.info("TTS voice loaded: $voiceId")
+    EventBus.publish(ModelEvent(eventType = ModelEvent.ModelEventType.LOADED, modelId = voiceId))
 }
 
 actual suspend fun RunAnywhere.unloadTTSVoice() {
     if (!isInitialized) {
         throw SDKError.notInitialized("SDK not initialized")
     }
+    val voiceId = CppBridgeTTS.getLoadedModelId()
     CppBridgeTTS.unload()
+    if (voiceId != null) {
+        EventBus.publish(ModelEvent(eventType = ModelEvent.ModelEventType.UNLOADED, modelId = voiceId))
+    }
 }
 
 actual suspend fun RunAnywhere.isTTSVoiceLoaded(): Boolean {

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+TTS.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+TTS.jvmAndroid.kt
@@ -38,8 +38,10 @@ actual suspend fun RunAnywhere.loadTTSVoice(voiceId: String) {
         modelInfo.localPath
             ?: throw SDKError.tts("Voice '$voiceId' is not downloaded")
 
-    // Pass modelPath, modelId, and modelName separately for correct telemetry
-    val result = CppBridgeTTS.loadModel(localPath, voiceId, modelInfo.name)
+    // Run on IO to prevent ANR — JNI model loading can take hundreds of ms
+    val result = kotlinx.coroutines.withContext(kotlinx.coroutines.Dispatchers.IO) {
+        CppBridgeTTS.loadModel(localPath, voiceId, modelInfo.name)
+    }
     if (result != 0) {
         ttsLogger.error("Failed to load TTS voice '$voiceId' (error code: $result)")
         throw SDKError.tts("Failed to load TTS voice '$voiceId' (error code: $result)")

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+TextGeneration.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+TextGeneration.jvmAndroid.kt
@@ -16,9 +16,7 @@ import com.runanywhere.sdk.public.extensions.LLM.LLMGenerationResult
 import com.runanywhere.sdk.public.extensions.LLM.LLMStreamingResult
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.async
 import kotlinx.coroutines.channels.awaitClose
-import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
@@ -192,12 +190,15 @@ actual suspend fun RunAnywhere.generateStreamWithMetrics(
             }
         }
 
-    return coroutineScope {
-        LLMStreamingResult(
-            stream = tokenStream,
-            result = async { resultDeferred.await() },
-        )
-    }
+    // Return immediately — the stream is cold (runs when collected),
+    // and resultDeferred completes after generation finishes.
+    // NOTE: Do NOT wrap in coroutineScope{} — it would deadlock because
+    // coroutineScope waits for all children, but the async result can only
+    // complete after the stream is collected (which hasn't started yet).
+    return LLMStreamingResult(
+        stream = tokenStream,
+        result = resultDeferred,
+    )
 }
 
 actual fun RunAnywhere.cancelGeneration() {

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+VLM.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+VLM.jvmAndroid.kt
@@ -12,6 +12,8 @@ import com.runanywhere.sdk.foundation.SDKLogger
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeVLM
 import com.runanywhere.sdk.foundation.errors.SDKError
 import com.runanywhere.sdk.public.RunAnywhere
+import com.runanywhere.sdk.public.events.EventBus
+import com.runanywhere.sdk.public.events.ModelEvent
 import com.runanywhere.sdk.public.extensions.VLM.VLMGenerationOptions
 import com.runanywhere.sdk.public.extensions.VLM.VLMImage
 import com.runanywhere.sdk.public.extensions.VLM.VLMImageFormat
@@ -232,6 +234,7 @@ actual suspend fun RunAnywhere.loadVLMModel(modelId: String) {
     }
 
     vlmLogger.info("VLM model loaded successfully by ID: $modelId")
+    EventBus.publish(ModelEvent(eventType = ModelEvent.ModelEventType.LOADED, modelId = modelId))
 }
 
 actual suspend fun RunAnywhere.loadVLMModel(
@@ -254,11 +257,16 @@ actual suspend fun RunAnywhere.loadVLMModel(
     }
 
     vlmLogger.info("VLM model loaded successfully: $modelId")
+    EventBus.publish(ModelEvent(eventType = ModelEvent.ModelEventType.LOADED, modelId = modelId))
 }
 
 actual suspend fun RunAnywhere.unloadVLMModel() {
+    val modelId = CppBridgeVLM.getLoadedModelId()
     CppBridgeVLM.unload()
     vlmLogger.info("VLM model unloaded")
+    if (modelId != null) {
+        EventBus.publish(ModelEvent(eventType = ModelEvent.ModelEventType.UNLOADED, modelId = modelId))
+    }
 }
 
 actual val RunAnywhere.isVLMModelLoaded: Boolean


### PR DESCRIPTION
## Summary
- **Fix incorrect RAM detection**: `collectAndroidDeviceInfo()` used `Runtime.maxMemory()` (JVM heap limit ~512MB) instead of `ActivityManager.MemoryInfo.totalMem` (actual physical RAM). Poco Pad with 8GB now correctly shows 8192 MB.
- **Fix model deletion not working**: `deleteModel()` only removed from C++ registry but never deleted files from disk or cleared the Kotlin in-memory cache. Models reappeared after restart and the "Use" button persisted in model selection.
- **Add memory compatibility badges**: Model selection cards now show "Fits" (green) or "Large" (red + warning) badges based on device RAM vs model memory requirement.

## Changes

### SDK (`sdk/runanywhere-kotlin/`)
- `DeviceInfo.kt`: Use `ActivityManager.MemoryInfo.totalMem` via reflection for actual physical RAM
- `RunAnywhere+ModelManagement.jvmAndroid.kt`:
  - `deleteModel()`: Delete files from disk, remove from C++ registry, clear Kotlin `registeredModels` cache `localPath`, publish `ModelEvent(DELETED)` to EventBus
  - `deleteAllModels()`: Implement (was a no-op stub)

### Android Example App (`examples/android/`)
- `SettingsViewModel.kt`: Optimistic UI removal + `deletedModelIds` set to filter stale C++ data
- `ModelSelectionViewModel.kt`: Handle `DELETED` event to refresh model list
- `ModelSelectionBottomSheet.kt`: Memory compatibility badges (`MemoryCompatibility` enum, `computeMemoryCompatibility()`)

## Test plan
- [ ] Install on device with ≥4GB RAM, verify Device Status card shows correct RAM (not ~512MB)
- [ ] Download a model, then delete from Settings — verify it disappears immediately from the list
- [ ] After deleting from Settings, open model selection sheet — verify model shows download button (not "Use")
- [ ] Restart app after deletion — verify model remains deleted (not restored)
- [ ] Verify memory badges: small models show "Fits", large models relative to device RAM show "Large"

Closes #455

🤖 Generated with [Claude Code](https://claude.com/claude-code)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Memory-fit badges and per-model Cancel for downloads
  * Concurrent per-model downloads with individual progress and cancel API
  * Error dialog to surface runtime errors in settings

* **Improvements**
  * Benchmark runs moved off the main thread with per-iteration progress updates
  * Progress bar shows indeterminate animation until measurable progress
  * Improved device memory detection for model recommendations
  * Event-driven model load/unload and download notifications

* **Bug Fixes**
  * Optimistic deletion with rollback on failure and refreshed state after events
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes two core bugs in the Android SDK (incorrect RAM detection and broken model deletion) and adds several supporting features: concurrent download tracking with per-model cancel, memory-fit badges in model selection, benchmark execution off the Main thread, and an error dialog in Settings.

**Key changes:**
- **RAM detection** (`DeviceInfo.kt`): Replaces `Runtime.maxMemory()` (JVM heap limit, ~512 MB) with `ActivityManager.MemoryInfo.totalMem` via reflection, falling back gracefully — a correct fix.
- **`deleteModel`** (`RunAnywhere+ModelManagement.jvmAndroid.kt`): Now unloads the model from all bridges, deletes files from disk, removes from the C++ registry, clears the Kotlin in-memory `localPath`, resets the scan flag, and emits both a C++ analytics event and a Kotlin `EventBus` `DELETED` event.
- **Resurrection guard**: After deletion, any in-flight download checks `CppBridgeModelRegistry.get(modelId)` before finalizing — the previous threads' concern is now properly addressed.
- **Concurrent downloads**: A multiplexing listener (`activeDownloadHandlers` + `downloadIdToModelId`) routes `CppBridgeDownload` callbacks to per-model handlers, replacing the single-global-listener approach.
- **`CancellationException` fix**: The download catch block now re-throws `CancellationException`, preventing cancelled downloads from appearing as user-visible errors.
- **`generateStreamWithMetrics` deadlock fix**: Removes the `coroutineScope { async { } }` wrapper that would deadlock because `coroutineScope` waits for children before returning, but the `async` result can only complete after stream collection starts.

**Remaining concerns:**
- `isMultiplexingListenerInstalled` is a `@Volatile` flag that is set to `true` once and never reset — if `CppBridgeDownload.downloadListener` is displaced by an SDK re-initialization, the multiplexing listener won't be re-registered and all download callbacks will be silently dropped (see inline comment).
- The four `CppBridgeLLM/TTS/STT/VLM.unload()` calls in `deleteModel` are not wrapped in `Dispatchers.IO`, unlike the corresponding `loadModel` calls introduced in this same PR.
- File deletion return values (`delete()`/`deleteRecursively()`) are still not checked, which was flagged in a previous review thread.

<h3>Confidence Score: 3/5</h3>

- Mostly safe to merge; the core bug fixes are correct but the multiplexing listener has a latent re-init bug that could silently break all downloads after SDK re-initialization.
- The two stated bugs (RAM detection, model deletion) are fixed correctly. The resurrection guard, CancellationException handling, and error dialog fixes all address issues from prior review threads. However, `isMultiplexingListenerInstalled` is never reset, which is a logic bug that would silently drop all download callbacks after an SDK re-init cycle. Additionally, the `unload()` JNI calls in `deleteModel` are not wrapped in `Dispatchers.IO` — inconsistent with the `load()` changes in this same PR — risking ANR on slow hardware. File deletion failures remain silently ignored (previously flagged).
- `RunAnywhere+ModelManagement.jvmAndroid.kt` needs the most attention — the multiplexing listener re-init guard and the unload dispatcher wrapping.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt | Core SDK model management overhaul: adds full `deleteModel` (unload → delete files → remove from C++ registry → clear Kotlin cache → emit events), implements `deleteAllModels`, adds a multiplexing download listener for concurrent downloads, and adds resurrection guards. The `isMultiplexingListenerInstalled` flag is never reset on SDK re-init (could silently drop all download callbacks after re-initialization), and the unload JNI calls inside `deleteModel` are not wrapped in `Dispatchers.IO`. |
| sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/models/DeviceInfo.kt | Fixes RAM detection by replacing `Runtime.maxMemory()` (JVM heap limit, ~512 MB) with `ActivityManager.MemoryInfo.totalMem` via reflection. Fallback to `Runtime.maxMemory()` is preserved if reflection fails. Implementation is correct and well-guarded. |
| examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsViewModel.kt | Adds optimistic UI deletion (removes model immediately, rolls back on failure), a `deletedModelIds` set to filter stale C++ data, and a `clearError()` function enabling repeated-error dialogs. Logic is sound; the `deletedModelIds` set is only as fresh as the ViewModel instance but that's acceptable for in-session state. |
| examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionViewModel.kt | Refactors from single-download to concurrent per-model download tracking (`downloadingModelIds` + `downloadProgressMap`), adds `cancelDownload()` with proper `CancellationException` re-throw, and handles `DELETED` events by refreshing the model list. Clean implementation; stale `isLoadingModel`/`loadingProgress` fields remain in `ModelSelectionUiState` but are still used for model loading (not download) so they are not dead code. |
| examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionBottomSheet.kt | Adds `MemoryCompatibility` enum and `computeMemoryCompatibility()` to show "Fits" (green) and "Large" (red/warning) badges on model cards, switches the download spinner to a tappable "Cancel" badge, and wires per-model download progress. The use of `downloadSize` as a memory-requirement proxy is documented with a caveat comment addressing the already-flagged limitation. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant UI as ModelSelectionBottomSheet
    participant MSVM as ModelSelectionViewModel
    participant SDK as RunAnywhere SDK
    participant CPP as CppBridgeDownload
    participant MUX as multiplexingListener
    participant EB as EventBus

    UI->>MSVM: startDownload(modelId)
    MSVM->>MSVM: downloadJobs[modelId] = launch {}
    MSVM->>SDK: downloadModel(modelId).collect { }
    SDK->>MUX: activeDownloadHandlers[modelId] = listener
    SDK->>CPP: startDownload(url, modelId)
    CPP-->>MUX: onDownloadStarted(downloadId, modelId)
    MUX->>MUX: downloadIdToModelId[downloadId] = modelId
    CPP-->>MUX: onDownloadProgress(downloadId, ...)
    MUX->>MSVM: progress update → downloadProgressMap
    UI->>MSVM: cancelDownload(modelId) [optional]
    MSVM->>MSVM: downloadJobs[modelId]?.cancel()
    MSVM->>SDK: cancelDownload(modelId)
    SDK->>CPP: cancelDownload(downloadId)
    CPP-->>MUX: onDownloadCompleted(downloadId, modelId)
    MUX->>SDK: per-model handler → downloadCompletion.complete()
    SDK->>SDK: Guard: CppBridgeModelRegistry.get(modelId) != null?
    SDK->>SDK: addToModelCache() + updateDownloadStatus()
    SDK->>EB: publish(DOWNLOAD_COMPLETED, modelId)
    EB-->>MSVM: DOWNLOAD_COMPLETED → loadModelsAndFrameworks()
    EB-->>SVM: DOWNLOAD_COMPLETED → loadStorageData()

    Note over SDK,CPP: deleteModel flow
    UI->>SVM: deleteModel(modelId)
    SVM->>SVM: deletedModelIds.add(modelId) + optimistic UI update
    SVM->>SDK: deleteModel(modelId)
    SDK->>CPP: CppBridgeLLM/TTS/STT/VLM.unload() if loaded
    SDK->>SDK: delete files from disk
    SDK->>SDK: CppBridgeModelRegistry.remove(modelId)
    SDK->>SDK: registeredModels[idx].localPath = null
    SDK->>EB: publish(DELETED, modelId)
    EB-->>MSVM: DELETED → loadModelsAndFrameworks()
    EB-->>SVM: DELETED → (already handled optimistically)
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (2)</h3></summary>

1. `sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt`, line 1163-1165 ([link](https://github.com/runanywhereai/runanywhere-sdks/blob/bacd2bc3c1a3f22113df6743864be354deb4184c/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt#L1163-L1165)) 

   **Diverges from iOS source of truth: `remove()` vs `updateDownloadStatus(nil)`**

   The iOS implementation (`RunAnywhere+Storage.swift:93`) uses `CppBridge.ModelRegistry.shared.updateDownloadStatus(modelId: modelId, localPath: nil)`, which keeps the model entry in the C++ registry but clears the download path. This Android implementation uses `CppBridgeModelRegistry.remove(modelId)`, which deletes the entry entirely.

   While the Kotlin `registeredModels` cache (step 4) preserves the model for `availableModels()`, any code path that queries the C++ bridge directly (e.g., `downloadedModels()` at line 262, `models(category)` at line 244, or `model(modelId)` at line 269) will not find this model until the next app restart re-registers it via `ModelList.setupModels()`.

   Per the project's CLAUDE.md, iOS is the source of truth. Consider using `updateDownloadStatus` to match:

   **Rule Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=6b0c1c0a-6778-4c08-bb0e-ca0fca292f2f))
   
   <details><summary>Prompt To Fix With AI</summary>
   
   `````markdown
   This is a comment left during a code review.
   Path: sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
   Line: 1163-1165
   
   Comment:
   **Diverges from iOS source of truth: `remove()` vs `updateDownloadStatus(nil)`**
   
   The iOS implementation (`RunAnywhere+Storage.swift:93`) uses `CppBridge.ModelRegistry.shared.updateDownloadStatus(modelId: modelId, localPath: nil)`, which keeps the model entry in the C++ registry but clears the download path. This Android implementation uses `CppBridgeModelRegistry.remove(modelId)`, which deletes the entry entirely.
   
   While the Kotlin `registeredModels` cache (step 4) preserves the model for `availableModels()`, any code path that queries the C++ bridge directly (e.g., `downloadedModels()` at line 262, `models(category)` at line 244, or `model(modelId)` at line 269) will not find this model until the next app restart re-registers it via `ModelList.setupModels()`.
   
   Per the project's CLAUDE.md, iOS is the source of truth. Consider using `updateDownloadStatus` to match:
   
   
   
   **Rule Used:** CLAUDE.md ([source](https://app.greptile.com/review/custom-context?memory=6b0c1c0a-6778-4c08-bb0e-ca0fca292f2f))
   
   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

2. `sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt`, line 767-770 ([link](https://github.com/runanywhereai/runanywhere-sdks/blob/da0ecfe5d8288554245f1c6e914f9c2ceee7f53d/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt#L767-L770)) 

   **`isMultiplexingListenerInstalled` is never reset — SDK re-init breaks downloads**

   `isMultiplexingListenerInstalled` is a package-level `@Volatile` flag that is set to `true` once and never reset. If the SDK is de-initialized and re-initialized (e.g., the user calls `RunAnywhere.initialize()` a second time), `CppBridgeDownload.downloadListener` may be set to `null` or a different listener internally. Because `isMultiplexingListenerInstalled` stays `true`, the multiplexing listener will not be re-registered on the next download, and all download progress callbacks will be silently dropped — the `callbackFlow` will suspend indefinitely on `downloadCompletion.await()`.

   A more robust guard uses the actual registered value instead of a separate flag:

   ```kotlin
   if (CppBridgeDownload.downloadListener !== multiplexingListener) {
       CppBridgeDownload.downloadListener = multiplexingListener
       isMultiplexingListenerInstalled = true
   }
   ```

   This re-registers the listener whenever it has been displaced, at zero additional cost during normal operation.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
   Line: 767-770

   Comment:
   **`isMultiplexingListenerInstalled` is never reset — SDK re-init breaks downloads**

   `isMultiplexingListenerInstalled` is a package-level `@Volatile` flag that is set to `true` once and never reset. If the SDK is de-initialized and re-initialized (e.g., the user calls `RunAnywhere.initialize()` a second time), `CppBridgeDownload.downloadListener` may be set to `null` or a different listener internally. Because `isMultiplexingListenerInstalled` stays `true`, the multiplexing listener will not be re-registered on the next download, and all download progress callbacks will be silently dropped — the `callbackFlow` will suspend indefinitely on `downloadCompletion.await()`.

   A more robust guard uses the actual registered value instead of a separate flag:

   ```kotlin
   if (CppBridgeDownload.downloadListener !== multiplexingListener) {
       CppBridgeDownload.downloadListener = multiplexingListener
       isMultiplexingListenerInstalled = true
   }
   ```

   This re-registers the listener whenever it has been displaced, at zero additional cost during normal operation.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
Line: 767-770

Comment:
**`isMultiplexingListenerInstalled` is never reset — SDK re-init breaks downloads**

`isMultiplexingListenerInstalled` is a package-level `@Volatile` flag that is set to `true` once and never reset. If the SDK is de-initialized and re-initialized (e.g., the user calls `RunAnywhere.initialize()` a second time), `CppBridgeDownload.downloadListener` may be set to `null` or a different listener internally. Because `isMultiplexingListenerInstalled` stays `true`, the multiplexing listener will not be re-registered on the next download, and all download progress callbacks will be silently dropped — the `callbackFlow` will suspend indefinitely on `downloadCompletion.await()`.

A more robust guard uses the actual registered value instead of a separate flag:

```kotlin
if (CppBridgeDownload.downloadListener !== multiplexingListener) {
    CppBridgeDownload.downloadListener = multiplexingListener
    isMultiplexingListenerInstalled = true
}
```

This re-registers the listener whenever it has been displaced, at zero additional cost during normal operation.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
Line: 1283-1295

Comment:
**Duplicate step number in `deleteModel` comment sequence**

Steps 3 through 8 are mislabeled — there are two `// 3.` comments, causing every subsequent step to be off by one:

```
// 3. Delete actual files from disk   ← correct
// 3. Remove from C++ registry        ← should be // 4.
// 4. Clear localPath in Kotlin cache ← should be // 5.
// 5. Clean up multi-file cache       ← should be // 6.
// 6. Reset scan flag                 ← should be // 7.
// 7. Emit deletion event to C++      ← should be // 8.
// 8. Publish to Kotlin EventBus      ← should be // 9.
```

This makes it harder to trace the full deletion sequence in code review or debugging.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/benchmarks/services/BenchmarkRunner.kt
Line: 186-199

Comment:
**Post-iteration progress reports next benchmark's name, not the completed one**

The new post-benchmark `onProgress` call sets `currentScenario` to `workItems[index + 1].scenario.name` (i.e., the *next* benchmark), not the one that just finished. This means:

- UI shows "Running: Gemma 2B" (pre-benchmark update, `index = 0`)
- Gemma 2B finishes
- UI shows "2/N — Running: Llama 3B" (post-benchmark update, `index = 0`, `index + 1 = 1`) ← still says "Running" but the next one hasn't started yet
- Next iteration's pre-benchmark update also shows "Llama 3B"

The `completedCount` number is accurate, but the scenario label looks like the next benchmark is "currently running" before it has actually started. If the progress dialog uses `currentScenario` as a label for the item in progress, consider reporting the just-completed benchmark's name here instead:

```kotlin
// Report progress AFTER the benchmark completes
onProgress(
    BenchmarkProgressUpdate(
        completedCount = index + 1,
        totalCount = total,
        currentScenario = if (index + 1 < total) workItems[index + 1].scenario.name else "Done",
        currentModel = if (index + 1 < total) workItems[index + 1].model.name else "",
    ),
)
```

If the intent is to show the *upcoming* benchmark name while `completedCount` increments, this is fine — but a comment clarifying the intent would help future readers.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
Line: 1261-1277

Comment:
**JNI `unload()` calls in `deleteModel` could block the calling dispatcher**

`loadLLMModel` and `loadTTSVoice` now correctly dispatch to `Dispatchers.IO` for the JNI model-load call, since JNI loading can take hundreds of milliseconds. However, the four `CppBridgeLLM/TTS/STT/VLM.unload()` calls inside `deleteModel` run on whatever dispatcher the caller uses — typically `Dispatchers.IO` (since `deleteModel` itself is a `suspend fun` often invoked from a background scope), but if called from Main it could cause an ANR.

Consider wrapping the unload calls the same way `loadLLMModel` does:

```kotlin
withContext(Dispatchers.IO) {
    if (CppBridgeLLM.getLoadedModelId() == modelId) CppBridgeLLM.unload()
    if (CppBridgeTTS.getLoadedModelId() == modelId) CppBridgeTTS.unload()
    if (CppBridgeSTT.getLoadedModelId() == modelId) CppBridgeSTT.unload()
    if (CppBridgeVLM.getLoadedModelId() == modelId) CppBridgeVLM.unload()
}
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Last reviewed commit: da0ecfe</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->