### PR TITLE
feat: add grammar-constrained structured output across SDKs

### DIFF
--- a/sdk/runanywhere-commons/exports/RACommons.exports
+++ b/sdk/runanywhere-commons/exports/RACommons.exports
@@ -226,6 +226,13 @@ _rac_llm_component_load_model
 _rac_llm_component_supports_streaming
 _rac_llm_component_unload
 
+# LLM Component - Structured Output
+_rac_llm_component_generate_structured
+_rac_llm_component_generate_structured_stream
+
+# LLM Service - Grammar
+_rac_llm_json_schema_to_grammar
+
 # LLM Component - LoRA
 _rac_llm_component_load_lora
 _rac_llm_component_remove_lora

--- a/sdk/runanywhere-commons/include/rac/backends/rac_llm_llamacpp.h
+++ b/sdk/runanywhere-commons/include/rac/backends/rac_llm_llamacpp.h
@@ -289,6 +289,26 @@ RAC_LLAMACPP_API rac_result_t rac_llm_llamacpp_generate_from_context(
 RAC_LLAMACPP_API rac_result_t rac_llm_llamacpp_clear_context(rac_handle_t handle);
 
 // =============================================================================
+// JSON SCHEMA → GBNF GRAMMAR CONVERSION
+// =============================================================================
+
+/**
+ * Convert a JSON Schema string to a GBNF grammar string for constrained decoding.
+ *
+ * Uses llama.cpp's built-in json-schema-to-grammar converter. The resulting
+ * grammar can be passed via rac_llm_options_t.grammar for grammar-constrained
+ * token generation.
+ *
+ * @param handle Service handle (from rac_llm_llamacpp_create)
+ * @param json_schema JSON Schema string
+ * @param out_grammar Output: GBNF grammar string (caller must free with rac_free)
+ * @return RAC_SUCCESS or error code
+ */
+RAC_LLAMACPP_API rac_result_t rac_llm_llamacpp_json_schema_to_grammar(rac_handle_t handle,
+                                                                        const char* json_schema,
+                                                                        char** out_grammar);
+
+// =============================================================================
 // BACKEND REGISTRATION
 // =============================================================================
 

--- a/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_component.h
+++ b/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_component.h
@@ -166,6 +166,51 @@ RAC_API rac_result_t rac_llm_component_generate(rac_handle_t handle, const char*
                                                 const rac_llm_options_t* options,
                                                 rac_llm_result_t* out_result);
 
+// =============================================================================
+// STRUCTURED OUTPUT - Grammar-constrained generation
+// =============================================================================
+
+/**
+ * @brief Generate structured output with grammar-constrained decoding
+ *
+ * Converts JSON schema to GBNF grammar, applies grammar constraint during
+ * token generation so the LLM can only produce valid JSON matching the schema.
+ * Falls back to prompt-only mode if grammar conversion is not supported.
+ *
+ * @param handle Component handle
+ * @param prompt Input prompt
+ * @param options Generation options (can be NULL for defaults)
+ * @param so_config Structured output config with JSON schema and fallback settings
+ * @param out_result Output: Generation result (text will be valid JSON)
+ * @return RAC_SUCCESS or error code
+ */
+RAC_API rac_result_t rac_llm_component_generate_structured(
+    rac_handle_t handle, const char* prompt, const rac_llm_options_t* options,
+    const rac_structured_output_config_t* so_config, rac_llm_result_t* out_result);
+
+/**
+ * @brief Generate structured output with streaming and grammar constraints
+ *
+ * Same as generate_structured but with token-by-token streaming callbacks.
+ * Each emitted token is guaranteed to conform to the grammar.
+ *
+ * @param handle Component handle
+ * @param prompt Input prompt
+ * @param options Generation options (can be NULL for defaults)
+ * @param so_config Structured output config with JSON schema
+ * @param token_callback Called for each generated token
+ * @param complete_callback Called when generation completes
+ * @param error_callback Called on error
+ * @param user_data User context passed to callbacks
+ * @return RAC_SUCCESS or error code
+ */
+RAC_API rac_result_t rac_llm_component_generate_structured_stream(
+    rac_handle_t handle, const char* prompt, const rac_llm_options_t* options,
+    const rac_structured_output_config_t* so_config,
+    rac_llm_component_token_callback_fn token_callback,
+    rac_llm_component_complete_callback_fn complete_callback,
+    rac_llm_component_error_callback_fn error_callback, void* user_data);
+
 /**
  * @brief Check if streaming is supported
  *

--- a/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_service.h
+++ b/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_service.h
@@ -78,6 +78,12 @@ typedef struct rac_llm_service_ops {
 
     /** Clear all KV cache state (optional, NULL if not supported) */
     rac_result_t (*clear_context)(void* impl);
+
+    /**
+     * Convert JSON Schema to GBNF grammar string (optional, NULL if not supported).
+     * Caller must free out_grammar with rac_free().
+     */
+    rac_result_t (*json_schema_to_grammar)(void* impl, const char* json_schema, char** out_grammar);
 } rac_llm_service_ops_t;
 
 /**
@@ -184,6 +190,21 @@ RAC_API void rac_llm_destroy(rac_handle_t handle);
  * @param result Result to free
  */
 RAC_API void rac_llm_result_free(rac_llm_result_t* result);
+
+/**
+ * @brief Convert JSON Schema to GBNF grammar string
+ *
+ * Routes through service registry to the backend's json_schema_to_grammar op.
+ * The resulting GBNF grammar can be passed in rac_llm_options_t.grammar
+ * for grammar-constrained decoding.
+ *
+ * @param handle Service handle
+ * @param json_schema JSON Schema string
+ * @param out_grammar Output: GBNF grammar string (caller must free with rac_free)
+ * @return RAC_SUCCESS or RAC_ERROR_NOT_SUPPORTED if backend doesn't support grammar
+ */
+RAC_API rac_result_t rac_llm_json_schema_to_grammar(rac_handle_t handle, const char* json_schema,
+                                                      char** out_grammar);
 
 // =============================================================================
 // ADAPTIVE CONTEXT API - For RAG and similar pipelines

--- a/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_types.h
+++ b/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_types.h
@@ -93,6 +93,9 @@ typedef struct rac_llm_options {
 
     /** System prompt (can be NULL) */
     const char* system_prompt;
+
+    /** GBNF grammar string for constrained decoding (can be NULL for unconstrained) */
+    const char* grammar;
 } rac_llm_options_t;
 
 /**
@@ -104,7 +107,8 @@ static const rac_llm_options_t RAC_LLM_OPTIONS_DEFAULT = {.max_tokens = 100,
                                                           .stop_sequences = RAC_NULL,
                                                           .num_stop_sequences = 0,
                                                           .streaming_enabled = RAC_FALSE,
-                                                          .system_prompt = RAC_NULL};
+                                                          .system_prompt = RAC_NULL,
+                                                          .grammar = RAC_NULL};
 
 // =============================================================================
 // RESULT - Mirrors Swift's LLMGenerationResult
@@ -210,6 +214,18 @@ static const rac_thinking_tag_pattern_t RAC_THINKING_TAG_FULL = {.opening_tag = 
 // =============================================================================
 
 /**
+ * @brief Fallback strategy when grammar-constrained structured output fails
+ */
+typedef enum rac_structured_output_fallback {
+    /** Return raw text output (no parsing attempt) */
+    RAC_STRUCTURED_OUTPUT_FALLBACK_RAW = 0,
+    /** Retry generation with grammar constraint (default) */
+    RAC_STRUCTURED_OUTPUT_FALLBACK_RETRY = 1,
+    /** Fall back to prompt-only mode (no grammar constraint) */
+    RAC_STRUCTURED_OUTPUT_FALLBACK_PROMPT_ONLY = 2
+} rac_structured_output_fallback_t;
+
+/**
  * @brief Structured output configuration
  *
  * Mirrors Swift's StructuredOutputConfig struct.
@@ -223,13 +239,26 @@ typedef struct rac_structured_output_config {
 
     /** Whether to include the schema in the prompt */
     rac_bool_t include_schema_in_prompt;
