### PR TITLE
feat(commons): benchmark timing infrastructure (rebased from #343)

### DIFF
--- a/sdk/runanywhere-commons/CMakeLists.txt
+++ b/sdk/runanywhere-commons/CMakeLists.txt
@@ -276,6 +276,9 @@ set(RAC_CORE_SOURCES
     src/core/rac_error.cpp
     src/core/rac_time.cpp
     src/core/rac_benchmark.cpp
+    src/core/rac_benchmark_metrics.cpp
+    src/core/rac_benchmark_log.cpp
+    src/core/rac_benchmark_stats.cpp
     src/core/rac_memory.cpp
     src/core/rac_logger.cpp
     src/core/rac_audio_utils.cpp

--- a/sdk/runanywhere-commons/CMakeLists.txt
+++ b/sdk/runanywhere-commons/CMakeLists.txt
@@ -275,6 +275,7 @@ set(RAC_CORE_SOURCES
     src/core/rac_core.cpp
     src/core/rac_error.cpp
     src/core/rac_time.cpp
+    src/core/rac_benchmark.cpp
     src/core/rac_memory.cpp
     src/core/rac_logger.cpp
     src/core/rac_audio_utils.cpp

--- a/sdk/runanywhere-commons/include/rac/backends/rac_llm_llamacpp.h
+++ b/sdk/runanywhere-commons/include/rac/backends/rac_llm_llamacpp.h
@@ -11,6 +11,7 @@
 #ifndef RAC_LLM_LLAMACPP_H
 #define RAC_LLM_LLAMACPP_H
 
+#include "rac/core/rac_benchmark.h"
 #include "rac/core/rac_error.h"
 #include "rac/core/rac_types.h"
 #include "rac/features/llm/rac_llm.h"
@@ -162,6 +163,27 @@ typedef rac_bool_t (*rac_llm_llamacpp_stream_callback_fn)(const char* token, rac
 RAC_LLAMACPP_API rac_result_t rac_llm_llamacpp_generate_stream(
     rac_handle_t handle, const char* prompt, const rac_llm_options_t* options,
     rac_llm_llamacpp_stream_callback_fn callback, void* user_data);
+
+/**
+ * Generates text with streaming callback and benchmark timing.
+ *
+ * Same as rac_llm_llamacpp_generate_stream but captures benchmark timing:
+ * - t2: Before prefill (llama_decode for prompt batch)
+ * - t3: After prefill completes
+ * - t5: When decode loop exits (last token)
+ *
+ * @param handle Service handle
+ * @param prompt Input prompt text
+ * @param options Generation options
+ * @param callback Callback for each token
+ * @param user_data User context passed to callback
+ * @param timing_out Output: Benchmark timing (can be NULL for no timing)
+ * @return RAC_SUCCESS or error code
+ */
+RAC_LLAMACPP_API rac_result_t rac_llm_llamacpp_generate_stream_with_timing(
+    rac_handle_t handle, const char* prompt, const rac_llm_options_t* options,
+    rac_llm_llamacpp_stream_callback_fn callback, void* user_data,
+    rac_benchmark_timing_t* timing_out);
 
 /**
  * Cancels ongoing generation.

--- a/sdk/runanywhere-commons/include/rac/backends/rac_llm_llamacpp.h
+++ b/sdk/runanywhere-commons/include/rac/backends/rac_llm_llamacpp.h
@@ -177,7 +177,12 @@ RAC_LLAMACPP_API rac_result_t rac_llm_llamacpp_generate_stream(
  * @param options Generation options
  * @param callback Callback for each token
  * @param user_data User context passed to callback
- * @param timing_out Output: Benchmark timing (can be NULL for no timing)
+ * @param timing_out Output: Benchmark timing struct, caller-allocated.
+ *                   Must remain valid for the duration of the call.
+ *                   Caller should initialize via rac_benchmark_timing_init() before passing.
+ *                   On success, all t2/t3/t5 fields are populated.
+ *                   On failure, status is set but timing fields may be partial.
+ *                   Pass NULL to skip timing (zero overhead).
  * @return RAC_SUCCESS or error code
  */
 RAC_LLAMACPP_API rac_result_t rac_llm_llamacpp_generate_stream_with_timing(

--- a/sdk/runanywhere-commons/include/rac/core/rac_benchmark.h
+++ b/sdk/runanywhere-commons/include/rac/core/rac_benchmark.h
@@ -67,9 +67,12 @@ typedef struct rac_benchmark_timing {
     int32_t output_tokens;
 
     /**
-     * Status of the request:
-     * - 0: Success
-     * - Non-zero: Error code (from rac_result_t)
+     * Status of the benchmark request.
+     * Uses RAC_BENCHMARK_STATUS_* codes:
+     * - RAC_BENCHMARK_STATUS_SUCCESS (0): Completed successfully
+     * - RAC_BENCHMARK_STATUS_ERROR (1): Failed
+     * - RAC_BENCHMARK_STATUS_TIMEOUT (2): Timed out
+     * - RAC_BENCHMARK_STATUS_CANCELLED (3): Cancelled
      */
     int32_t status;
 

--- a/sdk/runanywhere-commons/include/rac/core/rac_benchmark.h
+++ b/sdk/runanywhere-commons/include/rac/core/rac_benchmark.h
@@ -1,0 +1,126 @@
+/**
+ * @file rac_benchmark.h
+ * @brief RunAnywhere Commons - Benchmark Timing Support
+ *
+ * This header provides types and functions for benchmark timing instrumentation.
+ * The timing struct captures key timestamps during LLM inference for performance
+ * measurement and analysis.
+ *
+ * Design principles:
+ * - Zero overhead when not benchmarking: timing is opt-in via pointer parameter
+ * - Monotonic clock: uses steady_clock for accurate cross-platform timing
+ * - All timestamps are relative to a process-local epoch (not wall-clock)
+ */
+
+#ifndef RAC_BENCHMARK_H
+#define RAC_BENCHMARK_H
+
+#include "rac/core/rac_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// =============================================================================
+// BENCHMARK TIMING STRUCT
+// =============================================================================
+
+/**
+ * Benchmark timing structure for LLM inference.
+ *
+ * Captures timestamps at key points during inference:
+ * - t0: Request start (component API entry)
+ * - t2: Prefill start (backend, before llama_decode for prompt)
+ * - t3: Prefill end (backend, after llama_decode returns)
+ * - t4: First token (component, first token callback)
+ * - t5: Last token (backend, decode loop exits)
+ * - t6: Request end (component, before complete callback)
+ *
+ * All timestamps are in milliseconds from a process-local epoch.
+ * Use rac_monotonic_now_ms() to get comparable timestamps.
+ *
+ * Note: t1 is intentionally skipped to match the specification.
+ */
+typedef struct rac_benchmark_timing {
+    /** t0: Request start - recorded at component API entry */
+    int64_t t0_request_start_ms;
+
+    /** t2: Prefill start - recorded before llama_decode for prompt batch */
+    int64_t t2_prefill_start_ms;
+
+    /** t3: Prefill end - recorded after llama_decode returns for prompt */
+    int64_t t3_prefill_end_ms;
+
+    /** t4: First token - recorded when first token callback is invoked */
+    int64_t t4_first_token_ms;
+
+    /** t5: Last token - recorded when decode loop exits */
+    int64_t t5_last_token_ms;
+
+    /** t6: Request end - recorded before complete callback */
+    int64_t t6_request_end_ms;
+
+    /** Number of tokens in the prompt */
+    int32_t prompt_tokens;
+
+    /** Number of tokens generated */
+    int32_t output_tokens;
+
+    /**
+     * Status of the request:
+     * - 0: Success
+     * - Non-zero: Error code (from rac_result_t)
+     */
+    int32_t status;
+
+} rac_benchmark_timing_t;
+
+// =============================================================================
+// BENCHMARK STATUS CODES
+// =============================================================================
+
+/** Benchmark request completed successfully */
+#define RAC_BENCHMARK_STATUS_SUCCESS ((int32_t)0)
+
+/** Benchmark request failed due to error */
+#define RAC_BENCHMARK_STATUS_ERROR ((int32_t)1)
+
+/** Benchmark request timed out */
+#define RAC_BENCHMARK_STATUS_TIMEOUT ((int32_t)2)
+
+/** Benchmark request was cancelled */
+#define RAC_BENCHMARK_STATUS_CANCELLED ((int32_t)3)
+
+// =============================================================================
+// MONOTONIC TIME API
+// =============================================================================
+
+/**
+ * Gets the current monotonic time in milliseconds.
+ *
+ * Uses std::chrono::steady_clock for accurate, monotonic timing that is not
+ * affected by system clock changes. The returned value is relative to a
+ * process-local epoch (the first call to this function).
+ *
+ * This function is thread-safe and lock-free on all supported platforms.
+ *
+ * @return Current monotonic time in milliseconds from process-local epoch
+ */
+RAC_API int64_t rac_monotonic_now_ms(void);
+
+// =============================================================================
+// UTILITY FUNCTIONS
+// =============================================================================
+
+/**
+ * Initializes a benchmark timing struct to zero values.
+ *
+ * @param timing Pointer to timing struct to initialize
+ */
+RAC_API void rac_benchmark_timing_init(rac_benchmark_timing_t* timing);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RAC_BENCHMARK_H */

--- a/sdk/runanywhere-commons/include/rac/core/rac_benchmark.h
+++ b/sdk/runanywhere-commons/include/rac/core/rac_benchmark.h
@@ -76,6 +76,13 @@ typedef struct rac_benchmark_timing {
      */
     int32_t status;
 
+    /**
+     * Specific error code when status is not RAC_BENCHMARK_STATUS_SUCCESS.
+     * Uses rac_result_t error codes (e.g., RAC_ERROR_NOT_SUPPORTED).
+     * Set to RAC_SUCCESS (0) when status is RAC_BENCHMARK_STATUS_SUCCESS.
+     */
+    rac_result_t error_code;
+
 } rac_benchmark_timing_t;
 
 // =============================================================================

--- a/sdk/runanywhere-commons/include/rac/core/rac_benchmark_log.h
+++ b/sdk/runanywhere-commons/include/rac/core/rac_benchmark_log.h
@@ -1,0 +1,87 @@
+/**
+ * @file rac_benchmark_log.h
+ * @brief RunAnywhere Commons - Benchmark Logging and Serialization
+ *
+ * Provides functions to serialize benchmark timing data as JSON or CSV,
+ * and to log benchmark results via the RAC logging system.
+ *
+ * Usage:
+ *   // Log timing summary
+ *   rac_benchmark_timing_log(&timing, "inference_run_1");
+ *
+ *   // Export as JSON
+ *   char* json = rac_benchmark_timing_to_json(&timing);
+ *   // ... use json ...
+ *   free(json);
+ *
+ *   // Export as CSV
+ *   char* header = rac_benchmark_timing_to_csv(NULL, RAC_TRUE);
+ *   char* row = rac_benchmark_timing_to_csv(&timing, RAC_FALSE);
+ *   free(header);
+ *   free(row);
+ */
+
+#ifndef RAC_BENCHMARK_LOG_H
+#define RAC_BENCHMARK_LOG_H
+
+#include "rac/core/rac_benchmark.h"
+#include "rac/core/rac_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// =============================================================================
+// JSON SERIALIZATION
+// =============================================================================
+
+/**
+ * Serializes a benchmark timing struct as a JSON string.
+ *
+ * Includes all timing fields plus derived metrics:
+ * - ttft_ms: Time to first token (t4 - t0)
+ * - prefill_ms: Prefill duration (t3 - t2)
+ * - decode_ms: Decode duration (t5 - t3)
+ * - e2e_ms: End-to-end latency (t6 - t0)
+ * - decode_tps: Decode throughput (output_tokens / decode_ms * 1000)
+ *
+ * @param timing Timing struct to serialize (NULL returns NULL)
+ * @return Heap-allocated JSON string (caller must free()), or NULL on error
+ */
+RAC_API char* rac_benchmark_timing_to_json(const rac_benchmark_timing_t* timing);
+
+// =============================================================================
+// CSV SERIALIZATION
+// =============================================================================
+
+/**
+ * Serializes a benchmark timing struct as a CSV row.
+ *
+ * @param timing Timing struct to serialize (ignored when header is RAC_TRUE)
+ * @param header If RAC_TRUE, returns the CSV header row instead of data
+ * @return Heap-allocated CSV string (caller must free()), or NULL on error
+ */
+RAC_API char* rac_benchmark_timing_to_csv(const rac_benchmark_timing_t* timing, rac_bool_t header);
+
+// =============================================================================
+// LOGGING
+// =============================================================================
+
+/**
+ * Logs a benchmark timing summary via the RAC logging system.
+ *
+ * Outputs key metrics at INFO level under the "Benchmark" category:
+ * - TTFT, prefill time, decode time, E2E latency
+ * - Token counts and throughput
+ * - Status and error code
+ *
+ * @param timing Timing struct to log (NULL is a no-op)
+ * @param label Optional label for this benchmark run (can be NULL)
+ */
+RAC_API void rac_benchmark_timing_log(const rac_benchmark_timing_t* timing, const char* label);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RAC_BENCHMARK_LOG_H */

--- a/sdk/runanywhere-commons/include/rac/core/rac_benchmark_log.h
+++ b/sdk/runanywhere-commons/include/rac/core/rac_benchmark_log.h
@@ -5,18 +5,26 @@
  * Provides functions to serialize benchmark timing data as JSON or CSV,
  * and to log benchmark results via the RAC logging system.
  *
+ * All functions return rac_result_t for consistent error handling.
+ * Serialization functions write a heap-allocated string to an out-parameter
+ * (caller must free() on success).
+ *
  * Usage:
  *   // Log timing summary
  *   rac_benchmark_timing_log(&timing, "inference_run_1");
  *
  *   // Export as JSON
- *   char* json = rac_benchmark_timing_to_json(&timing);
- *   // ... use json ...
- *   free(json);
+ *   char* json = NULL;
+ *   if (rac_benchmark_timing_to_json(&timing, &json) == RAC_SUCCESS) {
+ *       // ... use json ...
+ *       free(json);
+ *   }
  *
  *   // Export as CSV
- *   char* header = rac_benchmark_timing_to_csv(NULL, RAC_TRUE);
- *   char* row = rac_benchmark_timing_to_csv(&timing, RAC_FALSE);
+ *   char* header = NULL;
+ *   char* row = NULL;
+ *   rac_benchmark_timing_to_csv(NULL, RAC_TRUE, &header);
+ *   rac_benchmark_timing_to_csv(&timing, RAC_FALSE, &row);
  *   free(header);
  *   free(row);
  */
@@ -25,6 +33,7 @@
 #define RAC_BENCHMARK_LOG_H
 
 #include "rac/core/rac_benchmark.h"
+#include "rac/core/rac_error.h"
 #include "rac/core/rac_types.h"
 
 #ifdef __cplusplus
@@ -45,10 +54,17 @@ extern "C" {
  * - e2e_ms: End-to-end latency (t6 - t0)
  * - decode_tps: Decode throughput (output_tokens / decode_ms * 1000)
  *
- * @param timing Timing struct to serialize (NULL returns NULL)
- * @return Heap-allocated JSON string (caller must free()), or NULL on error
+ * On success, *out_json is set to a heap-allocated string that the caller
+ * must release via free(). On failure, *out_json is set to NULL.
+ *
+ * @param timing   Timing struct to serialize (must not be NULL)
+ * @param out_json Output pointer that receives the JSON string (must not be NULL)
+ * @return RAC_SUCCESS on success,
+ *         RAC_ERROR_NULL_POINTER if timing or out_json is NULL,
+ *         RAC_ERROR_OUT_OF_MEMORY if allocation fails
  */
-RAC_API char* rac_benchmark_timing_to_json(const rac_benchmark_timing_t* timing);
+RAC_API rac_result_t rac_benchmark_timing_to_json(const rac_benchmark_timing_t* timing,
+                                                  char** out_json);
 
 // =============================================================================
 // CSV SERIALIZATION
@@ -57,11 +73,24 @@ RAC_API char* rac_benchmark_timing_to_json(const rac_benchmark_timing_t* timing)
 /**
  * Serializes a benchmark timing struct as a CSV row.
  *
- * @param timing Timing struct to serialize (ignored when header is RAC_TRUE)
- * @param header If RAC_TRUE, returns the CSV header row instead of data
- * @return Heap-allocated CSV string (caller must free()), or NULL on error
+ * When header is RAC_TRUE, emits the CSV header row (timing may be NULL).
+ * When header is RAC_FALSE, emits a data row (timing must not be NULL).
+ *
+ * On success, *out_csv is set to a heap-allocated string that the caller
+ * must release via free(). On failure, *out_csv is set to NULL.
+ *
+ * @param timing  Timing struct to serialize (ignored when header is RAC_TRUE,
+ *                otherwise must not be NULL)
+ * @param header  If RAC_TRUE, emits the CSV header row instead of data
+ * @param out_csv Output pointer that receives the CSV string (must not be NULL)
+ * @return RAC_SUCCESS on success,
+ *         RAC_ERROR_NULL_POINTER if out_csv is NULL, or if header is RAC_FALSE
+ *             and timing is NULL,
+ *         RAC_ERROR_OUT_OF_MEMORY if allocation fails
  */
-RAC_API char* rac_benchmark_timing_to_csv(const rac_benchmark_timing_t* timing, rac_bool_t header);
+RAC_API rac_result_t rac_benchmark_timing_to_csv(const rac_benchmark_timing_t* timing,
+                                                 rac_bool_t header,
+                                                 char** out_csv);
 
 // =============================================================================
 // LOGGING
@@ -75,10 +104,13 @@ RAC_API char* rac_benchmark_timing_to_csv(const rac_benchmark_timing_t* timing, 
  * - Token counts and throughput
  * - Status and error code
  *
- * @param timing Timing struct to log (NULL is a no-op)
- * @param label Optional label for this benchmark run (can be NULL)
+ * @param timing Timing struct to log (must not be NULL)
+ * @param label  Optional label for this benchmark run (may be NULL)
+ * @return RAC_SUCCESS on success,
+ *         RAC_ERROR_NULL_POINTER if timing is NULL
  */
-RAC_API void rac_benchmark_timing_log(const rac_benchmark_timing_t* timing, const char* label);
+RAC_API rac_result_t rac_benchmark_timing_log(const rac_benchmark_timing_t* timing,
+                                              const char* label);
 
 #ifdef __cplusplus
 }

--- a/sdk/runanywhere-commons/include/rac/core/rac_benchmark_metrics.h
+++ b/sdk/runanywhere-commons/include/rac/core/rac_benchmark_metrics.h
@@ -1,0 +1,119 @@
+/**
+ * @file rac_benchmark_metrics.h
+ * @brief RunAnywhere Commons - Extended Benchmark Metrics
+ *
+ * Defines extended device/platform metrics captured alongside benchmark timing.
+ * Actual metric collection is platform-specific (iOS/Android) and provided
+ * via a callback provider pattern. The C++ layer defines interfaces only.
+ *
+ * Usage:
+ *   // Platform SDK registers a provider during init:
+ *   rac_benchmark_set_metrics_provider(my_provider_fn, my_context);
+ *
+ *   // Commons layer captures metrics at t0 and t6:
+ *   rac_benchmark_extended_metrics_t metrics;
+ *   rac_benchmark_capture_metrics(&metrics);
+ */
+
+#ifndef RAC_BENCHMARK_METRICS_H
+#define RAC_BENCHMARK_METRICS_H
+
+#include "rac/core/rac_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// =============================================================================
+// EXTENDED METRICS STRUCT
+// =============================================================================
+
+/**
+ * Extended device/platform metrics captured during benchmark.
+ *
+ * All fields default to -1 (unavailable) unless the platform provider
+ * populates them. This allows partial metric support across platforms.
+ */
+typedef struct rac_benchmark_extended_metrics {
+    /** Resident memory usage in bytes at capture time (-1 if unavailable) */
+    int64_t memory_usage_bytes;
+
+    /** Peak memory usage in bytes during request (-1 if unavailable) */
+    int64_t memory_peak_bytes;
+
+    /** CPU temperature in Celsius (-1.0 if unavailable) */
+    float cpu_temperature_celsius;
+
+    /** Battery level 0.0-1.0 (-1.0 if unavailable) */
+    float battery_level;
+
+    /** GPU utilization 0-100% (-1.0 if unavailable) */
+    float gpu_utilization_percent;
+
+    /**
+     * Thermal state of the device.
+     *  0 = nominal
+     *  1 = fair
+     *  2 = serious
+     *  3 = critical
+     * -1 = unavailable
+     */
+    int32_t thermal_state;
+
+} rac_benchmark_extended_metrics_t;
+
+// =============================================================================
+// METRICS PROVIDER CALLBACK
+// =============================================================================
+
+/**
+ * Callback type for platform-specific metrics collection.
+ *
+ * The platform SDK (Swift/Kotlin) implements this to fill in
+ * whatever device metrics are available on that platform.
+ *
+ * @param out Metrics struct to populate (pre-initialized to unavailable values)
+ * @param user_data Platform context passed during registration
+ */
+typedef void (*rac_benchmark_metrics_provider_fn)(rac_benchmark_extended_metrics_t* out,
+                                                   void* user_data);
+
+// =============================================================================
+// METRICS API
+// =============================================================================
+
+/**
+ * Registers a platform-specific metrics provider.
+ *
+ * Call this during SDK initialization. Only one provider can be active.
+ * Setting a new provider replaces the previous one.
+ * Pass NULL to unregister.
+ *
+ * @param provider Metrics provider callback (NULL to unregister)
+ * @param user_data Platform context passed to provider calls
+ */
+RAC_API void rac_benchmark_set_metrics_provider(rac_benchmark_metrics_provider_fn provider,
+                                                 void* user_data);
+
+/**
+ * Captures current device metrics using the registered provider.
+ *
+ * If no provider is registered, all fields are set to unavailable (-1).
+ * Thread-safe: can be called from any thread.
+ *
+ * @param out Metrics struct to populate (must not be NULL)
+ */
+RAC_API void rac_benchmark_capture_metrics(rac_benchmark_extended_metrics_t* out);
+
+/**
+ * Initializes an extended metrics struct to unavailable values.
+ *
+ * @param metrics Metrics struct to initialize (must not be NULL)
+ */
+RAC_API void rac_benchmark_extended_metrics_init(rac_benchmark_extended_metrics_t* metrics);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RAC_BENCHMARK_METRICS_H */

--- a/sdk/runanywhere-commons/include/rac/core/rac_benchmark_stats.h
+++ b/sdk/runanywhere-commons/include/rac/core/rac_benchmark_stats.h
@@ -1,0 +1,157 @@
+/**
+ * @file rac_benchmark_stats.h
+ * @brief RunAnywhere Commons - Benchmark Statistical Analysis
+ *
+ * Collects benchmark timing observations and computes statistical summaries
+ * including percentiles (P50/P95/P99), mean, stddev, and outlier detection.
+ *
+ * Usage:
+ *   rac_benchmark_stats_handle_t stats;
+ *   rac_benchmark_stats_create(&stats);
+ *
+ *   // Record observations
+ *   rac_benchmark_stats_record(stats, &timing1);
+ *   rac_benchmark_stats_record(stats, &timing2);
+ *
+ *   // Get summary
+ *   rac_benchmark_summary_t summary;
+ *   rac_benchmark_stats_get_summary(stats, &summary);
+ *
+ *   // Export as JSON
+ *   char* json = rac_benchmark_stats_summary_to_json(&summary);
+ *   free(json);
+ *
+ *   rac_benchmark_stats_destroy(stats);
+ */
+
+#ifndef RAC_BENCHMARK_STATS_H
+#define RAC_BENCHMARK_STATS_H
+
+#include "rac/core/rac_benchmark.h"
+#include "rac/core/rac_types.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+// =============================================================================
+// STATS HANDLE (OPAQUE)
+// =============================================================================
+
+/** Opaque handle for a benchmark stats collector */
+typedef void* rac_benchmark_stats_handle_t;
+
+// =============================================================================
+// SUMMARY STRUCT
+// =============================================================================
+
+/**
+ * Statistical summary of collected benchmark observations.
+ *
+ * All time values are in milliseconds. Throughput is in tokens/second.
+ * Fields are 0 if no valid observations were recorded for that metric.
+ */
+typedef struct rac_benchmark_summary {
+    /** Number of observations recorded */
+    int32_t count;
+
+    // Time to First Token stats (t4 - t0)
+    double ttft_p50_ms;
+    double ttft_p95_ms;
+    double ttft_p99_ms;
+    double ttft_min_ms;
+    double ttft_max_ms;
+    double ttft_mean_ms;
+    double ttft_stddev_ms;
+
+    // Prefill duration stats (t3 - t2)
+    double prefill_p50_ms;
+    double prefill_p95_ms;
+    double prefill_p99_ms;
+
+    // Decode throughput stats (output_tokens / (t5 - t3) * 1000)
+    double decode_tps_p50;
+    double decode_tps_p95;
+    double decode_tps_p99;
+
+    // End-to-end latency stats (t6 - t0)
+    double e2e_p50_ms;
+    double e2e_p95_ms;
+    double e2e_p99_ms;
+
+    /** Number of observations where E2E > mean + 2*stddev */
+    int32_t outlier_count;
+
+} rac_benchmark_summary_t;
+
+// =============================================================================
+// STATS COLLECTOR API
+// =============================================================================
+
+/**
+ * Creates a new benchmark stats collector.
+ *
+ * @param out_handle Output: collector handle
+ * @return RAC_SUCCESS or RAC_ERROR_NULL_POINTER
+ */
+RAC_API rac_result_t rac_benchmark_stats_create(rac_benchmark_stats_handle_t* out_handle);
+
+/**
+ * Destroys a stats collector and frees all associated memory.
+ *
+ * @param handle Collector handle (NULL is a no-op)
+ */
+RAC_API void rac_benchmark_stats_destroy(rac_benchmark_stats_handle_t handle);
+
+/**
+ * Records a benchmark timing observation.
+ *
+ * Only observations with status == RAC_BENCHMARK_STATUS_SUCCESS are recorded.
+ * Derived metrics (TTFT, prefill, decode TPS, E2E) are extracted and stored.
+ *
+ * Thread-safe: can be called from any thread.
+ *
+ * @param handle Collector handle
+ * @param timing Timing struct to record
+ */
+RAC_API void rac_benchmark_stats_record(rac_benchmark_stats_handle_t handle,
+                                         const rac_benchmark_timing_t* timing);
+
+/**
+ * Resets the collector, discarding all recorded observations.
+ *
+ * @param handle Collector handle
+ */
+RAC_API void rac_benchmark_stats_reset(rac_benchmark_stats_handle_t handle);
+
+/**
+ * Returns the number of recorded observations.
+ *
+ * @param handle Collector handle
+ * @return Observation count (0 if handle is NULL)
+ */
+RAC_API int32_t rac_benchmark_stats_count(rac_benchmark_stats_handle_t handle);
+
+/**
+ * Computes a statistical summary of all recorded observations.
+ *
+ * @param handle Collector handle
+ * @param out_summary Output: summary struct
+ * @return RAC_SUCCESS, RAC_ERROR_NULL_POINTER, or RAC_ERROR_INVALID_STATE (no data)
+ */
+RAC_API rac_result_t rac_benchmark_stats_get_summary(rac_benchmark_stats_handle_t handle,
+                                                      rac_benchmark_summary_t* out_summary);
+
+/**
+ * Serializes a summary struct as a JSON string.
+ *
+ * @param summary Summary struct to serialize (NULL returns NULL)
+ * @return Heap-allocated JSON string (caller must free()), or NULL on error
+ */
+RAC_API char* rac_benchmark_stats_summary_to_json(const rac_benchmark_summary_t* summary);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RAC_BENCHMARK_STATS_H */

--- a/sdk/runanywhere-commons/include/rac/core/rac_benchmark_stats.h
+++ b/sdk/runanywhere-commons/include/rac/core/rac_benchmark_stats.h
@@ -68,16 +68,28 @@ typedef struct rac_benchmark_summary {
     double prefill_p50_ms;
     double prefill_p95_ms;
     double prefill_p99_ms;
+    double prefill_min_ms;
+    double prefill_max_ms;
+    double prefill_mean_ms;
+    double prefill_stddev_ms;
 
     // Decode throughput stats (output_tokens / (t5 - t3) * 1000)
     double decode_tps_p50;
     double decode_tps_p95;
     double decode_tps_p99;
+    double decode_tps_min;
+    double decode_tps_max;
+    double decode_tps_mean;
+    double decode_tps_stddev;
 
     // End-to-end latency stats (t6 - t0)
     double e2e_p50_ms;
     double e2e_p95_ms;
     double e2e_p99_ms;
+    double e2e_min_ms;
+    double e2e_max_ms;
+    double e2e_mean_ms;
+    double e2e_stddev_ms;
 
     /** Number of observations where E2E > mean + 2*stddev */
     int32_t outlier_count;

--- a/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_component.h
+++ b/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_component.h
@@ -13,6 +13,7 @@
 #define RAC_LLM_COMPONENT_H
 
 #include "rac/core/capabilities/rac_lifecycle.h"
+#include "rac/core/rac_benchmark.h"
 #include "rac/core/rac_error.h"
 #include "rac/features/llm/rac_llm_types.h"
 
@@ -195,6 +196,36 @@ RAC_API rac_result_t rac_llm_component_generate_stream(
     rac_llm_component_token_callback_fn token_callback,
     rac_llm_component_complete_callback_fn complete_callback,
     rac_llm_component_error_callback_fn error_callback, void* user_data);
+
+/**
+ * @brief Generate text with streaming and benchmark timing
+ *
+ * Same as rac_llm_component_generate_stream but with optional benchmark timing.
+ * When timing_out is non-NULL, captures detailed timing information:
+ * - t0: Request start (set at API entry)
+ * - t4: First token (set in token callback)
+ * - t6: Request end (set before complete callback)
+ *
+ * Backend timestamps (t2, t3, t5) are captured by the backend if it supports timing.
+ *
+ * Zero overhead when timing_out is NULL - behaves exactly like generate_stream.
+ *
+ * @param handle Component handle
+ * @param prompt Input prompt
+ * @param options Generation options (can be NULL for defaults)
+ * @param token_callback Called for each generated token
+ * @param complete_callback Called when generation completes
+ * @param error_callback Called on error
+ * @param user_data User context passed to callbacks
+ * @param timing_out Output: Benchmark timing (can be NULL for no timing)
+ * @return RAC_SUCCESS or error code
+ */
+RAC_API rac_result_t rac_llm_component_generate_stream_with_timing(
+    rac_handle_t handle, const char* prompt, const rac_llm_options_t* options,
+    rac_llm_component_token_callback_fn token_callback,
+    rac_llm_component_complete_callback_fn complete_callback,
+    rac_llm_component_error_callback_fn error_callback, void* user_data,
+    rac_benchmark_timing_t* timing_out);
 
 /**
  * @brief Get lifecycle state

--- a/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_component.h
+++ b/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_component.h
@@ -217,7 +217,13 @@ RAC_API rac_result_t rac_llm_component_generate_stream(
  * @param complete_callback Called when generation completes
  * @param error_callback Called on error
  * @param user_data User context passed to callbacks
- * @param timing_out Output: Benchmark timing (can be NULL for no timing)
+ * @param timing_out Output: Benchmark timing struct, caller-allocated.
+ *                   Must remain valid for the duration of the call.
+ *                   Caller should initialize via rac_benchmark_timing_init() before passing.
+ *                   Component fills t0/t4/t6, backend fills t2/t3/t5.
+ *                   On success, all timing fields are populated.
+ *                   On failure, status is set but timing fields may be partial.
+ *                   Pass NULL to skip timing (zero overhead).
  * @return RAC_SUCCESS or error code
  */
 RAC_API rac_result_t rac_llm_component_generate_stream_with_timing(

--- a/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_service.h
+++ b/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_service.h
@@ -10,6 +10,7 @@
 #ifndef RAC_LLM_SERVICE_H
 #define RAC_LLM_SERVICE_H
 
+#include "rac/core/rac_benchmark.h"
 #include "rac/core/rac_error.h"
 #include "rac/features/llm/rac_llm_types.h"
 
@@ -37,6 +38,21 @@ typedef struct rac_llm_service_ops {
     rac_result_t (*generate_stream)(void* impl, const char* prompt,
                                     const rac_llm_options_t* options,
                                     rac_llm_stream_callback_fn callback, void* user_data);
+
+    /**
+     * Generate text with streaming callback and benchmark timing.
+     * Optional: backends that don't support timing can leave this NULL.
+     * If NULL, rac_llm_generate_stream_with_timing falls back to generate_stream.
+     *
+     * Backends that implement this should capture:
+     * - t2: Before prefill (llama_decode for prompt)
+     * - t3: After prefill completes
+     * - t5: When decode loop exits (last token)
+     */
+    rac_result_t (*generate_stream_with_timing)(void* impl, const char* prompt,
+                                                const rac_llm_options_t* options,
+                                                rac_llm_stream_callback_fn callback, void* user_data,
+                                                rac_benchmark_timing_t* timing_out);
 
     /** Get service info */
     rac_result_t (*get_info)(void* impl, rac_llm_info_t* out_info);
@@ -145,6 +161,32 @@ RAC_API rac_result_t rac_llm_generate(rac_handle_t handle, const char* prompt,
 RAC_API rac_result_t rac_llm_generate_stream(rac_handle_t handle, const char* prompt,
                                              const rac_llm_options_t* options,
                                              rac_llm_stream_callback_fn callback, void* user_data);
+
+/**
+ * @brief Stream generate text with benchmark timing
+ *
+ * Same as rac_llm_generate_stream but with optional benchmark timing.
+ * If timing_out is non-NULL and the backend supports timing, captures:
+ * - t2: Before prefill
+ * - t3: After prefill
+ * - t5: Last token generated
+ *
+ * If the backend doesn't implement generate_stream_with_timing, falls back
+ * to generate_stream (timing_out will have t2/t3/t5 as zeros).
+ *
+ * @param handle Service handle
+ * @param prompt Input prompt
+ * @param options Generation options (can be NULL for defaults)
+ * @param callback Callback for each token
+ * @param user_data User context passed to callback
+ * @param timing_out Output: Benchmark timing (can be NULL for no timing)
+ * @return RAC_SUCCESS or error code
+ */
+RAC_API rac_result_t rac_llm_generate_stream_with_timing(rac_handle_t handle, const char* prompt,
+                                                         const rac_llm_options_t* options,
+                                                         rac_llm_stream_callback_fn callback,
+                                                         void* user_data,
+                                                         rac_benchmark_timing_t* timing_out);
 
 /**
  * @brief Get service information

--- a/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
@@ -883,6 +883,11 @@ bool LlamaCppTextGeneration::generate_stream_with_timing(const TextGenerationReq
 
     if (llama_decode(context_, batch) != 0) {
         LOGE("llama_decode failed for prompt");
+        if (timing_out != nullptr) {
+            int64_t now = rac_monotonic_now_ms();
+            timing_out->t3_prefill_end_ms = now;
+            timing_out->t5_last_token_ms = now;
+        }
         llama_batch_free(batch);
         return false;
     }

--- a/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
@@ -598,7 +598,8 @@ TextGenerationResult LlamaCppTextGeneration::generate(const TextGenerationReques
 
 bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& request,
                                              TextStreamCallback callback,
-                                             int* out_prompt_tokens) {
+                                             int* out_prompt_tokens,
+                                             rac_benchmark_timing_t* timing_out) {
     std::lock_guard<std::mutex> lock(mutex_);
 
     if (!is_ready()) {
@@ -632,6 +633,12 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
 
     if (available_tokens <= 0) {
         RAC_LOG_ERROR("LLM.LlamaCpp","Prompt too long: %d tokens, context size: %d", prompt_tokens, n_ctx);
+        if (timing_out != nullptr) {
+            int64_t now = rac_monotonic_now_ms();
+            timing_out->t2_prefill_start_ms = now;
+            timing_out->t3_prefill_end_ms = now;
+            timing_out->t5_last_token_ms = now;
+        }
         return false;
     }
 
@@ -642,6 +649,11 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
     const int n_batch = batch_size_ > 0 ? batch_size_ : n_ctx;
     RAC_LOG_INFO("LLM.LlamaCpp", "generate_stream: processing %d prompt tokens in chunks of %d", prompt_tokens, n_batch);
     llama_batch batch = llama_batch_init(n_batch, 0, 1);
+
+    // t2: Record prefill start (before the first llama_decode on the prompt chunks)
+    if (timing_out != nullptr) {
+        timing_out->t2_prefill_start_ms = rac_monotonic_now_ms();
+    }
 
     for (int chunk_start = 0; chunk_start < prompt_tokens; chunk_start += n_batch) {
         batch.n_tokens = 0;
@@ -655,11 +667,21 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
 
         if (llama_decode(context_, batch) != 0) {
             RAC_LOG_ERROR("LLM.LlamaCpp", "llama_decode failed for prompt chunk [%d..%d)", chunk_start, chunk_end);
+            if (timing_out != nullptr) {
+                int64_t now = rac_monotonic_now_ms();
+                timing_out->t3_prefill_end_ms = now;
+                timing_out->t5_last_token_ms = now;
+            }
             llama_batch_free(batch);
             return false;
         }
     }
     RAC_LOG_INFO("LLM.LlamaCpp", "generate_stream: prompt decoded successfully");
+
+    // t3: Record prefill end (after the prompt prefill loop completes)
+    if (timing_out != nullptr) {
+        timing_out->t3_prefill_end_ms = rac_monotonic_now_ms();
+    }
 
     // Configure sampler with request parameters — skip rebuild if params unchanged
     {
@@ -809,6 +831,12 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
         }
     }
 
+    // t5: Record last token time (decode loop exit)
+    if (timing_out != nullptr) {
+        timing_out->t5_last_token_ms = rac_monotonic_now_ms();
+        timing_out->output_tokens = static_cast<int32_t>(tokens_generated);
+    }
+
     // Flush any remaining partial UTF-8 bytes (e.g. trailing multi-byte char at end of generation)
     if (!cancel_requested_.load() && !stop_sequence_hit && !partial_utf8_buffer.empty()) {
         stop_window.append(partial_utf8_buffer);
@@ -825,191 +853,6 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
     llama_batch_free(batch);
 
     RAC_LOG_INFO("LLM.LlamaCpp","Generation complete: %d tokens", tokens_generated);
-    return !cancel_requested_.load();
-}
-
-bool LlamaCppTextGeneration::generate_stream_with_timing(const TextGenerationRequest& request,
-                                                         TextStreamCallback callback,
-                                                         int* out_prompt_tokens,
-                                                         rac_benchmark_timing_t* timing_out) {
-    std::lock_guard<std::mutex> lock(mutex_);
-
-    if (!is_ready()) {
-        LOGE("Model not ready for generation");
-        return false;
-    }
-
-    cancel_requested_.store(false);
-
-    std::string prompt = build_prompt(request);
-    LOGI("Generating with timing, prompt length: %zu", prompt.length());
-
-    const auto tokens_list = common_tokenize(context_, prompt, true, true);
-
-    int n_ctx = llama_n_ctx(context_);
-    int prompt_tokens = static_cast<int>(tokens_list.size());
-
-    if (out_prompt_tokens) {
-        *out_prompt_tokens = prompt_tokens;
-    }
-
-    int available_tokens = n_ctx - prompt_tokens - 4;
-
-    if (available_tokens <= 0) {
-        LOGE("Prompt too long: %d tokens, context size: %d", prompt_tokens, n_ctx);
-        return false;
-    }
-
-    int effective_max_tokens = std::min(request.max_tokens, available_tokens);
-    if (effective_max_tokens < request.max_tokens) {
-        LOGI("Capping max_tokens: %d → %d (context=%d, prompt=%d tokens)", request.max_tokens,
-             effective_max_tokens, n_ctx, prompt_tokens);
-    }
-    LOGI("Generation with timing: prompt_tokens=%d, max_tokens=%d, context=%d", prompt_tokens,
-         effective_max_tokens, n_ctx);
-
-    llama_batch batch = llama_batch_init(n_ctx, 0, 1);
-
-    batch.n_tokens = 0;
-    for (size_t i = 0; i < tokens_list.size(); i++) {
-        common_batch_add(batch, tokens_list[i], i, {0}, false);
-    }
-    batch.logits[batch.n_tokens - 1] = true;
-
-    // t2: Record prefill start (before llama_decode for prompt)
-    if (timing_out != nullptr) {
-        timing_out->t2_prefill_start_ms = rac_monotonic_now_ms();
-    }
-
-    if (llama_decode(context_, batch) != 0) {
-        LOGE("llama_decode failed for prompt");
-        if (timing_out != nullptr) {
-            int64_t now = rac_monotonic_now_ms();
-            timing_out->t3_prefill_end_ms = now;
-            timing_out->t5_last_token_ms = now;
-        }
-        llama_batch_free(batch);
-        return false;
-    }
-
-    // t3: Record prefill end (after llama_decode returns)
-    if (timing_out != nullptr) {
-        timing_out->t3_prefill_end_ms = rac_monotonic_now_ms();
-    }
-
-    llama_sampler_reset(sampler_);
-
-    const auto vocab = llama_model_get_vocab(model_);
-
-    static const std::vector<std::string> STOP_SEQUENCES = {
-        "<|im_end|>", "<|eot_id|>", "</s>", "<|end|>", "<|endoftext|>",
-        "\n\nUser:", "\n\nHuman:",
-    };
-
-    static const size_t MAX_STOP_LEN = []{
-        size_t m = 0;
-        for (const auto& s : STOP_SEQUENCES) m = std::max(m, s.size());
-        return m;
-    }();
-
-    std::string stop_window;
-    stop_window.reserve(MAX_STOP_LEN * 2);
-
-    std::string partial_utf8_buffer;
-    partial_utf8_buffer.reserve(8);
-
-    int n_cur = batch.n_tokens;
-    int tokens_generated = 0;
-    bool stop_sequence_hit = false;
-
-    while (tokens_generated < effective_max_tokens && !cancel_requested_.load()) {
-        const llama_token new_token_id = llama_sampler_sample(sampler_, context_, -1);
-
-        llama_sampler_accept(sampler_, new_token_id);
-
-        if (llama_vocab_is_eog(vocab, new_token_id)) {
-            LOGI("End of generation token received");
-            break;
-        }
-
-        const std::string new_token_chars =
-            common_token_to_piece(context_, new_token_id);
-
-        partial_utf8_buffer.append(new_token_chars);
-
-        Utf8State scanner_state;
-        size_t valid_upto = 0;
-        for (size_t i = 0; i < partial_utf8_buffer.size(); ++i) {
-            scanner_state.process(static_cast<uint8_t>(partial_utf8_buffer[i]));
-            if (scanner_state.state == 0) {
-                valid_upto = i + 1;
-            }
-        }
-
-        if (valid_upto > 0) {
-            std::string valid_chunk = partial_utf8_buffer.substr(0, valid_upto);
-            stop_window.append(valid_chunk);
-            partial_utf8_buffer.erase(0, valid_upto);
-
-            size_t found_stop_pos = std::string::npos;
-            for (const auto& stop_seq : STOP_SEQUENCES) {
-                size_t pos = stop_window.find(stop_seq);
-                if (pos != std::string::npos) {
-                    if (found_stop_pos == std::string::npos || pos < found_stop_pos) {
-                        found_stop_pos = pos;
-                    }
-                }
-            }
-
-            if (found_stop_pos != std::string::npos) {
-                LOGI("Stop sequence detected");
-                stop_sequence_hit = true;
-                if (found_stop_pos > 0) {
-                    if (!callback(stop_window.substr(0, found_stop_pos))) {
-                        cancel_requested_.store(true);
-                    }
-                }
-                break;
-            }
-
-            if (stop_window.size() > MAX_STOP_LEN) {
-                size_t safe_len = stop_window.size() - MAX_STOP_LEN;
-                if (!callback(stop_window.substr(0, safe_len))) {
-                    LOGI("Generation cancelled by callback");
-                    cancel_requested_.store(true);
-                    break;
-                }
-                stop_window.erase(0, safe_len);
-            }
-        }
-
-        batch.n_tokens = 0;
-        common_batch_add(batch, new_token_id, n_cur, {0}, true);
-
-        n_cur++;
-        tokens_generated++;
-
-        if (llama_decode(context_, batch) != 0) {
-            LOGE("llama_decode failed during generation");
-            break;
-        }
-    }
-
-    // t5: Record last token time (decode loop exit)
-    if (timing_out != nullptr) {
-        timing_out->t5_last_token_ms = rac_monotonic_now_ms();
-        timing_out->output_tokens = static_cast<int32_t>(tokens_generated);
-    }
-
-    if (!cancel_requested_.load() && !stop_sequence_hit && !stop_window.empty()) {
-        callback(stop_window);
-    }
-
-    llama_memory_clear(llama_get_memory(context_), true);
-
-    llama_batch_free(batch);
-
-    LOGI("Generation with timing complete: %d tokens", tokens_generated);
     return !cancel_requested_.load();
 }
 

--- a/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
@@ -828,6 +828,154 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
     return !cancel_requested_.load();
 }
 
+bool LlamaCppTextGeneration::generate_stream_with_timing(const TextGenerationRequest& request,
+                                                         TextStreamCallback callback,
+                                                         int* out_prompt_tokens,
+                                                         rac_benchmark_timing_t* timing_out) {
+    std::lock_guard<std::mutex> lock(mutex_);
+
+    if (!is_ready()) {
+        LOGE("Model not ready for generation");
+        return false;
+    }
+
+    cancel_requested_.store(false);
+
+    std::string prompt = build_prompt(request);
+    LOGI("Generating with timing, prompt length: %zu", prompt.length());
+
+    const auto tokens_list = common_tokenize(context_, prompt, true, true);
+
+    int n_ctx = llama_n_ctx(context_);
+    int prompt_tokens = static_cast<int>(tokens_list.size());
+
+    if (out_prompt_tokens) {
+        *out_prompt_tokens = prompt_tokens;
+    }
+
+    int available_tokens = n_ctx - prompt_tokens - 4;
+
+    if (available_tokens <= 0) {
+        LOGE("Prompt too long: %d tokens, context size: %d", prompt_tokens, n_ctx);
+        return false;
+    }
+
+    int effective_max_tokens = std::min(request.max_tokens, available_tokens);
+    if (effective_max_tokens < request.max_tokens) {
+        LOGI("Capping max_tokens: %d → %d (context=%d, prompt=%d tokens)", request.max_tokens,
+             effective_max_tokens, n_ctx, prompt_tokens);
+    }
+    LOGI("Generation with timing: prompt_tokens=%d, max_tokens=%d, context=%d", prompt_tokens,
+         effective_max_tokens, n_ctx);
+
+    llama_batch batch = llama_batch_init(n_ctx, 0, 1);
+
+    batch.n_tokens = 0;
+    for (size_t i = 0; i < tokens_list.size(); i++) {
+        common_batch_add(batch, tokens_list[i], i, {0}, false);
+    }
+    batch.logits[batch.n_tokens - 1] = true;
+
+    // t2: Record prefill start (before llama_decode for prompt)
+    if (timing_out != nullptr) {
+        timing_out->t2_prefill_start_ms = rac_monotonic_now_ms();
+    }
+
+    if (llama_decode(context_, batch) != 0) {
+        LOGE("llama_decode failed for prompt");
+        llama_batch_free(batch);
+        return false;
+    }
+
+    // t3: Record prefill end (after llama_decode returns)
+    if (timing_out != nullptr) {
+        timing_out->t3_prefill_end_ms = rac_monotonic_now_ms();
+    }
+
+    llama_sampler_reset(sampler_);
+
+    const auto vocab = llama_model_get_vocab(model_);
+    std::string cached_token_chars;
+    std::string accumulated_text;
+    int n_cur = batch.n_tokens;
+    int tokens_generated = 0;
+
+    while (tokens_generated < effective_max_tokens && !cancel_requested_.load()) {
+        const llama_token new_token_id = llama_sampler_sample(sampler_, context_, -1);
+
+        llama_sampler_accept(sampler_, new_token_id);
+
+        if (llama_vocab_is_eog(vocab, new_token_id)) {
+            LOGI("End of generation token received");
+            break;
+        }
+
+        auto new_token_chars = common_token_to_piece(context_, new_token_id);
+        cached_token_chars += new_token_chars;
+        accumulated_text += new_token_chars;
+
+        static const std::vector<std::string> stop_sequences = {
+            "<|im_end|>",
+            "<|eot_id|>",
+            "</s>",
+            "<|end|>",
+            "<|endoftext|>",
+            "\n\nUser:",
+            "\n\nHuman:",
+        };
+
+        bool hit_stop_sequence = false;
+        for (const auto& stop_seq : stop_sequences) {
+            size_t pos = accumulated_text.find(stop_seq);
+            if (pos != std::string::npos) {
+                LOGI("Stop sequence detected: %s", stop_seq.c_str());
+                hit_stop_sequence = true;
+                break;
+            }
+        }
+
+        if (hit_stop_sequence) {
+            break;
+        }
+
+        if (is_valid_utf8(cached_token_chars.c_str())) {
+            if (!callback(cached_token_chars)) {
+                LOGI("Generation cancelled by callback");
+                cancel_requested_.store(true);
+                break;
+            }
+            cached_token_chars.clear();
+        }
+
+        batch.n_tokens = 0;
+        common_batch_add(batch, new_token_id, n_cur, {0}, true);
+
+        n_cur++;
+        tokens_generated++;
+
+        if (llama_decode(context_, batch) != 0) {
+            LOGE("llama_decode failed during generation");
+            break;
+        }
+    }
+
+    // t5: Record last token time (decode loop exit)
+    if (timing_out != nullptr) {
+        timing_out->t5_last_token_ms = rac_monotonic_now_ms();
+    }
+
+    if (!cached_token_chars.empty() && is_valid_utf8(cached_token_chars.c_str())) {
+        callback(cached_token_chars);
+    }
+
+    llama_memory_clear(llama_get_memory(context_), true);
+
+    llama_batch_free(batch);
+
+    LOGI("Generation with timing complete: %d tokens", tokens_generated);
+    return !cancel_requested_.load();
+}
+
 void LlamaCppTextGeneration::cancel() {
     cancel_requested_.store(true);
     RAC_LOG_INFO("LLM.LlamaCpp","Generation cancel requested");

--- a/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
@@ -900,10 +900,27 @@ bool LlamaCppTextGeneration::generate_stream_with_timing(const TextGenerationReq
     llama_sampler_reset(sampler_);
 
     const auto vocab = llama_model_get_vocab(model_);
-    std::string cached_token_chars;
-    std::string accumulated_text;
+
+    static const std::vector<std::string> STOP_SEQUENCES = {
+        "<|im_end|>", "<|eot_id|>", "</s>", "<|end|>", "<|endoftext|>",
+        "\n\nUser:", "\n\nHuman:",
+    };
+
+    static const size_t MAX_STOP_LEN = []{
+        size_t m = 0;
+        for (const auto& s : STOP_SEQUENCES) m = std::max(m, s.size());
+        return m;
+    }();
+
+    std::string stop_window;
+    stop_window.reserve(MAX_STOP_LEN * 2);
+
+    std::string partial_utf8_buffer;
+    partial_utf8_buffer.reserve(8);
+
     int n_cur = batch.n_tokens;
     int tokens_generated = 0;
+    bool stop_sequence_hit = false;
 
     while (tokens_generated < effective_max_tokens && !cancel_requested_.load()) {
         const llama_token new_token_id = llama_sampler_sample(sampler_, context_, -1);
@@ -915,41 +932,55 @@ bool LlamaCppTextGeneration::generate_stream_with_timing(const TextGenerationReq
             break;
         }
 
-        auto new_token_chars = common_token_to_piece(context_, new_token_id);
-        cached_token_chars += new_token_chars;
-        accumulated_text += new_token_chars;
+        const std::string new_token_chars =
+            common_token_to_piece(context_, new_token_id);
 
-        static const std::vector<std::string> stop_sequences = {
-            "<|im_end|>",
-            "<|eot_id|>",
-            "</s>",
-            "<|end|>",
-            "<|endoftext|>",
-            "\n\nUser:",
-            "\n\nHuman:",
-        };
+        partial_utf8_buffer.append(new_token_chars);
 
-        bool hit_stop_sequence = false;
-        for (const auto& stop_seq : stop_sequences) {
-            size_t pos = accumulated_text.find(stop_seq);
-            if (pos != std::string::npos) {
-                LOGI("Stop sequence detected: %s", stop_seq.c_str());
-                hit_stop_sequence = true;
-                break;
+        Utf8State scanner_state;
+        size_t valid_upto = 0;
+        for (size_t i = 0; i < partial_utf8_buffer.size(); ++i) {
+            scanner_state.process(static_cast<uint8_t>(partial_utf8_buffer[i]));
+            if (scanner_state.state == 0) {
+                valid_upto = i + 1;
             }
         }
 
-        if (hit_stop_sequence) {
-            break;
-        }
+        if (valid_upto > 0) {
+            std::string valid_chunk = partial_utf8_buffer.substr(0, valid_upto);
+            stop_window.append(valid_chunk);
+            partial_utf8_buffer.erase(0, valid_upto);
 
-        if (is_valid_utf8(cached_token_chars.c_str())) {
-            if (!callback(cached_token_chars)) {
-                LOGI("Generation cancelled by callback");
-                cancel_requested_.store(true);
+            size_t found_stop_pos = std::string::npos;
+            for (const auto& stop_seq : STOP_SEQUENCES) {
+                size_t pos = stop_window.find(stop_seq);
+                if (pos != std::string::npos) {
+                    if (found_stop_pos == std::string::npos || pos < found_stop_pos) {
+                        found_stop_pos = pos;
+                    }
+                }
+            }
+
+            if (found_stop_pos != std::string::npos) {
+                LOGI("Stop sequence detected");
+                stop_sequence_hit = true;
+                if (found_stop_pos > 0) {
+                    if (!callback(stop_window.substr(0, found_stop_pos))) {
+                        cancel_requested_.store(true);
+                    }
+                }
                 break;
             }
-            cached_token_chars.clear();
+
+            if (stop_window.size() > MAX_STOP_LEN) {
+                size_t safe_len = stop_window.size() - MAX_STOP_LEN;
+                if (!callback(stop_window.substr(0, safe_len))) {
+                    LOGI("Generation cancelled by callback");
+                    cancel_requested_.store(true);
+                    break;
+                }
+                stop_window.erase(0, safe_len);
+            }
         }
 
         batch.n_tokens = 0;
@@ -967,10 +998,11 @@ bool LlamaCppTextGeneration::generate_stream_with_timing(const TextGenerationReq
     // t5: Record last token time (decode loop exit)
     if (timing_out != nullptr) {
         timing_out->t5_last_token_ms = rac_monotonic_now_ms();
+        timing_out->output_tokens = static_cast<int32_t>(tokens_generated);
     }
 
-    if (!cached_token_chars.empty() && is_valid_utf8(cached_token_chars.c_str())) {
-        callback(cached_token_chars);
+    if (!cancel_requested_.load() && !stop_sequence_hit && !stop_window.empty()) {
+        callback(stop_window);
     }
 
     llama_memory_clear(llama_get_memory(context_), true);

--- a/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.h
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.h
@@ -135,20 +135,25 @@ class LlamaCppTextGeneration {
     bool unload_model();
 
     TextGenerationResult generate(const TextGenerationRequest& request);
-    bool generate_stream(const TextGenerationRequest& request, TextStreamCallback callback) {
-        return generate_stream(request, callback, nullptr);
-    }
-    bool generate_stream(const TextGenerationRequest& request, TextStreamCallback callback,
-                         int* out_prompt_tokens);
 
     /**
-     * Generate text with streaming and benchmark timing.
-     * Captures t2 (prefill start), t3 (prefill end), t5 (last token).
-     * @param timing_out Benchmark timing struct (can be NULL for no timing)
+     * Generate text with streaming, optional prompt-token output, and optional benchmark timing.
+     *
+     * When @p timing_out is non-null, captures:
+     *   - t2_prefill_start_ms: before the first llama_decode on the prompt
+     *   - t3_prefill_end_ms:   after the prompt prefill loop completes
+     *   - t5_last_token_ms:    after the decode loop exits
+     *   - output_tokens:       number of tokens generated
+     * Note: t4 (first token) is written at the LLM component layer, not in the backend.
+     *
+     * @param request           Generation request.
+     * @param callback          Streaming callback; return false to cancel.
+     * @param out_prompt_tokens Optional: tokenized prompt length (may be NULL).
+     * @param timing_out        Optional: benchmark timing struct (may be NULL for no timing).
      */
-    bool generate_stream_with_timing(const TextGenerationRequest& request,
-                                     TextStreamCallback callback, int* out_prompt_tokens,
-                                     rac_benchmark_timing_t* timing_out);
+    bool generate_stream(const TextGenerationRequest& request, TextStreamCallback callback,
+                         int* out_prompt_tokens = nullptr,
+                         rac_benchmark_timing_t* timing_out = nullptr);
 
     void cancel();
 

--- a/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.h
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.h
@@ -18,6 +18,8 @@
 
 #include <nlohmann/json.hpp>
 
+#include "rac/core/rac_benchmark.h"
+
 namespace runanywhere {
 
 // =============================================================================
@@ -138,6 +140,16 @@ class LlamaCppTextGeneration {
     }
     bool generate_stream(const TextGenerationRequest& request, TextStreamCallback callback,
                          int* out_prompt_tokens);
+
+    /**
+     * Generate text with streaming and benchmark timing.
+     * Captures t2 (prefill start), t3 (prefill end), t5 (last token).
+     * @param timing_out Benchmark timing struct (can be NULL for no timing)
+     */
+    bool generate_stream_with_timing(const TextGenerationRequest& request,
+                                     TextStreamCallback callback, int* out_prompt_tokens,
+                                     rac_benchmark_timing_t* timing_out);
+
     void cancel();
 
     /**

--- a/sdk/runanywhere-commons/src/backends/llamacpp/rac_backend_llamacpp_register.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/rac_backend_llamacpp_register.cpp
@@ -64,6 +64,18 @@ static rac_result_t llamacpp_vtable_generate_stream(void* impl, const char* prom
                                             &adapter);
 }
 
+// Generate stream with benchmark timing
+static rac_result_t llamacpp_vtable_generate_stream_with_timing(void* impl, const char* prompt,
+                                                                const rac_llm_options_t* options,
+                                                                rac_llm_stream_callback_fn callback,
+                                                                void* user_data,
+                                                                rac_benchmark_timing_t* timing_out) {
+    StreamAdapter adapter = {callback, user_data};
+    return rac_llm_llamacpp_generate_stream_with_timing(impl, prompt, options,
+                                                        stream_adapter_callback, &adapter,
+                                                        timing_out);
+}
+
 // Get info
 static rac_result_t llamacpp_vtable_get_info(void* impl, rac_llm_info_t* out_info) {
     if (!out_info)
@@ -151,6 +163,7 @@ static const rac_llm_service_ops_t g_llamacpp_ops = {
     .initialize = llamacpp_vtable_initialize,
     .generate = llamacpp_vtable_generate,
     .generate_stream = llamacpp_vtable_generate_stream,
+    .generate_stream_with_timing = llamacpp_vtable_generate_stream_with_timing,
     .get_info = llamacpp_vtable_get_info,
     .cancel = llamacpp_vtable_cancel,
     .cleanup = llamacpp_vtable_cleanup,

--- a/sdk/runanywhere-commons/src/backends/llamacpp/rac_llm_llamacpp.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/rac_llm_llamacpp.cpp
@@ -296,6 +296,52 @@ rac_result_t rac_llm_llamacpp_generate_stream(rac_handle_t handle, const char* p
     return success ? RAC_SUCCESS : RAC_ERROR_INFERENCE_FAILED;
 }
 
+rac_result_t rac_llm_llamacpp_generate_stream_with_timing(rac_handle_t handle, const char* prompt,
+                                                          const rac_llm_options_t* options,
+                                                          rac_llm_llamacpp_stream_callback_fn callback,
+                                                          void* user_data,
+                                                          rac_benchmark_timing_t* timing_out) {
+    if (handle == nullptr || prompt == nullptr || callback == nullptr) {
+        return RAC_ERROR_NULL_POINTER;
+    }
+
+    auto* h = static_cast<rac_llm_llamacpp_handle_impl*>(handle);
+    if (!h->text_gen) {
+        return RAC_ERROR_INVALID_HANDLE;
+    }
+
+    runanywhere::TextGenerationRequest request;
+    request.prompt = prompt;
+    if (options != nullptr) {
+        request.max_tokens = options->max_tokens;
+        request.temperature = options->temperature;
+        request.top_p = options->top_p;
+        if (options->stop_sequences != nullptr && options->num_stop_sequences > 0) {
+            for (int32_t i = 0; i < options->num_stop_sequences; i++) {
+                if (options->stop_sequences[i]) {
+                    request.stop_sequences.push_back(options->stop_sequences[i]);
+                }
+            }
+        }
+    }
+
+    // Stream using C++ class with timing
+    bool success = h->text_gen->generate_stream_with_timing(
+        request,
+        [callback, user_data](const std::string& token) -> bool {
+            return callback(token.c_str(), RAC_FALSE, user_data) == RAC_TRUE;
+        },
+        nullptr,    // out_prompt_tokens not needed, timing is captured internally
+        timing_out  // Pass timing struct to backend
+    );
+
+    if (success) {
+        callback("", RAC_TRUE, user_data);  // Final token
+    }
+
+    return success ? RAC_SUCCESS : RAC_ERROR_INFERENCE_FAILED;
+}
+
 void rac_llm_llamacpp_cancel(rac_handle_t handle) {
     if (handle == nullptr) {
         return;

--- a/sdk/runanywhere-commons/src/backends/llamacpp/rac_llm_llamacpp.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/rac_llm_llamacpp.cpp
@@ -316,6 +316,9 @@ rac_result_t rac_llm_llamacpp_generate_stream_with_timing(rac_handle_t handle, c
         request.max_tokens = options->max_tokens;
         request.temperature = options->temperature;
         request.top_p = options->top_p;
+        if (options->system_prompt != nullptr) {
+            request.system_prompt = options->system_prompt;
+        }
         if (options->stop_sequences != nullptr && options->num_stop_sequences > 0) {
             for (int32_t i = 0; i < options->num_stop_sequences; i++) {
                 if (options->stop_sequences[i]) {
@@ -325,16 +328,24 @@ rac_result_t rac_llm_llamacpp_generate_stream_with_timing(rac_handle_t handle, c
         }
     }
 
-    // Stream using C++ class with timing
+    // Stream using C++ class with timing (see generate for rationale on try-catch)
     int prompt_tokens = 0;
-    bool success = h->text_gen->generate_stream_with_timing(
-        request,
-        [callback, user_data](const std::string& token) -> bool {
-            return callback(token.c_str(), RAC_FALSE, user_data) == RAC_TRUE;
-        },
-        &prompt_tokens,
-        timing_out
-    );
+    bool success = false;
+    try {
+        success = h->text_gen->generate_stream(
+            request,
+            [callback, user_data](const std::string& token) -> bool {
+                return callback(token.c_str(), RAC_FALSE, user_data) == RAC_TRUE;
+            },
+            &prompt_tokens,
+            timing_out);
+    } catch (const std::exception& e) {
+        rac_error_set_details(e.what());
+        return RAC_ERROR_INFERENCE_FAILED;
+    } catch (...) {
+        rac_error_set_details("Unknown C++ exception during timed streaming LLM generation");
+        return RAC_ERROR_INFERENCE_FAILED;
+    }
 
     // Capture prompt token count in timing struct
     if (timing_out != nullptr && prompt_tokens > 0) {

--- a/sdk/runanywhere-commons/src/backends/llamacpp/rac_llm_llamacpp.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/rac_llm_llamacpp.cpp
@@ -326,14 +326,20 @@ rac_result_t rac_llm_llamacpp_generate_stream_with_timing(rac_handle_t handle, c
     }
 
     // Stream using C++ class with timing
+    int prompt_tokens = 0;
     bool success = h->text_gen->generate_stream_with_timing(
         request,
         [callback, user_data](const std::string& token) -> bool {
             return callback(token.c_str(), RAC_FALSE, user_data) == RAC_TRUE;
         },
-        nullptr,    // out_prompt_tokens not needed, timing is captured internally
-        timing_out  // Pass timing struct to backend
+        &prompt_tokens,
+        timing_out
     );
+
+    // Capture prompt token count in timing struct
+    if (timing_out != nullptr && prompt_tokens > 0) {
+        timing_out->prompt_tokens = static_cast<int32_t>(prompt_tokens);
+    }
 
     if (success) {
         callback("", RAC_TRUE, user_data);  // Final token

--- a/sdk/runanywhere-commons/src/core/rac_benchmark.cpp
+++ b/sdk/runanywhere-commons/src/core/rac_benchmark.cpp
@@ -1,0 +1,55 @@
+/**
+ * @file rac_benchmark.cpp
+ * @brief RunAnywhere Commons - Benchmark Timing Implementation
+ *
+ * Implements monotonic time helper and benchmark timing utilities.
+ * Uses std::chrono::steady_clock for accurate, cross-platform timing
+ * that is not affected by system clock adjustments.
+ */
+
+#include "rac/core/rac_benchmark.h"
+
+#include <chrono>
+#include <cstring>
+
+namespace {
+
+/**
+ * Process-local epoch for monotonic timing.
+ * Initialized on first call to rac_monotonic_now_ms().
+ * Using a local epoch keeps timestamp values small and manageable.
+ */
+class MonotonicEpoch {
+   public:
+    static MonotonicEpoch& instance() {
+        static MonotonicEpoch epoch;
+        return epoch;
+    }
+
+    int64_t elapsed_ms() const {
+        auto now = std::chrono::steady_clock::now();
+        auto duration = now - epoch_;
+        return std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
+    }
+
+   private:
+    MonotonicEpoch() : epoch_(std::chrono::steady_clock::now()) {}
+
+    std::chrono::steady_clock::time_point epoch_;
+};
+
+}  // namespace
+
+extern "C" {
+
+int64_t rac_monotonic_now_ms(void) {
+    return MonotonicEpoch::instance().elapsed_ms();
+}
+
+void rac_benchmark_timing_init(rac_benchmark_timing_t* timing) {
+    if (timing != nullptr) {
+        std::memset(timing, 0, sizeof(rac_benchmark_timing_t));
+    }
+}
+
+}  // extern "C"

--- a/sdk/runanywhere-commons/src/core/rac_benchmark_log.cpp
+++ b/sdk/runanywhere-commons/src/core/rac_benchmark_log.cpp
@@ -117,7 +117,7 @@ char* rac_benchmark_timing_to_csv(const rac_benchmark_timing_t* timing, rac_bool
         char buf[512];
         snprintf(buf, sizeof(buf),
                  "%" PRId64 ",%" PRId64 ",%" PRId64 ",%" PRId64 ",%" PRId64 ",%" PRId64
-                 ",%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%.2f",
+                 ",%" PRId32 ",%" PRId32 ",%" PRId32 ",%" PRId32 ",%.2f,%.2f,%.2f,%.2f,%.2f",
                  timing->t0_request_start_ms, timing->t2_prefill_start_ms,
                  timing->t3_prefill_end_ms, timing->t4_first_token_ms, timing->t5_last_token_ms,
                  timing->t6_request_end_ms, timing->prompt_tokens, timing->output_tokens,

--- a/sdk/runanywhere-commons/src/core/rac_benchmark_log.cpp
+++ b/sdk/runanywhere-commons/src/core/rac_benchmark_log.cpp
@@ -1,0 +1,156 @@
+/**
+ * @file rac_benchmark_log.cpp
+ * @brief RunAnywhere Commons - Benchmark Logging Implementation
+ *
+ * Serializes benchmark timing data to JSON and CSV formats,
+ * and provides a convenience function to log via the RAC logging system.
+ */
+
+#include "rac/core/rac_benchmark_log.h"
+
+#include <cinttypes>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "rac/core/rac_logger.h"
+
+namespace {
+
+/**
+ * Computes a derived metric (difference) safely.
+ * Returns 0.0 if either timestamp is 0 (not captured).
+ */
+double safe_diff(int64_t end_ms, int64_t start_ms) {
+    if (end_ms <= 0 || start_ms <= 0) {
+        return 0.0;
+    }
+    return static_cast<double>(end_ms - start_ms);
+}
+
+/**
+ * Computes decode throughput in tokens/second.
+ * Returns 0.0 if decode time is 0 or output_tokens is 0.
+ */
+double decode_tps(const rac_benchmark_timing_t* t) {
+    double decode_ms = safe_diff(t->t5_last_token_ms, t->t3_prefill_end_ms);
+    if (decode_ms <= 0.0 || t->output_tokens <= 0) {
+        return 0.0;
+    }
+    return static_cast<double>(t->output_tokens) / decode_ms * 1000.0;
+}
+
+}  // namespace
+
+extern "C" {
+
+char* rac_benchmark_timing_to_json(const rac_benchmark_timing_t* timing) {
+    if (timing == nullptr) {
+        return nullptr;
+    }
+
+    double ttft_ms = safe_diff(timing->t4_first_token_ms, timing->t0_request_start_ms);
+    double prefill_ms = safe_diff(timing->t3_prefill_end_ms, timing->t2_prefill_start_ms);
+    double decode_ms_val = safe_diff(timing->t5_last_token_ms, timing->t3_prefill_end_ms);
+    double e2e_ms = safe_diff(timing->t6_request_end_ms, timing->t0_request_start_ms);
+    double tps = decode_tps(timing);
+
+    // Build JSON string
+    std::string json;
+    json.reserve(512);
+    json += "{";
+    json += "\"t0_request_start_ms\":" + std::to_string(timing->t0_request_start_ms) + ",";
+    json += "\"t2_prefill_start_ms\":" + std::to_string(timing->t2_prefill_start_ms) + ",";
+    json += "\"t3_prefill_end_ms\":" + std::to_string(timing->t3_prefill_end_ms) + ",";
+    json += "\"t4_first_token_ms\":" + std::to_string(timing->t4_first_token_ms) + ",";
+    json += "\"t5_last_token_ms\":" + std::to_string(timing->t5_last_token_ms) + ",";
+    json += "\"t6_request_end_ms\":" + std::to_string(timing->t6_request_end_ms) + ",";
+    json += "\"prompt_tokens\":" + std::to_string(timing->prompt_tokens) + ",";
+    json += "\"output_tokens\":" + std::to_string(timing->output_tokens) + ",";
+    json += "\"status\":" + std::to_string(timing->status) + ",";
+    json += "\"error_code\":" + std::to_string(timing->error_code) + ",";
+
+    // Derived metrics
+    char buf[64];
+    snprintf(buf, sizeof(buf), "%.2f", ttft_ms);
+    json += "\"ttft_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", prefill_ms);
+    json += "\"prefill_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", decode_ms_val);
+    json += "\"decode_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", e2e_ms);
+    json += "\"e2e_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", tps);
+    json += "\"decode_tps\":" + std::string(buf);
+
+    json += "}";
+
+    // Copy to heap-allocated C string
+    char* result = static_cast<char*>(malloc(json.size() + 1));
+    if (result != nullptr) {
+        memcpy(result, json.c_str(), json.size() + 1);
+    }
+    return result;
+}
+
+char* rac_benchmark_timing_to_csv(const rac_benchmark_timing_t* timing, rac_bool_t header) {
+    std::string csv;
+    csv.reserve(256);
+
+    if (header) {
+        csv = "t0_request_start_ms,t2_prefill_start_ms,t3_prefill_end_ms,"
+              "t4_first_token_ms,t5_last_token_ms,t6_request_end_ms,"
+              "prompt_tokens,output_tokens,status,error_code,"
+              "ttft_ms,prefill_ms,decode_ms,e2e_ms,decode_tps";
+    } else {
+        if (timing == nullptr) {
+            return nullptr;
+        }
+
+        double ttft_ms = safe_diff(timing->t4_first_token_ms, timing->t0_request_start_ms);
+        double prefill_ms = safe_diff(timing->t3_prefill_end_ms, timing->t2_prefill_start_ms);
+        double decode_ms_val = safe_diff(timing->t5_last_token_ms, timing->t3_prefill_end_ms);
+        double e2e_ms = safe_diff(timing->t6_request_end_ms, timing->t0_request_start_ms);
+        double tps = decode_tps(timing);
+
+        char buf[512];
+        snprintf(buf, sizeof(buf),
+                 "%" PRId64 ",%" PRId64 ",%" PRId64 ",%" PRId64 ",%" PRId64 ",%" PRId64
+                 ",%d,%d,%d,%d,%.2f,%.2f,%.2f,%.2f,%.2f",
+                 timing->t0_request_start_ms, timing->t2_prefill_start_ms,
+                 timing->t3_prefill_end_ms, timing->t4_first_token_ms, timing->t5_last_token_ms,
+                 timing->t6_request_end_ms, timing->prompt_tokens, timing->output_tokens,
+                 timing->status, timing->error_code, ttft_ms, prefill_ms, decode_ms_val, e2e_ms,
+                 tps);
+        csv = buf;
+    }
+
+    char* result = static_cast<char*>(malloc(csv.size() + 1));
+    if (result != nullptr) {
+        memcpy(result, csv.c_str(), csv.size() + 1);
+    }
+    return result;
+}
+
+void rac_benchmark_timing_log(const rac_benchmark_timing_t* timing, const char* label) {
+    if (timing == nullptr) {
+        return;
+    }
+
+    double ttft_ms = safe_diff(timing->t4_first_token_ms, timing->t0_request_start_ms);
+    double prefill_ms = safe_diff(timing->t3_prefill_end_ms, timing->t2_prefill_start_ms);
+    double decode_ms_val = safe_diff(timing->t5_last_token_ms, timing->t3_prefill_end_ms);
+    double e2e_ms = safe_diff(timing->t6_request_end_ms, timing->t0_request_start_ms);
+    double tps = decode_tps(timing);
+
+    const char* tag = (label != nullptr) ? label : "run";
+
+    RAC_LOG_INFO("Benchmark",
+                 "[%s] TTFT=%.1fms prefill=%.1fms decode=%.1fms E2E=%.1fms "
+                 "prompt=%d output=%d tps=%.1f status=%d error=%d",
+                 tag, ttft_ms, prefill_ms, decode_ms_val, e2e_ms, timing->prompt_tokens,
+                 timing->output_tokens, tps, timing->status, timing->error_code);
+}
+
+}  // extern "C"

--- a/sdk/runanywhere-commons/src/core/rac_benchmark_log.cpp
+++ b/sdk/runanywhere-commons/src/core/rac_benchmark_log.cpp
@@ -14,6 +14,7 @@
 #include <cstring>
 #include <string>
 
+#include "rac/core/rac_error.h"
 #include "rac/core/rac_logger.h"
 
 namespace {
@@ -41,13 +42,30 @@ double decode_tps(const rac_benchmark_timing_t* t) {
     return static_cast<double>(t->output_tokens) / decode_ms * 1000.0;
 }
 
+/**
+ * Duplicates a std::string to a heap-allocated C string.
+ * Returns nullptr on allocation failure.
+ */
+char* strdup_from_string(const std::string& s) {
+    char* result = static_cast<char*>(malloc(s.size() + 1));
+    if (result != nullptr) {
+        memcpy(result, s.c_str(), s.size() + 1);
+    }
+    return result;
+}
+
 }  // namespace
 
 extern "C" {
 
-char* rac_benchmark_timing_to_json(const rac_benchmark_timing_t* timing) {
+rac_result_t rac_benchmark_timing_to_json(const rac_benchmark_timing_t* timing, char** out_json) {
+    if (out_json == nullptr) {
+        return RAC_ERROR_NULL_POINTER;
+    }
+    *out_json = nullptr;
+
     if (timing == nullptr) {
-        return nullptr;
+        return RAC_ERROR_NULL_POINTER;
     }
 
     double ttft_ms = safe_diff(timing->t4_first_token_ms, timing->t0_request_start_ms);
@@ -87,14 +105,22 @@ char* rac_benchmark_timing_to_json(const rac_benchmark_timing_t* timing) {
     json += "}";
 
     // Copy to heap-allocated C string
-    char* result = static_cast<char*>(malloc(json.size() + 1));
-    if (result != nullptr) {
-        memcpy(result, json.c_str(), json.size() + 1);
+    char* result = strdup_from_string(json);
+    if (result == nullptr) {
+        return RAC_ERROR_OUT_OF_MEMORY;
     }
-    return result;
+
+    *out_json = result;
+    return RAC_SUCCESS;
 }
 
-char* rac_benchmark_timing_to_csv(const rac_benchmark_timing_t* timing, rac_bool_t header) {
+rac_result_t rac_benchmark_timing_to_csv(const rac_benchmark_timing_t* timing, rac_bool_t header,
+                                         char** out_csv) {
+    if (out_csv == nullptr) {
+        return RAC_ERROR_NULL_POINTER;
+    }
+    *out_csv = nullptr;
+
     std::string csv;
     csv.reserve(256);
 
@@ -105,7 +131,7 @@ char* rac_benchmark_timing_to_csv(const rac_benchmark_timing_t* timing, rac_bool
               "ttft_ms,prefill_ms,decode_ms,e2e_ms,decode_tps";
     } else {
         if (timing == nullptr) {
-            return nullptr;
+            return RAC_ERROR_NULL_POINTER;
         }
 
         double ttft_ms = safe_diff(timing->t4_first_token_ms, timing->t0_request_start_ms);
@@ -126,16 +152,18 @@ char* rac_benchmark_timing_to_csv(const rac_benchmark_timing_t* timing, rac_bool
         csv = buf;
     }
 
-    char* result = static_cast<char*>(malloc(csv.size() + 1));
-    if (result != nullptr) {
-        memcpy(result, csv.c_str(), csv.size() + 1);
+    char* result = strdup_from_string(csv);
+    if (result == nullptr) {
+        return RAC_ERROR_OUT_OF_MEMORY;
     }
-    return result;
+
+    *out_csv = result;
+    return RAC_SUCCESS;
 }
 
-void rac_benchmark_timing_log(const rac_benchmark_timing_t* timing, const char* label) {
+rac_result_t rac_benchmark_timing_log(const rac_benchmark_timing_t* timing, const char* label) {
     if (timing == nullptr) {
-        return;
+        return RAC_ERROR_NULL_POINTER;
     }
 
     double ttft_ms = safe_diff(timing->t4_first_token_ms, timing->t0_request_start_ms);
@@ -151,6 +179,8 @@ void rac_benchmark_timing_log(const rac_benchmark_timing_t* timing, const char* 
                  "prompt=%d output=%d tps=%.1f status=%d error=%d",
                  tag, ttft_ms, prefill_ms, decode_ms_val, e2e_ms, timing->prompt_tokens,
                  timing->output_tokens, tps, timing->status, timing->error_code);
+
+    return RAC_SUCCESS;
 }
 
 }  // extern "C"

--- a/sdk/runanywhere-commons/src/core/rac_benchmark_metrics.cpp
+++ b/sdk/runanywhere-commons/src/core/rac_benchmark_metrics.cpp
@@ -1,0 +1,77 @@
+/**
+ * @file rac_benchmark_metrics.cpp
+ * @brief RunAnywhere Commons - Extended Benchmark Metrics Implementation
+ *
+ * Implements the metrics provider registry. Platform SDKs (iOS/Android)
+ * register a provider callback during initialization. The commons layer
+ * calls rac_benchmark_capture_metrics() at t0 and t6 to snapshot device state.
+ */
+
+#include "rac/core/rac_benchmark_metrics.h"
+
+#include <atomic>
+#include <cstring>
+
+namespace {
+
+struct MetricsProvider {
+    rac_benchmark_metrics_provider_fn fn = nullptr;
+    void* user_data = nullptr;
+};
+
+// Atomic pointer for lock-free provider access.
+// Provider registration is rare; reads are frequent.
+std::atomic<MetricsProvider*> g_provider{nullptr};
+
+// Storage for the current provider (swapped atomically)
+MetricsProvider g_provider_storage[2];
+std::atomic<int> g_provider_index{0};
+
+}  // namespace
+
+extern "C" {
+
+void rac_benchmark_extended_metrics_init(rac_benchmark_extended_metrics_t* metrics) {
+    if (metrics == nullptr) {
+        return;
+    }
+    metrics->memory_usage_bytes = -1;
+    metrics->memory_peak_bytes = -1;
+    metrics->cpu_temperature_celsius = -1.0f;
+    metrics->battery_level = -1.0f;
+    metrics->gpu_utilization_percent = -1.0f;
+    metrics->thermal_state = -1;
+}
+
+void rac_benchmark_set_metrics_provider(rac_benchmark_metrics_provider_fn provider,
+                                         void* user_data) {
+    if (provider == nullptr) {
+        g_provider.store(nullptr, std::memory_order_release);
+        return;
+    }
+
+    // Use double-buffering to avoid data races on the provider struct
+    int idx = g_provider_index.load(std::memory_order_relaxed);
+    int next = 1 - idx;
+    g_provider_storage[next].fn = provider;
+    g_provider_storage[next].user_data = user_data;
+    g_provider.store(&g_provider_storage[next], std::memory_order_release);
+    g_provider_index.store(next, std::memory_order_relaxed);
+}
+
+void rac_benchmark_capture_metrics(rac_benchmark_extended_metrics_t* out) {
+    if (out == nullptr) {
+        return;
+    }
+
+    // Initialize to unavailable
+    rac_benchmark_extended_metrics_init(out);
+
+    // Call provider if registered
+    MetricsProvider* provider = g_provider.load(std::memory_order_acquire);
+    if (provider != nullptr && provider->fn != nullptr) {
+        provider->fn(out, provider->user_data);
+    }
+}
+
+}  // extern "C"

--- a/sdk/runanywhere-commons/src/core/rac_benchmark_metrics.cpp
+++ b/sdk/runanywhere-commons/src/core/rac_benchmark_metrics.cpp
@@ -9,24 +9,38 @@
 
 #include "rac/core/rac_benchmark_metrics.h"
 
-#include <atomic>
 #include <cstring>
+#include <memory>
 #include <mutex>
 
 namespace {
 
-struct MetricsProvider {
+struct ProviderWrapper {
     rac_benchmark_metrics_provider_fn fn = nullptr;
     void* user_data = nullptr;
 };
 
-// Atomic pointer for lock-free provider access.
-// Provider registration is rare; reads are frequent.
-std::atomic<MetricsProvider*> g_provider{nullptr};
+// Published as a shared_ptr under a mutex so concurrent capture callers keep
+// the wrapper (fn + user_data) alive for the duration of their invocation,
+// even if the platform unregisters or replaces the provider mid-call.
+//
+// A std::atomic<std::shared_ptr<T>> would be preferable, but Apple Clang's
+// libc++ has not yet shipped the C++20 specialization (requires trivially
+// copyable T). A short mutex-guarded load/store is equally lifetime-safe and
+// only marginally slower on the capture path — which is invoked twice per
+// benchmark, not in a hot loop.
+std::mutex g_provider_mutex;
+std::shared_ptr<ProviderWrapper> g_provider;
 
-// Storage for the current provider (swapped atomically)
-MetricsProvider g_provider_storage[2];
-std::atomic<int> g_provider_index{0};
+std::shared_ptr<ProviderWrapper> load_provider() {
+    std::lock_guard<std::mutex> lock(g_provider_mutex);
+    return g_provider;
+}
+
+void store_provider(std::shared_ptr<ProviderWrapper> next) {
+    std::lock_guard<std::mutex> lock(g_provider_mutex);
+    g_provider = std::move(next);
+}
 
 }  // namespace
 
@@ -46,21 +60,12 @@ void rac_benchmark_extended_metrics_init(rac_benchmark_extended_metrics_t* metri
 
 void rac_benchmark_set_metrics_provider(rac_benchmark_metrics_provider_fn provider,
                                          void* user_data) {
-    static std::mutex write_mutex;
-
     if (provider == nullptr) {
-        g_provider.store(nullptr, std::memory_order_release);
+        store_provider(nullptr);
         return;
     }
 
-    // Serialize the rare registration path to prevent torn fn/user_data pairs
-    std::lock_guard<std::mutex> lock(write_mutex);
-    int idx = g_provider_index.load(std::memory_order_relaxed);
-    int next = 1 - idx;
-    g_provider_storage[next].fn = provider;
-    g_provider_storage[next].user_data = user_data;
-    g_provider.store(&g_provider_storage[next], std::memory_order_release);
-    g_provider_index.store(next, std::memory_order_relaxed);
+    store_provider(std::make_shared<ProviderWrapper>(ProviderWrapper{provider, user_data}));
 }
 
 void rac_benchmark_capture_metrics(rac_benchmark_extended_metrics_t* out) {
@@ -71,10 +76,12 @@ void rac_benchmark_capture_metrics(rac_benchmark_extended_metrics_t* out) {
     // Initialize to unavailable
     rac_benchmark_extended_metrics_init(out);
 
-    // Call provider if registered
-    MetricsProvider* provider = g_provider.load(std::memory_order_acquire);
-    if (provider != nullptr && provider->fn != nullptr) {
-        provider->fn(out, provider->user_data);
+    // Snapshot the provider; the local shared_ptr keeps the wrapper (and its
+    // user_data pointer) alive for the duration of the call, even if another
+    // thread concurrently unregisters or replaces it.
+    auto local = load_provider();
+    if (local && local->fn != nullptr) {
+        local->fn(out, local->user_data);
     }
 }
 

--- a/sdk/runanywhere-commons/src/core/rac_benchmark_stats.cpp
+++ b/sdk/runanywhere-commons/src/core/rac_benchmark_stats.cpp
@@ -1,0 +1,324 @@
+/**
+ * @file rac_benchmark_stats.cpp
+ * @brief RunAnywhere Commons - Benchmark Statistical Analysis Implementation
+ *
+ * Collects derived metrics from timing observations and computes
+ * percentiles, mean, stddev, and outlier counts.
+ */
+
+#include "rac/core/rac_benchmark_stats.h"
+
+#include "rac/core/rac_error.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace {
+
+/**
+ * Internal stats collector.
+ * Stores vectors of derived metrics extracted from timing observations.
+ */
+class BenchmarkStatsCollector {
+   public:
+    void record(const rac_benchmark_timing_t* timing) {
+        if (timing == nullptr) {
+            return;
+        }
+
+        // Only record successful observations
+        if (timing->status != RAC_BENCHMARK_STATUS_SUCCESS) {
+            return;
+        }
+
+        std::lock_guard<std::mutex> lock(mutex_);
+
+        // TTFT: t4 - t0
+        if (timing->t4_first_token_ms > 0 && timing->t0_request_start_ms > 0) {
+            ttft_values_.push_back(
+                static_cast<double>(timing->t4_first_token_ms - timing->t0_request_start_ms));
+        }
+
+        // Prefill: t3 - t2
+        if (timing->t3_prefill_end_ms > 0 && timing->t2_prefill_start_ms > 0) {
+            prefill_values_.push_back(
+                static_cast<double>(timing->t3_prefill_end_ms - timing->t2_prefill_start_ms));
+        }
+
+        // Decode TPS: output_tokens / (t5 - t3) * 1000
+        if (timing->t5_last_token_ms > 0 && timing->t3_prefill_end_ms > 0 &&
+            timing->output_tokens > 0) {
+            double decode_ms =
+                static_cast<double>(timing->t5_last_token_ms - timing->t3_prefill_end_ms);
+            if (decode_ms > 0.0) {
+                decode_tps_values_.push_back(
+                    static_cast<double>(timing->output_tokens) / decode_ms * 1000.0);
+            }
+        }
+
+        // E2E: t6 - t0
+        if (timing->t6_request_end_ms > 0 && timing->t0_request_start_ms > 0) {
+            e2e_values_.push_back(
+                static_cast<double>(timing->t6_request_end_ms - timing->t0_request_start_ms));
+        }
+
+        count_++;
+    }
+
+    void reset() {
+        std::lock_guard<std::mutex> lock(mutex_);
+        ttft_values_.clear();
+        prefill_values_.clear();
+        decode_tps_values_.clear();
+        e2e_values_.clear();
+        count_ = 0;
+    }
+
+    int32_t count() const {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return count_;
+    }
+
+    rac_result_t get_summary(rac_benchmark_summary_t* out) {
+        if (out == nullptr) {
+            return RAC_ERROR_NULL_POINTER;
+        }
+
+        std::lock_guard<std::mutex> lock(mutex_);
+        std::memset(out, 0, sizeof(rac_benchmark_summary_t));
+
+        if (count_ == 0) {
+            return RAC_ERROR_INVALID_STATE;
+        }
+
+        out->count = count_;
+
+        // TTFT stats
+        if (!ttft_values_.empty()) {
+            auto sorted = ttft_values_;
+            std::sort(sorted.begin(), sorted.end());
+            out->ttft_p50_ms = percentile(sorted, 50);
+            out->ttft_p95_ms = percentile(sorted, 95);
+            out->ttft_p99_ms = percentile(sorted, 99);
+            out->ttft_min_ms = sorted.front();
+            out->ttft_max_ms = sorted.back();
+            out->ttft_mean_ms = mean(sorted);
+            out->ttft_stddev_ms = stddev(sorted, out->ttft_mean_ms);
+        }
+
+        // Prefill stats
+        if (!prefill_values_.empty()) {
+            auto sorted = prefill_values_;
+            std::sort(sorted.begin(), sorted.end());
+            out->prefill_p50_ms = percentile(sorted, 50);
+            out->prefill_p95_ms = percentile(sorted, 95);
+            out->prefill_p99_ms = percentile(sorted, 99);
+        }
+
+        // Decode TPS stats
+        if (!decode_tps_values_.empty()) {
+            auto sorted = decode_tps_values_;
+            std::sort(sorted.begin(), sorted.end());
+            out->decode_tps_p50 = percentile(sorted, 50);
+            out->decode_tps_p95 = percentile(sorted, 95);
+            out->decode_tps_p99 = percentile(sorted, 99);
+        }
+
+        // E2E stats + outlier detection
+        if (!e2e_values_.empty()) {
+            auto sorted = e2e_values_;
+            std::sort(sorted.begin(), sorted.end());
+            out->e2e_p50_ms = percentile(sorted, 50);
+            out->e2e_p95_ms = percentile(sorted, 95);
+            out->e2e_p99_ms = percentile(sorted, 99);
+
+            // Outlier detection: count observations > mean + 2*stddev
+            double e2e_mean = mean(sorted);
+            double e2e_sd = stddev(sorted, e2e_mean);
+            double threshold = e2e_mean + 2.0 * e2e_sd;
+            int32_t outliers = 0;
+            for (double val : e2e_values_) {
+                if (val > threshold) {
+                    outliers++;
+                }
+            }
+            out->outlier_count = outliers;
+        }
+
+        return RAC_SUCCESS;
+    }
+
+   private:
+    /**
+     * Nearest-rank percentile calculation.
+     * Assumes sorted is non-empty and sorted in ascending order.
+     */
+    static double percentile(const std::vector<double>& sorted, int p) {
+        size_t n = sorted.size();
+        if (n == 1) {
+            return sorted[0];
+        }
+        size_t rank = static_cast<size_t>(std::ceil(static_cast<double>(p) / 100.0 * n));
+        if (rank == 0) {
+            rank = 1;
+        }
+        if (rank > n) {
+            rank = n;
+        }
+        return sorted[rank - 1];
+    }
+
+    static double mean(const std::vector<double>& values) {
+        double sum = 0.0;
+        for (double v : values) {
+            sum += v;
+        }
+        return sum / static_cast<double>(values.size());
+    }
+
+    static double stddev(const std::vector<double>& values, double mean_val) {
+        if (values.size() <= 1) {
+            return 0.0;
+        }
+        double sum_sq = 0.0;
+        for (double v : values) {
+            double diff = v - mean_val;
+            sum_sq += diff * diff;
+        }
+        return std::sqrt(sum_sq / static_cast<double>(values.size()));
+    }
+
+    mutable std::mutex mutex_;
+    std::vector<double> ttft_values_;
+    std::vector<double> prefill_values_;
+    std::vector<double> decode_tps_values_;
+    std::vector<double> e2e_values_;
+    int32_t count_ = 0;
+};
+
+}  // namespace
+
+extern "C" {
+
+rac_result_t rac_benchmark_stats_create(rac_benchmark_stats_handle_t* out_handle) {
+    if (out_handle == nullptr) {
+        return RAC_ERROR_NULL_POINTER;
+    }
+
+    auto* collector = new (std::nothrow) BenchmarkStatsCollector();
+    if (collector == nullptr) {
+        return RAC_ERROR_INITIALIZATION_FAILED;
+    }
+
+    *out_handle = static_cast<rac_benchmark_stats_handle_t>(collector);
+    return RAC_SUCCESS;
+}
+
+void rac_benchmark_stats_destroy(rac_benchmark_stats_handle_t handle) {
+    if (handle == nullptr) {
+        return;
+    }
+    delete static_cast<BenchmarkStatsCollector*>(handle);
+}
+
+void rac_benchmark_stats_record(rac_benchmark_stats_handle_t handle,
+                                 const rac_benchmark_timing_t* timing) {
+    if (handle == nullptr || timing == nullptr) {
+        return;
+    }
+    static_cast<BenchmarkStatsCollector*>(handle)->record(timing);
+}
+
+void rac_benchmark_stats_reset(rac_benchmark_stats_handle_t handle) {
+    if (handle == nullptr) {
+        return;
+    }
+    static_cast<BenchmarkStatsCollector*>(handle)->reset();
+}
+
+int32_t rac_benchmark_stats_count(rac_benchmark_stats_handle_t handle) {
+    if (handle == nullptr) {
+        return 0;
+    }
+    return static_cast<BenchmarkStatsCollector*>(handle)->count();
+}
+
+rac_result_t rac_benchmark_stats_get_summary(rac_benchmark_stats_handle_t handle,
+                                              rac_benchmark_summary_t* out_summary) {
+    if (handle == nullptr || out_summary == nullptr) {
+        return RAC_ERROR_NULL_POINTER;
+    }
+    return static_cast<BenchmarkStatsCollector*>(handle)->get_summary(out_summary);
+}
+
+char* rac_benchmark_stats_summary_to_json(const rac_benchmark_summary_t* summary) {
+    if (summary == nullptr) {
+        return nullptr;
+    }
+
+    std::string json;
+    json.reserve(1024);
+
+    char buf[64];
+
+    json += "{";
+    json += "\"count\":" + std::to_string(summary->count) + ",";
+
+    // TTFT
+    snprintf(buf, sizeof(buf), "%.2f", summary->ttft_p50_ms);
+    json += "\"ttft_p50_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->ttft_p95_ms);
+    json += "\"ttft_p95_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->ttft_p99_ms);
+    json += "\"ttft_p99_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->ttft_min_ms);
+    json += "\"ttft_min_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->ttft_max_ms);
+    json += "\"ttft_max_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->ttft_mean_ms);
+    json += "\"ttft_mean_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->ttft_stddev_ms);
+    json += "\"ttft_stddev_ms\":" + std::string(buf) + ",";
+
+    // Prefill
+    snprintf(buf, sizeof(buf), "%.2f", summary->prefill_p50_ms);
+    json += "\"prefill_p50_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->prefill_p95_ms);
+    json += "\"prefill_p95_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->prefill_p99_ms);
+    json += "\"prefill_p99_ms\":" + std::string(buf) + ",";
+
+    // Decode TPS
+    snprintf(buf, sizeof(buf), "%.2f", summary->decode_tps_p50);
+    json += "\"decode_tps_p50\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->decode_tps_p95);
+    json += "\"decode_tps_p95\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->decode_tps_p99);
+    json += "\"decode_tps_p99\":" + std::string(buf) + ",";
+
+    // E2E
+    snprintf(buf, sizeof(buf), "%.2f", summary->e2e_p50_ms);
+    json += "\"e2e_p50_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->e2e_p95_ms);
+    json += "\"e2e_p95_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->e2e_p99_ms);
+    json += "\"e2e_p99_ms\":" + std::string(buf) + ",";
+
+    // Outliers
+    json += "\"outlier_count\":" + std::to_string(summary->outlier_count);
+
+    json += "}";
+
+    char* result = static_cast<char*>(malloc(json.size() + 1));
+    if (result != nullptr) {
+        memcpy(result, json.c_str(), json.size() + 1);
+    }
+    return result;
+}
+
+}  // extern "C"

--- a/sdk/runanywhere-commons/src/core/rac_benchmark_stats.cpp
+++ b/sdk/runanywhere-commons/src/core/rac_benchmark_stats.cpp
@@ -118,6 +118,10 @@ class BenchmarkStatsCollector {
             out->prefill_p50_ms = percentile(sorted, 50);
             out->prefill_p95_ms = percentile(sorted, 95);
             out->prefill_p99_ms = percentile(sorted, 99);
+            out->prefill_min_ms = sorted.front();
+            out->prefill_max_ms = sorted.back();
+            out->prefill_mean_ms = mean(sorted);
+            out->prefill_stddev_ms = stddev(sorted, out->prefill_mean_ms);
         }
 
         // Decode TPS stats
@@ -127,6 +131,10 @@ class BenchmarkStatsCollector {
             out->decode_tps_p50 = percentile(sorted, 50);
             out->decode_tps_p95 = percentile(sorted, 95);
             out->decode_tps_p99 = percentile(sorted, 99);
+            out->decode_tps_min = sorted.front();
+            out->decode_tps_max = sorted.back();
+            out->decode_tps_mean = mean(sorted);
+            out->decode_tps_stddev = stddev(sorted, out->decode_tps_mean);
         }
 
         // E2E stats + outlier detection
@@ -136,11 +144,13 @@ class BenchmarkStatsCollector {
             out->e2e_p50_ms = percentile(sorted, 50);
             out->e2e_p95_ms = percentile(sorted, 95);
             out->e2e_p99_ms = percentile(sorted, 99);
+            out->e2e_min_ms = sorted.front();
+            out->e2e_max_ms = sorted.back();
+            out->e2e_mean_ms = mean(sorted);
+            out->e2e_stddev_ms = stddev(sorted, out->e2e_mean_ms);
 
             // Outlier detection: count observations > mean + 2*stddev
-            double e2e_mean = mean(sorted);
-            double e2e_sd = stddev(sorted, e2e_mean);
-            double threshold = e2e_mean + 2.0 * e2e_sd;
+            double threshold = out->e2e_mean_ms + 2.0 * out->e2e_stddev_ms;
             int32_t outliers = 0;
             for (double val : e2e_values_) {
                 if (val > threshold) {
@@ -181,6 +191,9 @@ class BenchmarkStatsCollector {
         return sum / static_cast<double>(values.size());
     }
 
+    // Sample stddev (Bessel-corrected, ÷ N−1). Benchmark samples are a subset of
+    // a larger distribution, so population stddev (÷ N) underestimates spread
+    // for small sample sizes.
     static double stddev(const std::vector<double>& values, double mean_val) {
         if (values.size() <= 1) {
             return 0.0;
@@ -190,7 +203,7 @@ class BenchmarkStatsCollector {
             double diff = v - mean_val;
             sum_sq += diff * diff;
         }
-        return std::sqrt(sum_sq / static_cast<double>(values.size()));
+        return std::sqrt(sum_sq / static_cast<double>(values.size() - 1));
     }
 
     mutable std::mutex mutex_;
@@ -292,6 +305,14 @@ char* rac_benchmark_stats_summary_to_json(const rac_benchmark_summary_t* summary
     json += "\"prefill_p95_ms\":" + std::string(buf) + ",";
     snprintf(buf, sizeof(buf), "%.2f", summary->prefill_p99_ms);
     json += "\"prefill_p99_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->prefill_min_ms);
+    json += "\"prefill_min_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->prefill_max_ms);
+    json += "\"prefill_max_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->prefill_mean_ms);
+    json += "\"prefill_mean_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->prefill_stddev_ms);
+    json += "\"prefill_stddev_ms\":" + std::string(buf) + ",";
 
     // Decode TPS
     snprintf(buf, sizeof(buf), "%.2f", summary->decode_tps_p50);
@@ -300,6 +321,14 @@ char* rac_benchmark_stats_summary_to_json(const rac_benchmark_summary_t* summary
     json += "\"decode_tps_p95\":" + std::string(buf) + ",";
     snprintf(buf, sizeof(buf), "%.2f", summary->decode_tps_p99);
     json += "\"decode_tps_p99\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->decode_tps_min);
+    json += "\"decode_tps_min\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->decode_tps_max);
+    json += "\"decode_tps_max\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->decode_tps_mean);
+    json += "\"decode_tps_mean\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->decode_tps_stddev);
+    json += "\"decode_tps_stddev\":" + std::string(buf) + ",";
 
     // E2E
     snprintf(buf, sizeof(buf), "%.2f", summary->e2e_p50_ms);
@@ -308,6 +337,14 @@ char* rac_benchmark_stats_summary_to_json(const rac_benchmark_summary_t* summary
     json += "\"e2e_p95_ms\":" + std::string(buf) + ",";
     snprintf(buf, sizeof(buf), "%.2f", summary->e2e_p99_ms);
     json += "\"e2e_p99_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->e2e_min_ms);
+    json += "\"e2e_min_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->e2e_max_ms);
+    json += "\"e2e_max_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->e2e_mean_ms);
+    json += "\"e2e_mean_ms\":" + std::string(buf) + ",";
+    snprintf(buf, sizeof(buf), "%.2f", summary->e2e_stddev_ms);
+    json += "\"e2e_stddev_ms\":" + std::string(buf) + ",";
 
     // Outliers
     json += "\"outlier_count\":" + std::to_string(summary->outlier_count);

--- a/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
@@ -947,8 +947,20 @@ extern "C" rac_result_t rac_llm_component_generate_stream_with_timing(
 
     rac_llm_result_t final_result = {};
     final_result.text = strdup(ctx.full_text.c_str());
-    final_result.prompt_tokens = ctx.prompt_tokens;
-    final_result.completion_tokens = estimate_tokens(ctx.full_text.c_str());
+
+    // Use actual backend token counts if available, fall back to estimates
+    if (timing_out != nullptr && timing_out->prompt_tokens > 0) {
+        final_result.prompt_tokens = timing_out->prompt_tokens;
+    } else {
+        final_result.prompt_tokens = ctx.prompt_tokens;
+    }
+
+    if (timing_out != nullptr && timing_out->output_tokens > 0) {
+        final_result.completion_tokens = timing_out->output_tokens;
+    } else {
+        final_result.completion_tokens = estimate_tokens(ctx.full_text.c_str());
+    }
+
     final_result.total_tokens = final_result.prompt_tokens + final_result.completion_tokens;
     final_result.total_time_ms = total_time_ms;
 
@@ -972,8 +984,7 @@ extern "C" rac_result_t rac_llm_component_generate_stream_with_timing(
     // Record t6 (request end) before complete callback
     if (timing_out != nullptr) {
         timing_out->t6_request_end_ms = rac_monotonic_now_ms();
-        timing_out->prompt_tokens = final_result.prompt_tokens;
-        timing_out->output_tokens = final_result.completion_tokens;
+        // prompt_tokens and output_tokens already set by backend
         timing_out->status = RAC_BENCHMARK_STATUS_SUCCESS;
         timing_out->error_code = RAC_SUCCESS;
     }

--- a/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
@@ -18,6 +18,7 @@
 
 #include "rac/core/capabilities/rac_lifecycle.h"
 #include "rac/core/rac_analytics_events.h"
+#include "rac/core/rac_benchmark.h"
 #include "rac/core/rac_logger.h"
 #include "rac/core/rac_platform_adapter.h"
 #include "rac/core/rac_structured_error.h"
@@ -514,6 +515,9 @@ struct llm_stream_context {
     float temperature;
     int32_t max_tokens;
     int32_t token_count;  // Track tokens for streaming updates
+
+    // Benchmark timing (optional, NULL when not benchmarking)
+    rac_benchmark_timing_t* timing_out;
 };
 
 /**
@@ -526,6 +530,11 @@ static rac_bool_t llm_stream_token_callback(const char* token, void* user_data) 
     if (!ctx->first_token_recorded) {
         ctx->first_token_recorded = true;
         ctx->first_token_time = std::chrono::steady_clock::now();
+
+        // Record t4 (first token) for benchmark timing
+        if (ctx->timing_out != nullptr) {
+            ctx->timing_out->t4_first_token_ms = rac_monotonic_now_ms();
+        }
 
         // Calculate TTFT
         auto ttft_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
@@ -674,6 +683,7 @@ extern "C" rac_result_t rac_llm_component_generate_stream(
     ctx.token_count = 0;
     // Pre-allocate to avoid repeated reallocations during streaming
     ctx.full_text.reserve(2048);
+    ctx.timing_out = nullptr;  // No benchmark timing for regular generate_stream
 
     // Perform streaming generation
     result = rac_llm_generate_stream(service, prompt, effective_options, llm_stream_token_callback,
@@ -766,6 +776,231 @@ extern "C" rac_result_t rac_llm_component_generate_stream(
     free(final_result.text);
 
     log_info("LLM.Component", "Streaming generation completed");
+
+    return RAC_SUCCESS;
+}
+
+extern "C" rac_result_t rac_llm_component_generate_stream_with_timing(
+    rac_handle_t handle, const char* prompt, const rac_llm_options_t* options,
+    rac_llm_component_token_callback_fn token_callback,
+    rac_llm_component_complete_callback_fn complete_callback,
+    rac_llm_component_error_callback_fn error_callback, void* user_data,
+    rac_benchmark_timing_t* timing_out) {
+    if (!handle)
+        return RAC_ERROR_INVALID_HANDLE;
+    if (!prompt)
+        return RAC_ERROR_INVALID_ARGUMENT;
+
+    auto* component = reinterpret_cast<rac_llm_component*>(handle);
+    std::lock_guard<std::mutex> lock(component->mtx);
+
+    // Initialize timing if provided
+    if (timing_out != nullptr) {
+        rac_benchmark_timing_init(timing_out);
+        // Record t0 (request start) - first thing after validation
+        timing_out->t0_request_start_ms = rac_monotonic_now_ms();
+    }
+
+    // Generate unique ID for this generation
+    std::string generation_id = generate_unique_id();
+    const char* model_id = rac_lifecycle_get_model_id(component->lifecycle);
+    const char* model_name = rac_lifecycle_get_model_name(component->lifecycle);
+
+    // Get service from lifecycle manager
+    rac_handle_t service = nullptr;
+    rac_result_t result = rac_lifecycle_require_service(component->lifecycle, &service);
+    if (result != RAC_SUCCESS) {
+        log_error("LLM.Component", "No model loaded - cannot generate stream");
+
+        // Emit generation failed event
+        rac_analytics_event_data_t event = {};
+        event.type = RAC_EVENT_LLM_GENERATION_FAILED;
+        event.data.llm_generation = RAC_ANALYTICS_LLM_GENERATION_DEFAULT;
+        event.data.llm_generation.generation_id = generation_id.c_str();
+        event.data.llm_generation.model_id = model_id;
+        event.data.llm_generation.model_name = model_name;
+        event.data.llm_generation.error_code = result;
+        event.data.llm_generation.error_message = "No model loaded";
+        rac_analytics_event_emit(RAC_EVENT_LLM_GENERATION_FAILED, &event);
+
+        if (timing_out != nullptr) {
+            timing_out->status = RAC_BENCHMARK_STATUS_ERROR;
+        }
+
+        if (error_callback) {
+            error_callback(result, "No model loaded", user_data);
+        }
+        return result;
+    }
+
+    // Check if streaming is supported
+    rac_llm_info_t info;
+    result = rac_llm_get_info(service, &info);
+    if (result != RAC_SUCCESS || (info.supports_streaming == 0)) {
+        log_error("LLM.Component", "Streaming not supported");
+
+        // Emit generation failed event
+        rac_analytics_event_data_t event = {};
+        event.type = RAC_EVENT_LLM_GENERATION_FAILED;
+        event.data.llm_generation = RAC_ANALYTICS_LLM_GENERATION_DEFAULT;
+        event.data.llm_generation.generation_id = generation_id.c_str();
+        event.data.llm_generation.model_id = model_id;
+        event.data.llm_generation.model_name = model_name;
+        event.data.llm_generation.error_code = RAC_ERROR_NOT_SUPPORTED;
+        event.data.llm_generation.error_message = "Streaming not supported";
+        rac_analytics_event_emit(RAC_EVENT_LLM_GENERATION_FAILED, &event);
+
+        if (timing_out != nullptr) {
+            timing_out->status = RAC_BENCHMARK_STATUS_ERROR;
+        }
+
+        if (error_callback) {
+            error_callback(RAC_ERROR_NOT_SUPPORTED, "Streaming not supported", user_data);
+        }
+        return RAC_ERROR_NOT_SUPPORTED;
+    }
+
+    log_info("LLM.Component", "Starting streaming generation with timing");
+
+    // Get context_length from service info
+    int32_t context_length = info.context_length;
+
+    // Use provided options or defaults
+    const rac_llm_options_t* effective_options = options ? options : &component->default_options;
+
+    // Emit generation started event
+    {
+        rac_analytics_event_data_t event = {};
+        event.type = RAC_EVENT_LLM_GENERATION_STARTED;
+        event.data.llm_generation = RAC_ANALYTICS_LLM_GENERATION_DEFAULT;
+        event.data.llm_generation.generation_id = generation_id.c_str();
+        event.data.llm_generation.model_id = model_id;
+        event.data.llm_generation.model_name = model_name;
+        event.data.llm_generation.is_streaming = RAC_TRUE;
+        event.data.llm_generation.framework =
+            static_cast<rac_inference_framework_t>(component->config.preferred_framework);
+        event.data.llm_generation.temperature = effective_options->temperature;
+        event.data.llm_generation.max_tokens = effective_options->max_tokens;
+        event.data.llm_generation.context_length = context_length;
+        rac_analytics_event_emit(RAC_EVENT_LLM_GENERATION_STARTED, &event);
+    }
+
+    // Setup streaming context
+    llm_stream_context ctx;
+    ctx.token_callback = token_callback;
+    ctx.complete_callback = complete_callback;
+    ctx.error_callback = error_callback;
+    ctx.user_data = user_data;
+    ctx.start_time = std::chrono::steady_clock::now();
+    ctx.first_token_recorded = false;
+    ctx.prompt_tokens = estimate_tokens(prompt);
+    ctx.generation_id = generation_id;
+    ctx.model_id = model_id;
+    ctx.model_name = model_name;
+    ctx.framework = static_cast<rac_inference_framework_t>(component->config.preferred_framework);
+    ctx.temperature = effective_options->temperature;
+    ctx.max_tokens = effective_options->max_tokens;
+    ctx.token_count = 0;
+    ctx.timing_out = timing_out;  // Pass timing for t4 capture in callback
+
+    // Perform streaming generation with timing
+    // Note: Backend timing (t2, t3, t5) will be captured if backend supports it
+    result = rac_llm_generate_stream_with_timing(service, prompt, effective_options,
+                                                 llm_stream_token_callback, &ctx, timing_out);
+
+    if (result != RAC_SUCCESS) {
+        log_error("LLM.Component", "Streaming generation failed");
+        rac_lifecycle_track_error(component->lifecycle, result, "generateStream");
+
+        // Emit generation failed event
+        rac_analytics_event_data_t event = {};
+        event.type = RAC_EVENT_LLM_GENERATION_FAILED;
+        event.data.llm_generation = RAC_ANALYTICS_LLM_GENERATION_DEFAULT;
+        event.data.llm_generation.generation_id = generation_id.c_str();
+        event.data.llm_generation.model_id = model_id;
+        event.data.llm_generation.model_name = model_name;
+        event.data.llm_generation.error_code = result;
+        event.data.llm_generation.error_message = "Streaming generation failed";
+        rac_analytics_event_emit(RAC_EVENT_LLM_GENERATION_FAILED, &event);
+
+        if (timing_out != nullptr) {
+            timing_out->status = RAC_BENCHMARK_STATUS_ERROR;
+        }
+
+        if (error_callback) {
+            error_callback(result, "Streaming generation failed", user_data);
+        }
+        return result;
+    }
+
+    // Build final result for completion callback
+    auto end_time = std::chrono::steady_clock::now();
+    auto total_duration =
+        std::chrono::duration_cast<std::chrono::milliseconds>(end_time - ctx.start_time);
+    int64_t total_time_ms = total_duration.count();
+
+    rac_llm_result_t final_result = {};
+    final_result.text = strdup(ctx.full_text.c_str());
+    final_result.prompt_tokens = ctx.prompt_tokens;
+    final_result.completion_tokens = estimate_tokens(ctx.full_text.c_str());
+    final_result.total_tokens = final_result.prompt_tokens + final_result.completion_tokens;
+    final_result.total_time_ms = total_time_ms;
+
+    double ttft_ms = 0.0;
+    // Calculate TTFT
+    if (ctx.first_token_recorded) {
+        auto ttft_duration = std::chrono::duration_cast<std::chrono::milliseconds>(
+            ctx.first_token_time - ctx.start_time);
+        final_result.time_to_first_token_ms = ttft_duration.count();
+        ttft_ms = static_cast<double>(ttft_duration.count());
+    }
+
+    // Calculate tokens per second
+    double tokens_per_second = 0.0;
+    if (final_result.total_time_ms > 0) {
+        tokens_per_second = static_cast<double>(final_result.completion_tokens) /
+                            (static_cast<double>(final_result.total_time_ms) / 1000.0);
+        final_result.tokens_per_second = static_cast<float>(tokens_per_second);
+    }
+
+    // Record t6 (request end) before complete callback
+    if (timing_out != nullptr) {
+        timing_out->t6_request_end_ms = rac_monotonic_now_ms();
+        timing_out->prompt_tokens = final_result.prompt_tokens;
+        timing_out->output_tokens = final_result.completion_tokens;
+        timing_out->status = RAC_BENCHMARK_STATUS_SUCCESS;
+    }
+
+    if (complete_callback) {
+        complete_callback(&final_result, user_data);
+    }
+
+    // Emit generation completed event
+    {
+        rac_analytics_event_data_t event = {};
+        event.type = RAC_EVENT_LLM_GENERATION_COMPLETED;
+        event.data.llm_generation.generation_id = generation_id.c_str();
+        event.data.llm_generation.model_id = model_id;
+        event.data.llm_generation.model_name = model_name;
+        event.data.llm_generation.input_tokens = final_result.prompt_tokens;
+        event.data.llm_generation.output_tokens = final_result.completion_tokens;
+        event.data.llm_generation.duration_ms = static_cast<double>(total_time_ms);
+        event.data.llm_generation.tokens_per_second = tokens_per_second;
+        event.data.llm_generation.is_streaming = RAC_TRUE;
+        event.data.llm_generation.time_to_first_token_ms = ttft_ms;
+        event.data.llm_generation.framework =
+            static_cast<rac_inference_framework_t>(component->config.preferred_framework);
+        event.data.llm_generation.temperature = effective_options->temperature;
+        event.data.llm_generation.max_tokens = effective_options->max_tokens;
+        event.data.llm_generation.context_length = context_length;
+        event.data.llm_generation.error_code = RAC_SUCCESS;
+        rac_analytics_event_emit(RAC_EVENT_LLM_GENERATION_COMPLETED, &event);
+    }
+
+    // Free the duplicated text
+    free(final_result.text);
+
+    log_info("LLM.Component", "Streaming generation with timing completed");
 
     return RAC_SUCCESS;
 }

--- a/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
@@ -881,8 +881,7 @@ extern "C" rac_result_t rac_llm_component_generate_stream_with_timing(
         event.data.llm_generation.model_id = model_id;
         event.data.llm_generation.model_name = model_name;
         event.data.llm_generation.is_streaming = RAC_TRUE;
-        event.data.llm_generation.framework =
-            static_cast<rac_inference_framework_t>(component->config.preferred_framework);
+        event.data.llm_generation.framework = component->actual_framework;
         event.data.llm_generation.temperature = effective_options->temperature;
         event.data.llm_generation.max_tokens = effective_options->max_tokens;
         event.data.llm_generation.context_length = context_length;
@@ -901,7 +900,7 @@ extern "C" rac_result_t rac_llm_component_generate_stream_with_timing(
     ctx.generation_id = generation_id;
     ctx.model_id = model_id;
     ctx.model_name = model_name;
-    ctx.framework = static_cast<rac_inference_framework_t>(component->config.preferred_framework);
+    ctx.framework = component->actual_framework;
     ctx.temperature = effective_options->temperature;
     ctx.max_tokens = effective_options->max_tokens;
     ctx.token_count = 0;
@@ -947,6 +946,18 @@ extern "C" rac_result_t rac_llm_component_generate_stream_with_timing(
 
     rac_llm_result_t final_result = {};
     final_result.text = strdup(ctx.full_text.c_str());
+    if (final_result.text == nullptr) {
+        log_error("LLM.Component", "strdup failed for result text");
+        if (timing_out != nullptr) {
+            timing_out->status = RAC_BENCHMARK_STATUS_ERROR;
+            timing_out->error_code = RAC_ERROR_OUT_OF_MEMORY;
+            timing_out->t6_request_end_ms = rac_monotonic_now_ms();
+        }
+        if (error_callback) {
+            error_callback(RAC_ERROR_OUT_OF_MEMORY, "Failed to allocate result text", user_data);
+        }
+        return RAC_ERROR_OUT_OF_MEMORY;
+    }
 
     // Use actual backend token counts if available, fall back to estimates
     if (timing_out != nullptr && timing_out->prompt_tokens > 0) {
@@ -981,10 +992,17 @@ extern "C" rac_result_t rac_llm_component_generate_stream_with_timing(
         final_result.tokens_per_second = static_cast<float>(tokens_per_second);
     }
 
-    // Record t6 (request end) before complete callback
+    // Record t6 (request end) before complete callback.
+    // Backfill prompt/output tokens when backend didn't populate them (fallback path)
+    // so downstream decode-TPS and CSV/JSON stats are computed from estimates, not zero.
     if (timing_out != nullptr) {
+        if (timing_out->prompt_tokens <= 0) {
+            timing_out->prompt_tokens = final_result.prompt_tokens;
+        }
+        if (timing_out->output_tokens <= 0) {
+            timing_out->output_tokens = final_result.completion_tokens;
+        }
         timing_out->t6_request_end_ms = rac_monotonic_now_ms();
-        // prompt_tokens and output_tokens already set by backend
         timing_out->status = RAC_BENCHMARK_STATUS_SUCCESS;
         timing_out->error_code = RAC_SUCCESS;
     }
@@ -1006,8 +1024,7 @@ extern "C" rac_result_t rac_llm_component_generate_stream_with_timing(
         event.data.llm_generation.tokens_per_second = tokens_per_second;
         event.data.llm_generation.is_streaming = RAC_TRUE;
         event.data.llm_generation.time_to_first_token_ms = ttft_ms;
-        event.data.llm_generation.framework =
-            static_cast<rac_inference_framework_t>(component->config.preferred_framework);
+        event.data.llm_generation.framework = component->actual_framework;
         event.data.llm_generation.temperature = effective_options->temperature;
         event.data.llm_generation.max_tokens = effective_options->max_tokens;
         event.data.llm_generation.context_length = context_length;

--- a/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
@@ -825,6 +825,8 @@ extern "C" rac_result_t rac_llm_component_generate_stream_with_timing(
 
         if (timing_out != nullptr) {
             timing_out->status = RAC_BENCHMARK_STATUS_ERROR;
+            timing_out->error_code = result;
+            timing_out->t6_request_end_ms = rac_monotonic_now_ms();
         }
 
         if (error_callback) {
@@ -852,6 +854,8 @@ extern "C" rac_result_t rac_llm_component_generate_stream_with_timing(
 
         if (timing_out != nullptr) {
             timing_out->status = RAC_BENCHMARK_STATUS_ERROR;
+            timing_out->error_code = RAC_ERROR_NOT_SUPPORTED;
+            timing_out->t6_request_end_ms = rac_monotonic_now_ms();
         }
 
         if (error_callback) {
@@ -925,6 +929,8 @@ extern "C" rac_result_t rac_llm_component_generate_stream_with_timing(
 
         if (timing_out != nullptr) {
             timing_out->status = RAC_BENCHMARK_STATUS_ERROR;
+            timing_out->error_code = result;
+            timing_out->t6_request_end_ms = rac_monotonic_now_ms();
         }
 
         if (error_callback) {
@@ -969,6 +975,7 @@ extern "C" rac_result_t rac_llm_component_generate_stream_with_timing(
         timing_out->prompt_tokens = final_result.prompt_tokens;
         timing_out->output_tokens = final_result.completion_tokens;
         timing_out->status = RAC_BENCHMARK_STATUS_SUCCESS;
+        timing_out->error_code = RAC_SUCCESS;
     }
 
     if (complete_callback) {

--- a/sdk/runanywhere-commons/src/features/llm/rac_llm_service.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/rac_llm_service.cpp
@@ -171,7 +171,10 @@ rac_result_t rac_llm_generate_stream_with_timing(rac_handle_t handle, const char
                                                          user_data, timing_out);
     }
 
-    // Fallback to regular streaming (timing_out won't have t2/t3/t5)
+    // Fallback to regular streaming for backends that don't implement timing.
+    // Backend timestamps (t2/t3/t5) will remain 0 from rac_benchmark_timing_init().
+    // The component layer (llm_component.cpp) is responsible for setting t0/t4/t6
+    // and the final status/error_code regardless of which path is taken here.
     if (service->ops->generate_stream) {
         return service->ops->generate_stream(service->impl, prompt, options, callback, user_data);
     }

--- a/sdk/runanywhere-commons/src/features/llm/rac_llm_service.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/rac_llm_service.cpp
@@ -152,6 +152,33 @@ rac_result_t rac_llm_generate_stream(rac_handle_t handle, const char* prompt,
     return service->ops->generate_stream(service->impl, prompt, options, callback, user_data);
 }
 
+rac_result_t rac_llm_generate_stream_with_timing(rac_handle_t handle, const char* prompt,
+                                                 const rac_llm_options_t* options,
+                                                 rac_llm_stream_callback_fn callback,
+                                                 void* user_data,
+                                                 rac_benchmark_timing_t* timing_out) {
+    if (!handle || !prompt || !callback)
+        return RAC_ERROR_NULL_POINTER;
+
+    auto* service = static_cast<rac_llm_service_t*>(handle);
+    if (!service->ops) {
+        return RAC_ERROR_NOT_SUPPORTED;
+    }
+
+    // If backend implements timing-aware streaming, use it
+    if (service->ops->generate_stream_with_timing) {
+        return service->ops->generate_stream_with_timing(service->impl, prompt, options, callback,
+                                                         user_data, timing_out);
+    }
+
+    // Fallback to regular streaming (timing_out won't have t2/t3/t5)
+    if (service->ops->generate_stream) {
+        return service->ops->generate_stream(service->impl, prompt, options, callback, user_data);
+    }
+
+    return RAC_ERROR_NOT_SUPPORTED;
+}
+
 rac_result_t rac_llm_get_info(rac_handle_t handle, rac_llm_info_t* out_info) {
     if (!handle || !out_info)
         return RAC_ERROR_NULL_POINTER;

--- a/sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp
+++ b/sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp
@@ -1102,6 +1102,7 @@ Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racLlmComponentGenerate
 
     jclass callbackClass = env->GetObjectClass(tokenCallback);
     jmethodID onTokenMethod = env->GetMethodID(callbackClass, "onToken", "(Ljava/lang/String;)Z");
+    env->DeleteLocalRef(callbackClass);
 
     if (!onTokenMethod) {
         LOGe("racLlmComponentGenerateStreamWithTiming: could not find onToken method");
@@ -1191,7 +1192,8 @@ Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racLlmComponentGenerate
     json += "\"t6_request_end_ms\":" + std::to_string(timing.t6_request_end_ms) + ",";
     json += "\"prompt_tokens\":" + std::to_string(timing.prompt_tokens) + ",";
     json += "\"output_tokens\":" + std::to_string(timing.output_tokens) + ",";
-    json += "\"benchmark_status\":" + std::to_string(timing.status);
+    json += "\"benchmark_status\":" + std::to_string(timing.status) + ",";
+    json += "\"benchmark_error_code\":" + std::to_string(timing.error_code);
     json += "}";
 
     LOGi("racLlmComponentGenerateStreamWithTiming returning JSON: %zu bytes", json.length());

--- a/sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp
+++ b/sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp
@@ -30,6 +30,7 @@
 // Include runanywhere-commons C API headers
 #include "rac/core/rac_analytics_events.h"
 #include "rac/core/rac_audio_utils.h"
+#include "rac/core/rac_benchmark.h"
 #include "rac/core/rac_core.h"
 #include "rac/core/rac_error.h"
 #include "rac/core/rac_logger.h"
@@ -1065,6 +1066,135 @@ Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racLlmComponentGenerate
     std::string json = json_obj.dump();
 
     LOGi("racLlmComponentGenerateStreamWithCallback returning JSON: %zu bytes", json.length());
+
+    return env->NewStringUTF(json.c_str());
+}
+
+// ========================================================================
+// STREAMING WITH KOTLIN CALLBACK AND BENCHMARK TIMING
+// ========================================================================
+
+JNIEXPORT jstring JNICALL
+Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racLlmComponentGenerateStreamWithTiming(
+    JNIEnv* env, jclass clazz, jlong handle, jstring prompt, jstring configJson,
+    jobject tokenCallback) {
+    LOGi("racLlmComponentGenerateStreamWithTiming called with handle=%lld", (long long)handle);
+
+    if (handle == 0) {
+        LOGe("racLlmComponentGenerateStreamWithTiming: invalid handle");
+        return nullptr;
+    }
+
+    if (!tokenCallback) {
+        LOGe("racLlmComponentGenerateStreamWithTiming: null callback");
+        return nullptr;
+    }
+
+    std::string promptStr = getCString(env, prompt);
+    LOGi("racLlmComponentGenerateStreamWithTiming prompt length=%zu", promptStr.length());
+
+    std::string configStorage;
+    const char* config = getNullableCString(env, configJson, configStorage);
+
+    // Get JVM and callback method
+    JavaVM* jvm = nullptr;
+    env->GetJavaVM(&jvm);
+
+    jclass callbackClass = env->GetObjectClass(tokenCallback);
+    jmethodID onTokenMethod = env->GetMethodID(callbackClass, "onToken", "(Ljava/lang/String;)Z");
+
+    if (!onTokenMethod) {
+        LOGe("racLlmComponentGenerateStreamWithTiming: could not find onToken method");
+        return nullptr;
+    }
+
+    // Create global ref to callback to ensure it survives across threads
+    jobject globalCallback = env->NewGlobalRef(tokenCallback);
+
+    // Parse config for options
+    rac_llm_options_t options = {};
+    options.max_tokens = 512;
+    options.temperature = 0.7f;
+    options.top_p = 1.0f;
+    options.streaming_enabled = RAC_TRUE;
+
+    // Create streaming callback context
+    LLMStreamCallbackContext ctx;
+    ctx.jvm = jvm;
+    ctx.callback = globalCallback;
+    ctx.onTokenMethod = onTokenMethod;
+
+    // Initialize benchmark timing struct
+    rac_benchmark_timing_t timing = {};
+    rac_benchmark_timing_init(&timing);
+
+    LOGi("racLlmComponentGenerateStreamWithTiming calling rac_llm_component_generate_stream_with_timing...");
+
+    rac_result_t status = rac_llm_component_generate_stream_with_timing(
+        reinterpret_cast<rac_handle_t>(handle), promptStr.c_str(), &options,
+        llm_stream_callback_token, llm_stream_callback_complete, llm_stream_callback_error, &ctx,
+        &timing);
+
+    // Clean up global ref
+    env->DeleteGlobalRef(globalCallback);
+
+    if (status != RAC_SUCCESS) {
+        LOGe("rac_llm_component_generate_stream_with_timing failed with status=%d", status);
+        return nullptr;
+    }
+
+    if (ctx.has_error) {
+        LOGe("Streaming with timing failed: %s", ctx.error_message.c_str());
+        return nullptr;
+    }
+
+    LOGi("racLlmComponentGenerateStreamWithTiming result text length=%zu, tokens=%d",
+         ctx.accumulated_text.length(), ctx.token_count);
+
+    // Build JSON result with timing
+    std::string json = "{";
+    json += "\"text\":\"";
+    for (char c : ctx.accumulated_text) {
+        switch (c) {
+            case '"':
+                json += "\\\"";
+                break;
+            case '\\':
+                json += "\\\\";
+                break;
+            case '\n':
+                json += "\\n";
+                break;
+            case '\r':
+                json += "\\r";
+                break;
+            case '\t':
+                json += "\\t";
+                break;
+            default:
+                json += c;
+                break;
+        }
+    }
+    json += "\",";
+    json += "\"tokens_generated\":" + std::to_string(ctx.final_result.completion_tokens) + ",";
+    json += "\"tokens_evaluated\":" + std::to_string(ctx.final_result.prompt_tokens) + ",";
+    json += "\"stop_reason\":" + std::to_string(0) + ",";
+    json += "\"total_time_ms\":" + std::to_string(ctx.final_result.total_time_ms) + ",";
+    json += "\"tokens_per_second\":" + std::to_string(ctx.final_result.tokens_per_second) + ",";
+    // Add benchmark timing fields
+    json += "\"t0_request_start_ms\":" + std::to_string(timing.t0_request_start_ms) + ",";
+    json += "\"t2_prefill_start_ms\":" + std::to_string(timing.t2_prefill_start_ms) + ",";
+    json += "\"t3_prefill_end_ms\":" + std::to_string(timing.t3_prefill_end_ms) + ",";
+    json += "\"t4_first_token_ms\":" + std::to_string(timing.t4_first_token_ms) + ",";
+    json += "\"t5_last_token_ms\":" + std::to_string(timing.t5_last_token_ms) + ",";
+    json += "\"t6_request_end_ms\":" + std::to_string(timing.t6_request_end_ms) + ",";
+    json += "\"prompt_tokens\":" + std::to_string(timing.prompt_tokens) + ",";
+    json += "\"output_tokens\":" + std::to_string(timing.output_tokens) + ",";
+    json += "\"benchmark_status\":" + std::to_string(timing.status);
+    json += "}";
+
+    LOGi("racLlmComponentGenerateStreamWithTiming returning JSON: %zu bytes", json.length());
 
     return env->NewStringUTF(json.c_str());
 }

--- a/sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp
+++ b/sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp
@@ -1101,7 +1101,13 @@ Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racLlmComponentGenerate
     env->GetJavaVM(&jvm);
 
     jclass callbackClass = env->GetObjectClass(tokenCallback);
-    jmethodID onTokenMethod = env->GetMethodID(callbackClass, "onToken", "(Ljava/lang/String;)Z");
+    bool onTokenExpectsBytes = true;
+    jmethodID onTokenMethod = env->GetMethodID(callbackClass, "onToken", "([B)Z");
+    if (!onTokenMethod) {
+        env->ExceptionClear();
+        onTokenMethod = env->GetMethodID(callbackClass, "onToken", "(Ljava/lang/String;)Z");
+        onTokenExpectsBytes = false;
+    }
     env->DeleteLocalRef(callbackClass);
 
     if (!onTokenMethod) {
@@ -1118,12 +1124,34 @@ Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racLlmComponentGenerate
     options.temperature = 0.7f;
     options.top_p = 1.0f;
     options.streaming_enabled = RAC_TRUE;
+    options.system_prompt = RAC_NULL;
+
+    std::string sys_prompt_storage;
+    if (config != nullptr) {
+        try {
+            auto j = nlohmann::json::parse(config);
+            options.max_tokens = j.value("max_tokens", 512);
+            options.temperature = j.value("temperature", 0.7f);
+            options.top_p = j.value("top_p", 1.0f);
+            sys_prompt_storage = j.value("system_prompt", std::string(""));
+            if (!sys_prompt_storage.empty()) {
+                options.system_prompt = sys_prompt_storage.c_str();
+            }
+        } catch (const nlohmann::json::exception& e) {
+            LOGe("Failed to parse LLM timing config JSON: %s", e.what());
+        }
+    }
+
+    LOGi("racLlmComponentGenerateStreamWithTiming options: temp=%.2f, max_tokens=%d, top_p=%.2f, system_prompt=%s",
+         options.temperature, options.max_tokens, options.top_p,
+         options.system_prompt ? "(set)" : "(none)");
 
     // Create streaming callback context
     LLMStreamCallbackContext ctx;
     ctx.jvm = jvm;
     ctx.callback = globalCallback;
     ctx.onTokenMethod = onTokenMethod;
+    ctx.onTokenExpectsBytes = onTokenExpectsBytes;
 
     // Initialize benchmark timing struct
     rac_benchmark_timing_t timing = {};
@@ -1136,13 +1164,25 @@ Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racLlmComponentGenerate
         llm_stream_callback_token, llm_stream_callback_complete, llm_stream_callback_error, &ctx,
         &timing);
 
-    // Clean up global ref
-    env->DeleteGlobalRef(globalCallback);
-
     if (status != RAC_SUCCESS) {
+        env->DeleteGlobalRef(globalCallback);
         LOGe("rac_llm_component_generate_stream_with_timing failed with status=%d", status);
         return nullptr;
     }
+
+    // Wait until completion/error before releasing callback/context.
+    {
+        std::unique_lock<std::mutex> lock(ctx.mtx);
+        constexpr auto kStreamWaitTimeout = std::chrono::minutes(10);
+        if (!ctx.cv.wait_for(lock, kStreamWaitTimeout, [&ctx] { return ctx.is_complete; })) {
+            ctx.has_error = true;
+            ctx.error_message = "Streaming timed out waiting for completion callback";
+            ctx.is_complete = true;
+        }
+    }
+
+    // Clean up global ref after callbacks have finished.
+    env->DeleteGlobalRef(globalCallback);
 
     if (ctx.has_error) {
         LOGe("Streaming with timing failed: %s", ctx.error_message.c_str());

--- a/sdk/runanywhere-commons/tests/CMakeLists.txt
+++ b/sdk/runanywhere-commons/tests/CMakeLists.txt
@@ -208,3 +208,41 @@ if(RAC_BACKEND_RAG)
         COMMAND rac_simple_tokenizer_test
     )
 endif()
+# =============================================================================
+# RunAnywhere Commons - Benchmark Unit Tests (GoogleTest)
+# =============================================================================
+
+include(FetchContent)
+
+FetchContent_Declare(
+    googletest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.14.0
+)
+
+# Prevent GoogleTest from overriding compiler/linker options
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+set(INSTALL_GTEST OFF CACHE BOOL "" FORCE)
+
+FetchContent_MakeAvailable(googletest)
+
+add_executable(rac_benchmark_tests
+    benchmark/test_monotonic_clock.cpp
+    benchmark/test_timing_struct.cpp
+    benchmark/test_benchmark_log.cpp
+    benchmark/test_benchmark_stats.cpp
+)
+
+target_link_libraries(rac_benchmark_tests
+    PRIVATE
+        rac_commons
+        GTest::gtest_main
+)
+
+target_include_directories(rac_benchmark_tests
+    PRIVATE
+        ${CMAKE_SOURCE_DIR}/include
+)
+
+include(GoogleTest)
+gtest_discover_tests(rac_benchmark_tests)

--- a/sdk/runanywhere-commons/tests/benchmark/test_benchmark_log.cpp
+++ b/sdk/runanywhere-commons/tests/benchmark/test_benchmark_log.cpp
@@ -1,0 +1,134 @@
+/**
+ * @file test_benchmark_log.cpp
+ * @brief Tests for benchmark JSON/CSV serialization and logging
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "rac/core/rac_benchmark.h"
+#include "rac/core/rac_benchmark_log.h"
+
+namespace {
+
+// Helper: create a populated timing struct for testing
+rac_benchmark_timing_t make_test_timing() {
+    rac_benchmark_timing_t timing;
+    rac_benchmark_timing_init(&timing);
+
+    timing.t0_request_start_ms = 1000;
+    timing.t2_prefill_start_ms = 1010;
+    timing.t3_prefill_end_ms = 1060;
+    timing.t4_first_token_ms = 1065;
+    timing.t5_last_token_ms = 2065;
+    timing.t6_request_end_ms = 2070;
+    timing.prompt_tokens = 50;
+    timing.output_tokens = 100;
+    timing.status = RAC_BENCHMARK_STATUS_SUCCESS;
+    timing.error_code = 0;
+
+    return timing;
+}
+
+}  // namespace
+
+// =============================================================================
+// JSON SERIALIZATION
+// =============================================================================
+
+TEST(BenchmarkLog, TimingToJsonContainsAllFields) {
+    auto timing = make_test_timing();
+    char* json = rac_benchmark_timing_to_json(&timing);
+
+    ASSERT_NE(json, nullptr);
+
+    std::string s(json);
+
+    // Verify raw timing fields
+    EXPECT_NE(s.find("\"t0_request_start_ms\":1000"), std::string::npos);
+    EXPECT_NE(s.find("\"t2_prefill_start_ms\":1010"), std::string::npos);
+    EXPECT_NE(s.find("\"t3_prefill_end_ms\":1060"), std::string::npos);
+    EXPECT_NE(s.find("\"t4_first_token_ms\":1065"), std::string::npos);
+    EXPECT_NE(s.find("\"t5_last_token_ms\":2065"), std::string::npos);
+    EXPECT_NE(s.find("\"t6_request_end_ms\":2070"), std::string::npos);
+    EXPECT_NE(s.find("\"prompt_tokens\":50"), std::string::npos);
+    EXPECT_NE(s.find("\"output_tokens\":100"), std::string::npos);
+    EXPECT_NE(s.find("\"status\":0"), std::string::npos);
+    EXPECT_NE(s.find("\"error_code\":0"), std::string::npos);
+
+    // Verify derived metrics exist
+    EXPECT_NE(s.find("\"ttft_ms\":"), std::string::npos);
+    EXPECT_NE(s.find("\"prefill_ms\":"), std::string::npos);
+    EXPECT_NE(s.find("\"decode_ms\":"), std::string::npos);
+    EXPECT_NE(s.find("\"e2e_ms\":"), std::string::npos);
+    EXPECT_NE(s.find("\"decode_tps\":"), std::string::npos);
+
+    // Verify it's valid JSON (starts with { and ends with })
+    EXPECT_EQ(s.front(), '{');
+    EXPECT_EQ(s.back(), '}');
+
+    free(json);
+}
+
+TEST(BenchmarkLog, TimingToJsonNullReturnsNull) {
+    char* json = rac_benchmark_timing_to_json(nullptr);
+    EXPECT_EQ(json, nullptr);
+}
+
+// =============================================================================
+// CSV SERIALIZATION
+// =============================================================================
+
+TEST(BenchmarkLog, TimingToCsvHeader) {
+    char* header = rac_benchmark_timing_to_csv(nullptr, RAC_TRUE);
+
+    ASSERT_NE(header, nullptr);
+
+    std::string s(header);
+    EXPECT_NE(s.find("t0_request_start_ms"), std::string::npos);
+    EXPECT_NE(s.find("ttft_ms"), std::string::npos);
+    EXPECT_NE(s.find("decode_tps"), std::string::npos);
+
+    free(header);
+}
+
+TEST(BenchmarkLog, TimingToCsvRow) {
+    auto timing = make_test_timing();
+    char* row = rac_benchmark_timing_to_csv(&timing, RAC_FALSE);
+
+    ASSERT_NE(row, nullptr);
+
+    std::string s(row);
+    // Should contain the t0 value
+    EXPECT_NE(s.find("1000"), std::string::npos);
+    // Should contain commas separating fields
+    size_t comma_count = 0;
+    for (char c : s) {
+        if (c == ',') comma_count++;
+    }
+    // CSV header has 14 commas (15 fields), data row should match
+    EXPECT_EQ(comma_count, 14u);
+
+    free(row);
+}
+
+TEST(BenchmarkLog, TimingToCsvNullDataReturnsNull) {
+    char* row = rac_benchmark_timing_to_csv(nullptr, RAC_FALSE);
+    EXPECT_EQ(row, nullptr);
+}
+
+// =============================================================================
+// LOGGING
+// =============================================================================
+
+TEST(BenchmarkLog, TimingLogNoCrash) {
+    auto timing = make_test_timing();
+
+    // Should not crash even without platform adapter
+    rac_benchmark_timing_log(&timing, "test_run");
+    rac_benchmark_timing_log(&timing, nullptr);
+    rac_benchmark_timing_log(nullptr, "test_run");
+}

--- a/sdk/runanywhere-commons/tests/benchmark/test_benchmark_log.cpp
+++ b/sdk/runanywhere-commons/tests/benchmark/test_benchmark_log.cpp
@@ -11,6 +11,7 @@
 
 #include "rac/core/rac_benchmark.h"
 #include "rac/core/rac_benchmark_log.h"
+#include "rac/core/rac_error.h"
 
 namespace {
 
@@ -41,8 +42,10 @@ rac_benchmark_timing_t make_test_timing() {
 
 TEST(BenchmarkLog, TimingToJsonContainsAllFields) {
     auto timing = make_test_timing();
-    char* json = rac_benchmark_timing_to_json(&timing);
+    char* json = nullptr;
+    rac_result_t rc = rac_benchmark_timing_to_json(&timing, &json);
 
+    EXPECT_EQ(rc, RAC_SUCCESS);
     ASSERT_NE(json, nullptr);
 
     std::string s(json);
@@ -73,9 +76,19 @@ TEST(BenchmarkLog, TimingToJsonContainsAllFields) {
     free(json);
 }
 
-TEST(BenchmarkLog, TimingToJsonNullReturnsNull) {
-    char* json = rac_benchmark_timing_to_json(nullptr);
+TEST(BenchmarkLog, TimingToJsonNullTimingReturnsError) {
+    char* json = reinterpret_cast<char*>(0xdeadbeef);  // sentinel to verify reset
+    rac_result_t rc = rac_benchmark_timing_to_json(nullptr, &json);
+
+    EXPECT_EQ(rc, RAC_ERROR_NULL_POINTER);
     EXPECT_EQ(json, nullptr);
+}
+
+TEST(BenchmarkLog, TimingToJsonNullOutParamReturnsError) {
+    auto timing = make_test_timing();
+    rac_result_t rc = rac_benchmark_timing_to_json(&timing, nullptr);
+
+    EXPECT_EQ(rc, RAC_ERROR_NULL_POINTER);
 }
 
 // =============================================================================
@@ -83,8 +96,10 @@ TEST(BenchmarkLog, TimingToJsonNullReturnsNull) {
 // =============================================================================
 
 TEST(BenchmarkLog, TimingToCsvHeader) {
-    char* header = rac_benchmark_timing_to_csv(nullptr, RAC_TRUE);
+    char* header = nullptr;
+    rac_result_t rc = rac_benchmark_timing_to_csv(nullptr, RAC_TRUE, &header);
 
+    EXPECT_EQ(rc, RAC_SUCCESS);
     ASSERT_NE(header, nullptr);
 
     std::string s(header);
@@ -97,8 +112,10 @@ TEST(BenchmarkLog, TimingToCsvHeader) {
 
 TEST(BenchmarkLog, TimingToCsvRow) {
     auto timing = make_test_timing();
-    char* row = rac_benchmark_timing_to_csv(&timing, RAC_FALSE);
+    char* row = nullptr;
+    rac_result_t rc = rac_benchmark_timing_to_csv(&timing, RAC_FALSE, &row);
 
+    EXPECT_EQ(rc, RAC_SUCCESS);
     ASSERT_NE(row, nullptr);
 
     std::string s(row);
@@ -115,9 +132,23 @@ TEST(BenchmarkLog, TimingToCsvRow) {
     free(row);
 }
 
-TEST(BenchmarkLog, TimingToCsvNullDataReturnsNull) {
-    char* row = rac_benchmark_timing_to_csv(nullptr, RAC_FALSE);
+TEST(BenchmarkLog, TimingToCsvNullDataReturnsError) {
+    char* row = reinterpret_cast<char*>(0xdeadbeef);  // sentinel to verify reset
+    rac_result_t rc = rac_benchmark_timing_to_csv(nullptr, RAC_FALSE, &row);
+
+    EXPECT_EQ(rc, RAC_ERROR_NULL_POINTER);
     EXPECT_EQ(row, nullptr);
+}
+
+TEST(BenchmarkLog, TimingToCsvNullOutParamReturnsError) {
+    auto timing = make_test_timing();
+    rac_result_t rc = rac_benchmark_timing_to_csv(&timing, RAC_FALSE, nullptr);
+
+    EXPECT_EQ(rc, RAC_ERROR_NULL_POINTER);
+
+    // Also verify for the header case
+    rc = rac_benchmark_timing_to_csv(nullptr, RAC_TRUE, nullptr);
+    EXPECT_EQ(rc, RAC_ERROR_NULL_POINTER);
 }
 
 // =============================================================================
@@ -128,7 +159,11 @@ TEST(BenchmarkLog, TimingLogNoCrash) {
     auto timing = make_test_timing();
 
     // Should not crash even without platform adapter
-    rac_benchmark_timing_log(&timing, "test_run");
-    rac_benchmark_timing_log(&timing, nullptr);
-    rac_benchmark_timing_log(nullptr, "test_run");
+    EXPECT_EQ(rac_benchmark_timing_log(&timing, "test_run"), RAC_SUCCESS);
+    EXPECT_EQ(rac_benchmark_timing_log(&timing, nullptr), RAC_SUCCESS);
+}
+
+TEST(BenchmarkLog, TimingLogNullTimingReturnsError) {
+    EXPECT_EQ(rac_benchmark_timing_log(nullptr, "test_run"), RAC_ERROR_NULL_POINTER);
+    EXPECT_EQ(rac_benchmark_timing_log(nullptr, nullptr), RAC_ERROR_NULL_POINTER);
 }

--- a/sdk/runanywhere-commons/tests/benchmark/test_benchmark_stats.cpp
+++ b/sdk/runanywhere-commons/tests/benchmark/test_benchmark_stats.cpp
@@ -1,0 +1,247 @@
+/**
+ * @file test_benchmark_stats.cpp
+ * @brief Tests for benchmark statistical analysis
+ */
+
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstdlib>
+#include <cstring>
+#include <string>
+
+#include "rac/core/rac_benchmark.h"
+#include "rac/core/rac_benchmark_stats.h"
+
+namespace {
+
+// Helper: create a timing with known derived metric values
+rac_benchmark_timing_t make_timing(int64_t ttft_ms, int64_t prefill_ms, double decode_tps_target,
+                                    int32_t output_tokens, int64_t e2e_ms) {
+    rac_benchmark_timing_t timing;
+    rac_benchmark_timing_init(&timing);
+
+    timing.t0_request_start_ms = 1000;
+    timing.t2_prefill_start_ms = 1010;
+    timing.t3_prefill_end_ms = 1010 + prefill_ms;
+    timing.t4_first_token_ms = 1000 + ttft_ms;
+    timing.output_tokens = output_tokens;
+
+    // Compute t5 from target decode_tps: t5 - t3 = output_tokens / decode_tps * 1000
+    if (decode_tps_target > 0.0 && output_tokens > 0) {
+        int64_t decode_ms =
+            static_cast<int64_t>(static_cast<double>(output_tokens) / decode_tps_target * 1000.0);
+        timing.t5_last_token_ms = timing.t3_prefill_end_ms + decode_ms;
+    }
+
+    timing.t6_request_end_ms = 1000 + e2e_ms;
+    timing.prompt_tokens = 50;
+    timing.status = RAC_BENCHMARK_STATUS_SUCCESS;
+    timing.error_code = 0;
+
+    return timing;
+}
+
+}  // namespace
+
+// =============================================================================
+// CREATE / DESTROY
+// =============================================================================
+
+TEST(BenchmarkStats, CreateDestroy) {
+    rac_benchmark_stats_handle_t handle = nullptr;
+    rac_result_t result = rac_benchmark_stats_create(&handle);
+
+    EXPECT_EQ(result, RAC_SUCCESS);
+    EXPECT_NE(handle, nullptr);
+
+    rac_benchmark_stats_destroy(handle);
+}
+
+TEST(BenchmarkStats, CreateNullReturnsError) {
+    rac_result_t result = rac_benchmark_stats_create(nullptr);
+    EXPECT_NE(result, RAC_SUCCESS);
+}
+
+TEST(BenchmarkStats, DestroyNullNoCrash) {
+    rac_benchmark_stats_destroy(nullptr);
+}
+
+// =============================================================================
+// RECORD AND COUNT
+// =============================================================================
+
+TEST(BenchmarkStats, RecordAndCount) {
+    rac_benchmark_stats_handle_t handle = nullptr;
+    rac_benchmark_stats_create(&handle);
+
+    for (int i = 0; i < 10; ++i) {
+        auto timing = make_timing(65, 50, 100.0, 100, 1070);
+        rac_benchmark_stats_record(handle, &timing);
+    }
+
+    EXPECT_EQ(rac_benchmark_stats_count(handle), 10);
+
+    rac_benchmark_stats_destroy(handle);
+}
+
+TEST(BenchmarkStats, OnlySuccessfulObservationsRecorded) {
+    rac_benchmark_stats_handle_t handle = nullptr;
+    rac_benchmark_stats_create(&handle);
+
+    auto timing = make_timing(65, 50, 100.0, 100, 1070);
+    rac_benchmark_stats_record(handle, &timing);
+
+    // Error observation should be skipped
+    auto error_timing = timing;
+    error_timing.status = RAC_BENCHMARK_STATUS_ERROR;
+    rac_benchmark_stats_record(handle, &error_timing);
+
+    EXPECT_EQ(rac_benchmark_stats_count(handle), 1);
+
+    rac_benchmark_stats_destroy(handle);
+}
+
+// =============================================================================
+// RESET
+// =============================================================================
+
+TEST(BenchmarkStats, Reset) {
+    rac_benchmark_stats_handle_t handle = nullptr;
+    rac_benchmark_stats_create(&handle);
+
+    auto timing = make_timing(65, 50, 100.0, 100, 1070);
+    rac_benchmark_stats_record(handle, &timing);
+    EXPECT_EQ(rac_benchmark_stats_count(handle), 1);
+
+    rac_benchmark_stats_reset(handle);
+    EXPECT_EQ(rac_benchmark_stats_count(handle), 0);
+
+    rac_benchmark_stats_destroy(handle);
+}
+
+// =============================================================================
+// SUMMARY
+// =============================================================================
+
+TEST(BenchmarkStats, EmptyDataReturnsError) {
+    rac_benchmark_stats_handle_t handle = nullptr;
+    rac_benchmark_stats_create(&handle);
+
+    rac_benchmark_summary_t summary;
+    rac_result_t result = rac_benchmark_stats_get_summary(handle, &summary);
+    EXPECT_NE(result, RAC_SUCCESS);
+
+    rac_benchmark_stats_destroy(handle);
+}
+
+TEST(BenchmarkStats, SingleObservation) {
+    rac_benchmark_stats_handle_t handle = nullptr;
+    rac_benchmark_stats_create(&handle);
+
+    auto timing = make_timing(65, 50, 100.0, 100, 1070);
+    rac_benchmark_stats_record(handle, &timing);
+
+    rac_benchmark_summary_t summary;
+    rac_result_t result = rac_benchmark_stats_get_summary(handle, &summary);
+    EXPECT_EQ(result, RAC_SUCCESS);
+    EXPECT_EQ(summary.count, 1);
+
+    // For a single observation, P50=P95=P99=that value
+    EXPECT_DOUBLE_EQ(summary.ttft_p50_ms, summary.ttft_p95_ms);
+    EXPECT_DOUBLE_EQ(summary.ttft_p95_ms, summary.ttft_p99_ms);
+    EXPECT_EQ(summary.ttft_p50_ms, 65.0);
+
+    // Stddev should be 0 for a single observation
+    EXPECT_DOUBLE_EQ(summary.ttft_stddev_ms, 0.0);
+
+    rac_benchmark_stats_destroy(handle);
+}
+
+TEST(BenchmarkStats, PercentilesBasic) {
+    rac_benchmark_stats_handle_t handle = nullptr;
+    rac_benchmark_stats_create(&handle);
+
+    // Record 100 observations with TTFT values 1,2,3,...,100
+    for (int i = 1; i <= 100; ++i) {
+        auto timing = make_timing(i, 50, 100.0, 100, 100 + i);
+        rac_benchmark_stats_record(handle, &timing);
+    }
+
+    rac_benchmark_summary_t summary;
+    rac_result_t result = rac_benchmark_stats_get_summary(handle, &summary);
+    EXPECT_EQ(result, RAC_SUCCESS);
+    EXPECT_EQ(summary.count, 100);
+
+    // P50 should be 50 (nearest rank: ceil(50/100 * 100) = 50th element = 50)
+    EXPECT_DOUBLE_EQ(summary.ttft_p50_ms, 50.0);
+
+    // P95 should be 95
+    EXPECT_DOUBLE_EQ(summary.ttft_p95_ms, 95.0);
+
+    // P99 should be 99
+    EXPECT_DOUBLE_EQ(summary.ttft_p99_ms, 99.0);
+
+    // Min and max
+    EXPECT_DOUBLE_EQ(summary.ttft_min_ms, 1.0);
+    EXPECT_DOUBLE_EQ(summary.ttft_max_ms, 100.0);
+
+    // Mean should be 50.5
+    EXPECT_NEAR(summary.ttft_mean_ms, 50.5, 0.01);
+
+    rac_benchmark_stats_destroy(handle);
+}
+
+TEST(BenchmarkStats, OutlierDetection) {
+    rac_benchmark_stats_handle_t handle = nullptr;
+    rac_benchmark_stats_create(&handle);
+
+    // Record 99 normal observations (E2E = 100ms) + 1 extreme (E2E = 10000ms)
+    for (int i = 0; i < 99; ++i) {
+        auto timing = make_timing(10, 10, 100.0, 100, 100);
+        rac_benchmark_stats_record(handle, &timing);
+    }
+
+    auto extreme = make_timing(10, 10, 100.0, 100, 10000);
+    rac_benchmark_stats_record(handle, &extreme);
+
+    rac_benchmark_summary_t summary;
+    rac_result_t result = rac_benchmark_stats_get_summary(handle, &summary);
+    EXPECT_EQ(result, RAC_SUCCESS);
+    EXPECT_GE(summary.outlier_count, 1);
+
+    rac_benchmark_stats_destroy(handle);
+}
+
+// =============================================================================
+// JSON EXPORT
+// =============================================================================
+
+TEST(BenchmarkStats, SummaryToJson) {
+    rac_benchmark_stats_handle_t handle = nullptr;
+    rac_benchmark_stats_create(&handle);
+
+    auto timing = make_timing(65, 50, 100.0, 100, 1070);
+    rac_benchmark_stats_record(handle, &timing);
+
+    rac_benchmark_summary_t summary;
+    rac_benchmark_stats_get_summary(handle, &summary);
+
+    char* json = rac_benchmark_stats_summary_to_json(&summary);
+    ASSERT_NE(json, nullptr);
+
+    std::string s(json);
+    EXPECT_EQ(s.front(), '{');
+    EXPECT_EQ(s.back(), '}');
+    EXPECT_NE(s.find("\"count\":1"), std::string::npos);
+    EXPECT_NE(s.find("\"ttft_p50_ms\":"), std::string::npos);
+    EXPECT_NE(s.find("\"outlier_count\":"), std::string::npos);
+
+    free(json);
+    rac_benchmark_stats_destroy(handle);
+}
+
+TEST(BenchmarkStats, SummaryToJsonNullReturnsNull) {
+    char* json = rac_benchmark_stats_summary_to_json(nullptr);
+    EXPECT_EQ(json, nullptr);
+}

--- a/sdk/runanywhere-commons/tests/benchmark/test_benchmark_stats.cpp
+++ b/sdk/runanywhere-commons/tests/benchmark/test_benchmark_stats.cpp
@@ -189,6 +189,27 @@ TEST(BenchmarkStats, PercentilesBasic) {
     // Mean should be 50.5
     EXPECT_NEAR(summary.ttft_mean_ms, 50.5, 0.01);
 
+    // Prefill is a constant 50ms across all 100 observations, so
+    // min/max/mean all equal 50 and stddev is 0.
+    EXPECT_DOUBLE_EQ(summary.prefill_min_ms, 50.0);
+    EXPECT_DOUBLE_EQ(summary.prefill_max_ms, 50.0);
+    EXPECT_DOUBLE_EQ(summary.prefill_mean_ms, 50.0);
+    EXPECT_DOUBLE_EQ(summary.prefill_stddev_ms, 0.0);
+
+    // Decode TPS is a constant 100 tokens/sec across all observations.
+    EXPECT_DOUBLE_EQ(summary.decode_tps_min, 100.0);
+    EXPECT_DOUBLE_EQ(summary.decode_tps_max, 100.0);
+    EXPECT_DOUBLE_EQ(summary.decode_tps_mean, 100.0);
+    EXPECT_DOUBLE_EQ(summary.decode_tps_stddev, 0.0);
+
+    // E2E varies from 101..200 (e2e_ms = 100 + i for i in 1..100).
+    // Mean = 150.5, sample stddev (Bessel-corrected, N-1) for 1..100 is
+    // sqrt(100 * 101 / 12) / sqrt(99/100) ≈ 29.01.
+    EXPECT_DOUBLE_EQ(summary.e2e_min_ms, 101.0);
+    EXPECT_DOUBLE_EQ(summary.e2e_max_ms, 200.0);
+    EXPECT_NEAR(summary.e2e_mean_ms, 150.5, 0.01);
+    EXPECT_NEAR(summary.e2e_stddev_ms, 29.01, 0.05);
+
     rac_benchmark_stats_destroy(handle);
 }
 
@@ -235,6 +256,12 @@ TEST(BenchmarkStats, SummaryToJson) {
     EXPECT_EQ(s.back(), '}');
     EXPECT_NE(s.find("\"count\":1"), std::string::npos);
     EXPECT_NE(s.find("\"ttft_p50_ms\":"), std::string::npos);
+    EXPECT_NE(s.find("\"prefill_mean_ms\":"), std::string::npos);
+    EXPECT_NE(s.find("\"prefill_stddev_ms\":"), std::string::npos);
+    EXPECT_NE(s.find("\"decode_tps_min\":"), std::string::npos);
+    EXPECT_NE(s.find("\"decode_tps_max\":"), std::string::npos);
+    EXPECT_NE(s.find("\"e2e_mean_ms\":"), std::string::npos);
+    EXPECT_NE(s.find("\"e2e_stddev_ms\":"), std::string::npos);
     EXPECT_NE(s.find("\"outlier_count\":"), std::string::npos);
 
     free(json);

--- a/sdk/runanywhere-commons/tests/benchmark/test_monotonic_clock.cpp
+++ b/sdk/runanywhere-commons/tests/benchmark/test_monotonic_clock.cpp
@@ -1,0 +1,88 @@
+/**
+ * @file test_monotonic_clock.cpp
+ * @brief Tests for rac_monotonic_now_ms() monotonic clock
+ */
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <chrono>
+#include <thread>
+#include <vector>
+
+#include "rac/core/rac_benchmark.h"
+
+// =============================================================================
+// BASIC FUNCTIONALITY
+// =============================================================================
+
+TEST(MonotonicClock, ReturnsNonNegative) {
+    int64_t now = rac_monotonic_now_ms();
+    EXPECT_GE(now, 0);
+}
+
+TEST(MonotonicClock, MonotonicallyNonDecreasing) {
+    int64_t prev = rac_monotonic_now_ms();
+    for (int i = 0; i < 1000; ++i) {
+        int64_t curr = rac_monotonic_now_ms();
+        EXPECT_GE(curr, prev) << "Clock went backwards at iteration " << i;
+        prev = curr;
+    }
+}
+
+TEST(MonotonicClock, ElapsedTimeAccuracy) {
+    int64_t before = rac_monotonic_now_ms();
+    std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    int64_t after = rac_monotonic_now_ms();
+
+    int64_t elapsed = after - before;
+    // Allow generous range for CI environments: 80ms to 300ms
+    EXPECT_GE(elapsed, 80) << "Elapsed time too short: " << elapsed << "ms";
+    EXPECT_LE(elapsed, 300) << "Elapsed time too long: " << elapsed << "ms";
+}
+
+TEST(MonotonicClock, DistinctOverTime) {
+    int64_t first = rac_monotonic_now_ms();
+    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    int64_t second = rac_monotonic_now_ms();
+
+    EXPECT_GT(second, first) << "Two calls 10ms apart should produce distinct values";
+}
+
+// =============================================================================
+// THREAD SAFETY
+// =============================================================================
+
+TEST(MonotonicClock, ThreadSafety) {
+    constexpr int kNumThreads = 8;
+    constexpr int kCallsPerThread = 10000;
+
+    std::atomic<bool> any_negative{false};
+    std::atomic<bool> any_decreasing{false};
+
+    auto worker = [&]() {
+        int64_t prev = rac_monotonic_now_ms();
+        for (int i = 0; i < kCallsPerThread; ++i) {
+            int64_t curr = rac_monotonic_now_ms();
+            if (curr < 0) {
+                any_negative.store(true, std::memory_order_relaxed);
+            }
+            if (curr < prev) {
+                any_decreasing.store(true, std::memory_order_relaxed);
+            }
+            prev = curr;
+        }
+    };
+
+    std::vector<std::thread> threads;
+    threads.reserve(kNumThreads);
+    for (int i = 0; i < kNumThreads; ++i) {
+        threads.emplace_back(worker);
+    }
+    for (auto& t : threads) {
+        t.join();
+    }
+
+    EXPECT_FALSE(any_negative.load()) << "Got negative timestamp from thread";
+    EXPECT_FALSE(any_decreasing.load()) << "Clock went backwards in thread";
+}

--- a/sdk/runanywhere-commons/tests/benchmark/test_timing_struct.cpp
+++ b/sdk/runanywhere-commons/tests/benchmark/test_timing_struct.cpp
@@ -1,0 +1,133 @@
+/**
+ * @file test_timing_struct.cpp
+ * @brief Tests for rac_benchmark_timing_t struct and initialization
+ */
+
+#include <gtest/gtest.h>
+
+#include <cstring>
+
+#include "rac/core/rac_benchmark.h"
+
+// =============================================================================
+// INITIALIZATION
+// =============================================================================
+
+TEST(TimingStruct, InitZeroesAllFields) {
+    rac_benchmark_timing_t timing;
+
+    // Fill with non-zero to ensure init actually clears
+    std::memset(&timing, 0xFF, sizeof(timing));
+
+    rac_benchmark_timing_init(&timing);
+
+    EXPECT_EQ(timing.t0_request_start_ms, 0);
+    EXPECT_EQ(timing.t2_prefill_start_ms, 0);
+    EXPECT_EQ(timing.t3_prefill_end_ms, 0);
+    EXPECT_EQ(timing.t4_first_token_ms, 0);
+    EXPECT_EQ(timing.t5_last_token_ms, 0);
+    EXPECT_EQ(timing.t6_request_end_ms, 0);
+    EXPECT_EQ(timing.prompt_tokens, 0);
+    EXPECT_EQ(timing.output_tokens, 0);
+    EXPECT_EQ(timing.status, 0);
+    EXPECT_EQ(timing.error_code, 0);
+}
+
+TEST(TimingStruct, InitNullPointerNoCrash) {
+    // Should not crash
+    rac_benchmark_timing_init(nullptr);
+}
+
+// =============================================================================
+// STATUS CODES
+// =============================================================================
+
+TEST(TimingStruct, StatusCodeValues) {
+    EXPECT_EQ(RAC_BENCHMARK_STATUS_SUCCESS, 0);
+    EXPECT_EQ(RAC_BENCHMARK_STATUS_ERROR, 1);
+    EXPECT_EQ(RAC_BENCHMARK_STATUS_TIMEOUT, 2);
+    EXPECT_EQ(RAC_BENCHMARK_STATUS_CANCELLED, 3);
+}
+
+// =============================================================================
+// FIELD ORDERING AND USAGE PATTERNS
+// =============================================================================
+
+TEST(TimingStruct, TimestampOrdering) {
+    rac_benchmark_timing_t timing;
+    rac_benchmark_timing_init(&timing);
+
+    // Simulate a successful inference with ordered timestamps
+    timing.t0_request_start_ms = 100;
+    timing.t2_prefill_start_ms = 110;
+    timing.t3_prefill_end_ms = 150;
+    timing.t4_first_token_ms = 155;
+    timing.t5_last_token_ms = 500;
+    timing.t6_request_end_ms = 510;
+
+    EXPECT_LE(timing.t0_request_start_ms, timing.t2_prefill_start_ms);
+    EXPECT_LE(timing.t2_prefill_start_ms, timing.t3_prefill_end_ms);
+    EXPECT_LE(timing.t3_prefill_end_ms, timing.t4_first_token_ms);
+    EXPECT_LE(timing.t4_first_token_ms, timing.t5_last_token_ms);
+    EXPECT_LE(timing.t5_last_token_ms, timing.t6_request_end_ms);
+}
+
+TEST(TimingStruct, ErrorPathTimestamps) {
+    rac_benchmark_timing_t timing;
+    rac_benchmark_timing_init(&timing);
+
+    // Simulate error: only t0 and t6 captured
+    timing.t0_request_start_ms = 100;
+    timing.t6_request_end_ms = 105;
+    timing.status = RAC_BENCHMARK_STATUS_ERROR;
+    timing.error_code = -130;  // Some error code
+
+    // Middle timestamps should remain 0
+    EXPECT_EQ(timing.t2_prefill_start_ms, 0);
+    EXPECT_EQ(timing.t3_prefill_end_ms, 0);
+    EXPECT_EQ(timing.t4_first_token_ms, 0);
+    EXPECT_EQ(timing.t5_last_token_ms, 0);
+
+    // But t0, t6, status, error_code should be set
+    EXPECT_GT(timing.t0_request_start_ms, 0);
+    EXPECT_GT(timing.t6_request_end_ms, 0);
+    EXPECT_EQ(timing.status, RAC_BENCHMARK_STATUS_ERROR);
+    EXPECT_NE(timing.error_code, RAC_SUCCESS);
+}
+
+TEST(TimingStruct, DerivedMetrics) {
+    rac_benchmark_timing_t timing;
+    rac_benchmark_timing_init(&timing);
+
+    timing.t0_request_start_ms = 1000;
+    timing.t2_prefill_start_ms = 1010;
+    timing.t3_prefill_end_ms = 1060;
+    timing.t4_first_token_ms = 1065;
+    timing.t5_last_token_ms = 2065;
+    timing.t6_request_end_ms = 2070;
+    timing.prompt_tokens = 50;
+    timing.output_tokens = 100;
+
+    // TTFT: t4 - t0 = 65ms
+    EXPECT_EQ(timing.t4_first_token_ms - timing.t0_request_start_ms, 65);
+
+    // Prefill: t3 - t2 = 50ms
+    EXPECT_EQ(timing.t3_prefill_end_ms - timing.t2_prefill_start_ms, 50);
+
+    // Decode: t5 - t3 = 1005ms
+    int64_t decode_ms = timing.t5_last_token_ms - timing.t3_prefill_end_ms;
+    EXPECT_EQ(decode_ms, 1005);
+
+    // Decode TPS: 100 tokens / 1.005s ≈ 99.50 tokens/s
+    double tps = static_cast<double>(timing.output_tokens) / static_cast<double>(decode_ms) * 1000.0;
+    EXPECT_NEAR(tps, 99.50, 0.1);
+
+    // E2E: t6 - t0 = 1070ms
+    EXPECT_EQ(timing.t6_request_end_ms - timing.t0_request_start_ms, 1070);
+
+    // Component overhead: E2E - decode - prefill
+    int64_t overhead = (timing.t6_request_end_ms - timing.t0_request_start_ms) -
+                       decode_ms -
+                       (timing.t3_prefill_end_ms - timing.t2_prefill_start_ms);
+    EXPECT_EQ(overhead, 15);  // 1070 - 1005 - 50 = 15ms
+}


### PR DESCRIPTION
## Summary

Cherry-picked benchmark timing infrastructure from #343 onto a fresh branch from current `main`. Credits for the original work go to @AmanSwar and @abhisekupadhyaya — commits retain original authorship.

Closes #343 (rebased version; original branch had accumulated 442 merge conflicts after 2+ months of drift).

## What's Included

Four cherry-picked commits, **24 files, +2542 lines, pure additions, zero conflicts**:

| Commit | Purpose |
|--------|---------|
| `afe1f80e6` | Initial `rac_benchmark.h/.cpp` — 6-timestamp struct, monotonic clock, integration into LLM component + llamacpp + JNI |
| `2e5ad14f7` | Status field semantic fix — split `status` from `rac_result_t error_code` |
| `8d8a09416` | Extended metrics, JSON/CSV logging, stats collector + 29 unit tests |
| `ad34445ca` | CodeRabbit review fixes (stop-sequence, format specifiers, race condition, token counts) |

## Core API

**Timing** (`rac_benchmark.h`) — 6 timestamps captured during LLM inference:
```
t0: Request start        t4: First token
t2: Prefill start        t5: Last token
t3: Prefill end          t6: Request end
```
Plus `rac_monotonic_now_ms()` using `steady_clock`, status codes, opt-in via pointer param.

**Extended metrics** (`rac_benchmark_metrics.h`) — memory, CPU temp, battery, GPU util, thermal state via callback provider pattern (platform SDKs register their own).

**Logging** (`rac_benchmark_log.h`) — JSON/CSV serialization + derived metrics (TTFT, prefill, decode TPS, E2E).

**Stats** (`rac_benchmark_stats.h`) — opaque handle collector, P50/P95/P99 + mean/stddev/min/max, outlier detection, thread-safe.

**Integration** — new optional vtable op `generate_stream_with_timing`. LlamaCPP implements it; Apple Foundation Models falls back to regular generate. Zero overhead when `timing_out = NULL`.

## Scope & Known Gaps

**Scope**: LLM only. VLM/STT/TTS/VAD/Diffusion/Embeddings are not instrumented (addressable separately).

**Known gaps** (to be addressed in follow-up PRs — not blockers for this core infrastructure):
- Exports file (`RACommons.exports`) doesn't export benchmark symbols yet — needed for iOS xcframework visibility
- Swift `CRACommons` umbrella header not synced — Swift can't see the timing API yet
- Kotlin JNI has no benchmark bindings
- No platform SDK registers a metrics provider — extended metrics always return `-1`
- `timing_out->output_tokens` not populated by LlamaCPP backend (always 0; component falls back to estimate)
- No CI perf regression gate

## Verification

```
cmake -B build -DRAC_BUILD_TESTS=ON && cmake --build build -j 8
./build/tests/rac_benchmark_tests
# [==========] 29 tests from 4 test suites ran. (114 ms total)
# [  PASSED  ] 29 tests.
```

## Test Plan

- [x] commons library builds cleanly
- [x] 29 benchmark unit tests pass (MonotonicClock × 5, TimingStruct × 6, BenchmarkLog × 6, BenchmarkStats × 12)
- [ ] LlamaCPP backend integration tested end-to-end with a real model generation
- [ ] Exports wired up in follow-up PR
- [ ] Swift bindings added in follow-up PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR adds benchmark timing infrastructure for LLM inference: a 6-timestamp struct (`t0`–`t6`) captured across the component and LlamaCPP backend layers, JSON/CSV serialization, a thread-safe percentile stats collector, and an extended device-metrics provider pattern — all opt-in via a `timing_out` pointer.

Two P1 defects are in `rac_llm_llamacpp_generate_stream_with_timing` in `rac_llm_llamacpp.cpp`:
- `options->system_prompt` is not copied to the request, so all timed generation calls silently drop the system prompt.
- The try-catch guard present in the non-timing sibling is missing, allowing llama.cpp template/tokenizer exceptions to propagate through `extern "C"` (undefined behaviour on WASM/iOS).

<h3>Confidence Score: 3/5</h3>

- Not safe to merge as-is: system prompt is silently dropped for all timed generation calls, and a missing try-catch can cause UB on WASM/iOS.
- Two P1 bugs in the same new C-API wrapper function: missing system_prompt copy causes wrong model behaviour on every timed call, and missing exception guard introduces potential undefined behaviour on certain platforms. Both are straightforward fixes but must be resolved before merge.
- sdk/runanywhere-commons/src/backends/llamacpp/rac_llm_llamacpp.cpp — both P1 issues are in the new `rac_llm_llamacpp_generate_stream_with_timing` function

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-commons/src/backends/llamacpp/rac_llm_llamacpp.cpp | New `rac_llm_llamacpp_generate_stream_with_timing` C-API wrapper has two P1 defects: `system_prompt` from options is not copied to the request (silently dropped for all timed calls), and the try-catch guard present in the non-timing sibling is absent (exceptions from llama.cpp's template engine can propagate through extern "C"). |
| sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp | Adds `generate_stream_with_timing` — a near-verbatim ~190-line copy of `generate_stream` with timing checkpoints injected. STOP_SEQUENCES static is duplicated, creating a maintenance hazard. Logic is correct but the duplication is the main concern. |
| sdk/runanywhere-commons/include/rac/core/rac_benchmark.h | Well-documented public API for the 6-timestamp struct, monotonic clock, and status codes. `RAC_BENCHMARK_STATUS_CANCELLED` and `RAC_BENCHMARK_STATUS_TIMEOUT` are defined but never populated in any code path. |
| sdk/runanywhere-commons/src/core/rac_benchmark_stats.cpp | Correct thread-safe stats collector with nearest-rank percentile implementation. Uses population stddev (÷N) instead of sample stddev (÷N−1), which underestimates spread for small sample sizes. |
| sdk/runanywhere-commons/src/core/rac_benchmark_log.cpp | Clean JSON/CSV serialization and logging helpers. Correct null-guard patterns throughout; derived metrics computed consistently with the stats collector. |
| sdk/runanywhere-commons/src/core/rac_benchmark_metrics.cpp | Two-slot atomic provider registry. Write path is mutex-serialized; read path is lock-free. With three rapid back-to-back registrations during an active capture, a reader can observe a partially-overwritten slot — very unlikely in practice since registration only occurs at SDK init. |
| sdk/runanywhere-commons/src/features/llm/llm_component.cpp | New `rac_llm_component_generate_stream_with_timing` correctly captures t0/t4/t6 and wires timing_out through to the backend. Status/error_code always set on both success and failure paths. No path sets CANCELLED or TIMEOUT status. |
| sdk/runanywhere-commons/src/backends/llamacpp/rac_backend_llamacpp_register.cpp | Correctly wires `llamacpp_vtable_generate_stream_with_timing` into the static vtable. Adapter pattern consistent with existing vtable functions. |
| sdk/runanywhere-commons/src/core/rac_benchmark.cpp | Minimal, correct implementation of the monotonic clock using `steady_clock` with a process-local epoch. Thread-safe via Meyers singleton. |
| sdk/runanywhere-commons/tests/benchmark/test_benchmark_stats.cpp | Good coverage for stats collector: create/destroy, record filtering, reset, percentiles on 100 observations, outlier detection, and JSON export. All 12 tests pass per PR description. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant Component as llm_component.cpp
    participant Service as rac_llm_service.cpp
    participant Vtable as rac_backend_llamacpp_register.cpp
    participant CAPI as rac_llm_llamacpp.cpp
    participant Backend as llamacpp_backend.cpp

    App->>Component: rac_llm_component_generate_stream_with_timing(timing_out)
    Component->>Component: rac_benchmark_timing_init(timing_out)
    Component->>Component: "timing_out->t0 = rac_monotonic_now_ms()"
    Component->>Service: rac_llm_generate_stream_with_timing(timing_out)
    Service->>Vtable: "ops->generate_stream_with_timing(timing_out)"
    Vtable->>CAPI: rac_llm_llamacpp_generate_stream_with_timing(timing_out)
    Note over CAPI: ⚠️ system_prompt NOT copied<br/>⚠️ No try-catch
    CAPI->>Backend: generate_stream_with_timing(timing_out)
    Backend->>Backend: "timing_out->t2 = now (prefill start)"
    Backend->>Backend: llama_decode (prompt)
    Backend->>Backend: "timing_out->t3 = now (prefill end)"
    loop Each token
        Backend-->>Component: "token_callback → timing_out->t4 (first token)"
        Backend->>Backend: llama_decode (decode step)
    end
    Backend->>Backend: "timing_out->t5 = now (last token)"
    Backend-->>CAPI: return success
    CAPI-->>Component: return
    Component->>Component: "timing_out->t6 = now (request end)"
    Component->>Component: "timing_out->status = SUCCESS"
    Component-->>App: RAC_SUCCESS + populated timing_out
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `sdk/runanywhere-commons/include/rac/core/rac_benchmark.h`, line 165-168 ([link](https://github.com/runanywhereai/runanywhere-sdks/blob/bacb277ac072d3befd90a9d71e7f20c5393a6d83/sdk/runanywhere-commons/include/rac/core/rac_benchmark.h#L165-L168)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`RAC_BENCHMARK_STATUS_CANCELLED` and `RAC_BENCHMARK_STATUS_TIMEOUT` are never set**

   Both constants are documented and exported as part of the public API, but no code path in this PR assigns them to `timing_out->status`. All non-success paths in `llm_component.cpp` unconditionally write `RAC_BENCHMARK_STATUS_ERROR`, including paths that are triggered by cancellation. Consumers reading the status field will never observe these values, making the distinction meaningless today. Either populate them correctly (detect `cancel_requested_` on the return path) or document that they are reserved for future use.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/runanywhere-commons/include/rac/core/rac_benchmark.h
   Line: 165-168

   Comment:
   **`RAC_BENCHMARK_STATUS_CANCELLED` and `RAC_BENCHMARK_STATUS_TIMEOUT` are never set**

   Both constants are documented and exported as part of the public API, but no code path in this PR assigns them to `timing_out->status`. All non-success paths in `llm_component.cpp` unconditionally write `RAC_BENCHMARK_STATUS_ERROR`, including paths that are triggered by cancellation. Consumers reading the status field will never observe these values, making the distinction meaningless today. Either populate them correctly (detect `cancel_requested_` on the return path) or document that they are reserved for future use.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: sdk/runanywhere-commons/src/backends/llamacpp/rac_llm_llamacpp.cpp
Line: 313-326

Comment:
**`system_prompt` silently dropped for timed calls**

`rac_llm_llamacpp_generate_stream_with_timing` never copies `options->system_prompt` into the request, so every timed generation silently discards the system prompt. The non-timing sibling `rac_llm_llamacpp_generate_stream` (lines 257-259) correctly copies it. Any call going through the timing path — including the component layer via `rac_llm_component_generate_stream_with_timing` — will produce responses without a system prompt with no error or warning.

```suggestion
    if (options != nullptr) {
        request.max_tokens = options->max_tokens;
        request.temperature = options->temperature;
        request.top_p = options->top_p;
        if (options->system_prompt != nullptr) {
            request.system_prompt = options->system_prompt;
        }
        if (options->stop_sequences != nullptr && options->num_stop_sequences > 0) {
            for (int32_t i = 0; i < options->num_stop_sequences; i++) {
                if (options->stop_sequences[i]) {
                    request.stop_sequences.push_back(options->stop_sequences[i]);
                }
            }
        }
    }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-commons/src/backends/llamacpp/rac_llm_llamacpp.cpp
Line: 328-337

Comment:
**Missing try-catch around `generate_stream_with_timing`**

The existing `rac_llm_llamacpp_generate_stream` wraps its backend call in a try-catch with a comment explicitly explaining the rationale: llama.cpp's Jinja/minja template engine and tokenizer can throw C++ exceptions, and allowing them to propagate through an `extern "C"` boundary is undefined behaviour (on WASM, Emscripten returns the exception pointer as the return value). The new timing variant omits that guard entirely.

```suggestion
    // Stream using C++ class with timing (see generate for rationale on try-catch)
    int prompt_tokens = 0;
    bool success = false;
    try {
        success = h->text_gen->generate_stream_with_timing(
            request,
            [callback, user_data](const std::string& token) -> bool {
                return callback(token.c_str(), RAC_FALSE, user_data) == RAC_TRUE;
            },
            &prompt_tokens,
            timing_out
        );
    } catch (const std::exception& e) {
        rac_error_set_details(e.what());
        return RAC_ERROR_INFERENCE_FAILED;
    } catch (...) {
        rac_error_set_details("Unknown C++ exception during streaming LLM generation with timing");
        return RAC_ERROR_INFERENCE_FAILED;
    }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
Line: 831-897

Comment:
**Near-verbatim duplication of `generate_stream`**

`generate_stream_with_timing` is ~190 lines that copy `generate_stream` almost exactly — including its own `static const std::vector<std::string> STOP_SEQUENCES` declaration (already defined identically in `generate_stream`). Any bug fix or behavioural change to `generate_stream` now silently diverges unless the same fix is applied here, and the two static locals are separate objects despite being identical.

A simpler approach is to add an optional `rac_benchmark_timing_t*` parameter to the existing `generate_stream` and gate all timestamp writes on `timing_out != nullptr`, eliminating the duplication entirely. This also aligns with the project's stated goal of SIMPLICITY and SOLID principles in CLAUDE.md.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-commons/src/core/rac_benchmark_stats.cpp
Line: 184-194

Comment:
**Population stddev (÷N) instead of sample stddev (÷N−1)**

Benchmark samples are a subset drawn from a larger distribution; the standard convention for reporting variability on a sample is Bessel-corrected (divide by `N-1`). Dividing by `N` systematically underestimates the spread when the sample is small (e.g. <30 runs), which can mask higher real variance.

```suggestion
    static double stddev(const std::vector<double>& values, double mean_val) {
        if (values.size() <= 1) {
            return 0.0;
        }
        double sum_sq = 0.0;
        for (double v : values) {
            double diff = v - mean_val;
            sum_sq += diff * diff;
        }
        return std::sqrt(sum_sq / static_cast<double>(values.size() - 1));
    }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-commons/include/rac/core/rac_benchmark.h
Line: 165-168

Comment:
**`RAC_BENCHMARK_STATUS_CANCELLED` and `RAC_BENCHMARK_STATUS_TIMEOUT` are never set**

Both constants are documented and exported as part of the public API, but no code path in this PR assigns them to `timing_out->status`. All non-success paths in `llm_component.cpp` unconditionally write `RAC_BENCHMARK_STATUS_ERROR`, including paths that are triggered by cancellation. Consumers reading the status field will never observe these values, making the distinction meaningless today. Either populate them correctly (detect `cancel_requested_` on the return path) or document that they are reserved for future use.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix: address CodeRabbit review — stop-se..."](https://github.com/runanywhereai/runanywhere-sdks/commit/bacb277ac072d3befd90a9d71e7f20c5393a6d83) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28316162)</sub>

> Greptile also left **4 inline comments** on this PR.

<!-- /greptile_comment -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added comprehensive inference benchmarking (detailed lifecycle timestamps, prompt/output token counts, status/error).
  * Streaming APIs now optionally produce benchmark timing when requested.
  * Added system metrics collection (memory, CPU temp, battery, GPU) and statistical summaries (percentiles, mean/stddev, outlier detection).
  * JSON and CSV export and runtime logging for benchmark summaries.
* **Tests**
  * New unit tests validating clock, timing structs, serialization, and statistics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->