+
+    /** Enable GBNF grammar-constrained decoding (default: true when json_schema is set) */
+    rac_bool_t use_grammar;
+
+    /** Maximum retry attempts on failure (default: 3) */
+    int32_t max_retries;
+
+    /** Fallback strategy on failure (default: RETRY) */
+    rac_structured_output_fallback_t fallback;
 } rac_structured_output_config_t;
 
 /**
  * @brief Default structured output configuration
  */
 static const rac_structured_output_config_t RAC_STRUCTURED_OUTPUT_DEFAULT = {
-    .json_schema = RAC_NULL, .include_schema_in_prompt = RAC_TRUE};
+    .json_schema = RAC_NULL,
+    .include_schema_in_prompt = RAC_TRUE,
+    .use_grammar = RAC_TRUE,
+    .max_retries = 3,
+    .fallback = RAC_STRUCTURED_OUTPUT_FALLBACK_RETRY};
 
 /**
  * @brief Structured output validation result

--- a/sdk/runanywhere-commons/src/backends/llamacpp/jni/rac_backend_llamacpp_jni.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/jni/rac_backend_llamacpp_jni.cpp
@@ -219,7 +219,8 @@ Java_com_runanywhere_sdk_llm_llamacpp_LlamaCPPBridge_nativeDestroy(
 JNIEXPORT jstring JNICALL
 Java_com_runanywhere_sdk_llm_llamacpp_LlamaCPPBridge_nativeGenerate(
     JNIEnv* env, jclass clazz,
-    jlong handle, jstring prompt, jint maxTokens, jfloat temperature) {
+    jlong handle, jstring prompt, jint maxTokens, jfloat temperature,
+    jstring grammar) {
     (void)clazz;
 
     if (handle == 0) {
@@ -240,12 +241,24 @@ Java_com_runanywhere_sdk_llm_llamacpp_LlamaCPPBridge_nativeGenerate(
     options.max_tokens = maxTokens;
     options.temperature = temperature;
 
+    // Wire grammar field for constrained decoding
+    const char* grammarStr = nullptr;
+    if (grammar != nullptr) {
+        grammarStr = env->GetStringUTFChars(grammar, nullptr);
+        if (grammarStr && grammarStr[0] != '\0') {
+            options.grammar = grammarStr;
+        }
+    }
+
     rac_llm_result_t result = {};
     rac_result_t status = rac_llm_llamacpp_generate(
         reinterpret_cast<rac_handle_t>(handle),
         promptStr, &options, &result);
 
     env->ReleaseStringUTFChars(prompt, promptStr);
+    if (grammarStr) {
+        env->ReleaseStringUTFChars(grammar, grammarStr);
+    }
 
     if (status != RAC_SUCCESS) {
         LOGe("nativeGenerate: Failed with status %d", status);
@@ -261,6 +274,43 @@ Java_com_runanywhere_sdk_llm_llamacpp_LlamaCPPBridge_nativeGenerate(
     }
 
     return output;
+}
+
+/**
+ * Convert JSON Schema to GBNF grammar string
+ */
+JNIEXPORT jstring JNICALL
+Java_com_runanywhere_sdk_llm_llamacpp_LlamaCPPBridge_nativeJsonSchemaToGrammar(
+    JNIEnv* env, jclass clazz,
+    jlong handle, jstring jsonSchema) {
+    (void)clazz;
+
+    if (handle == 0) {
+        LOGe("nativeJsonSchemaToGrammar: Invalid handle");
+        return nullptr;
+    }
+
+    const char* schemaStr = env->GetStringUTFChars(jsonSchema, nullptr);
+    if (!schemaStr) {
+        LOGe("nativeJsonSchemaToGrammar: Failed to get schema");
+        return nullptr;
+    }
+
+    char* grammarOut = nullptr;
+    rac_result_t status = rac_llm_llamacpp_json_schema_to_grammar(
+        reinterpret_cast<rac_handle_t>(handle),
+        schemaStr, &grammarOut);
+
+    env->ReleaseStringUTFChars(jsonSchema, schemaStr);
+
+    if (status != RAC_SUCCESS || !grammarOut) {
+        LOGe("nativeJsonSchemaToGrammar: Failed with status %d", status);
+        return nullptr;
+    }
+
+    jstring result = env->NewStringUTF(grammarOut);
+    free(grammarOut);
+    return result;
 }
 
 /**

--- a/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
@@ -1,6 +1,7 @@
 #include "llamacpp_backend.h"
 
 #include "common.h"
+#include "json-schema-to-grammar.h"
 
 #include <algorithm>
 #include <chrono>
@@ -667,7 +668,8 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
             cached_temperature_ == request.temperature &&
             cached_top_p_ == request.top_p &&
             cached_top_k_ == request.top_k &&
-            cached_repetition_penalty_ == request.repetition_penalty;
+            cached_repetition_penalty_ == request.repetition_penalty &&
+            cached_grammar_ == request.grammar;
 
         if (!params_match) {
             if (sampler_) {
@@ -677,6 +679,22 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
             auto sparams = llama_sampler_chain_default_params();
             sparams.no_perf = true;
             sampler_ = llama_sampler_chain_init(sparams);
+
+            // Grammar sampler goes first — masks invalid tokens before other samplers run
+            if (!request.grammar.empty()) {
+                const auto* const grammar_vocab = llama_model_get_vocab(model_);
+                auto* grammar_sampler =
+                    llama_sampler_init_grammar(grammar_vocab, request.grammar.c_str(), "root");
+                if (grammar_sampler) {
+                    llama_sampler_chain_add(sampler_, grammar_sampler);
+                    RAC_LOG_INFO("LLM.LlamaCpp",
+                                 "Grammar-constrained decoding enabled (GBNF length=%zu)",
+                                 request.grammar.size());
+                } else {
+                    RAC_LOG_WARNING("LLM.LlamaCpp",
+                                    "Failed to parse GBNF grammar, proceeding without constraint");
+                }
+            }
 
             if (request.temperature > 0.0f) {
                 llama_sampler_chain_add(sampler_,
@@ -697,16 +715,18 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
             cached_top_p_ = request.top_p;
             cached_top_k_ = request.top_k;
             cached_repetition_penalty_ = request.repetition_penalty;
+            cached_grammar_ = request.grammar;
         }
     }
 
     // Log generation parameters
     RAC_LOG_INFO("LLM.LlamaCpp","[PARAMS] LLM generate_stream (per-request options): temperature=%.4f, top_p=%.4f, top_k=%d, "
          "max_tokens=%d (effective=%d), repetition_penalty=%.4f, "
-         "system_prompt_len=%zu",
+         "system_prompt_len=%zu, grammar=%s",
          request.temperature, request.top_p, request.top_k,
          request.max_tokens, effective_max_tokens, request.repetition_penalty,
-         request.system_prompt.length());
+         request.system_prompt.length(),
+         request.grammar.empty() ? "none" : "enabled");
 
     const auto* const vocab = llama_model_get_vocab(model_);
 
@@ -992,10 +1012,20 @@ TextGenerationResult LlamaCppTextGeneration::generate_from_context(const TextGen
     }
 
     llama_sampler* sampler = nullptr;
+    const auto vocab = llama_model_get_vocab(model_);
     {
         auto sparams = llama_sampler_chain_default_params();
         sparams.no_perf = true;
         sampler = llama_sampler_chain_init(sparams);
+
+        // Grammar sampler first (masks invalid tokens)
+        if (!request.grammar.empty()) {
+            auto* grammar_sampler =
+                llama_sampler_init_grammar(vocab, request.grammar.c_str(), "root");
+            if (grammar_sampler) {
+                llama_sampler_chain_add(sampler, grammar_sampler);
+            }
+        }
 
         if (request.temperature > 0.0f) {
             llama_sampler_chain_add(sampler,
@@ -1010,8 +1040,6 @@ TextGenerationResult LlamaCppTextGeneration::generate_from_context(const TextGen
             llama_sampler_chain_add(sampler, llama_sampler_init_greedy());
         }
     }
-
-    const auto vocab = llama_model_get_vocab(model_);
 
     static const std::vector<std::string> STOP_SEQUENCES = {
         "<|im_end|>", "<|eot_id|>", "</s>", "<|end|>", "<|endoftext|>",
@@ -1220,6 +1248,7 @@ bool LlamaCppTextGeneration::recreate_context() {
     cached_top_p_ = -1.0f;
     cached_top_k_ = -1;
     cached_repetition_penalty_ = -1.0f;
+    cached_grammar_.clear();
 
     RAC_LOG_INFO("LLM.LlamaCpp","Context recreated successfully");
     return true;
@@ -1370,6 +1399,28 @@ nlohmann::json LlamaCppTextGeneration::get_lora_info() const {
         adapters.push_back(adapter_info);
     }
     return adapters;
+}
+
+// =============================================================================
+// JSON SCHEMA → GBNF GRAMMAR CONVERSION
+// =============================================================================
+
+std::string LlamaCppTextGeneration::convert_json_schema_to_grammar(const std::string& json_schema) {
+    if (json_schema.empty()) {
+        LOGW("convert_json_schema_to_grammar: empty schema");
+        return "";
+    }
+
+    try {
+        auto schema = nlohmann::ordered_json::parse(json_schema);
+        std::string grammar = json_schema_to_grammar(schema);
+        LOGI("Converted JSON schema to GBNF grammar (schema=%zu chars, grammar=%zu chars)",
+             json_schema.size(), grammar.size());
+        return grammar;
+    } catch (const std::exception& e) {
+        LOGW("Failed to convert JSON schema to GBNF: %s", e.what());
+        return "";
+    }
 }
 
 }  // namespace runanywhere

--- a/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.h
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.h
@@ -46,6 +46,9 @@ struct TextGenerationRequest {
     int top_k = 40;
     float repetition_penalty = 1.1f;
     std::vector<std::string> stop_sequences;
+
+    /** GBNF grammar string for constrained decoding (empty = no constraint) */
+    std::string grammar;
 };
 
 struct TextGenerationResult {
@@ -168,6 +171,13 @@ class LlamaCppTextGeneration {
 
     nlohmann::json get_model_info() const;
 
+    /**
+     * @brief Convert JSON Schema to GBNF grammar string
+     * @param json_schema JSON Schema as string
+     * @return GBNF grammar string, or empty on error
+     */
+    std::string convert_json_schema_to_grammar(const std::string& json_schema);
+
     // LoRA adapter management
     bool load_lora_adapter(const std::string& adapter_path, float scale);
     bool remove_lora_adapter(const std::string& adapter_path);
@@ -192,6 +202,7 @@ class LlamaCppTextGeneration {
     float cached_top_p_ = -1.0f;
     int cached_top_k_ = -1;
     float cached_repetition_penalty_ = -1.0f;
+    std::string cached_grammar_;
 
     bool model_loaded_ = false;
     std::atomic<bool> cancel_requested_{false};

--- a/sdk/runanywhere-commons/src/backends/llamacpp/rac_backend_llamacpp_register.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/rac_backend_llamacpp_register.cpp
@@ -146,6 +146,12 @@ static rac_result_t llamacpp_vtable_clear_context(void* impl) {
     return rac_llm_llamacpp_clear_context(impl);
 }
 
+// JSON Schema → GBNF grammar conversion
+static rac_result_t llamacpp_vtable_json_schema_to_grammar(void* impl, const char* json_schema,
+                                                            char** out_grammar) {
+    return rac_llm_llamacpp_json_schema_to_grammar(impl, json_schema, out_grammar);
+}
+
 // Static vtable for LlamaCpp
 static const rac_llm_service_ops_t g_llamacpp_ops = {
     .initialize = llamacpp_vtable_initialize,
@@ -163,6 +169,7 @@ static const rac_llm_service_ops_t g_llamacpp_ops = {
     .append_context = llamacpp_vtable_append_context,
 .generate_from_context = llamacpp_vtable_generate_from_context,
     .clear_context = llamacpp_vtable_clear_context,
+    .json_schema_to_grammar = llamacpp_vtable_json_schema_to_grammar,
 };
 
 // =============================================================================

--- a/sdk/runanywhere-commons/src/backends/llamacpp/rac_llm_llamacpp.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/rac_llm_llamacpp.cpp
@@ -174,10 +174,15 @@ rac_result_t rac_llm_llamacpp_generate(rac_handle_t handle, const char* prompt,
                 }
             }
         }
+        // Wire grammar field for constrained decoding
+        if (options->grammar != nullptr) {
+            request.grammar = options->grammar;
+        }
         RAC_LOG_INFO("LLM.LlamaCpp.C-API","[PARAMS] LLM C-API (from caller options): max_tokens=%d, temperature=%.4f, "
-             "top_p=%.4f, system_prompt=%s",
+             "top_p=%.4f, system_prompt=%s, grammar=%s",
              request.max_tokens, request.temperature, request.top_p,
-             request.system_prompt.empty() ? "(none)" : "(set)");
+             request.system_prompt.empty() ? "(none)" : "(set)",
+             request.grammar.empty() ? "(none)" : "(set)");
     } else {
         RAC_LOG_INFO("LLM.LlamaCpp.C-API","[PARAMS] LLM C-API (using struct defaults): max_tokens=%d, temperature=%.4f, "
              "top_p=%.4f, system_prompt=(none)",
@@ -264,10 +269,15 @@ rac_result_t rac_llm_llamacpp_generate_stream(rac_handle_t handle, const char* p
                 }
             }
         }
+        // Wire grammar field for constrained decoding
+        if (options->grammar != nullptr) {
+            request.grammar = options->grammar;
+        }
         RAC_LOG_INFO("LLM.LlamaCpp.C-API","[PARAMS] LLM C-API (from caller options): max_tokens=%d, temperature=%.4f, "
-             "top_p=%.4f, system_prompt=%s",
+             "top_p=%.4f, system_prompt=%s, grammar=%s",
              request.max_tokens, request.temperature, request.top_p,
-             request.system_prompt.empty() ? "(none)" : "(set)");
+             request.system_prompt.empty() ? "(none)" : "(set)",
+             request.grammar.empty() ? "(none)" : "(set)");
     } else {
         RAC_LOG_INFO("LLM.LlamaCpp.C-API","[PARAMS] LLM C-API (using struct defaults): max_tokens=%d, temperature=%.4f, "
              "top_p=%.4f, system_prompt=(none)",
@@ -479,6 +489,10 @@ rac_result_t rac_llm_llamacpp_generate_from_context(rac_handle_t handle, const c
                 }
             }
         }
+        // Wire grammar field for constrained decoding
+        if (options->grammar != nullptr) {
+            request.grammar = options->grammar;
+        }
     }
 
     try {
@@ -520,6 +534,37 @@ rac_result_t rac_llm_llamacpp_clear_context(rac_handle_t handle) {
 
     h->text_gen->clear_context();
     return RAC_SUCCESS;
+}
+
+// =============================================================================
+// JSON SCHEMA → GBNF GRAMMAR CONVERSION
+// =============================================================================
+
+rac_result_t rac_llm_llamacpp_json_schema_to_grammar(rac_handle_t handle,
+                                                       const char* json_schema,
+                                                       char** out_grammar) {
+    if (handle == nullptr || json_schema == nullptr || out_grammar == nullptr) {
+        return RAC_ERROR_NULL_POINTER;
+    }
+
+    auto* h = static_cast<rac_llm_llamacpp_handle_impl*>(handle);
+    if (!h->text_gen) {
+        return RAC_ERROR_INVALID_HANDLE;
+    }
+
+    try {
+        std::string grammar = h->text_gen->convert_json_schema_to_grammar(json_schema);
+        if (grammar.empty()) {
+            rac_error_set_details("Failed to convert JSON schema to GBNF grammar");
+            return RAC_ERROR_INVALID_ARGUMENT;
+        }
+
+        *out_grammar = strdup(grammar.c_str());
+        return RAC_SUCCESS;
+    } catch (const std::exception& e) {
+        rac_error_set_details(e.what());
+        return RAC_ERROR_INFERENCE_FAILED;
+    }
 }
 
 void rac_llm_llamacpp_destroy(rac_handle_t handle) {

--- a/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
@@ -770,6 +770,117 @@ extern "C" rac_result_t rac_llm_component_generate_stream(
     return RAC_SUCCESS;
 }
 
+// =============================================================================
+// STRUCTURED OUTPUT API
+// =============================================================================
+
+extern "C" rac_result_t rac_llm_component_generate_structured(
+    rac_handle_t handle, const char* prompt, const rac_llm_options_t* options,
+    const rac_structured_output_config_t* so_config, rac_llm_result_t* out_result) {
+    if (!handle)
+        return RAC_ERROR_INVALID_HANDLE;
+    if (!prompt || !so_config || !out_result)
+        return RAC_ERROR_INVALID_ARGUMENT;
+
+    auto* component = reinterpret_cast<rac_llm_component*>(handle);
+    std::lock_guard<std::mutex> lock(component->mtx);
+
+    // Get service from lifecycle manager
+    rac_handle_t service = nullptr;
+    rac_result_t result = rac_lifecycle_require_service(component->lifecycle, &service);
+    if (result != RAC_SUCCESS) {
+        log_error("LLM.Component", "No model loaded - cannot generate structured");
+        return result;
+    }
+
+    // Use provided options or defaults
+    const rac_llm_options_t* base_options = options ? options : &component->default_options;
+
+    // Build effective options with grammar if requested
+    rac_llm_options_t effective_options = *base_options;
+
+    char* grammar_str = nullptr;
+    if (so_config->use_grammar && so_config->json_schema != nullptr) {
+        // Convert JSON schema to GBNF grammar via backend
+        result = rac_llm_json_schema_to_grammar(service, so_config->json_schema, &grammar_str);
+        if (result == RAC_SUCCESS && grammar_str) {
+            effective_options.grammar = grammar_str;
+            RAC_LOG_INFO("LLM.Component", "Grammar-constrained structured output enabled");
+        } else {
+            RAC_LOG_WARNING("LLM.Component",
+                            "Grammar conversion failed (result=%d), falling back to prompt-only",
+                            result);
+            // Proceed without grammar — prompt-only fallback
+        }
+    }
+
+    // Delegate to standard generate with grammar-augmented options
+    result = rac_llm_component_generate(handle, prompt, &effective_options, out_result);
+
+    // Free grammar string if we allocated one
+    if (grammar_str) {
+        free(grammar_str);
+    }
+
+    return result;
+}
+
+extern "C" rac_result_t rac_llm_component_generate_structured_stream(
+    rac_handle_t handle, const char* prompt, const rac_llm_options_t* options,
+    const rac_structured_output_config_t* so_config,
+    rac_llm_component_token_callback_fn token_callback,
+    rac_llm_component_complete_callback_fn complete_callback,
+    rac_llm_component_error_callback_fn error_callback, void* user_data) {
+    if (!handle)
+        return RAC_ERROR_INVALID_HANDLE;
+    if (!prompt || !so_config)
+        return RAC_ERROR_INVALID_ARGUMENT;
+
+    auto* component = reinterpret_cast<rac_llm_component*>(handle);
+    std::lock_guard<std::mutex> lock(component->mtx);
+
+    // Get service from lifecycle manager
+    rac_handle_t service = nullptr;
+    rac_result_t result = rac_lifecycle_require_service(component->lifecycle, &service);
+    if (result != RAC_SUCCESS) {
+        log_error("LLM.Component", "No model loaded - cannot generate structured stream");
+        if (error_callback) {
+            error_callback(result, "No model loaded", user_data);
+        }
+        return result;
+    }
+
+    // Use provided options or defaults
+    const rac_llm_options_t* base_options = options ? options : &component->default_options;
+
+    // Build effective options with grammar if requested
+    rac_llm_options_t effective_options = *base_options;
+
+    char* grammar_str = nullptr;
+    if (so_config->use_grammar && so_config->json_schema != nullptr) {
+        result = rac_llm_json_schema_to_grammar(service, so_config->json_schema, &grammar_str);
+        if (result == RAC_SUCCESS && grammar_str) {
+            effective_options.grammar = grammar_str;
+            RAC_LOG_INFO("LLM.Component", "Grammar-constrained structured streaming enabled");
+        } else {
+            RAC_LOG_WARNING("LLM.Component",
+                            "Grammar conversion failed (result=%d), falling back to prompt-only",
+                            result);
+        }
+    }
+
+    // Delegate to standard stream generate with grammar-augmented options
+    result = rac_llm_component_generate_stream(handle, prompt, &effective_options, token_callback,
+                                                complete_callback, error_callback, user_data);
+
+    // Free grammar string if we allocated one
+    if (grammar_str) {
+        free(grammar_str);
+    }
+
+    return result;
+}
+
 extern "C" rac_result_t rac_llm_component_cancel(rac_handle_t handle) {
     if (!handle)
         return RAC_ERROR_INVALID_HANDLE;

--- a/sdk/runanywhere-commons/src/features/llm/rac_llm_service.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/rac_llm_service.cpp
@@ -268,4 +268,20 @@ rac_result_t rac_llm_clear_context(rac_handle_t handle) {
     return service->ops->clear_context(service->impl);
 }
 
+// =============================================================================
+// JSON SCHEMA → GBNF GRAMMAR - VTable dispatch
+// =============================================================================
+
+rac_result_t rac_llm_json_schema_to_grammar(rac_handle_t handle, const char* json_schema,
+                                              char** out_grammar) {
+    if (!handle || !json_schema || !out_grammar)
+        return RAC_ERROR_NULL_POINTER;
+
+    auto* service = static_cast<rac_llm_service_t*>(handle);
+    if (!service->ops || !service->ops->json_schema_to_grammar)
+        return RAC_ERROR_NOT_SUPPORTED;
+
+    return service->ops->json_schema_to_grammar(service->impl, json_schema, out_grammar);
+}
+
 }  // extern "C"

--- a/sdk/runanywhere-commons/src/features/platform/rac_backend_platform_register.cpp
+++ b/sdk/runanywhere-commons/src/features/platform/rac_backend_platform_register.cpp
@@ -151,6 +151,15 @@ static const rac_llm_service_ops_t g_platform_llm_ops = {
     .cancel = platform_llm_vtable_cancel,
     .cleanup = platform_llm_vtable_cleanup,
     .destroy = platform_llm_vtable_destroy,
+    .load_lora = nullptr,
+    .remove_lora = nullptr,
+    .clear_lora = nullptr,
+    .get_lora_info = nullptr,
+    .inject_system_prompt = nullptr,
+    .append_context = nullptr,
+    .generate_from_context = nullptr,
+    .clear_context = nullptr,
+    .json_schema_to_grammar = nullptr,
 };
 
 // =============================================================================

--- a/sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp
+++ b/sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp
@@ -552,6 +552,7 @@ Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racLlmComponentGenerate
 
     // Parse configJson if provided
     std::string sys_prompt_storage;
+    std::string grammar_storage;
     if (config != nullptr) {
         try {
             auto j = nlohmann::json::parse(config);
@@ -561,6 +562,10 @@ Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racLlmComponentGenerate
             sys_prompt_storage = j.value("system_prompt", std::string(""));
             if (!sys_prompt_storage.empty()) {
                 options.system_prompt = sys_prompt_storage.c_str();
+            }
+            grammar_storage = j.value("grammar", std::string(""));
+            if (!grammar_storage.empty()) {
+                options.grammar = grammar_storage.c_str();
             }
         } catch (const nlohmann::json::exception& e) {
             LOGe("Failed to parse LLM config JSON: %s", e.what());
@@ -859,6 +864,7 @@ Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racLlmComponentGenerate
 
     // Parse configJson if provided
     std::string sys_prompt_storage;
+    std::string grammar_storage;
     if (config != nullptr) {
         try {
             auto j = nlohmann::json::parse(config);
@@ -868,6 +874,10 @@ Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racLlmComponentGenerate
             sys_prompt_storage = j.value("system_prompt", std::string(""));
             if (!sys_prompt_storage.empty()) {
                 options.system_prompt = sys_prompt_storage.c_str();
+            }
+            grammar_storage = j.value("grammar", std::string(""));
+            if (!grammar_storage.empty()) {
+                options.grammar = grammar_storage.c_str();
             }
         } catch (const nlohmann::json::exception& e) {
             LOGe("Failed to parse LLM config JSON: %s", e.what());
@@ -994,6 +1004,7 @@ Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racLlmComponentGenerate
 
     // Parse configJson if provided
     std::string sys_prompt_storage;
+    std::string grammar_storage;
     if (config != nullptr) {
         try {
             auto j = nlohmann::json::parse(config);
@@ -1003,6 +1014,10 @@ Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racLlmComponentGenerate
             sys_prompt_storage = j.value("system_prompt", std::string(""));
             if (!sys_prompt_storage.empty()) {
                 options.system_prompt = sys_prompt_storage.c_str();
+            }
+            grammar_storage = j.value("grammar", std::string(""));
+            if (!grammar_storage.empty()) {
+                options.grammar = grammar_storage.c_str();
             }
         } catch (const nlohmann::json::exception& e) {
             LOGe("Failed to parse LLM config JSON: %s", e.what());

--- a/sdk/runanywhere-kotlin/modules/runanywhere-core-llamacpp/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/llm/llamacpp/LlamaCPPBridge.kt
+++ b/sdk/runanywhere-kotlin/modules/runanywhere-core-llamacpp/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/llm/llamacpp/LlamaCPPBridge.kt
@@ -114,6 +114,63 @@ internal object LlamaCPPBridge {
     external fun nativeGetVersion(): String
 
     // ==========================================================================
+    // LLM Direct Operations
+    // ==========================================================================
+
+    /**
+     * Create a LlamaCPP instance and load a model.
+     *
+     * @param modelPath Path to the GGUF model file
+     * @param contextSize Context window size
+     * @param numThreads Number of inference threads
+     * @param gpuLayers Number of layers to offload to GPU
+     * @return Native handle (0 on failure)
+     */
+    @JvmStatic
+    external fun nativeCreate(modelPath: String, contextSize: Int, numThreads: Int, gpuLayers: Int): Long
+
+    /**
+     * Destroy a LlamaCPP instance.
+     */
+    @JvmStatic
+    external fun nativeDestroy(handle: Long)
+
+    /**
+     * Generate text (blocking).
+     *
+     * @param handle Native handle
+     * @param prompt Input prompt
+     * @param maxTokens Max tokens to generate
+     * @param temperature Sampling temperature
+     * @param grammar GBNF grammar string for constrained decoding (null for unconstrained)
+     * @return Generated text or null on failure
+     */
+    @JvmStatic
+    external fun nativeGenerate(handle: Long, prompt: String, maxTokens: Int, temperature: Float, grammar: String?): String?
+
+    /**
+     * Convert a JSON Schema to a GBNF grammar string.
+     *
+     * @param handle Native handle
+     * @param jsonSchema JSON Schema string
+     * @return GBNF grammar string or null on failure
+     */
+    @JvmStatic
+    external fun nativeJsonSchemaToGrammar(handle: Long, jsonSchema: String): String?
+
+    /**
+     * Cancel ongoing generation.
+     */
+    @JvmStatic
+    external fun nativeCancel(handle: Long)
+
+    /**
+     * Get model info as JSON.
+     */
+    @JvmStatic
+    external fun nativeGetModelInfo(handle: Long): String?
+
+    // ==========================================================================
     // VLM Registration JNI Methods
     // ==========================================================================
 

--- a/sdk/runanywhere-kotlin/src/commonMain/kotlin/com/runanywhere/sdk/public/extensions/LLM/LLMTypes.kt
+++ b/sdk/runanywhere-kotlin/src/commonMain/kotlin/com/runanywhere/sdk/public/extensions/LLM/LLMTypes.kt
@@ -240,6 +240,22 @@ interface Generatable {
 }
 
 /**
+ * Fallback strategy when grammar-constrained decoding fails.
+ * Mirrors Swift StructuredOutputFallback and C rac_structured_output_fallback.
+ */
+@Serializable
+enum class StructuredOutputFallback(val value: Int) {
+    /** Return raw output without validation */
+    RAW(0),
+
+    /** Retry generation (default) */
+    RETRY(1),
+
+    /** Fall back to prompt-only mode (no grammar constraint) */
+    PROMPT_ONLY(2),
+}
+
+/**
  * Structured output configuration.
  * Note: In Kotlin, we use KClass instead of Type.
  */
@@ -251,6 +267,12 @@ data class StructuredOutputConfig(
     val includeSchemaInPrompt: Boolean = true,
     /** JSON schema for the type */
     val jsonSchema: String = Generatable.DEFAULT_JSON_SCHEMA,
+    /** Whether to use GBNF grammar-constrained decoding (default: true) */
+    val useGrammar: Boolean = true,
+    /** Maximum retries for structured output parsing (default: 3) */
+    val maxRetries: Int = 3,
+    /** Fallback strategy when grammar fails */
+    val fallback: StructuredOutputFallback = StructuredOutputFallback.RETRY,
 )
 
 /**

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_llm_component.h
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_llm_component.h
@@ -166,6 +166,51 @@ RAC_API rac_result_t rac_llm_component_generate(rac_handle_t handle, const char*
                                                 const rac_llm_options_t* options,
                                                 rac_llm_result_t* out_result);
 
+// =============================================================================
+// STRUCTURED OUTPUT - Grammar-constrained generation
+// =============================================================================
+
+/**
+ * @brief Generate structured output with grammar-constrained decoding
+ *
+ * Converts JSON schema to GBNF grammar, applies grammar constraint during
+ * token generation so the LLM can only produce valid JSON matching the schema.
+ * Falls back to prompt-only mode if grammar conversion is not supported.
+ *
+ * @param handle Component handle
+ * @param prompt Input prompt
+ * @param options Generation options (can be NULL for defaults)
+ * @param so_config Structured output config with JSON schema and fallback settings
+ * @param out_result Output: Generation result (text will be valid JSON)
+ * @return RAC_SUCCESS or error code
+ */
+RAC_API rac_result_t rac_llm_component_generate_structured(
+    rac_handle_t handle, const char* prompt, const rac_llm_options_t* options,
+    const rac_structured_output_config_t* so_config, rac_llm_result_t* out_result);
+
+/**
+ * @brief Generate structured output with streaming and grammar constraints
+ *
+ * Same as generate_structured but with token-by-token streaming callbacks.
+ * Each emitted token is guaranteed to conform to the grammar.
+ *
+ * @param handle Component handle
+ * @param prompt Input prompt
+ * @param options Generation options (can be NULL for defaults)
+ * @param so_config Structured output config with JSON schema
+ * @param token_callback Called for each generated token
+ * @param complete_callback Called when generation completes
+ * @param error_callback Called on error
+ * @param user_data User context passed to callbacks
+ * @return RAC_SUCCESS or error code
+ */
+RAC_API rac_result_t rac_llm_component_generate_structured_stream(
+    rac_handle_t handle, const char* prompt, const rac_llm_options_t* options,
+    const rac_structured_output_config_t* so_config,
+    rac_llm_component_token_callback_fn token_callback,
+    rac_llm_component_complete_callback_fn complete_callback,
+    rac_llm_component_error_callback_fn error_callback, void* user_data);
+
 /**
  * @brief Check if streaming is supported
  *

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_llm_service.h
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_llm_service.h
@@ -78,6 +78,12 @@ typedef struct rac_llm_service_ops {
 
     /** Clear all KV cache state (optional, NULL if not supported) */
     rac_result_t (*clear_context)(void* impl);
+
+    /**
+     * Convert JSON Schema to GBNF grammar string (optional, NULL if not supported).
+     * Caller must free out_grammar with rac_free().
+     */
+    rac_result_t (*json_schema_to_grammar)(void* impl, const char* json_schema, char** out_grammar);
 } rac_llm_service_ops_t;
 
 /**
@@ -184,6 +190,21 @@ RAC_API void rac_llm_destroy(rac_handle_t handle);
  * @param result Result to free
  */
 RAC_API void rac_llm_result_free(rac_llm_result_t* result);
+
+/**
+ * @brief Convert JSON Schema to GBNF grammar string
+ *
+ * Routes through service registry to the backend's json_schema_to_grammar op.
+ * The resulting GBNF grammar can be passed in rac_llm_options_t.grammar
+ * for grammar-constrained decoding.
+ *
+ * @param handle Service handle
+ * @param json_schema JSON Schema string
+ * @param out_grammar Output: GBNF grammar string (caller must free with rac_free)
+ * @return RAC_SUCCESS or RAC_ERROR_NOT_SUPPORTED if backend doesn't support grammar
+ */
+RAC_API rac_result_t rac_llm_json_schema_to_grammar(rac_handle_t handle, const char* json_schema,
+                                                      char** out_grammar);
 
 // =============================================================================
 // ADAPTIVE CONTEXT API - For RAG and similar pipelines

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_llm_types.h
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_llm_types.h
@@ -93,6 +93,9 @@ typedef struct rac_llm_options {
 
     /** System prompt (can be NULL) */
     const char* system_prompt;
+
+    /** GBNF grammar string for constrained decoding (can be NULL for unconstrained) */
+    const char* grammar;
 } rac_llm_options_t;
 
 /**
@@ -104,7 +107,8 @@ static const rac_llm_options_t RAC_LLM_OPTIONS_DEFAULT = {.max_tokens = 100,
                                                           .stop_sequences = RAC_NULL,
                                                           .num_stop_sequences = 0,
                                                           .streaming_enabled = RAC_FALSE,
-                                                          .system_prompt = RAC_NULL};
+                                                          .system_prompt = RAC_NULL,
+                                                          .grammar = RAC_NULL};
 
 // =============================================================================
 // RESULT - Mirrors Swift's LLMGenerationResult
@@ -210,6 +214,18 @@ static const rac_thinking_tag_pattern_t RAC_THINKING_TAG_FULL = {.opening_tag = 
 // =============================================================================
 
 /**
+ * @brief Fallback strategy when grammar-constrained structured output fails
+ */
+typedef enum rac_structured_output_fallback {
+    /** Return raw text output (no parsing attempt) */
+    RAC_STRUCTURED_OUTPUT_FALLBACK_RAW = 0,
+    /** Retry generation with grammar constraint (default) */
+    RAC_STRUCTURED_OUTPUT_FALLBACK_RETRY = 1,
+    /** Fall back to prompt-only mode (no grammar constraint) */
+    RAC_STRUCTURED_OUTPUT_FALLBACK_PROMPT_ONLY = 2
+} rac_structured_output_fallback_t;
+
+/**
  * @brief Structured output configuration
  *
  * Mirrors Swift's StructuredOutputConfig struct.
@@ -223,13 +239,26 @@ typedef struct rac_structured_output_config {
 
     /** Whether to include the schema in the prompt */
     rac_bool_t include_schema_in_prompt;
+
+    /** Enable GBNF grammar-constrained decoding (default: true when json_schema is set) */
+    rac_bool_t use_grammar;
+
+    /** Maximum retry attempts on failure (default: 3) */
+    int32_t max_retries;
+
+    /** Fallback strategy on failure (default: RETRY) */
+    rac_structured_output_fallback_t fallback;
 } rac_structured_output_config_t;
 
 /**
  * @brief Default structured output configuration
  */
 static const rac_structured_output_config_t RAC_STRUCTURED_OUTPUT_DEFAULT = {
-    .json_schema = RAC_NULL, .include_schema_in_prompt = RAC_TRUE};
+    .json_schema = RAC_NULL,
+    .include_schema_in_prompt = RAC_TRUE,
+    .use_grammar = RAC_TRUE,
+    .max_retries = 3,
+    .fallback = RAC_STRUCTURED_OUTPUT_FALLBACK_RETRY};
 
 /**
  * @brief Structured output validation result

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/LLMTypes.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/LLMTypes.swift
@@ -540,6 +540,16 @@ public extension Generatable {
     }
 }
 
+/// Fallback strategy when grammar-constrained structured output fails
+public enum StructuredOutputFallback: Int32, Sendable {
+    /// Return raw text output (no parsing attempt)
+    case raw = 0
+    /// Retry generation with grammar constraint (default)
+    case retry = 1
+    /// Fall back to prompt-only mode (no grammar constraint)
+    case promptOnly = 2
+}
+
 /// Structured output configuration
 public struct StructuredOutputConfig: @unchecked Sendable {
     /// The type to generate
@@ -548,12 +558,27 @@ public struct StructuredOutputConfig: @unchecked Sendable {
     /// Whether to include schema in prompt
     public let includeSchemaInPrompt: Bool
 
+    /// Enable GBNF grammar-constrained decoding (default: true)
+    public let useGrammar: Bool
+
+    /// Maximum retry attempts on failure (default: 3)
+    public let maxRetries: Int
+
+    /// Fallback strategy on failure (default: .retry)
+    public let fallback: StructuredOutputFallback
+
     public init(
         type: Generatable.Type,
-        includeSchemaInPrompt: Bool = true
+        includeSchemaInPrompt: Bool = true,
+        useGrammar: Bool = true,
+        maxRetries: Int = 3,
+        fallback: StructuredOutputFallback = .retry
     ) {
         self.type = type
         self.includeSchemaInPrompt = includeSchemaInPrompt
+        self.useGrammar = useGrammar
+        self.maxRetries = maxRetries
+        self.fallback = fallback
     }
 }
 

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+StructuredOutput.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+StructuredOutput.swift
@@ -224,7 +224,7 @@ public extension RunAnywhere {
         }
     }
 
-    /// Internal generation for structured output (calls C++ directly)
+    /// Internal generation for structured output using grammar-constrained decoding
     private static func generateForStructuredOutput(
         _ prompt: String,
         options: LLMGenerationOptions
@@ -248,21 +248,59 @@ public extension RunAnywhere {
         cOptions.temperature = options.temperature
         cOptions.top_p = options.topP
         cOptions.streaming_enabled = RAC_FALSE
+        cOptions.grammar = nil
 
-        // Generate - wrap in system_prompt lifetime scope
+        // Build structured output C config
+        var soConfig = rac_structured_output_config_t()
+        if let structuredOutput = options.structuredOutput {
+            soConfig.include_schema_in_prompt = structuredOutput.includeSchemaInPrompt ? RAC_TRUE : RAC_FALSE
+            soConfig.use_grammar = structuredOutput.useGrammar ? RAC_TRUE : RAC_FALSE
+            soConfig.max_retries = Int32(structuredOutput.maxRetries)
+            soConfig.fallback = rac_structured_output_fallback(rawValue: UInt32(structuredOutput.fallback.rawValue))
+        } else {
+            soConfig.include_schema_in_prompt = RAC_TRUE
+            soConfig.use_grammar = RAC_TRUE
+            soConfig.max_retries = 3
+            soConfig.fallback = RAC_STRUCTURED_OUTPUT_FALLBACK_RETRY
+        }
+
+        // Generate using grammar-constrained structured output API
         var llmResult = rac_llm_result_t()
         let generateResult: rac_result_t
+
+        // Get JSON schema from the structured output type
+        let jsonSchema = options.structuredOutput?.type.jsonSchema
+
         if let systemPrompt = options.systemPrompt {
             generateResult = systemPrompt.withCString { sysPromptPtr in
                 cOptions.system_prompt = sysPromptPtr
                 return prompt.withCString { promptPtr in
-                    rac_llm_component_generate(handle, promptPtr, &cOptions, &llmResult)
+                    if let schema = jsonSchema {
+                        return schema.withCString { schemaPtr in
+                            soConfig.json_schema = schemaPtr
+                            return rac_llm_component_generate_structured(
+                                handle, promptPtr, &cOptions, &soConfig, &llmResult
+                            )
+                        }
+                    } else {
+                        // No schema - fall back to regular generate
+                        return rac_llm_component_generate(handle, promptPtr, &cOptions, &llmResult)
+                    }
                 }
             }
         } else {
             cOptions.system_prompt = nil
             generateResult = prompt.withCString { promptPtr in
-                rac_llm_component_generate(handle, promptPtr, &cOptions, &llmResult)
+                if let schema = jsonSchema {
+                    return schema.withCString { schemaPtr in
+                        soConfig.json_schema = schemaPtr
+                        return rac_llm_component_generate_structured(
+                            handle, promptPtr, &cOptions, &soConfig, &llmResult
+                        )
+                    }
+                } else {
+                    return rac_llm_component_generate(handle, promptPtr, &cOptions, &llmResult)
+                }
             }
         }
 

--- a/sdk/runanywhere-web/packages/core/src/Foundation/StructOffsets.ts
+++ b/sdk/runanywhere-web/packages/core/src/Foundation/StructOffsets.ts
@@ -13,12 +13,12 @@
 // ---------------------------------------------------------------------------
 
 export interface ConfigOffsets { logLevel: number; }
-export interface LLMOptionsOffsets { maxTokens: number; temperature: number; topP: number; systemPrompt: number; }
+export interface LLMOptionsOffsets { maxTokens: number; temperature: number; topP: number; systemPrompt: number; grammar: number; }
 export interface LLMResultOffsets { text: number; promptTokens: number; completionTokens: number; }
 export interface VLMImageOffsets { format: number; filePath: number; pixelData: number; base64Data: number; width: number; height: number; dataSize: number; }
 export interface VLMOptionsOffsets { maxTokens: number; temperature: number; topP: number; streamingEnabled: number; systemPrompt: number; modelFamily: number; }
 export interface VLMResultOffsets { text: number; promptTokens: number; imageTokens: number; completionTokens: number; totalTokens: number; timeToFirstTokenMs: number; imageEncodeTimeMs: number; totalTimeMs: number; tokensPerSecond: number; }
-export interface StructuredOutputConfigOffsets { jsonSchema: number; includeSchemaInPrompt: number; }
+export interface StructuredOutputConfigOffsets { jsonSchema: number; includeSchemaInPrompt: number; useGrammar: number; maxRetries: number; fallback: number; }
 export interface StructuredOutputValidationOffsets { isValid: number; errorMessage: number; extractedJson: number; }
 export interface EmbeddingsOptionsOffsets { normalize: number; pooling: number; nThreads: number; }
 export interface EmbeddingsResultOffsets { embeddings: number; numEmbeddings: number; dimension: number; processingTimeMs: number; totalTokens: number; }

--- a/sdk/runanywhere-web/packages/llamacpp/src/Extensions/RunAnywhere+StructuredOutput.ts
+++ b/sdk/runanywhere-web/packages/llamacpp/src/Extensions/RunAnywhere+StructuredOutput.ts
@@ -32,11 +32,27 @@ function requireBridge(): LlamaCppBridge {
 // Structured Output Types
 // ---------------------------------------------------------------------------
 
+/** Fallback strategy when grammar-constrained decoding fails */
+export enum StructuredOutputFallback {
+  /** Return raw output without validation */
+  Raw = 0,
+  /** Retry generation (default) */
+  Retry = 1,
+  /** Fall back to prompt-only mode (no grammar constraint) */
+  PromptOnly = 2,
+}
+
 export interface StructuredOutputConfig {
   /** JSON Schema string */
   jsonSchema: string;
   /** Whether to include the schema in the prompt (default: true) */
   includeSchemaInPrompt?: boolean;
+  /** Whether to use GBNF grammar-constrained decoding (default: true) */
+  useGrammar?: boolean;
+  /** Maximum retries for structured output parsing (default: 3) */
+  maxRetries?: number;
+  /** Fallback strategy when grammar fails (default: Retry) */
+  fallback?: StructuredOutputFallback;
 }
 
 export interface StructuredOutputValidation {
@@ -106,6 +122,9 @@ export const StructuredOutput = {
     const schemaPtr = bridge.allocString(config.jsonSchema);
     m.setValue(configPtr + soConf.jsonSchema, schemaPtr, '*');
     m.setValue(configPtr + soConf.includeSchemaInPrompt, (config.includeSchemaInPrompt !== false) ? 1 : 0, 'i32');
+    m.setValue(configPtr + soConf.useGrammar, (config.useGrammar !== false) ? 1 : 0, 'i32');
+    m.setValue(configPtr + soConf.maxRetries, config.maxRetries ?? 3, 'i32');
+    m.setValue(configPtr + soConf.fallback, config.fallback ?? StructuredOutputFallback.Retry, 'i32');
 
     const outPromptPtr = m._malloc(4);
 
@@ -188,6 +207,9 @@ export const StructuredOutput = {
     const schemaPtr = bridge.allocString(config.jsonSchema);
     m.setValue(configPtr + soConf2.jsonSchema, schemaPtr, '*');
     m.setValue(configPtr + soConf2.includeSchemaInPrompt, (config.includeSchemaInPrompt !== false) ? 1 : 0, 'i32');
+    m.setValue(configPtr + soConf2.useGrammar, (config.useGrammar !== false) ? 1 : 0, 'i32');
+    m.setValue(configPtr + soConf2.maxRetries, config.maxRetries ?? 3, 'i32');
+    m.setValue(configPtr + soConf2.fallback, config.fallback ?? StructuredOutputFallback.Retry, 'i32');
 
     // rac_structured_output_validation_t (size from sizeof helper)
     const valSize = 12; // 3 fields × 4 bytes on wasm32 — all i32/ptr

--- a/sdk/runanywhere-web/packages/llamacpp/src/Foundation/LlamaCppOffsets.ts
+++ b/sdk/runanywhere-web/packages/llamacpp/src/Foundation/LlamaCppOffsets.ts
@@ -44,6 +44,7 @@ function loadLLMOptionsOffsets(): LLMOptionsOffsets {
     temperature: off('llm_options_temperature'),
     topP: off('llm_options_top_p'),
     systemPrompt: off('llm_options_system_prompt'),
+    grammar: off('llm_options_grammar'),
   };
 }
 
@@ -96,6 +97,9 @@ function loadStructuredOutputConfigOffsets(): StructuredOutputConfigOffsets {
   return {
     jsonSchema: off('structured_output_config_json_schema'),
     includeSchemaInPrompt: off('structured_output_config_include_schema_in_prompt'),
+    useGrammar: off('structured_output_config_use_grammar'),
+    maxRetries: off('structured_output_config_max_retries'),
+    fallback: off('structured_output_config_fallback'),
   };
 }
 

--- a/sdk/runanywhere-web/packages/llamacpp/src/index.ts
+++ b/sdk/runanywhere-web/packages/llamacpp/src/index.ts
@@ -39,7 +39,7 @@ export type {
   ToolValue, ToolParameterType, ToolParameter, ToolDefinition,
   ToolCall, ToolResult, ToolCallingOptions, ToolCallingResult, ToolExecutor,
 } from './Extensions/RunAnywhere+ToolCalling';
-export { StructuredOutput } from './Extensions/RunAnywhere+StructuredOutput';
+export { StructuredOutput, StructuredOutputFallback } from './Extensions/RunAnywhere+StructuredOutput';
 export type { StructuredOutputConfig, StructuredOutputValidation } from './Extensions/RunAnywhere+StructuredOutput';
 export { Diffusion } from './Extensions/RunAnywhere+Diffusion';
 export { DiffusionScheduler, DiffusionModelVariant, DiffusionMode } from './Extensions/RunAnywhere+Diffusion';

--- a/sdk/runanywhere-web/wasm/src/wasm_exports.cpp
+++ b/sdk/runanywhere-web/wasm/src/wasm_exports.cpp
@@ -302,6 +302,9 @@ EMSCRIPTEN_KEEPALIVE int rac_wasm_offsetof_llm_options_top_p(void) {
 EMSCRIPTEN_KEEPALIVE int rac_wasm_offsetof_llm_options_system_prompt(void) {
     return (int)offsetof(rac_llm_options_t, system_prompt);
 }
+EMSCRIPTEN_KEEPALIVE int rac_wasm_offsetof_llm_options_grammar(void) {
+    return (int)offsetof(rac_llm_options_t, grammar);
+}
 
 // ---- rac_llm_result_t ----
 EMSCRIPTEN_KEEPALIVE int rac_wasm_offsetof_llm_result_text(void) {
@@ -392,6 +395,15 @@ EMSCRIPTEN_KEEPALIVE int rac_wasm_offsetof_structured_output_config_json_schema(
 }
 EMSCRIPTEN_KEEPALIVE int rac_wasm_offsetof_structured_output_config_include_schema(void) {
     return (int)offsetof(rac_structured_output_config_t, include_schema_in_prompt);
+}
+EMSCRIPTEN_KEEPALIVE int rac_wasm_offsetof_structured_output_config_use_grammar(void) {
+    return (int)offsetof(rac_structured_output_config_t, use_grammar);
+}
+EMSCRIPTEN_KEEPALIVE int rac_wasm_offsetof_structured_output_config_max_retries(void) {
+    return (int)offsetof(rac_structured_output_config_t, max_retries);
+}
+EMSCRIPTEN_KEEPALIVE int rac_wasm_offsetof_structured_output_config_fallback(void) {
+    return (int)offsetof(rac_structured_output_config_t, fallback);
 }
 
 // ---- rac_structured_output_validation_t ----


### PR DESCRIPTION
Introduces GBNF grammar-constrained decoding for guaranteed valid JSON output matching a developer schema. Implementation layered through the C++ core, with bindings exposed in all platform SDKs.

- Commons (C++): llamacpp grammar sampler at head of sampler chain, JSON Schema → GBNF converter, new component-level structured generate/stream APIs, vtable op json_schema_to_grammar, updated platform backend vtable with explicit NULL entries
- JNI: wire grammar field through commons + llamacpp bridges
- Swift: StructuredOutputFallback, extended StructuredOutputConfig, generate via rac_llm_component_generate_structured
- Web: WASM offset helpers for new fields, TypeScript types updated, StructuredOutputFallback exported
- Kotlin: StructuredOutputFallback enum, extended config, LlamaCPPBridge JNI declarations for direct LLM ops + schema-to-grammar

## Description
Brief description of the changes made.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Playground:**
- [ ] Tested on target platform
- [ ] Verified no regressions in existing Playground projects
**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`sdk/runanywhere-kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`sdk/runanywhere-flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`sdk/runanywhere-react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`sdk/runanywhere-web`)
- [ ] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

**Sample Apps:**
- [ ] `iOS Sample` - Changes to iOS example app (`examples/ios`)
- [ ] `Android Sample` - Changes to Android example app (`examples/android`)
- [ ] `Flutter Sample` - Changes to Flutter example app (`examples/flutter`)
- [ ] `React Native Sample` - Changes to React Native example app (`examples/react-native`)
- [ ] `Web Sample` - Changes to Web example app (`examples/web`)

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)

## Screenshots
Attach relevant UI screenshots for changes (if applicable):
- Mobile (Phone)
- Tablet / iPad
- Desktop / Mac

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Grammar-constrained structured output generation now available, enabling models to produce outputs that strictly conform to specified JSON schemas.
  * Added automatic JSON Schema to GBNF grammar conversion support for all backends.
  * New configuration options: fallback strategies (raw output, retry, prompt-only) and retry limits for grammar-constrained generation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR wires GBNF grammar-constrained decoding through the full stack — C++ core, JNI, Swift, Kotlin, and Web — to enable guaranteed-valid JSON output matching a developer schema. The C++ backend integration (grammar sampler placement, JSON Schema → GBNF conversion, vtable extension) is well-structured, but the new component-level structured-output APIs in `llm_component.cpp` have a critical concurrency defect.

- **P0 deadlock**: Both `rac_llm_component_generate_structured` and `_stream` acquire `component->mtx`, then immediately delegate to `rac_llm_component_generate` / `rac_llm_component_generate_stream`, which unconditionally re-acquire the same non-recursive `std::mutex`. Every call through the new API will hang indefinitely.
- **P1 silent no-op**: `max_retries` and `fallback` are documented in the public API and set by all four platform SDKs, but neither field is read anywhere in the C++ implementation; the advertised retry-on-failure behaviour is never executed.

<h3>Confidence Score: 4/5</h3>

Not safe to merge — the new structured-output component APIs will deadlock on every call due to non-recursive mutex re-acquisition.

The underlying backend work (grammar sampler, schema converter, vtable wiring, platform SDK types) is solid, but the glue layer in llm_component.cpp introduces a guaranteed deadlock that makes both new exported functions completely unusable. Once the mutex re-acquisition is fixed and the max_retries/fallback fields are either implemented or documented as future work, the PR can be merged.

sdk/runanywhere-commons/src/features/llm/llm_component.cpp — both new structured-output functions deadlock; max_retries and fallback are silently dropped.

<h3>Important Files Changed</h3>

| Filename | Overview |
|----------|----------|
| sdk/runanywhere-commons/src/features/llm/llm_component.cpp | Adds rac_llm_component_generate_structured and _stream — both acquire component->mtx then delegate to generate/generate_stream which re-acquire the same non-recursive mutex, causing a guaranteed deadlock; max_retries and fallback fields are also silently ignored. |
| sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp | Adds grammar sampler to the sampler chain (correctly placed first before temperature/top-p/top-k samplers), adds convert_json_schema_to_grammar using llama.cpp's built-in converter, and caches grammar string for sampler invalidation — implementation looks correct. |
| sdk/runanywhere-commons/src/backends/llamacpp/jni/rac_backend_llamacpp_jni.cpp | Wires grammar through nativeGenerate and adds nativeJsonSchemaToGrammar; JNI string lifecycle is handled correctly, but free() is used instead of rac_free() for the allocated grammar string. |
| sdk/runanywhere-commons/include/rac/features/llm/rac_llm_types.h | Adds grammar field to rac_llm_options_t, rac_structured_output_fallback_t enum, and extends rac_structured_output_config_t — struct layout and defaults look correct. |
| sdk/runanywhere-commons/src/features/platform/rac_backend_platform_register.cpp | Adds explicit NULL entries for all optional vtable ops including json_schema_to_grammar — prevents undefined behaviour from uninitialized function pointers. |
| sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+StructuredOutput.swift | Migrates generateForStructuredOutput to call rac_llm_component_generate_structured with correct C struct mapping; will deadlock at the C layer, but Swift-side code itself is structurally sound. |
| sdk/runanywhere-kotlin/modules/runanywhere-core-llamacpp/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/llm/llamacpp/LlamaCPPBridge.kt | Adds JNI declarations for direct LlamaCPP ops (nativeCreate, nativeDestroy, nativeGenerate with grammar, nativeJsonSchemaToGrammar, nativeCancel, nativeGetModelInfo) — signatures are consistent with the JNI C implementations. |
| sdk/runanywhere-web/packages/llamacpp/src/Extensions/RunAnywhere+StructuredOutput.ts | Adds StructuredOutputFallback enum and wires useGrammar/maxRetries/fallback into the WASM struct memory — offset names are consistent with the new wasm_exports.cpp helpers. |
| sdk/runanywhere-commons/src/backends/llamacpp/rac_llm_llamacpp.cpp | Adds grammar field wiring in generate/generate_stream/generate_from_context C-API paths and implements rac_llm_llamacpp_json_schema_to_grammar — implementation is clean and handles null/error cases. |

</details>

<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller
    participant generate_structured
    participant mtx as component->mtx
    participant generate

    Caller->>generate_structured: rac_llm_component_generate_structured()
    generate_structured->>mtx: lock_guard acquire ✓
    generate_structured->>generate_structured: rac_llm_json_schema_to_grammar()
    generate_structured->>generate: rac_llm_component_generate()
    generate->>mtx: lock_guard acquire ✗ DEADLOCK
    Note over generate,mtx: std::mutex is non-recursive — hangs forever
```

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: sdk/runanywhere-commons/src/features/llm/llm_component.cpp
Line: 786-818

Comment:
**Guaranteed deadlock via non-recursive mutex re-acquisition**

`rac_llm_component_generate_structured` acquires `component->mtx` (line 786) and then delegates to `rac_llm_component_generate` (line 818). `rac_llm_component_generate` unconditionally acquires the same `component->mtx` (line 336). Because `std::mutex` is not recursive, this will deadlock every time the function is called.

The same problem occurs in `rac_llm_component_generate_structured_stream` (line 840) → `rac_llm_component_generate_stream` (line 582), which also immediately acquires `component->mtx`.

The fix is to extract the mutex-free core logic of `generate` and `generate_stream` into internal helpers (e.g., `generate_locked`) and have both the public APIs and the new structured wrappers call those helpers, acquiring the mutex only once at the public API boundary.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-commons/src/features/llm/llm_component.cpp
Line: 800-825

Comment:
**`max_retries` and `fallback` silently ignored**

The public API exposes `so_config->max_retries` (default 3) and `so_config->fallback` (default `RETRY`), and the header docs promise retry behaviour on grammar failure. However, neither field is read anywhere in `rac_llm_component_generate_structured` or `rac_llm_component_generate_structured_stream`. Grammar conversion is attempted exactly once, and if it fails the code unconditionally falls through to prompt-only mode — the `RETRY` default is never honoured.

Callers relying on `fallback = RAC_STRUCTURED_OUTPUT_FALLBACK_RETRY` or a non-zero `max_retries` to get a second attempt at constrained decoding will silently receive prompt-only output instead. Either implement the retry loop or document these fields as reserved/future.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-commons/src/backends/llamacpp/jni/rac_backend_llamacpp_jni.cpp
Line: 311-312

Comment:
**`free` instead of `rac_free` violates API contract**

Both `rac_llm_llamacpp_json_schema_to_grammar` and `rac_llm_json_schema_to_grammar` document their output pointer as "caller must free with `rac_free()`". Here and in `llm_component.cpp` lines 822 and 878, the raw `free()` is called on memory owned by the RAC API. If the allocator strategy ever changes (e.g., a custom arena), this will silently corrupt memory.

```suggestion
    jstring result = env->NewStringUTF(grammarOut);
    rac_free(grammarOut);
    return result;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["feat: add grammar-constrained structured..."](https://github.com/runanywhereai/runanywhere-sdks/commit/446d5929a5196e038859c6a2afbbb7a94831f34e) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28422230)</sub>

> Greptile also left **3 inline comments** on this PR.

<!-- /greptile_comment -->