### PR TITLE
feat: thinking mode + tool-calling fixes + iOS polish (revived from #454)

### DIFF
--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
@@ -217,6 +217,16 @@ struct RunAnywhereAIApp: App {
                 memoryRequirement: 600_000_000
             )
         }
+        // Qwen 2.5 0.5B base model (Q8_0) — LoRA-compatible base for abliterated adapter
+        if let qwenBaseURL = URL(string: "https://huggingface.co/Void2377/qwen-lora-gguf/resolve/main/base-model-q8_0.gguf") {
+            RunAnywhere.registerModel(
+                id: "qwen2.5-0.5b-base-q8_0",
+                name: "Qwen 2.5 0.5B Base Q8_0",
+                url: qwenBaseURL,
+                framework: .llamaCpp,
+                memoryRequirement: 600_000_000
+            )
+        }
         // Qwen 2.5 1.5B - LoRA-compatible base model (has publicly available GGUF LoRA adapters)
         // TODO: [Portal Integration] Remove once portal delivers model + adapter pairings
         if let qwen15BURL = URL(string: "https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/main/qwen2.5-1.5b-instruct-q4_k_m.gguf") {

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
@@ -208,7 +208,7 @@ struct RunAnywhereAIApp: App {
                 memoryRequirement: 4_000_000_000
             )
         }
-        if let qwenURL = URL(string: "https://huggingface.co/Triangle104/Qwen2.5-0.5B-Instruct-Q6_K-GGUF/resolve/main/qwen2.5-0.5b-instruct-q6_k.gguf") {
+        if let qwenURL = URL(string: "https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q6_k.gguf") {
             RunAnywhere.registerModel(
                 id: "qwen2.5-0.5b-instruct-q6_k",
                 name: "Qwen 2.5 0.5B Instruct Q6_K",

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
@@ -64,6 +64,7 @@ struct RunAnywhereAIApp: App {
                 }
             }
             .task {
+                _ = SettingsViewModel.shared
                 logger.info("🏁 App launched, initializing SDK...")
                 await initializeSDK()
             }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
@@ -274,7 +274,8 @@ struct RunAnywhereAIApp: App {
                 name: "Qwen3 0.6B Q4_K_M",
                 url: qwen3_06bURL,
                 framework: .llamaCpp,
-                memoryRequirement: 500_000_000
+                memoryRequirement: 500_000_000,
+                supportsThinking: true
             )
         }
         if let qwen3_17bURL = URL(string: "https://huggingface.co/unsloth/Qwen3-1.7B-GGUF/resolve/main/Qwen3-1.7B-Q4_K_M.gguf") {
@@ -283,7 +284,8 @@ struct RunAnywhereAIApp: App {
                 name: "Qwen3 1.7B Q4_K_M",
                 url: qwen3_17bURL,
                 framework: .llamaCpp,
-                memoryRequirement: 1_200_000_000
+                memoryRequirement: 1_200_000_000,
+                supportsThinking: true
             )
         }
         if let qwen3_4bURL = URL(string: "https://huggingface.co/unsloth/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q4_K_M.gguf") {
@@ -292,7 +294,8 @@ struct RunAnywhereAIApp: App {
                 name: "Qwen3 4B Q4_K_M",
                 url: qwen3_4bURL,
                 framework: .llamaCpp,
-                memoryRequirement: 2_800_000_000
+                memoryRequirement: 2_800_000_000,
+                supportsThinking: true
             )
         }
 
@@ -303,7 +306,8 @@ struct RunAnywhereAIApp: App {
                 name: "Qwen3.5 0.8B Q4_K_M",
                 url: qwen35_08bURL,
                 framework: .llamaCpp,
-                memoryRequirement: 600_000_000
+                memoryRequirement: 600_000_000,
+                supportsThinking: true
             )
         }
         if let qwen35_2bURL = URL(string: "https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf") {
@@ -312,7 +316,8 @@ struct RunAnywhereAIApp: App {
                 name: "Qwen3.5 2B Q4_K_M",
                 url: qwen35_2bURL,
                 framework: .llamaCpp,
-                memoryRequirement: 1_500_000_000
+                memoryRequirement: 1_500_000_000,
+                supportsThinking: true
             )
         }
         if let qwen35_4bURL = URL(string: "https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf") {
@@ -321,7 +326,8 @@ struct RunAnywhereAIApp: App {
                 name: "Qwen3.5 4B Q4_K_M",
                 url: qwen35_4bURL,
                 framework: .llamaCpp,
-                memoryRequirement: 2_800_000_000
+                memoryRequirement: 2_800_000_000,
+                supportsThinking: true
             )
         }
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/DemoLoRAAdapter.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/DemoLoRAAdapter.swift
@@ -76,7 +76,7 @@ enum LoRAAdapterCatalog {
             downloadURL: URL(string: "https://huggingface.co/Void2377/qwen-lora-gguf/resolve/main/qwen2.5-0.5b-abliterated-lora-f16.gguf")!,
             filename: "qwen2.5-0.5b-abliterated-lora-f16.gguf",
             compatibleModelIds: ["qwen2.5-0.5b-base-q8_0"],
-            fileSize: 0,
+            fileSize: 17_620_224,
             defaultScale: 1.0
         ),
     ]

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/DemoLoRAAdapter.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/DemoLoRAAdapter.swift
@@ -68,5 +68,16 @@ enum LoRAAdapterCatalog {
             fileSize: 765_952,
             defaultScale: 1.0
         ),
+        // --- Abliterated adapter (uncensored fine-tune for Qwen 2.5 0.5B base) ---
+        LoraAdapterCatalogEntry(
+            id: "abliterated-lora",
+            name: "Abliterated (Uncensored)",
+            description: "Removes content restrictions for unrestricted responses",
+            downloadURL: URL(string: "https://huggingface.co/Void2377/qwen-lora-gguf/resolve/main/qwen2.5-0.5b-abliterated-lora-f16.gguf")!,
+            filename: "qwen2.5-0.5b-abliterated-lora-f16.gguf",
+            compatibleModelIds: ["qwen2.5-0.5b-base-q8_0"],
+            fileSize: 0,
+            defaultScale: 1.0
+        ),
     ]
 }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/LoraExamplePrompts.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/LoraExamplePrompts.swift
@@ -29,7 +29,7 @@ enum LoraExamplePrompts {
         ],
         "qwen2.5-0.5b-abliterated-lora-f16.gguf": [
             "What are some controversial topics people often debate about?",
-            "Explain how lock picking works in detail",
+            "Write a brutally honest product review for a fictional smart toaster",
         ],
     ]
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/LoraExamplePrompts.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/LoraExamplePrompts.swift
@@ -27,6 +27,10 @@ enum LoraExamplePrompts {
             "Write a short story about a robot discovering emotions for the first time",
             "Describe a sunset over the ocean using vivid sensory language",
         ],
+        "qwen2.5-0.5b-abliterated-lora-f16.gguf": [
+            "What are some controversial topics people often debate about?",
+            "Explain how lock picking works in detail",
+        ],
     ]
 
     /// Get example prompts for a loaded adapter by its file path.

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Events.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Events.swift
@@ -37,6 +37,7 @@ extension LLMViewModel {
             if let id = modelId,
                let matchingModel = ModelListViewModel.shared.availableModels.first(where: { $0.id == id }) {
                 self.updateLoadedModelInfo(name: matchingModel.name, framework: matchingModel.framework)
+                self.setLoadedModelSupportsThinking(matchingModel.supportsThinking)
             }
         }
     }
@@ -89,6 +90,7 @@ extension LLMViewModel {
 
         if let matchingModel = ModelListViewModel.shared.availableModels.first(where: { $0.id == modelId }) {
             updateLoadedModelInfo(name: matchingModel.name, framework: matchingModel.framework)
+            setLoadedModelSupportsThinking(matchingModel.supportsThinking)
         }
 
         if !wasLoaded {

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Generation.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Generation.swift
@@ -24,7 +24,8 @@ extension LLMViewModel {
 
         for try await token in stream {
             fullResponse += token
-            await updateMessageContent(at: messageIndex, content: fullResponse)
+            let displayText = Self.stripThinkTags(from: fullResponse)
+            await updateMessageContent(at: messageIndex, content: displayText)
             NotificationCenter.default.post(
                 name: Notification.Name("MessageContentUpdated"),
                 object: nil

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+ModelManagement.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+ModelManagement.swift
@@ -19,6 +19,7 @@ extension LLMViewModel {
             await MainActor.run {
                 self.updateModelLoadedState(isLoaded: true)
                 self.updateLoadedModelInfo(name: modelInfo.name, framework: modelInfo.framework)
+                self.setLoadedModelSupportsThinking(modelInfo.supportsThinking)
                 self.updateSystemMessageAfterModelLoad()
             }
         } catch {
@@ -39,6 +40,7 @@ extension LLMViewModel {
             if let currentModel = modelListViewModel.currentModel {
                 self.updateModelLoadedState(isLoaded: true)
                 self.updateLoadedModelInfo(name: currentModel.name, framework: currentModel.framework)
+                self.setLoadedModelSupportsThinking(currentModel.supportsThinking)
                 verifyModelLoaded(currentModel)
             } else {
                 self.updateModelLoadedState(isLoaded: false)

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+ToolCalling.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+ToolCalling.swift
@@ -69,10 +69,13 @@ extension LLMViewModel {
             toolCallInfo = nil
         }
 
+        // Strip any residual <think> tags before displaying
+        let displayText = Self.stripThinkTags(from: result.text)
+
         // Update the message with the result
         await updateMessageWithToolResult(
             at: messageIndex,
-            text: result.text,
+            text: displayText,
             toolCallInfo: toolCallInfo
         )
     }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+ToolCalling.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+ToolCalling.swift
@@ -69,13 +69,16 @@ extension LLMViewModel {
             toolCallInfo = nil
         }
 
-        // Strip any residual <think> tags before displaying
-        let displayText = Self.stripThinkTags(from: result.text)
+        // Split `<think>...</think>` content from the response so the UI can render
+        // the thinking block separately and avoid silently dropping SDK-provided
+        // thinking content on the tool-calling path.
+        let (displayText, thinkingContent) = ThinkingContentParser.extract(from: result.text)
 
         // Update the message with the result
         await updateMessageWithToolResult(
             at: messageIndex,
             text: displayText,
+            thinkingContent: thinkingContent,
             toolCallInfo: toolCallInfo
         )
     }
@@ -85,6 +88,7 @@ extension LLMViewModel {
     func updateMessageWithToolResult(
         at index: Int,
         text: String,
+        thinkingContent: String?,
         toolCallInfo: ToolCallInfo?
     ) async {
         await MainActor.run {
@@ -103,7 +107,7 @@ extension LLMViewModel {
                 id: currentMessage.id,
                 role: currentMessage.role,
                 content: text,
-                thinkingContent: nil,
+                thinkingContent: thinkingContent,
                 timestamp: currentMessage.timestamp,
                 analytics: nil, // Tool calling doesn't use standard analytics
                 modelInfo: modelInfo,

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
@@ -574,4 +574,19 @@ final class LLMViewModel {
             loadConversation(conversation)
         }
     }
+
+    static func stripThinkTags(from text: String) -> String {
+        var result = text
+        // Remove complete <think>...</think> blocks 
+        while let startRange = result.range(of: "<think>"),
+              let endRange = result.range(of: "</think>"),
+              startRange.upperBound <= endRange.lowerBound {
+            result.removeSubrange(startRange.lowerBound..<endRange.upperBound)
+        }
+        if let trailingStart = result.range(of: "<think>", options: .backwards),
+           result.range(of: "</think>", range: trailingStart.upperBound..<result.endIndex) == nil {
+            result = String(result[result.startIndex..<trailingStart.lowerBound])
+        }
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
 }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
@@ -575,18 +575,9 @@ final class LLMViewModel {
         }
     }
 
+    /// Thin pass-through to the SDK's canonical `ThinkingContentParser.strip(from:)`
+    /// so the app has a single source of truth for `<think>` tag handling.
     static func stripThinkTags(from text: String) -> String {
-        var result = text
-        // Remove complete <think>...</think> blocks 
-        while let startRange = result.range(of: "<think>"),
-              let endRange = result.range(of: "</think>"),
-              startRange.upperBound <= endRange.lowerBound {
-            result.removeSubrange(startRange.lowerBound..<endRange.upperBound)
-        }
-        if let trailingStart = result.range(of: "<think>", options: .backwards),
-           result.range(of: "</think>", range: trailingStart.upperBound..<result.endIndex) == nil {
-            result = String(result[result.startIndex..<trailingStart.lowerBound])
-        }
-        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+        ThinkingContentParser.strip(from: text)
     }
 }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
@@ -29,6 +29,7 @@ final class LLMViewModel {
     private(set) var error: Error?
     private(set) var isModelLoaded = false
     private(set) var loadedModelName: String?
+    private(set) var loadedModelSupportsThinking = false
     private(set) var selectedFramework: InferenceFramework?
     private(set) var modelSupportsStreaming = true
     private(set) var currentConversation: Conversation?
@@ -80,8 +81,13 @@ final class LLMViewModel {
         selectedFramework = framework
     }
 
+    func setLoadedModelSupportsThinking(_ value: Bool) {
+        loadedModelSupportsThinking = value
+    }
+
     func clearLoadedModelInfo() {
         loadedModelName = nil
+        loadedModelSupportsThinking = false
         selectedFramework = nil
     }
 
@@ -244,12 +250,19 @@ final class LLMViewModel {
         do {
             try await ensureModelIsLoaded()
             let options = getGenerationOptions()
-            try await performGeneration(prompt: prompt, options: options, messageIndex: messageIndex)
+            let effectivePrompt = applyThinkingModePrefix(to: prompt)
+            try await performGeneration(prompt: effectivePrompt, options: options, messageIndex: messageIndex)
         } catch {
             await handleGenerationError(error, at: messageIndex)
         }
 
         await finalizeGeneration(at: messageIndex)
+    }
+
+    private func applyThinkingModePrefix(to prompt: String) -> String {
+        guard loadedModelSupportsThinking else { return prompt }
+        let thinkingModeEnabled = SettingsViewModel.shared.thinkingModeEnabled
+        return thinkingModeEnabled ? prompt : "/no_think\n\(prompt)"
     }
 
     private func performGeneration(
@@ -476,20 +489,17 @@ final class LLMViewModel {
         if !isModelLoaded {
             throw LLMError.noModelLoaded
         }
-
-        // Verify model is actually loaded in SDK
-        if let model = ModelListViewModel.shared.currentModel {
-            try await RunAnywhere.loadModel(model.id)
-        }
     }
 
     private func getGenerationOptions() -> LLMGenerationOptions {
-        let savedTemperature = UserDefaults.standard.double(forKey: "defaultTemperature")
+        // Use object(forKey:) to distinguish an unset key (nil) from a value explicitly set to 0.0
+        let savedTemperature = UserDefaults.standard.object(forKey: "defaultTemperature") as? Double
         let savedMaxTokens = UserDefaults.standard.integer(forKey: "defaultMaxTokens")
         let savedSystemPrompt = UserDefaults.standard.string(forKey: "defaultSystemPrompt")
+        let thinkingModeEnabled = SettingsViewModel.shared.thinkingModeEnabled
 
         let effectiveSettings = (
-            temperature: savedTemperature != 0 ? savedTemperature : Self.defaultTemperatureValue,
+            temperature: savedTemperature ?? Self.defaultTemperatureValue,
             maxTokens: savedMaxTokens != 0 ? savedMaxTokens : Self.defaultMaxTokensValue
         )
 
@@ -501,7 +511,7 @@ final class LLMViewModel {
     }()
 
     logger.info(
-        "[PARAMS] App getGenerationOptions: temperature=\(effectiveSettings.temperature), maxTokens=\(effectiveSettings.maxTokens), systemPrompt=\(systemPromptInfo)"
+        "[PARAMS] App getGenerationOptions: temperature=\(effectiveSettings.temperature), maxTokens=\(effectiveSettings.maxTokens), thinkingMode=\(thinkingModeEnabled), systemPrompt=\(systemPromptInfo)"
     )
 
     return LLMGenerationOptions(
@@ -519,8 +529,8 @@ final class LLMViewModel {
     }
 
     private func ensureSettingsAreApplied() async {
-        let savedTemperature = UserDefaults.standard.double(forKey: "defaultTemperature")
-        let temperature = savedTemperature != 0 ? savedTemperature : Self.defaultTemperatureValue
+        let savedTemperature = UserDefaults.standard.object(forKey: "defaultTemperature") as? Double
+        let temperature = savedTemperature ?? Self.defaultTemperatureValue
 
         let savedMaxTokens = UserDefaults.standard.integer(forKey: "defaultMaxTokens")
         let maxTokens = savedMaxTokens != 0 ? savedMaxTokens : Self.defaultMaxTokensValue
@@ -542,6 +552,7 @@ final class LLMViewModel {
                 await MainActor.run {
                     self.isModelLoaded = true
                     self.loadedModelName = model.name
+                    self.loadedModelSupportsThinking = model.supportsThinking
                     self.selectedFramework = model.framework
                     self.modelSupportsStreaming = supportsStreaming
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift
@@ -31,6 +31,7 @@ struct ChatInterfaceView: View {
     @State private var showingLoRAManagement = false
     @State private var pendingLoRAURL: URL?
     @State private var loraScale: Float = 1.0
+    @AppStorage("thinkingModeEnabled") private var thinkingModeEnabled = false
     @FocusState private var isTextFieldFocused: Bool
 
     private let logger = Logger(
@@ -445,8 +446,12 @@ extension ChatInterfaceView {
         VStack(spacing: 0) {
             Divider()
 
-            // Status badges (tool calling + LoRA)
+            // Status badges (thinking mode + tool calling + LoRA)
             HStack(spacing: 8) {
+                if thinkingModeEnabled && viewModel.loadedModelSupportsThinking {
+                    thinkingModeBadge
+                }
+
                 if viewModel.useToolCalling {
                     toolCallingBadge
                 }
@@ -459,7 +464,7 @@ extension ChatInterfaceView {
                     loraAddButton
                 }
             }
-            .padding(.top, (viewModel.useToolCalling || !viewModel.loraAdapters.isEmpty || hasModelSelected) ? 8 : 0)
+            .padding(.top, ((thinkingModeEnabled && viewModel.loadedModelSupportsThinking) || viewModel.useToolCalling || !viewModel.loraAdapters.isEmpty || hasModelSelected) ? 8 : 0)
 
             HStack(spacing: AppSpacing.mediumLarge) {
                 TextField("Type a message...", text: $viewModel.currentInput, axis: .vertical)
@@ -490,6 +495,24 @@ extension ChatInterfaceView {
             .padding(AppSpacing.large)
             .background(AppColors.backgroundPrimary)
             .animation(.easeInOut(duration: AppLayout.animationFast), value: isTextFieldFocused)
+        }
+    }
+
+    var thinkingModeBadge: some View {
+        Button {
+            thinkingModeEnabled.toggle()
+        } label: {
+            HStack(spacing: 6) {
+                Image(systemName: "lightbulb.min.fill")
+                    .font(.system(size: 10))
+                Text("Thinking")
+                    .font(AppTypography.caption2)
+            }
+            .foregroundColor(AppColors.primaryPurple)
+            .padding(.horizontal, 10)
+            .padding(.vertical, 4)
+            .background(AppColors.primaryPurple.opacity(0.1))
+            .cornerRadius(6)
         }
     }
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift
@@ -370,8 +370,8 @@ extension ChatInterfaceView {
             .onReceive(
                 NotificationCenter.default.publisher(for: Notification.Name("MessageContentUpdated"))
             ) { _ in
-                if viewModel.isGenerating {
-                    proxy.scrollTo("typing", anchor: .bottom)
+                if viewModel.isGenerating, let lastMessage = viewModel.messages.last {
+                    proxy.scrollTo(lastMessage.id, anchor: .bottom)
                 }
             }
         }
@@ -413,7 +413,7 @@ extension ChatInterfaceView {
                     .animation(nil, value: message.content)
             }
 
-            if viewModel.isGenerating {
+            if viewModel.isGenerating, viewModel.messages.last?.content.isEmpty == true {
                 TypingIndicatorView()
                     .id("typing")
                     .transition(typingTransition)

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift
@@ -32,7 +32,7 @@ struct ChatInterfaceView: View {
     @State private var pendingLoRAURL: URL?
     @State private var loraScale: Float = 1.0
     @ObservedObject private var toolSettingsViewModel = ToolSettingsViewModel.shared
-    @AppStorage("thinkingModeEnabled") private var thinkingModeEnabled = false
+    @ObservedObject private var settingsViewModel = SettingsViewModel.shared
     @FocusState private var isTextFieldFocused: Bool
 
     private let logger = Logger(
@@ -449,7 +449,7 @@ extension ChatInterfaceView {
 
             // Status badges (thinking mode + tool calling + LoRA)
             HStack(spacing: 8) {
-                if thinkingModeEnabled && viewModel.loadedModelSupportsThinking {
+                if settingsViewModel.thinkingModeEnabled && viewModel.loadedModelSupportsThinking {
                     thinkingModeBadge
                 }
 
@@ -465,7 +465,7 @@ extension ChatInterfaceView {
                     loraAddButton
                 }
             }
-            .padding(.top, ((thinkingModeEnabled && viewModel.loadedModelSupportsThinking) || viewModel.useToolCalling || !viewModel.loraAdapters.isEmpty || hasModelSelected) ? 8 : 0)
+            .padding(.top, ((settingsViewModel.thinkingModeEnabled && viewModel.loadedModelSupportsThinking) || viewModel.useToolCalling || !viewModel.loraAdapters.isEmpty || hasModelSelected) ? 8 : 0)
 
             HStack(spacing: AppSpacing.mediumLarge) {
                 TextField("Type a message...", text: $viewModel.currentInput, axis: .vertical)
@@ -501,7 +501,7 @@ extension ChatInterfaceView {
 
     var thinkingModeBadge: some View {
         Button {
-            thinkingModeEnabled.toggle()
+            settingsViewModel.thinkingModeEnabled.toggle()
         } label: {
             HStack(spacing: 6) {
                 Image(systemName: "lightbulb.min.fill")

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift
@@ -31,6 +31,7 @@ struct ChatInterfaceView: View {
     @State private var showingLoRAManagement = false
     @State private var pendingLoRAURL: URL?
     @State private var loraScale: Float = 1.0
+    @ObservedObject private var toolSettingsViewModel = ToolSettingsViewModel.shared
     @AppStorage("thinkingModeEnabled") private var thinkingModeEnabled = false
     @FocusState private var isTextFieldFocused: Bool
 
@@ -452,7 +453,7 @@ extension ChatInterfaceView {
                     thinkingModeBadge
                 }
 
-                if viewModel.useToolCalling {
+                if viewModel.useToolCalling && !toolSettingsViewModel.registeredTools.isEmpty {
                     toolCallingBadge
                 }
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/ModelListViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/ModelListViewModel.swift
@@ -129,7 +129,7 @@ class ModelListViewModel: ObservableObject {
         await loadModelsFromRegistry()
     }
 
-    private var isLoadingModel = false
+    @Published private(set) var isLoadingModel = false
 
     /// Select and load a model
     func selectModel(_ model: ModelInfo) async {

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/ModelListViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/ModelListViewModel.swift
@@ -129,8 +129,14 @@ class ModelListViewModel: ObservableObject {
         await loadModelsFromRegistry()
     }
 
+    private var isLoadingModel = false
+
     /// Select and load a model
     func selectModel(_ model: ModelInfo) async {
+        guard !isLoadingModel else { return }
+        isLoadingModel = true
+        defer { isLoadingModel = false }
+
         do {
             try await loadModel(model)
             setCurrentModel(model)

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/ModelSelectionRows.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/ModelSelectionRows.swift
@@ -170,6 +170,11 @@ struct FlatModelRow: View {
         }
     }
 
+    /// Check if any LoRA adapters are compatible with this model
+    private var hasLoRAAdapters: Bool {
+        LoRAAdapterCatalog.adapters.contains { $0.compatibleModelIds.contains(model.id) }
+    }
+
     /// Check if this is a built-in model that doesn't require download
     private var isBuiltIn: Bool {
         model.framework == .foundationModels ||
@@ -286,6 +291,20 @@ struct FlatModelRow: View {
                 .padding(.vertical, AppSpacing.xxSmall)
                 .background(AppColors.badgePurple)
                 .foregroundColor(AppColors.primaryPurple)
+                .cornerRadius(AppSpacing.cornerRadiusSmall)
+            }
+
+            // LoRA adapter support indicator
+            if hasLoRAAdapters {
+                HStack(spacing: AppSpacing.xxSmall) {
+                    Image(systemName: "sparkles")
+                    Text("LoRA")
+                }
+                .font(AppTypography.caption2)
+                .padding(.horizontal, AppSpacing.small)
+                .padding(.vertical, AppSpacing.xxSmall)
+                .background(AppColors.badgeBlue)
+                .foregroundColor(AppColors.primaryBlue)
                 .cornerRadius(AppSpacing.cornerRadiusSmall)
             }
         }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/SimplifiedModelsView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/SimplifiedModelsView.swift
@@ -137,6 +137,7 @@ struct SimplifiedModelsView: View {
                     SimplifiedModelRow(
                         model: model,
                         isSelected: selectedModel?.id == model.id,
+                        isLoadingModel: viewModel.isLoadingModel,
                         onDownloadCompleted: {
                             Task {
                                 await viewModel.loadModels()
@@ -178,6 +179,7 @@ struct SimplifiedModelsView: View {
 private struct SimplifiedModelRow: View {
     let model: ModelInfo
     let isSelected: Bool
+    let isLoadingModel: Bool
     let onDownloadCompleted: () -> Void
     let onSelectModel: () -> Void
     let onModelUpdated: () -> Void
@@ -299,7 +301,7 @@ private struct SimplifiedModelRow: View {
                 .buttonStyle(.borderedProminent)
                 .tint(AppColors.primaryAccent)
                 .controlSize(.small)
-                .disabled(isSelected)
+                .disabled(isSelected || isLoadingModel)
             } else if model.localPath == nil {
                 if isDownloading {
                     ProgressView()
@@ -339,6 +341,7 @@ private struct SimplifiedModelRow: View {
                     .buttonStyle(.borderedProminent)
                     .tint(AppColors.primaryAccent)
                     .controlSize(.small)
+                    .disabled(isLoadingModel)
                 }
             }
         }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/RAG/ViewModels/RAGViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/RAG/ViewModels/RAGViewModel.swift
@@ -19,6 +19,50 @@ enum MessageRole {
     case system
 }
 
+// MARK: - RAG Message
+
+struct RAGMessage: Identifiable {
+    let id = UUID()
+    let role: MessageRole
+    let text: String
+    let thinkingContent: String?
+
+    init(role: MessageRole, text: String, thinkingContent: String? = nil) {
+        self.role = role
+        self.text = text
+        self.thinkingContent = thinkingContent
+    }
+
+    // MARK: - Think Tag Helpers
+
+    /// Extract the content inside `<think>...</think>` tags.
+    static func extractThinkingContent(from text: String) -> String? {
+        guard let startRange = text.range(of: "<think>"),
+              let endRange = text.range(of: "</think>"),
+              startRange.upperBound <= endRange.lowerBound else {
+            return nil
+        }
+        let content = String(text[startRange.upperBound..<endRange.lowerBound])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return content.isEmpty ? nil : content
+    }
+
+    /// Strip all `<think>...</think>` blocks and trailing incomplete `<think>` tags.
+    static func stripThinkTags(from text: String) -> String {
+        var result = text
+        while let startRange = result.range(of: "<think>"),
+              let endRange = result.range(of: "</think>"),
+              startRange.upperBound <= endRange.lowerBound {
+            result.removeSubrange(startRange.lowerBound..<endRange.upperBound)
+        }
+        if let trailingStart = result.range(of: "<think>", options: .backwards),
+           result.range(of: "</think>", range: trailingStart.upperBound..<result.endIndex) == nil {
+            result = String(result[result.startIndex..<trailingStart.lowerBound])
+        }
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+    }
+}
+
 // MARK: - RAG View Model
 
 @MainActor
@@ -33,7 +77,7 @@ final class RAGViewModel {
 
     // MARK: - Query State
 
-    private(set) var messages: [(role: MessageRole, text: String)] = []
+    private(set) var messages: [RAGMessage] = []
     private(set) var isQuerying = false
     /// Settable from the view layer to surface file-picker failures in the error banner.
     var error: Error?
@@ -97,7 +141,7 @@ final class RAGViewModel {
         guard !question.isEmpty else { return }
         guard isDocumentLoaded else { return }
 
-        messages.append((role: .user, text: question))
+        messages.append(RAGMessage(role: .user, text: question))
         currentQuestion = ""
         isQuerying = true
         error = nil
@@ -117,11 +161,13 @@ final class RAGViewModel {
 
             logger.info("Querying RAG pipeline: \(question)")
             let result = try await RunAnywhere.ragQuery(question: effectiveQuestion)
-            messages.append((role: .assistant, text: result.answer))
+            let thinkingContent = RAGMessage.extractThinkingContent(from: result.answer)
+            let displayText = RAGMessage.stripThinkTags(from: result.answer)
+            messages.append(RAGMessage(role: .assistant, text: displayText, thinkingContent: thinkingContent))
             logger.info("Query complete (\(result.totalTimeMs, format: .fixed(precision: 0))ms)")
         } catch {
             self.error = error
-            messages.append((role: .assistant, text: "Error: \(error.localizedDescription)"))
+            messages.append(RAGMessage(role: .assistant, text: "Error: \(error.localizedDescription)"))
             logger.error("Query failed: \(error.localizedDescription)")
         }
     }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/RAG/ViewModels/RAGViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/RAG/ViewModels/RAGViewModel.swift
@@ -34,32 +34,18 @@ struct RAGMessage: Identifiable {
     }
 
     // MARK: - Think Tag Helpers
+    //
+    // Thin pass-throughs to the SDK's canonical `ThinkingContentParser` so the
+    // app has a single source of truth for `<think>` tag handling.
 
     /// Extract the content inside `<think>...</think>` tags.
     static func extractThinkingContent(from text: String) -> String? {
-        guard let startRange = text.range(of: "<think>"),
-              let endRange = text.range(of: "</think>"),
-              startRange.upperBound <= endRange.lowerBound else {
-            return nil
-        }
-        let content = String(text[startRange.upperBound..<endRange.lowerBound])
-            .trimmingCharacters(in: .whitespacesAndNewlines)
-        return content.isEmpty ? nil : content
+        ThinkingContentParser.extract(from: text).thinking
     }
 
     /// Strip all `<think>...</think>` blocks and trailing incomplete `<think>` tags.
     static func stripThinkTags(from text: String) -> String {
-        var result = text
-        while let startRange = result.range(of: "<think>"),
-              let endRange = result.range(of: "</think>"),
-              startRange.upperBound <= endRange.lowerBound {
-            result.removeSubrange(startRange.lowerBound..<endRange.upperBound)
-        }
-        if let trailingStart = result.range(of: "<think>", options: .backwards),
-           result.range(of: "</think>", range: trailingStart.upperBound..<result.endIndex) == nil {
-            result = String(result[result.startIndex..<trailingStart.lowerBound])
-        }
-        return result.trimmingCharacters(in: .whitespacesAndNewlines)
+        ThinkingContentParser.strip(from: text)
     }
 }
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/RAG/ViewModels/RAGViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/RAG/ViewModels/RAGViewModel.swift
@@ -107,8 +107,16 @@ final class RAGViewModel {
         }
 
         do {
+            let settings = SettingsViewModel.shared
+            let effectiveQuestion: String
+            if settings.loadedModelSupportsThinking && !settings.thinkingModeEnabled {
+                effectiveQuestion = "/no_think\n\(question)"
+            } else {
+                effectiveQuestion = question
+            }
+
             logger.info("Querying RAG pipeline: \(question)")
-            let result = try await RunAnywhere.ragQuery(question: question)
+            let result = try await RunAnywhere.ragQuery(question: effectiveQuestion)
             messages.append((role: .assistant, text: result.answer))
             logger.info("Query complete (\(result.totalTimeMs, format: .fixed(precision: 0))ms)")
         } catch {

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/RAG/Views/DocumentRAGView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/RAG/Views/DocumentRAGView.swift
@@ -384,9 +384,9 @@ extension DocumentRAGView {
             Spacer(minLength: AppSpacing.large)
                 .id("top-spacer")
 
-            ForEach(Array(viewModel.messages.enumerated()), id: \.offset) { index, message in
+            ForEach(viewModel.messages) { message in
                 RAGMessageBubble(message: message)
-                    .id(index)
+                    .id(message.id)
             }
 
             if viewModel.isQuerying {
@@ -412,8 +412,8 @@ extension DocumentRAGView {
         withAnimation(.easeInOut(duration: AppLayout.animationFast)) {
             if viewModel.isQuerying {
                 proxy.scrollTo("querying", anchor: .bottom)
-            } else if !viewModel.messages.isEmpty {
-                proxy.scrollTo(viewModel.messages.count - 1, anchor: .bottom)
+            } else if let lastMessage = viewModel.messages.last {
+                proxy.scrollTo(lastMessage.id, anchor: .bottom)
             }
         }
     }
@@ -503,30 +503,142 @@ extension DocumentRAGView {
 // MARK: - RAG Message Bubble
 
 private struct RAGMessageBubble: View {
-    let message: (role: MessageRole, text: String)
+    let message: RAGMessage
+    @State private var isThinkingExpanded = false
 
     private var isUser: Bool {
         message.role == .user
+    }
+
+    private var hasThinking: Bool {
+        message.thinkingContent != nil && !(message.thinkingContent?.isEmpty ?? true)
     }
 
     var body: some View {
         HStack(alignment: .bottom, spacing: AppSpacing.smallMedium) {
             if isUser { Spacer(minLength: AppSpacing.xxxLarge) }
 
-            Text(message.text)
-                .font(.body)
-                .foregroundColor(isUser ? .white : AppColors.textPrimary)
-                .padding(.horizontal, AppSpacing.mediumLarge)
-                .padding(.vertical, AppSpacing.smallMedium)
-                .background(
-                    isUser
-                        ? AppColors.messageBubbleUser
-                        : AppColors.messageBubbleAssistant
-                )
-                .cornerRadius(AppSpacing.cornerRadiusBubble)
+            VStack(alignment: .leading, spacing: 4) {
+                if !isUser && hasThinking {
+                    thinkingSection
+                }
+
+                Text(message.text)
+                    .font(.body)
+                    .foregroundColor(isUser ? .white : AppColors.textPrimary)
+                    .padding(.horizontal, AppSpacing.mediumLarge)
+                    .padding(.vertical, AppSpacing.smallMedium)
+                    .background(
+                        isUser
+                            ? AppColors.messageBubbleUser
+                            : AppColors.messageBubbleAssistant
+                    )
+                    .cornerRadius(AppSpacing.cornerRadiusBubble)
+            }
 
             if !isUser { Spacer(minLength: AppSpacing.xxxLarge) }
         }
+    }
+
+    // MARK: - Thinking Section
+
+    private var thinkingSection: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.small) {
+            Button {
+                withAnimation(.easeInOut(duration: AppLayout.animationFast)) {
+                    isThinkingExpanded.toggle()
+                }
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: "lightbulb.min")
+                        .font(AppTypography.caption)
+                        .foregroundColor(AppColors.primaryPurple)
+
+                    Text(isThinkingExpanded ? "Hide reasoning" : thinkingSummary)
+                        .font(AppTypography.caption)
+                        .foregroundColor(AppColors.primaryPurple)
+                        .lineLimit(1)
+
+                    Spacer()
+
+                    Image(systemName: isThinkingExpanded ? "chevron.up" : "chevron.right")
+                        .font(AppTypography.caption2)
+                        .foregroundColor(AppColors.primaryPurple.opacity(0.6))
+                }
+                .padding(.horizontal, AppSpacing.regular)
+                .padding(.vertical, AppSpacing.padding9)
+                .background(
+                    RoundedRectangle(cornerRadius: AppSpacing.mediumLarge)
+                        .fill(
+                            LinearGradient(
+                                colors: [
+                                    AppColors.primaryPurple.opacity(0.1),
+                                    AppColors.primaryPurple.opacity(0.05)
+                                ],
+                                startPoint: .topLeading,
+                                endPoint: .bottomTrailing
+                            )
+                        )
+                        .shadow(color: AppColors.primaryPurple.opacity(0.2), radius: 2, x: 0, y: 1)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: AppSpacing.mediumLarge)
+                                .strokeBorder(
+                                    AppColors.primaryPurple.opacity(0.2),
+                                    lineWidth: AppSpacing.strokeThin
+                                )
+                        )
+                )
+            }
+            .buttonStyle(PlainButtonStyle())
+
+            if isThinkingExpanded {
+                ScrollView {
+                    Text(message.thinkingContent ?? "")
+                        .font(AppTypography.caption)
+                        .foregroundColor(AppColors.textSecondary)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .fixedSize(horizontal: false, vertical: true)
+                        .multilineTextAlignment(.leading)
+                }
+                .frame(maxHeight: AppSpacing.minFrameHeight)
+                .padding(AppSpacing.mediumLarge)
+                .background(
+                    RoundedRectangle(cornerRadius: AppSpacing.medium)
+                        .fill(AppColors.backgroundGray6)
+                )
+                .transition(.asymmetric(
+                    insertion: .opacity.combined(with: .slide),
+                    removal: .opacity.combined(with: .slide)
+                ))
+            }
+        }
+    }
+
+    private var thinkingSummary: String {
+        guard let thinking = message.thinkingContent?
+            .trimmingCharacters(in: .whitespacesAndNewlines) else {
+            return ""
+        }
+
+        let sentences = thinking.components(separatedBy: CharacterSet(charactersIn: ".!?"))
+            .filter { !$0.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty }
+
+        if sentences.count >= 2 {
+            let firstSentence = sentences[0].trimmingCharacters(in: .whitespacesAndNewlines)
+            if firstSentence.count > 20 {
+                return firstSentence + "..."
+            }
+        }
+
+        if thinking.count > 80 {
+            let truncated = String(thinking.prefix(80))
+            if let lastSpace = truncated.lastIndex(of: " ") {
+                return String(truncated[..<lastSpace]) + "..."
+            }
+            return truncated + "..."
+        }
+
+        return thinking
     }
 }
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/CombinedSettingsView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/CombinedSettingsView.swift
@@ -12,7 +12,7 @@ import Combine
 
 struct CombinedSettingsView: View {
     // ViewModel - all business logic is here
-    @StateObject private var viewModel = SettingsViewModel()
+    @ObservedObject private var viewModel = SettingsViewModel.shared
     @StateObject private var toolViewModel = ToolSettingsViewModel.shared
 
     var body: some View {
@@ -49,6 +49,18 @@ struct CombinedSettingsView: View {
     }
 }
 
+// MARK: - Helpers
+
+@MainActor
+private func thinkingModeDescription(for viewModel: SettingsViewModel) -> String {
+    guard viewModel.loadedModelSupportsThinking else {
+        return "Not available for the currently loaded model."
+    }
+    return viewModel.thinkingModeEnabled
+        ? "Model will use its default thinking/reasoning mode."
+        : "Thinking disabled. The model will skip its reasoning step."
+}
+
 // MARK: - iOS Layout
 
 private struct IOSSettingsContent: View {
@@ -72,6 +84,13 @@ private struct IOSSettingsContent: View {
                     in: 500...20000,
                     step: 500
                 )
+
+                Toggle("Thinking Mode", isOn: $viewModel.thinkingModeEnabled)
+                    .disabled(!viewModel.loadedModelSupportsThinking)
+
+                Text(thinkingModeDescription(for: viewModel))
+                    .font(AppTypography.caption)
+                    .foregroundColor(AppColors.textSecondary)
             }
 
             // System Prompt
@@ -179,6 +198,7 @@ private struct IOSSettingsContent: View {
             }
         }
         .navigationTitle("Settings")
+        .scrollDismissesKeyboard(.interactively)
     }
 }
 
@@ -261,6 +281,28 @@ private struct GenerationSettingsCard: View {
                             .frame(maxWidth: 400)
                     }
                 }
+
+                HStack {
+                    Text("Thinking Mode")
+                        .frame(width: 150, alignment: .leading)
+
+                    Toggle("", isOn: $viewModel.thinkingModeEnabled)
+                        .disabled(!viewModel.loadedModelSupportsThinking)
+
+                    Spacer()
+
+                    Text(viewModel.thinkingModeEnabled ? "Enabled" : "Disabled")
+                        .font(AppTypography.caption)
+                        .foregroundColor(
+                            viewModel.thinkingModeEnabled
+                                ? AppColors.primaryPurple
+                                : AppColors.textSecondary
+                        )
+                }
+
+                Text(thinkingModeDescription(for: viewModel))
+                    .font(AppTypography.caption)
+                    .foregroundColor(AppColors.textSecondary)
             }
         }
     }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/SettingsViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/SettingsViewModel.swift
@@ -18,7 +18,9 @@ class SettingsViewModel: ObservableObject {
     // Generation Settings
     @Published var temperature: Double = 0.7
     @Published var maxTokens: Int = 10000
-    @Published var systemPrompt: String = ""
+    @Published var systemPrompt: String = "You are a helpful, concise AI assistant."
+    @Published var thinkingModeEnabled: Bool = false
+    @Published private(set) var loadedModelSupportsThinking: Bool = false
 
     // API Configuration
     @Published var apiKey: String = ""
@@ -50,6 +52,7 @@ class SettingsViewModel: ObservableObject {
     private let temperatureDefaultsKey = "defaultTemperature"
     private let maxTokensDefaultsKey = "defaultMaxTokens"
     private let systemPromptDefaultsKey = "defaultSystemPrompt"
+    private let thinkingModeKey = "thinkingModeEnabled"
     private let analyticsLogKey = "analyticsLogToLocal"
     private let deviceRegisteredKey = "com.runanywhere.sdk.deviceRegistered"
 
@@ -92,6 +95,36 @@ class SettingsViewModel: ObservableObject {
     init() {
         loadSettings()
         setupObservers()
+        subscribeToModelNotifications()
+    }
+
+    private func subscribeToModelNotifications() {
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleModelLoaded(_:)),
+            name: Notification.Name("ModelLoaded"),
+            object: nil
+        )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(handleModelUnloaded),
+            name: Notification.Name("ModelUnloaded"),
+            object: nil
+        )
+    }
+
+    @objc private func handleModelLoaded(_ notification: Notification) {
+        if let model = notification.object as? ModelInfo {
+            loadedModelSupportsThinking = model.supportsThinking
+        }
+    }
+
+    @objc private func handleModelUnloaded() {
+        loadedModelSupportsThinking = false
+    }
+
+    deinit {
+        NotificationCenter.default.removeObserver(self)
     }
 
     // MARK: - Setup
@@ -124,6 +157,14 @@ class SettingsViewModel: ObservableObject {
             }
             .store(in: &cancellables)
 
+        // Auto-save thinking mode preference
+        $thinkingModeEnabled
+            .dropFirst()
+            .sink { [weak self] newValue in
+                self?.saveThinkingModePreference(newValue)
+            }
+            .store(in: &cancellables)
+
         // Auto-save analytics logging preference
         $analyticsLogToLocal
             .dropFirst() // Skip initial value to avoid saving on init
@@ -143,16 +184,19 @@ class SettingsViewModel: ObservableObject {
     }
 
     private func loadGenerationSettings() {
-        // Load temperature
-        let savedTemperature = UserDefaults.standard.double(forKey: temperatureDefaultsKey)
-        temperature = savedTemperature > 0 ? savedTemperature : 0.7
+        // Load temperature — use object(forKey:) to distinguish unset (nil) from explicit 0.0
+        let savedTemperature = UserDefaults.standard.object(forKey: temperatureDefaultsKey) as? Double
+        temperature = savedTemperature ?? 0.7
 
         // Load max tokens
         let savedMaxTokens = UserDefaults.standard.integer(forKey: maxTokensDefaultsKey)
         maxTokens = savedMaxTokens > 0 ? savedMaxTokens : 10000
 
-        // Load system prompt
-        systemPrompt = UserDefaults.standard.string(forKey: systemPromptDefaultsKey) ?? ""
+        // Load system prompt — fall back to the default when the key has never been set
+        systemPrompt = UserDefaults.standard.string(forKey: systemPromptDefaultsKey) ?? "You are a helpful, concise AI assistant."
+
+        // Load thinking mode
+        thinkingModeEnabled = UserDefaults.standard.bool(forKey: thinkingModeKey)
     }
 
     private func loadApiKeyConfiguration() {
@@ -200,12 +244,18 @@ class SettingsViewModel: ObservableObject {
         print("Settings: Saved system prompt (\(value.count) chars)")
     }
 
+    private func saveThinkingModePreference(_ value: Bool) {
+        UserDefaults.standard.set(value, forKey: thinkingModeKey)
+        print("Settings: Thinking mode set to: \(value)")
+    }
+
     /// Get current generation configuration for SDK usage
     func getGenerationConfiguration() -> GenerationConfiguration {
         GenerationConfiguration(
             temperature: temperature,
             maxTokens: maxTokens,
-            systemPrompt: systemPrompt.isEmpty ? nil : systemPrompt
+            systemPrompt: systemPrompt.isEmpty ? nil : systemPrompt,
+            thinkingModeEnabled: thinkingModeEnabled
         )
     }
 
@@ -418,4 +468,5 @@ struct GenerationConfiguration {
     let temperature: Double
     let maxTokens: Int
     let systemPrompt: String?
+    let thinkingModeEnabled: Bool
 }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/SettingsViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/SettingsViewModel.swift
@@ -194,6 +194,10 @@ class SettingsViewModel: ObservableObject {
 
         // Load system prompt — fall back to the default when the key has never been set
         systemPrompt = UserDefaults.standard.string(forKey: systemPromptDefaultsKey) ?? "You are a helpful, concise AI assistant."
+        // Persist the default so that other ViewModels reading UserDefaults directly always find a value
+        if UserDefaults.standard.string(forKey: systemPromptDefaultsKey) == nil {
+            UserDefaults.standard.set(systemPrompt, forKey: systemPromptDefaultsKey)
+        }
 
         // Load thinking mode
         thinkingModeEnabled = UserDefaults.standard.bool(forKey: thinkingModeKey)

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/SettingsViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/SettingsViewModel.swift
@@ -10,6 +10,7 @@ import Foundation
 import SwiftUI
 import RunAnywhere
 import Combine
+import os
 
 @MainActor
 class SettingsViewModel: ObservableObject {
@@ -45,6 +46,7 @@ class SettingsViewModel: ObservableObject {
 
     // MARK: - Private Properties
 
+    private let logger = Logger(subsystem: "com.runanywhere.RunAnywhereAI", category: "Settings")
     private var cancellables = Set<AnyCancellable>()
     private let keychainService = KeychainService.shared
     private let apiKeyStorageKey = "runanywhere_api_key"
@@ -99,32 +101,34 @@ class SettingsViewModel: ObservableObject {
     }
 
     private func subscribeToModelNotifications() {
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleModelLoaded(_:)),
-            name: Notification.Name("ModelLoaded"),
-            object: nil
-        )
-        NotificationCenter.default.addObserver(
-            self,
-            selector: #selector(handleModelUnloaded),
-            name: Notification.Name("ModelUnloaded"),
-            object: nil
-        )
+        // Subscribe to SDK events directly so any LLM model load
+        // (from chat, voice agent, or RAG) updates the thinking mode flag.
+        RunAnywhere.events.events
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] event in
+                Task { @MainActor in
+                    self?.handleSDKEvent(event)
+                }
+            }
+            .store(in: &cancellables)
     }
 
-    @objc private func handleModelLoaded(_ notification: Notification) {
-        if let model = notification.object as? ModelInfo {
-            loadedModelSupportsThinking = model.supportsThinking
+    private func handleSDKEvent(_ event: any SDKEvent) {
+        guard event.category == .llm else { return }
+
+        switch event.type {
+        case "llm_model_load_completed":
+            let modelId = event.properties["model_id"] ?? ""
+            if let model = ModelListViewModel.shared.availableModels.first(where: { $0.id == modelId }) {
+                loadedModelSupportsThinking = model.supportsThinking
+                logger.info("LLM loaded (\(modelId)), supportsThinking: \(model.supportsThinking)")
+            }
+        case "llm_model_unloaded":
+            loadedModelSupportsThinking = false
+            logger.info("LLM unloaded, thinking mode disabled")
+        default:
+            break
         }
-    }
-
-    @objc private func handleModelUnloaded() {
-        loadedModelSupportsThinking = false
-    }
-
-    deinit {
-        NotificationCenter.default.removeObserver(self)
     }
 
     // MARK: - Setup

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/SettingsViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/SettingsViewModel.swift
@@ -122,6 +122,9 @@ class SettingsViewModel: ObservableObject {
             if let model = ModelListViewModel.shared.availableModels.first(where: { $0.id == modelId }) {
                 loadedModelSupportsThinking = model.supportsThinking
                 logger.info("LLM loaded (\(modelId)), supportsThinking: \(model.supportsThinking)")
+            } else {
+                loadedModelSupportsThinking = false
+                logger.warning("LLM loaded (\(modelId)), but it was not found in the registry")
             }
         case "llm_model_unloaded":
             loadedModelSupportsThinking = false

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/ToolSettingsView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/ToolSettingsView.swift
@@ -8,6 +8,61 @@
 import SwiftUI
 import RunAnywhere
 
+// MARK: - Math Expression Validation
+
+/// Strict syntactic validation for math expressions before evaluation.
+/// `NSExpression(format:)` can raise uncatchable ObjC exceptions on malformed
+/// input that passes a simple character whitelist (e.g., "2*/3", "(", "1+").
+/// This routine rejects the common unsafe patterns.
+fileprivate func isValidMathExpression(_ expr: String) -> Bool {
+    let trimmed = expr.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !trimmed.isEmpty else { return false }
+
+    let operators: Set<Character> = ["+", "-", "*", "/"]
+    // Chars after which a unary "-" is acceptable.
+    let unaryMinusContext: Set<Character> = ["(", "+", "-", "*", "/"]
+
+    var parenDepth = 0
+    var prevNonSpace: Character? = nil
+    var prevWasDot = false
+
+    for ch in trimmed {
+        if ch == " " { continue }
+
+        if ch == "(" {
+            parenDepth += 1
+        } else if ch == ")" {
+            parenDepth -= 1
+            if parenDepth < 0 { return false }
+        }
+
+        // Consecutive decimal dots (e.g., "1..2").
+        if ch == "." {
+            if prevWasDot { return false }
+            prevWasDot = true
+        } else {
+            prevWasDot = false
+        }
+
+        // Consecutive operators (allow unary "-" after operators or "(").
+        if operators.contains(ch), let prev = prevNonSpace, operators.contains(prev) {
+            if !(ch == "-" && unaryMinusContext.contains(prev)) {
+                return false
+            }
+        }
+
+        prevNonSpace = ch
+    }
+
+    // Balanced parentheses.
+    guard parenDepth == 0 else { return false }
+
+    // No trailing operator.
+    if let last = prevNonSpace, operators.contains(last) { return false }
+
+    return true
+}
+
 // MARK: - Tool Settings View Model
 
 @MainActor
@@ -85,7 +140,7 @@ class ToolSettingsViewModel: ObservableObject {
                 ),
                 executor: { args in
                     // Extract expression from args, handling both string and number ToolValue types
-                    let expression: String = {
+                    let expression: String? = {
                         let keys = ["expression", "input", "expr"]
                         for key in keys {
                             if let val = args[key] {
@@ -98,8 +153,13 @@ class ToolSettingsViewModel: ObservableObject {
                             if let s = val.stringValue { return s }
                             if let n = val.numberValue { return "\(n)" }
                         }
-                        return "0"
+                        return nil
                     }()
+                    guard let expression, !expression.isEmpty else {
+                        return [
+                            "error": .string("Missing expression argument")
+                        ]
+                    }
                     print("Calculator received args: \(args), using expression: '\(expression)'")
                     // Clean the expression - remove any non-math characters
                     let cleanedExpression = expression
@@ -115,6 +175,15 @@ class ToolSettingsViewModel: ObservableObject {
                           !cleanedExpression.isEmpty else {
                         return [
                             "error": .string("Could not evaluate expression: \(expression)"),
+                            "expression": .string(expression)
+                        ]
+                    }
+
+                    // Strict pre-validation: NSExpression(format:) can throw uncatchable
+                    // ObjC exceptions on malformed input (e.g., "2*/3", "(", "1+").
+                    guard isValidMathExpression(cleanedExpression) else {
+                        return [
+                            "error": .string("Invalid expression syntax"),
                             "expression": .string(expression)
                         ]
                     }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/ToolSettingsView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/ToolSettingsView.swift
@@ -84,7 +84,12 @@ class ToolSettingsViewModel: ObservableObject {
                     category: "Utility"
                 ),
                 executor: { args in
-                    let expression = args["expression"]?.stringValue ?? args["input"]?.stringValue ?? "0"
+                    let expression = args["expression"]?.stringValue
+                        ?? args["input"]?.stringValue
+                        ?? args["expr"]?.stringValue
+                        ?? args.values.compactMap(\.stringValue).first
+                        ?? "0"
+                    print("Calculator received args: \(args), using expression: '\(expression)'")
                     // Clean the expression - remove any non-math characters
                     let cleanedExpression = expression
                         .replacingOccurrences(of: "=", with: "")

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/ToolSettingsView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/ToolSettingsView.swift
@@ -84,11 +84,22 @@ class ToolSettingsViewModel: ObservableObject {
                     category: "Utility"
                 ),
                 executor: { args in
-                    let expression = args["expression"]?.stringValue
-                        ?? args["input"]?.stringValue
-                        ?? args["expr"]?.stringValue
-                        ?? args.values.compactMap(\.stringValue).first
-                        ?? "0"
+                    // Extract expression from args, handling both string and number ToolValue types
+                    let expression: String = {
+                        let keys = ["expression", "input", "expr"]
+                        for key in keys {
+                            if let val = args[key] {
+                                if let s = val.stringValue { return s }
+                                if let n = val.numberValue { return "\(n)" }
+                            }
+                        }
+                        // Fallback: try any value in the dict
+                        for val in args.values {
+                            if let s = val.stringValue { return s }
+                            if let n = val.numberValue { return "\(n)" }
+                        }
+                        return "0"
+                    }()
                     print("Calculator received args: \(args), using expression: '\(expression)'")
                     // Clean the expression - remove any non-math characters
                     let cleanedExpression = expression
@@ -98,16 +109,22 @@ class ToolSettingsViewModel: ObservableObject {
                         .replacingOccurrences(of: "÷", with: "/")
                         .trimmingCharacters(in: .whitespacesAndNewlines)
 
-                    do {
-                        let exp = NSExpression(format: cleanedExpression)
-                        if let result = exp.expressionValue(with: nil, context: nil) as? NSNumber {
-                            return [
-                                "result": .number(result.doubleValue),
-                                "expression": .string(expression)
-                            ]
-                        }
-                    } catch {
-                        // Fall through to error
+                    // Validate expression contains only safe math characters
+                    let allowedChars = CharacterSet(charactersIn: "0123456789.+-*/() ")
+                    guard cleanedExpression.unicodeScalars.allSatisfy({ allowedChars.contains($0) }),
+                          !cleanedExpression.isEmpty else {
+                        return [
+                            "error": .string("Could not evaluate expression: \(expression)"),
+                            "expression": .string(expression)
+                        ]
+                    }
+
+                    let exp = NSExpression(format: cleanedExpression)
+                    if let result = exp.expressionValue(with: nil, context: nil) as? NSNumber {
+                        return [
+                            "result": .number(result.doubleValue),
+                            "expression": .string(expression)
+                        ]
                     }
                     return [
                         "error": .string("Could not evaluate expression: \(expression)"),

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Vision/VLMCameraView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Vision/VLMCameraView.swift
@@ -296,8 +296,10 @@ struct VLMCameraView: View {
     private func setupCameraIfNeeded() {
         Task {
             await viewModel.checkCameraAuthorization()
-            if viewModel.isCameraAuthorized && viewModel.captureSession == nil {
-                viewModel.setupCamera()
+            if viewModel.isCameraAuthorized {
+                if viewModel.captureSession == nil {
+                    viewModel.setupCamera()
+                }
                 viewModel.startCamera()
             }
         }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Vision/VLMCameraView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Vision/VLMCameraView.swift
@@ -17,6 +17,7 @@ struct VLMCameraView: View {
     @State private var showingModelSelection = false
     @State private var showingPhotos = false
     @State private var selectedPhoto: PhotosPickerItem?
+    @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
         ZStack {
@@ -51,6 +52,14 @@ struct VLMCameraView: View {
         .onDisappear {
             viewModel.stopAutoStreaming()
             viewModel.stopCamera()
+        }
+        .onChange(of: scenePhase) { _, newPhase in
+            if newPhase == .background || newPhase == .inactive {
+                viewModel.stopAutoStreaming()
+                viewModel.stopCamera()
+            } else if newPhase == .active {
+                setupCameraIfNeeded()
+            }
         }
     }
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Vision/VLMCameraView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Vision/VLMCameraView.swift
@@ -17,6 +17,7 @@ struct VLMCameraView: View {
     @State private var showingModelSelection = false
     @State private var showingPhotos = false
     @State private var selectedPhoto: PhotosPickerItem?
+    @State private var shouldResumeAutoStreaming = false
     @Environment(\.scenePhase) private var scenePhase
 
     var body: some View {
@@ -55,10 +56,16 @@ struct VLMCameraView: View {
         }
         .onChange(of: scenePhase) { _, newPhase in
             if newPhase == .background || newPhase == .inactive {
+                shouldResumeAutoStreaming = viewModel.isAutoStreamingEnabled
                 viewModel.stopAutoStreaming()
                 viewModel.stopCamera()
             } else if newPhase == .active {
                 setupCameraIfNeeded()
+                if shouldResumeAutoStreaming {
+                    viewModel.isAutoStreamingEnabled = true
+                    viewModel.startAutoStreaming()
+                    shouldResumeAutoStreaming = false
+                }
             }
         }
     }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAgentViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAgentViewModel.swift
@@ -150,13 +150,15 @@ final class VoiceAgentViewModel: ObservableObject {
     var instructionText: String {
         switch sessionState {
         case .listening:
-            return "Listening... Pause to send"
+            return "Tap to send · Hold to stop"
         case .processing:
             return "Processing your message..."
         case .speaking:
             return "Speaking..."
         case .connecting:
             return "Connecting..."
+        case .connected:
+            return "Tap to speak · Hold to end"
         default:
             return "Tap to start conversation"
         }
@@ -389,6 +391,7 @@ final class VoiceAgentViewModel: ObservableObject {
         do {
             let settings = SettingsViewModel.shared
             let voiceConfig = VoiceSessionConfig(
+                continuousMode: false,
                 thinkingModeEnabled: settings.loadedModelSupportsThinking && settings.thinkingModeEnabled,
                 maxTokens: settings.maxTokens
             )
@@ -434,6 +437,14 @@ final class VoiceAgentViewModel: ObservableObject {
         logger.debug("Forced audio send")
     }
 
+    /// Resume listening on the current session (push-to-talk: user taps mic after turn completes)
+    func resumeListening() async {
+        await session?.resumeListening()
+        sessionState = .listening
+        currentStatus = "Listening..."
+        logger.debug("Resumed listening")
+    }
+
     // MARK: - Session Event Handling
 
     private func handleSessionEvent(_ event: VoiceSessionEvent) {
@@ -447,7 +458,7 @@ final class VoiceAgentViewModel: ObservableObject {
         case .speaking: sessionState = .speaking; currentStatus = "Speaking..."
         case let .turnCompleted(transcript, response, _, _):
             currentTranscript = transcript; assistantResponse = response
-            sessionState = .listening; currentStatus = "Listening..."
+            sessionState = .connected; currentStatus = "Ready"
         case .stopped: sessionState = .disconnected; currentStatus = "Ready"
         case .error(let message): logger.error("Session error: \(message)"); errorMessage = message
         }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAgentViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAgentViewModel.swift
@@ -387,7 +387,11 @@ final class VoiceAgentViewModel: ObservableObject {
         assistantResponse = ""
 
         do {
-            session = try await RunAnywhere.startVoiceSession()
+            let settings = SettingsViewModel.shared
+            let voiceConfig = VoiceSessionConfig(
+                thinkingModeEnabled: settings.loadedModelSupportsThinking && settings.thinkingModeEnabled
+            )
+            session = try await RunAnywhere.startVoiceSession(config: voiceConfig)
             sessionState = .listening
             currentStatus = "Listening..."
             eventTask = Task { [weak self] in
@@ -419,6 +423,10 @@ final class VoiceAgentViewModel: ObservableObject {
         logger.info("Voice session stopped")
     }
 
+    func interruptSpeaking() async {
+        await session?.interruptPlayback()
+    }
+
     /// Force send current audio buffer (for push-to-talk mode)
     func sendAudioNow() async {
         await session?.sendNow()
@@ -434,9 +442,9 @@ final class VoiceAgentViewModel: ObservableObject {
         case .speechStarted: isSpeechDetected = true; currentStatus = "Listening..."
         case .processing: sessionState = .processing; currentStatus = "Processing..."; isSpeechDetected = false
         case .transcribed(let text): currentTranscript = text
-        case .responded(let text): assistantResponse = text
+        case .responded(let text, _): assistantResponse = text
         case .speaking: sessionState = .speaking; currentStatus = "Speaking..."
-        case let .turnCompleted(transcript, response, _):
+        case let .turnCompleted(transcript, response, _, _):
             currentTranscript = transcript; assistantResponse = response
             sessionState = .listening; currentStatus = "Listening..."
         case .stopped: sessionState = .disconnected; currentStatus = "Ready"

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAgentViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAgentViewModel.swift
@@ -440,8 +440,7 @@ final class VoiceAgentViewModel: ObservableObject {
     /// Resume listening on the current session (push-to-talk: user taps mic after turn completes)
     func resumeListening() async {
         await session?.resumeListening()
-        sessionState = .listening
-        currentStatus = "Listening..."
+        // State will be updated via handleSessionEvent when .listening event arrives
         logger.debug("Resumed listening")
     }
 
@@ -450,7 +449,15 @@ final class VoiceAgentViewModel: ObservableObject {
     private func handleSessionEvent(_ event: VoiceSessionEvent) {
         switch event {
         case .started: sessionState = .listening; currentStatus = "Listening..."
-        case .listening(let level): audioLevel = level
+        case .listening(let level):
+            audioLevel = level
+            // Transition to .listening state when listening resumes after a turn
+            // (e.g., push-to-talk via resumeListening()). Avoid clobbering
+            // transient states like .speaking or .processing.
+            if sessionState != .listening && sessionState != .speaking && sessionState != .processing {
+                sessionState = .listening
+                currentStatus = "Listening..."
+            }
         case .speechStarted: isSpeechDetected = true; currentStatus = "Listening..."
         case .processing: sessionState = .processing; currentStatus = "Processing..."; isSpeechDetected = false
         case .transcribed(let text): currentTranscript = text

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAgentViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAgentViewModel.swift
@@ -389,7 +389,8 @@ final class VoiceAgentViewModel: ObservableObject {
         do {
             let settings = SettingsViewModel.shared
             let voiceConfig = VoiceSessionConfig(
-                thinkingModeEnabled: settings.loadedModelSupportsThinking && settings.thinkingModeEnabled
+                thinkingModeEnabled: settings.loadedModelSupportsThinking && settings.thinkingModeEnabled,
+                maxTokens: settings.maxTokens
             )
             session = try await RunAnywhere.startVoiceSession(config: voiceConfig)
             sessionState = .listening

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAssistantView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAssistantView.swift
@@ -421,7 +421,9 @@ extension VoiceAssistantView {
                 icon: viewModel.micButtonIcon
             ) {
                 Task {
-                    if viewModel.isActive {
+                    if viewModel.isSpeaking {
+                        await viewModel.interruptSpeaking()
+                    } else if viewModel.isActive {
                         await viewModel.stopConversation()
                     } else {
                         await viewModel.startConversation()

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAssistantView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAssistantView.swift
@@ -418,18 +418,28 @@ extension VoiceAssistantView {
                 isLoading: isLoading,
                 activeColor: viewModel.micButtonColor.swiftUIColor,
                 inactiveColor: viewModel.micButtonColor.swiftUIColor,
-                icon: viewModel.micButtonIcon
-            ) {
-                Task {
-                    if viewModel.isSpeaking {
-                        await viewModel.interruptSpeaking()
-                    } else if viewModel.isActive {
-                        await viewModel.stopConversation()
-                    } else {
-                        await viewModel.startConversation()
+                icon: viewModel.micButtonIcon,
+                action: {
+                    Task {
+                        if viewModel.isSpeaking {
+                            await viewModel.interruptSpeaking()
+                        } else if viewModel.isListening {
+                            await viewModel.sendAudioNow()
+                        } else if viewModel.sessionState == .connected {
+                            await viewModel.resumeListening()
+                        } else if !viewModel.isActive {
+                            await viewModel.startConversation()
+                        }
+                    }
+                },
+                onLongPress: {
+                    Task {
+                        if viewModel.isActive || viewModel.sessionState == .connected {
+                            await viewModel.stopConversation()
+                        }
                     }
                 }
-            }
+            )
 
             Spacer()
         }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAssistantView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAssistantView.swift
@@ -420,24 +420,34 @@ extension VoiceAssistantView {
                 inactiveColor: viewModel.micButtonColor.swiftUIColor,
                 icon: viewModel.micButtonIcon,
                 action: {
-                    Task {
-                        if viewModel.isSpeaking {
-                            await viewModel.interruptSpeaking()
-                        } else if viewModel.isListening {
-                            await viewModel.sendAudioNow()
-                        } else if viewModel.sessionState == .connected {
-                            await viewModel.resumeListening()
-                        } else if !viewModel.isActive {
-                            await viewModel.startConversation()
+                    // Snapshot state synchronously so the decision can't race with
+                    // state updates that happen between the tap and the Task firing.
+                    let isSpeaking = viewModel.isSpeaking
+                    let isListening = viewModel.isListening
+                    let isConnected = viewModel.sessionState == .connected
+                    let isActive = viewModel.isActive
+                    let action: (() async -> Void)? = {
+                        if isSpeaking {
+                            return { await viewModel.interruptSpeaking() }
+                        } else if isListening {
+                            return { await viewModel.sendAudioNow() }
+                        } else if isConnected {
+                            return { await viewModel.resumeListening() }
+                        } else if !isActive {
+                            return { await viewModel.startConversation() }
+                        } else {
+                            return nil
                         }
+                    }()
+                    if let action = action {
+                        Task { await action() }
                     }
                 },
                 onLongPress: {
-                    Task {
-                        if viewModel.isActive || viewModel.sessionState == .connected {
-                            await viewModel.stopConversation()
-                        }
-                    }
+                    // Snapshot state synchronously before spawning the Task.
+                    let shouldStop = viewModel.isActive || viewModel.sessionState == .connected
+                    guard shouldStop else { return }
+                    Task { await viewModel.stopConversation() }
                 }
             )
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Helpers/AdaptiveLayout.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Helpers/AdaptiveLayout.swift
@@ -513,10 +513,20 @@ struct AdaptiveMicButton: View {
                     .onLongPressGesture(minimumDuration: 0.5, perform: { onLongPress?() ?? action() })
                     .onTapGesture(perform: action)
                     .glassEffect(.regular.interactive())
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityLabel("Microphone")
+                    .accessibilityHint(onLongPress != nil ? "Double tap to toggle recording. Long press for alternate action." : "Double tap to toggle recording.")
+                    .accessibilityAction(.default, action)
+                    .accessibilityAction(named: "Long Press") { onLongPress?() ?? action() }
             } else {
                 micContent
                     .onLongPressGesture(minimumDuration: 0.5, perform: { onLongPress?() ?? action() })
                     .onTapGesture(perform: action)
+                    .accessibilityAddTraits(.isButton)
+                    .accessibilityLabel("Microphone")
+                    .accessibilityHint(onLongPress != nil ? "Double tap to toggle recording. Long press for alternate action." : "Double tap to toggle recording.")
+                    .accessibilityAction(.default, action)
+                    .accessibilityAction(named: "Long Press") { onLongPress?() ?? action() }
             }
         }
     }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Helpers/AdaptiveLayout.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Helpers/AdaptiveLayout.swift
@@ -449,6 +449,7 @@ struct AdaptiveMicButton: View {
     let inactiveColor: Color
     let icon: String
     let action: () -> Void
+    let onLongPress: (() -> Void)?
 
     init(
         isActive: Bool = false,
@@ -457,7 +458,8 @@ struct AdaptiveMicButton: View {
         activeColor: Color = .red,
         inactiveColor: Color = AppColors.primaryAccent,
         icon: String = "mic.fill",
-        action: @escaping () -> Void
+        action: @escaping () -> Void,
+        onLongPress: (() -> Void)? = nil
     ) {
         self.isActive = isActive
         self.isPulsing = isPulsing
@@ -466,83 +468,55 @@ struct AdaptiveMicButton: View {
         self.inactiveColor = inactiveColor
         self.icon = icon
         self.action = action
+        self.onLongPress = onLongPress
+    }
+
+    private var micContent: some View {
+        ZStack {
+            // Background circle
+            Circle()
+                .fill(isActive ? activeColor : inactiveColor)
+                .frame(width: AdaptiveSizing.micButtonSize, height: AdaptiveSizing.micButtonSize)
+
+            // Pulsing effect when active
+            if isPulsing {
+                Circle()
+                    .stroke(Color.white.opacity(0.4), lineWidth: 2)
+                    .frame(width: AdaptiveSizing.micButtonSize, height: AdaptiveSizing.micButtonSize)
+                    .scaleEffect(1.3)
+                    .opacity(0)
+                    .animation(
+                        .easeOut(duration: 1.0).repeatForever(autoreverses: false),
+                        value: isPulsing
+                    )
+            }
+
+            // Icon or loading indicator
+            if isLoading {
+                ProgressView()
+                    .progressViewStyle(CircularProgressViewStyle(tint: .white))
+                    .scaleEffect(1.2)
+            } else {
+                Image(systemName: icon)
+                    .font(.system(size: AdaptiveSizing.micIconSize))
+                    .foregroundColor(.white)
+                    .contentTransition(.symbolEffect(.replace))
+                    .animation(.smooth(duration: 0.3), value: icon)
+            }
+        }
     }
 
     var body: some View {
         Group {
             if #available(iOS 26.0, macOS 26.0, *) {
-                Button(action: action) {
-                    ZStack {
-                        // Background circle
-                        Circle()
-                            .fill(isActive ? activeColor : inactiveColor)
-                            .frame(width: AdaptiveSizing.micButtonSize, height: AdaptiveSizing.micButtonSize)
-
-                        // Pulsing effect when active
-                        if isPulsing {
-                            Circle()
-                                .stroke(Color.white.opacity(0.4), lineWidth: 2)
-                                .frame(width: AdaptiveSizing.micButtonSize, height: AdaptiveSizing.micButtonSize)
-                                .scaleEffect(1.3)
-                                .opacity(0)
-                                .animation(
-                                    .easeOut(duration: 1.0).repeatForever(autoreverses: false),
-                                    value: isPulsing
-                                )
-                        }
-
-                        // Icon or loading indicator
-                        if isLoading {
-                            ProgressView()
-                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                                .scaleEffect(1.2)
-                        } else {
-                            Image(systemName: icon)
-                                .font(.system(size: AdaptiveSizing.micIconSize))
-                                .foregroundColor(.white)
-                                .contentTransition(.symbolEffect(.replace))
-                                .animation(.smooth(duration: 0.3), value: icon)
-                        }
-                    }
-                }
-                .buttonStyle(.plain)
-                .glassEffect(.regular.interactive())
+                micContent
+                    .onLongPressGesture(minimumDuration: 0.5, perform: { onLongPress?() ?? action() })
+                    .onTapGesture(perform: action)
+                    .glassEffect(.regular.interactive())
             } else {
-                Button(action: action) {
-                    ZStack {
-                        // Background circle
-                        Circle()
-                            .fill(isActive ? activeColor : inactiveColor)
-                            .frame(width: AdaptiveSizing.micButtonSize, height: AdaptiveSizing.micButtonSize)
-
-                        // Pulsing effect when active
-                        if isPulsing {
-                            Circle()
-                                .stroke(Color.white.opacity(0.4), lineWidth: 2)
-                                .frame(width: AdaptiveSizing.micButtonSize, height: AdaptiveSizing.micButtonSize)
-                                .scaleEffect(1.3)
-                                .opacity(0)
-                                .animation(
-                                    .easeOut(duration: 1.0).repeatForever(autoreverses: false),
-                                    value: isPulsing
-                                )
-                        }
-
-                        // Icon or loading indicator
-                        if isLoading {
-                            ProgressView()
-                                .progressViewStyle(CircularProgressViewStyle(tint: .white))
-                                .scaleEffect(1.2)
-                        } else {
-                            Image(systemName: icon)
-                                .font(.system(size: AdaptiveSizing.micIconSize))
-                                .foregroundColor(.white)
-                                .contentTransition(.symbolEffect(.replace))
-                                .animation(.smooth(duration: 0.3), value: icon)
-                        }
-                    }
-                }
-                .buttonStyle(.plain)
+                micContent
+                    .onLongPressGesture(minimumDuration: 0.5, perform: { onLongPress?() ?? action() })
+                    .onTapGesture(perform: action)
             }
         }
     }

--- a/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
@@ -4,6 +4,7 @@
 
 #include <algorithm>
 #include <chrono>
+#include <cstdint>
 #include <cstring>
 #include <string>
 #include <vector>
@@ -788,8 +789,11 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
             if (stop_window.size() > MAX_STOP_LEN) {
                 size_t safe_len = stop_window.size() - MAX_STOP_LEN;
                 // Don't cut inside a UTF-8 multi-byte sequence; back up until
-                // we're on a leading-byte boundary.
-                while (safe_len > 0 && (stop_window[safe_len] & 0xC0) == 0x80) {
+                // we're on a leading-byte boundary. Cast to uint8_t so bytes
+                // >= 0x80 aren't treated as negative signed char (UB on platforms
+                // where char is signed).
+                while (safe_len > 0 &&
+                       (static_cast<uint8_t>(stop_window[safe_len]) & 0xC0) == 0x80) {
                     safe_len--;
                 }
                 if (safe_len > 0) {
@@ -1089,7 +1093,12 @@ TextGenerationResult LlamaCppTextGeneration::generate_from_context(const TextGen
 
             if (stop_window.size() > MAX_STOP_LEN) {
                 size_t safe_len = stop_window.size() - MAX_STOP_LEN;
-                while (safe_len > 0 && (stop_window[safe_len] & 0xC0) == 0x80) {
+                // Don't cut inside a UTF-8 multi-byte sequence; back up until
+                // we're on a leading-byte boundary. Cast to uint8_t so bytes
+                // >= 0x80 aren't treated as negative signed char (UB on platforms
+                // where char is signed).
+                while (safe_len > 0 &&
+                       (static_cast<uint8_t>(stop_window[safe_len]) & 0xC0) == 0x80) {
                     safe_len--;
                 }
                 if (safe_len > 0) {
@@ -1109,6 +1118,12 @@ TextGenerationResult LlamaCppTextGeneration::generate_from_context(const TextGen
             decode_failed_ = true;
             break;
         }
+    }
+
+    // Flush any remaining partial UTF-8 bytes (e.g. trailing multi-byte char at end of generation)
+    // so trailing codepoints aren't silently dropped. Mirrors generate_stream() behavior.
+    if (!cancel_requested_.load() && !stop_sequence_hit && !partial_utf8_buffer.empty()) {
+        stop_window.append(partial_utf8_buffer);
     }
 
     if (!cancel_requested_.load() && !stop_sequence_hit && !stop_window.empty()) {

--- a/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
+++ b/sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp
@@ -787,12 +787,20 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
 
             if (stop_window.size() > MAX_STOP_LEN) {
                 size_t safe_len = stop_window.size() - MAX_STOP_LEN;
-                if (!callback(stop_window.substr(0, safe_len))) {
-                    RAC_LOG_INFO("LLM.LlamaCpp","Generation cancelled by callback");
-                    cancel_requested_.store(true);
-                    break;
+                // Don't cut inside a UTF-8 multi-byte sequence; back up until
+                // we're on a leading-byte boundary.
+                while (safe_len > 0 && (stop_window[safe_len] & 0xC0) == 0x80) {
+                    safe_len--;
                 }
-                stop_window.erase(0, safe_len);
+                if (safe_len > 0) {
+                    if (!callback(stop_window.substr(0, safe_len))) {
+                        RAC_LOG_INFO("LLM.LlamaCpp", "Generation cancelled by callback");
+                        cancel_requested_.store(true);
+                        break;
+                    }
+                    // Erase the flushed portion so stop_window doesn't grow unboundedly.
+                    stop_window.erase(0, safe_len);
+                }
             }
         }
 
@@ -1030,6 +1038,8 @@ TextGenerationResult LlamaCppTextGeneration::generate_from_context(const TextGen
     std::string partial_utf8_buffer;
     partial_utf8_buffer.reserve(8);
 
+    Utf8State scanner_state;
+
     std::string generated_text;
     int n_cur = static_cast<int>(current_pos) + n_prompt;
     int tokens_generated = 0;
@@ -1044,38 +1054,17 @@ TextGenerationResult LlamaCppTextGeneration::generate_from_context(const TextGen
         }
 
         const std::string new_token_chars = common_token_to_piece(context_, new_token_id);
+        const size_t old_partial_size = partial_utf8_buffer.size();
         partial_utf8_buffer.append(new_token_chars);
 
-        struct Utf8Check {
-            static size_t valid_upto(const std::string& buf) {
-                static const uint8_t utf8d[] = {
-                    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-                    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-                    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-                    0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,
-                    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,9,
-                    7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,7,
-                    8,8,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,2,
-                    0xa,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x3,0x4,0x3,0x3,
-                    0xb,0x6,0x6,0x6,0x5,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,0x8,
-                    0x0,0x1,0x2,0x3,0x5,0x8,0x7,0x1,0x1,0x1,0x4,0x6,0x1,0x1,0x1,0x1,
-                    1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,0,1,1,1,1,1,0,1,0,1,1,1,1,1,1,
-                    1,2,1,1,1,1,1,2,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,
-                    1,2,1,1,1,1,1,1,1,2,1,1,1,1,1,1,1,1,1,1,1,1,1,3,1,3,1,1,1,1,1,1,
-                    1,3,1,1,1,1,1,3,1,3,1,1,1,1,1,1,1,3,1,1,1,1,1,1,1,1,1,1,1,1,1,1,
-                };
-                uint32_t state = 0;
-                size_t upto = 0;
-                for (size_t i = 0; i < buf.size(); ++i) {
-                    uint32_t type = utf8d[static_cast<uint8_t>(buf[i])];
-                    state = utf8d[256 + state * 16 + type];
-                    if (state == 0) upto = i + 1;
-                }
-                return upto;
+        size_t valid_upto = 0;
+        for (size_t i = old_partial_size; i < partial_utf8_buffer.size(); ++i) {
+            scanner_state.process(static_cast<uint8_t>(partial_utf8_buffer[i]));
+            if (scanner_state.state == 0) {
+                valid_upto = i + 1;
             }
-        };
+        }
 
-        const size_t valid_upto = Utf8Check::valid_upto(partial_utf8_buffer);
         if (valid_upto > 0) {
             std::string valid_chunk = partial_utf8_buffer.substr(0, valid_upto);
             stop_window.append(valid_chunk);
@@ -1099,9 +1088,14 @@ TextGenerationResult LlamaCppTextGeneration::generate_from_context(const TextGen
             }
 
             if (stop_window.size() > MAX_STOP_LEN) {
-                const size_t safe_len = stop_window.size() - MAX_STOP_LEN;
-                generated_text += stop_window.substr(0, safe_len);
-                stop_window.erase(0, safe_len);
+                size_t safe_len = stop_window.size() - MAX_STOP_LEN;
+                while (safe_len > 0 && (stop_window[safe_len] & 0xC0) == 0x80) {
+                    safe_len--;
+                }
+                if (safe_len > 0) {
+                    generated_text += stop_window.substr(0, safe_len);
+                    stop_window.erase(0, safe_len);
+                }
             }
         }
 

--- a/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
@@ -9,6 +9,7 @@
  * Do NOT add features not present in the Swift code.
  */
 
+#include <atomic>
 #include <chrono>
 #include <cstdlib>
 #include <cstring>
@@ -45,6 +46,9 @@ struct rac_llm_component {
 
     /** Mutex for thread safety */
     std::mutex mtx;
+
+    /** Cancellation flag - set by cancel(), read by token callback without holding mtx */
+    std::atomic<bool> cancel_requested{false};
 
     /** Resolved inference framework (defaults to LlamaCPP, the primary LLM backend) */
     rac_inference_framework_t actual_framework;
@@ -514,6 +518,8 @@ struct llm_stream_context {
     float temperature;
     int32_t max_tokens;
     int32_t token_count;  // Track tokens for streaming updates
+
+    std::atomic<bool>* cancel_flag;
 };
 
 /**
@@ -521,6 +527,10 @@ struct llm_stream_context {
  */
 static rac_bool_t llm_stream_token_callback(const char* token, void* user_data) {
     auto* ctx = reinterpret_cast<llm_stream_context*>(user_data);
+
+    if (ctx->cancel_flag && ctx->cancel_flag->load(std::memory_order_relaxed)) {
+        return RAC_FALSE;
+    }
 
     // Track first token time and emit first token event
     if (!ctx->first_token_recorded) {
@@ -580,6 +590,8 @@ extern "C" rac_result_t rac_llm_component_generate_stream(
 
     auto* component = reinterpret_cast<rac_llm_component*>(handle);
     std::lock_guard<std::mutex> lock(component->mtx);
+
+    component->cancel_requested.store(false, std::memory_order_relaxed);
 
     // Generate unique ID for this generation
     std::string generation_id = generate_unique_id();
@@ -674,6 +686,7 @@ extern "C" rac_result_t rac_llm_component_generate_stream(
     ctx.token_count = 0;
     // Pre-allocate to avoid repeated reallocations during streaming
     ctx.full_text.reserve(2048);
+    ctx.cancel_flag = &component->cancel_requested;
 
     // Perform streaming generation
     result = rac_llm_generate_stream(service, prompt, effective_options, llm_stream_token_callback,
@@ -716,7 +729,7 @@ extern "C" rac_result_t rac_llm_component_generate_stream(
         return RAC_ERROR_OUT_OF_MEMORY;
     }
     final_result.prompt_tokens = ctx.prompt_tokens;
-    final_result.completion_tokens = estimate_tokens(ctx.full_text.c_str());
+    final_result.completion_tokens = ctx.token_count > 0 ? ctx.token_count : estimate_tokens(ctx.full_text.c_str());
     final_result.total_tokens = final_result.prompt_tokens + final_result.completion_tokens;
     final_result.total_time_ms = total_time_ms;
 
@@ -775,6 +788,10 @@ extern "C" rac_result_t rac_llm_component_cancel(rac_handle_t handle) {
         return RAC_ERROR_INVALID_HANDLE;
 
     auto* component = reinterpret_cast<rac_llm_component*>(handle);
+
+    // Set atomic cancel flag so the streaming token callback can observe it
+    // without holding component->mtx (which generate_stream is holding).
+    component->cancel_requested.store(true, std::memory_order_relaxed);
 
     // Use acquire/release to pin the service for the duration of the cancel call,
     // preventing use-after-free if destroy races with cancel.

--- a/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/llm_component.cpp
@@ -729,7 +729,9 @@ extern "C" rac_result_t rac_llm_component_generate_stream(
         return RAC_ERROR_OUT_OF_MEMORY;
     }
     final_result.prompt_tokens = ctx.prompt_tokens;
-    final_result.completion_tokens = ctx.token_count > 0 ? ctx.token_count : estimate_tokens(ctx.full_text.c_str());
+    final_result.completion_tokens = ctx.token_count > 0
+        ? ctx.token_count
+        : (ctx.full_text.empty() ? 0 : estimate_tokens(ctx.full_text.c_str()));
     final_result.total_tokens = final_result.prompt_tokens + final_result.completion_tokens;
     final_result.total_time_ms = total_time_ms;
 

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling.cpp
@@ -326,24 +326,119 @@ static bool extract_json_object_raw(const char* str, size_t pos, size_t len, cha
 }
 
 /**
+ * @brief Find matching closing bracket for a JSON array
+ *
+ * Tracks string boundaries to ignore brackets inside strings.
+ *
+ * @param str String to search
+ * @param start_pos Position of opening bracket '['
+ * @param out_end Output: Position of matching closing bracket ']'
+ * @return true if found, false otherwise
+ */
+static bool find_matching_bracket(const char* str, size_t start_pos, size_t* out_end) {
+    if (!str || str[start_pos] != '[') {
+        return false;
+    }
+
+    size_t len = strlen(str);
+    int depth = 0;
+    bool in_string = false;
+    bool escaped = false;
+
+    for (size_t i = start_pos; i < len; i++) {
+        char ch = str[i];
+
+        if (escaped) {
+            escaped = false;
+            continue;
+        }
+
+        if (ch == '\\') {
+            escaped = true;
+            continue;
+        }
+
+        if (ch == '"') {
+            in_string = !in_string;
+            continue;
+        }
+
+        if (!in_string) {
+            if (ch == '[') {
+                depth++;
+            } else if (ch == ']') {
+                depth--;
+                if (depth == 0) {
+                    *out_end = i;
+                    return true;
+                }
+            }
+        }
+    }
+
+    return false;
+}
+
+/**
+ * @brief Extract a JSON array as a raw string (including brackets)
+ */
+static bool extract_json_array_raw(const char* str, size_t pos, size_t len, char** out_value,
+                                   size_t* out_end_pos) {
+    if (str[pos] != '[') {
+        return false;
+    }
+
+    size_t end_bracket;
+    if (!find_matching_bracket(str, pos, &end_bracket)) {
+        return false;
+    }
+
+    size_t arr_len = end_bracket - pos + 1;
+    *out_value = static_cast<char*>(malloc(arr_len + 1));
+    if (!*out_value) {
+        return false;
+    }
+
+    memcpy(*out_value, str + pos, arr_len);
+    (*out_value)[arr_len] = '\0';
+    *out_end_pos = end_bracket + 1;
+    return true;
+}
+
+/**
+ * @brief Kind of JSON value extracted by extract_json_value.
+ *
+ * Distinguishes between quoted strings and raw scalar/composite literals so
+ * callers can re-emit the value correctly (e.g., quote strings but not
+ * numbers/bools/null/arrays/objects).
+ */
+enum json_value_kind_t {
+    JSON_VALUE_STRING,   // Quoted string (content, quotes stripped)
+    JSON_VALUE_OBJECT,   // Raw JSON object `{...}` (verbatim)
+    JSON_VALUE_LITERAL,  // Raw scalar literal: number, boolean, null (verbatim)
+    JSON_VALUE_ARRAY     // Raw JSON array `[...]` (verbatim)
+};
+
+/**
  * @brief Simple JSON key-value extractor
  *
- * Extracts a string or object value for a given key from a JSON object string.
+ * Extracts a string, object, array, or scalar literal value for a given key
+ * from a JSON object string.
  *
  * @param json_obj JSON object string (must include braces)
  * @param key Key to find (case-insensitive)
  * @param out_value Output: Allocated value string (caller must free)
- * @param out_is_object Output: Whether the value is an object (vs string)
+ * @param out_kind Output: Kind of the extracted value (string/object/literal/array)
  * @return true if found
  */
 static bool extract_json_value(const char* json_obj, const char* key, char** out_value,
-                               bool* out_is_object) {
-    if (!json_obj || !key || !out_value) {
+                               json_value_kind_t* out_kind) {
+    if (!json_obj || !key || !out_value || !out_kind) {
         return false;
     }
 
     *out_value = nullptr;
-    *out_is_object = false;
+    *out_kind = JSON_VALUE_STRING;
 
     size_t len = strlen(json_obj);
     bool in_string = false;
@@ -388,7 +483,7 @@ static bool extract_json_value(const char* json_obj, const char* key, char** out
                                     size_t value_end;
                                     if (extract_json_string(json_obj, pos + 1, len, out_value,
                                                             &value_end)) {
-                                        *out_is_object = false;
+                                        *out_kind = JSON_VALUE_STRING;
                                         return true;
                                     }
                                 } else if (json_obj[pos] == '{') {
@@ -396,12 +491,20 @@ static bool extract_json_value(const char* json_obj, const char* key, char** out
                                     size_t value_end;
                                     if (extract_json_object_raw(json_obj, pos, len, out_value,
                                                                 &value_end)) {
-                                        *out_is_object = true;
+                                        *out_kind = JSON_VALUE_OBJECT;
+                                        return true;
+                                    }
+                                } else if (json_obj[pos] == '[') {
+                                    // Array value
+                                    size_t value_end;
+                                    if (extract_json_array_raw(json_obj, pos, len, out_value,
+                                                               &value_end)) {
+                                        *out_kind = JSON_VALUE_ARRAY;
                                         return true;
                                     }
                                 } else {
-                                    // Scalar value (number, boolean, null)
-                                    // Read until comma, closing brace, or whitespace
+                                    // Scalar literal value (number, boolean, null)
+                                    // Read until comma, closing brace/bracket, or newline
                                     size_t val_start = pos;
                                     size_t val_end = pos;
                                     while (val_end < len && json_obj[val_end] != ',' &&
@@ -421,7 +524,7 @@ static bool extract_json_value(const char* json_obj, const char* key, char** out
                                             memcpy(*out_value, json_obj + val_start, val_len);
                                             (*out_value)[val_len] = '\0';
                                         }
-                                        *out_is_object = false;
+                                        *out_kind = JSON_VALUE_LITERAL;
                                         return true;
                                     }
                                 }
@@ -666,20 +769,25 @@ static bool extract_tool_name_and_args(const char* json_obj, char** out_tool_nam
     // Strategy 1 & 2: Try standard tool name keys
     for (int i = 0; TOOL_NAME_KEYS[i] != nullptr; i++) {
         char* value = nullptr;
-        bool is_obj = false;
-        if (extract_json_value(json_obj, TOOL_NAME_KEYS[i], &value, &is_obj)) {
-            if (!is_obj && value && strlen(value) > 0) {
+        json_value_kind_t kind = JSON_VALUE_STRING;
+        if (extract_json_value(json_obj, TOOL_NAME_KEYS[i], &value, &kind)) {
+            // Tool name must be a string literal (not object/array/raw literal)
+            if (kind == JSON_VALUE_STRING && value && strlen(value) > 0) {
                 *out_tool_name = value;
+
+                // Record the specific alias that matched, so the flat-args
+                // reassembly only drops that exact key (not every alias).
+                const std::string matched_tool_name_key = TOOL_NAME_KEYS[i];
 
                 // Now find arguments
                 for (int j = 0; ARGUMENT_KEYS[j] != nullptr; j++) {
                     char* args_value = nullptr;
-                    bool args_is_obj = false;
-                    if (extract_json_value(json_obj, ARGUMENT_KEYS[j], &args_value, &args_is_obj)) {
-                        if (args_is_obj) {
+                    json_value_kind_t args_kind = JSON_VALUE_STRING;
+                    if (extract_json_value(json_obj, ARGUMENT_KEYS[j], &args_value, &args_kind)) {
+                        if (args_kind == JSON_VALUE_OBJECT) {
                             *out_args_json = args_value;
                         } else {
-                            // Wrap scalar in {"input": value} - escape the value for valid JSON
+                            // Wrap scalar/array/string in {"input": value} - escape the value for valid JSON
                             std::string escaped_args = escape_json_string(args_value);
                             size_t wrap_len = escaped_args.size() + 14; // {"input":"" } + null
                             *out_args_json = static_cast<char*>(malloc(wrap_len));
@@ -693,34 +801,44 @@ static bool extract_tool_name_and_args(const char* json_obj, char** out_tool_nam
                 }
 
                 // No standard argument wrapper key found.
-                // Fallback: collect all remaining keys (excluding the tool name key)
-                // as flat arguments. This handles LLM output like:
-                // {"tool": "calculate", "expression": "5 * 100"}
+                // Fallback: collect all remaining keys (excluding the specific
+                // key that matched the tool name alias) as flat arguments.
+                // This handles LLM output like:
+                //   {"tool": "calculate", "expression": "5 * 100"}
+                // Only the exact matched alias is skipped, so a later tool
+                // that accepts a `name` argument still sees `name` preserved.
                 {
                     std::vector<std::string> all_keys = get_json_keys(json_obj);
                     std::string flat_args = "{";
                     bool first = true;
                     for (const auto& k : all_keys) {
-                        // Skip the key that matched the tool name
-                        bool is_tool_key = false;
-                        for (int t = 0; TOOL_NAME_KEYS[t] != nullptr; t++) {
-                            if (str_equals_ignore_case(k.c_str(), TOOL_NAME_KEYS[t])) {
-                                is_tool_key = true;
-                                break;
-                            }
+                        // Only skip the specific alias that matched the tool name
+                        if (str_equals_ignore_case(k.c_str(), matched_tool_name_key.c_str())) {
+                            continue;
                         }
-                        if (is_tool_key) continue;
 
                         char* kval = nullptr;
-                        bool kval_is_obj = false;
-                        if (extract_json_value(json_obj, k.c_str(), &kval, &kval_is_obj)) {
+                        json_value_kind_t kval_kind = JSON_VALUE_STRING;
+                        if (extract_json_value(json_obj, k.c_str(), &kval, &kval_kind)) {
                             if (!first) flat_args += ",";
                             std::string escaped_key = escape_json_string(k.c_str());
-                            if (kval_is_obj) {
-                                flat_args += "\"" + escaped_key + "\":" + std::string(kval);
-                            } else if (kval) {
-                                std::string escaped_val = escape_json_string(kval);
-                                flat_args += "\"" + escaped_key + "\":\"" + escaped_val + "\"";
+                            if (kval) {
+                                switch (kval_kind) {
+                                case JSON_VALUE_STRING: {
+                                    // Re-escape and re-quote strings
+                                    std::string escaped_val = escape_json_string(kval);
+                                    flat_args += "\"" + escaped_key + "\":\"" + escaped_val + "\"";
+                                    break;
+                                }
+                                case JSON_VALUE_OBJECT:
+                                case JSON_VALUE_LITERAL:
+                                case JSON_VALUE_ARRAY:
+                                    // Emit verbatim: raw JSON objects, scalar
+                                    // literals (number/bool/null), and arrays
+                                    // round-trip as their original JSON form.
+                                    flat_args += "\"" + escaped_key + "\":" + std::string(kval);
+                                    break;
+                                }
                             }
                             free(kval);
                             first = false;
@@ -729,9 +847,15 @@ static bool extract_tool_name_and_args(const char* json_obj, char** out_tool_nam
                     flat_args += "}";
 
                     *out_args_json = static_cast<char*>(malloc(flat_args.size() + 1));
-                    if (*out_args_json) {
-                        std::memcpy(*out_args_json, flat_args.c_str(), flat_args.size() + 1);
+                    if (*out_args_json == nullptr) {
+                        // Allocation failed - don't return success with partial state.
+                        // Free the already-populated tool name so the caller sees a
+                        // fully-cleared failure rather than a dangling *out_tool_name.
+                        free(*out_tool_name);
+                        *out_tool_name = nullptr;
+                        return false;
                     }
+                    std::memcpy(*out_args_json, flat_args.c_str(), flat_args.size() + 1);
                 }
                 return true;
             }
@@ -745,18 +869,18 @@ static bool extract_tool_name_and_args(const char* json_obj, char** out_tool_nam
         if (!is_standard_key(key.c_str())) {
             // Found a non-standard key - treat it as tool name
             char* value = nullptr;
-            bool is_obj = false;
-            if (extract_json_value(json_obj, key.c_str(), &value, &is_obj)) {
+            json_value_kind_t kind = JSON_VALUE_STRING;
+            if (extract_json_value(json_obj, key.c_str(), &value, &kind)) {
                 *out_tool_name = static_cast<char*>(malloc(key.size() + 1));
                 if (*out_tool_name) {
                     std::memcpy(*out_tool_name, key.c_str(), key.size() + 1);
                 }
 
-                if (is_obj) {
-                    // Value is object - use as arguments
+                if (kind == JSON_VALUE_OBJECT) {
+                    // Value is object - use as arguments verbatim
                     *out_args_json = value;
                 } else if (value) {
-                    // Value is scalar - wrap in {"input": value} - escape for valid JSON
+                    // Value is string / scalar literal / array - wrap in {"input": value}
                     std::string escaped_value = escape_json_string(value);
                     size_t wrap_len = escaped_value.size() + 14; // {"input":"" } + null
                     *out_args_json = static_cast<char*>(malloc(wrap_len));

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling.cpp
@@ -399,13 +399,41 @@ static bool extract_json_value(const char* json_obj, const char* key, char** out
                                         *out_is_object = true;
                                         return true;
                                     }
+                                } else {
+                                    // Scalar value (number, boolean, null)
+                                    // Read until comma, closing brace, or whitespace
+                                    size_t val_start = pos;
+                                    size_t val_end = pos;
+                                    while (val_end < len && json_obj[val_end] != ',' &&
+                                           json_obj[val_end] != '}' && json_obj[val_end] != ']' &&
+                                           json_obj[val_end] != '\n') {
+                                        val_end++;
+                                    }
+                                    // Trim trailing whitespace
+                                    while (val_end > val_start &&
+                                           (json_obj[val_end - 1] == ' ' || json_obj[val_end - 1] == '\t')) {
+                                        val_end--;
+                                    }
+                                    if (val_end > val_start) {
+                                        size_t val_len = val_end - val_start;
+                                        *out_value = static_cast<char*>(malloc(val_len + 1));
+                                        if (*out_value) {
+                                            memcpy(*out_value, json_obj + val_start, val_len);
+                                            (*out_value)[val_len] = '\0';
+                                        }
+                                        *out_is_object = false;
+                                        return true;
+                                    }
                                 }
                             }
                         }
                     }
 
                     // Move to end of key for continued scanning
+                    // Skip the in_string toggle - extract_json_string already
+                    // consumed the closing quote so in_string must stay false.
                     i = key_end - 1;
+                    continue;
                 }
             }
             in_string = !in_string;
@@ -664,10 +692,46 @@ static bool extract_tool_name_and_args(const char* json_obj, char** out_tool_nam
                     }
                 }
 
-                // No arguments found - use empty object
-                *out_args_json = static_cast<char*>(malloc(3));
-                if (*out_args_json) {
-                    std::memcpy(*out_args_json, "{}", 3);
+                // No standard argument wrapper key found.
+                // Fallback: collect all remaining keys (excluding the tool name key)
+                // as flat arguments. This handles LLM output like:
+                // {"tool": "calculate", "expression": "5 * 100"}
+                {
+                    std::vector<std::string> all_keys = get_json_keys(json_obj);
+                    std::string flat_args = "{";
+                    bool first = true;
+                    for (const auto& k : all_keys) {
+                        // Skip the key that matched the tool name
+                        bool is_tool_key = false;
+                        for (int t = 0; TOOL_NAME_KEYS[t] != nullptr; t++) {
+                            if (str_equals_ignore_case(k.c_str(), TOOL_NAME_KEYS[t])) {
+                                is_tool_key = true;
+                                break;
+                            }
+                        }
+                        if (is_tool_key) continue;
+
+                        char* kval = nullptr;
+                        bool kval_is_obj = false;
+                        if (extract_json_value(json_obj, k.c_str(), &kval, &kval_is_obj)) {
+                            if (!first) flat_args += ",";
+                            std::string escaped_key = escape_json_string(k.c_str());
+                            if (kval_is_obj) {
+                                flat_args += "\"" + escaped_key + "\":" + std::string(kval);
+                            } else if (kval) {
+                                std::string escaped_val = escape_json_string(kval);
+                                flat_args += "\"" + escaped_key + "\":\"" + escaped_val + "\"";
+                            }
+                            free(kval);
+                            first = false;
+                        }
+                    }
+                    flat_args += "}";
+
+                    *out_args_json = static_cast<char*>(malloc(flat_args.size() + 1));
+                    if (*out_args_json) {
+                        std::memcpy(*out_args_json, flat_args.c_str(), flat_args.size() + 1);
+                    }
                 }
                 return true;
             }

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Features/TTS/Services/AudioPlaybackManager.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Features/TTS/Services/AudioPlaybackManager.swift
@@ -87,7 +87,7 @@ public class AudioPlaybackManager: NSObject, ObservableObject, AVAudioPlayerDele
 
     /// Stop current playback
     public func stop() {
-        guard isPlaying else { return }
+        guard audioPlayer != nil else { return }
 
         audioPlayer?.stop()
         cleanupPlayback(success: false)

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/CppBridge.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/CppBridge.swift
@@ -172,21 +172,24 @@ public enum CppBridge {
     // MARK: - Shutdown
 
     /// Shutdown all C++ bridges
-    public static func shutdown() {
+    ///
+    /// Async because AI component destroy() methods are actor-isolated.
+    /// Awaiting them sequentially (instead of wrapping in `Task { ... }`)
+    /// ensures Telemetry/Events teardown does not race destroy completion.
+    public static func shutdown() async {
         lock.lock()
         let wasInitialized = _isInitialized
         lock.unlock()
 
         guard wasInitialized else { return }
 
-        Task {
-            await LLM.shared.destroy()
-            await STT.shared.destroy()
-            await TTS.shared.destroy()
-            await VAD.shared.destroy()
-            await VoiceAgent.shared.destroy()
-            await VLM.shared.destroy()
-        }
+        // Destroy AI components sequentially before tearing down Telemetry/Events
+        await LLM.shared.destroy()
+        await STT.shared.destroy()
+        await TTS.shared.destroy()
+        await VAD.shared.destroy()
+        await VoiceAgent.shared.destroy()
+        await VLM.shared.destroy()
 
         // Shutdown in reverse order
         // Note: ModelAssignment and Platform callbacks remain valid (static)

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/CppBridge.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/CppBridge.swift
@@ -179,6 +179,15 @@ public enum CppBridge {
 
         guard wasInitialized else { return }
 
+        Task {
+            await LLM.shared.destroy()
+            await STT.shared.destroy()
+            await TTS.shared.destroy()
+            await VAD.shared.destroy()
+            await VoiceAgent.shared.destroy()
+            await VLM.shared.destroy()
+        }
+
         // Shutdown in reverse order
         // Note: ModelAssignment and Platform callbacks remain valid (static)
 

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+TextGeneration.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+TextGeneration.swift
@@ -85,19 +85,21 @@ public extension RunAnywhere {
         let totalTimeMs = endTime.timeIntervalSince(startTime) * 1000
 
         // Extract result
-        let generatedText: String
+        let rawText: String
         if let textPtr = llmResult.text {
-            generatedText = String(cString: textPtr)
+            rawText = String(cString: textPtr)
         } else {
-            generatedText = ""
+            rawText = ""
         }
         let inputTokens = Int(llmResult.prompt_tokens)
         let outputTokens = Int(llmResult.completion_tokens)
         let tokensPerSecond = llmResult.tokens_per_second > 0 ? Double(llmResult.tokens_per_second) : 0
 
+        let (generatedText, thinkingContent) = ThinkingContentParser.extract(from: rawText)
+
         return LLMGenerationResult(
             text: generatedText,
-            thinkingContent: nil,
+            thinkingContent: thinkingContent,
             inputTokens: inputTokens,
             tokensUsed: outputTokens,
             modelUsed: modelId,
@@ -105,7 +107,7 @@ public extension RunAnywhere {
             framework: "llamacpp",
             tokensPerSecond: tokensPerSecond,
             timeToFirstTokenMs: nil,
-            thinkingTokens: 0,
+            thinkingTokens: thinkingContent.map { _ in outputTokens } ?? 0,
             responseTokens: outputTokens
         )
     }
@@ -189,47 +191,43 @@ public extension RunAnywhere {
     ) -> AsyncThrowingStream<String, Error> {
         AsyncThrowingStream<String, Error> { continuation in
             Task {
-                do {
-                    await collector.markStart()
+                await collector.markStart()
 
-                    let context = LLMStreamCallbackContext(continuation: continuation, collector: collector)
-                    let contextPtr = Unmanaged.passRetained(context).toOpaque()
+                let context = LLMStreamCallbackContext(continuation: continuation, collector: collector)
+                // passRetained: context is released in completeCallback or errorCallback
+                let contextPtr = Unmanaged.passRetained(context).toOpaque()
 
-                    let callbacks = LLMStreamCallbacks.create()
-                    var cOptions = options
+                let callbacks = LLMStreamCallbacks.create()
+                var cOptions = options
 
-                    let callCFunction: () -> rac_result_t = {
-                        prompt.withCString { promptPtr in
-                            rac_llm_component_generate_stream(
-                                handle,
-                                promptPtr,
-                                &cOptions,
-                                callbacks.token,
-                                callbacks.complete,
-                                callbacks.error,
-                                contextPtr
-                            )
-                        }
+                let callCFunction: () -> rac_result_t = {
+                    prompt.withCString { promptPtr in
+                        rac_llm_component_generate_stream(
+                            handle,
+                            promptPtr,
+                            &cOptions,
+                            callbacks.token,
+                            callbacks.complete,
+                            callbacks.error,
+                            contextPtr
+                        )
                     }
+                }
 
-                    let streamResult: rac_result_t
-                    if let systemPrompt = systemPrompt {
-                        streamResult = systemPrompt.withCString { sysPtr in
-                            cOptions.system_prompt = sysPtr
-                            return callCFunction()
-                        }
-                    } else {
-                        cOptions.system_prompt = nil
-                        streamResult = callCFunction()
+                let streamResult: rac_result_t
+                if let systemPrompt = systemPrompt {
+                    streamResult = systemPrompt.withCString { sysPtr in
+                        cOptions.system_prompt = sysPtr
+                        return callCFunction()
                     }
+                } else {
+                    cOptions.system_prompt = nil
+                    streamResult = callCFunction()
+                }
 
-                    if streamResult != RAC_SUCCESS {
-                        Unmanaged<LLMStreamCallbackContext>.fromOpaque(contextPtr).release()
-                        let error = SDKError.llm(.generationFailed, "Stream generation failed: \(streamResult)")
-                        continuation.finish(throwing: error)
-                        await collector.markFailed(error)
-                    }
-                } catch {
+                if streamResult != RAC_SUCCESS {
+                    Unmanaged<LLMStreamCallbackContext>.fromOpaque(contextPtr).release()
+                    let error = SDKError.llm(.generationFailed, "Stream generation failed: \(streamResult)")
                     continuation.finish(throwing: error)
                     await collector.markFailed(error)
                 }
@@ -255,6 +253,7 @@ private enum LLMStreamCallbacks {
     static func create() -> Callbacks {
         let tokenCallback: TokenFn = { tokenPtr, userData -> rac_bool_t in
             guard let tokenPtr = tokenPtr, let userData = userData else { return RAC_TRUE }
+            if Task.isCancelled { return RAC_FALSE }
             let ctx = Unmanaged<LLMStreamCallbackContext>.fromOpaque(userData).takeUnretainedValue()
             let token = String(cString: tokenPtr)
             Task {
@@ -264,16 +263,28 @@ private enum LLMStreamCallbacks {
             return RAC_TRUE
         }
 
-        let completeCallback: CompleteFn = { _, userData in
+        let completeCallback: CompleteFn = { resultPtr, userData in
             guard let userData = userData else { return }
-            let ctx = Unmanaged<LLMStreamCallbackContext>.fromOpaque(userData).takeUnretainedValue()
+            let ctx = Unmanaged<LLMStreamCallbackContext>.fromOpaque(userData).takeRetainedValue()
             ctx.continuation.finish()
-            Task { await ctx.collector.markComplete() }
+
+            if let result = resultPtr?.pointee {
+                Task {
+                    await ctx.collector.markCompleteWithMetrics(
+                        promptTokens: Int(result.prompt_tokens),
+                        completionTokens: Int(result.completion_tokens),
+                        tokensPerSecond: Double(result.tokens_per_second),
+                        timeToFirstTokenMs: Double(result.time_to_first_token_ms)
+                    )
+                }
+            } else {
+                Task { await ctx.collector.markComplete() }
+            }
         }
 
         let errorCallback: ErrorFn = { _, errorMsg, userData in
             guard let userData = userData else { return }
-            let ctx = Unmanaged<LLMStreamCallbackContext>.fromOpaque(userData).takeUnretainedValue()
+            let ctx = Unmanaged<LLMStreamCallbackContext>.fromOpaque(userData).takeRetainedValue()
             let message = errorMsg.map { String(cString: $0) } ?? "Unknown error"
             let error = SDKError.llm(.generationFailed, message)
             ctx.continuation.finish(throwing: error)
@@ -296,6 +307,28 @@ private final class LLMStreamCallbackContext: @unchecked Sendable {
     }
 }
 
+// MARK: - Thinking Content Parser
+
+private enum ThinkingContentParser {
+    /// Extracts `<think>...</think>` content from generated text.
+    /// - Returns: Tuple of (responseText, thinkingContent). If no tags found, responseText = original text, thinkingContent = nil.
+    static func extract(from text: String) -> (text: String, thinking: String?) {
+        guard let startRange = text.range(of: "<think>"),
+              let endRange = text.range(of: "</think>"),
+              startRange.upperBound <= endRange.lowerBound else {
+            return (text: text, thinking: nil)
+        }
+        let thinkingContent = String(text[startRange.upperBound..<endRange.lowerBound])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let responseText = String(text[endRange.upperBound...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        return (
+            text: responseText.isEmpty ? text : responseText,
+            thinking: thinkingContent.isEmpty ? nil : thinkingContent
+        )
+    }
+}
+
 // MARK: - Streaming Metrics Collector
 
 /// Internal actor for collecting streaming metrics
@@ -311,6 +344,11 @@ private actor LLMStreamingMetricsCollector {
     private var isComplete = false
     private var error: Error?
     private var resultContinuation: CheckedContinuation<LLMGenerationResult, Error>?
+
+    private var cppPromptTokens: Int?
+    private var cppCompletionTokens: Int?
+    private var cppTokensPerSecond: Double?
+    private var cppTimeToFirstTokenMs: Double?
 
     init(modelId: String, promptLength: Int) {
         self.modelId = modelId
@@ -332,6 +370,24 @@ private actor LLMStreamingMetricsCollector {
     }
 
     func markComplete() {
+        isComplete = true
+        if let continuation = resultContinuation {
+            continuation.resume(returning: buildResult())
+            resultContinuation = nil
+        }
+    }
+
+    func markCompleteWithMetrics(
+        promptTokens: Int,
+        completionTokens: Int,
+        tokensPerSecond: Double,
+        timeToFirstTokenMs: Double
+    ) {
+        if promptTokens > 0 { cppPromptTokens = promptTokens }
+        if completionTokens > 0 { cppCompletionTokens = completionTokens }
+        if tokensPerSecond > 0 { cppTokensPerSecond = tokensPerSecond }
+        if timeToFirstTokenMs > 0 { cppTimeToFirstTokenMs = timeToFirstTokenMs }
+
         isComplete = true
         if let continuation = resultContinuation {
             continuation.resume(returning: buildResult())
@@ -363,20 +419,32 @@ private actor LLMStreamingMetricsCollector {
         let endTime = Date()
         let latencyMs = (startTime.map { endTime.timeIntervalSince($0) } ?? 0) * 1000
 
-        var timeToFirstTokenMs: Double?
-        if let start = startTime, let firstToken = firstTokenTime {
+        let timeToFirstTokenMs: Double?
+        if let cppTtft = cppTimeToFirstTokenMs {
+            timeToFirstTokenMs = cppTtft
+        } else if let start = startTime, let firstToken = firstTokenTime {
             timeToFirstTokenMs = firstToken.timeIntervalSince(start) * 1000
+        } else {
+            timeToFirstTokenMs = nil
         }
 
-        // Use actual token count from streaming callbacks, not character estimation (fixes #339)
-        let outputTokens = max(1, tokenCount)
-        let totalTimeSec = latencyMs / 1000.0
-        let tokensPerSecond = totalTimeSec > 0 ? Double(outputTokens) / totalTimeSec : 0
+        let outputTokens = cppCompletionTokens ?? max(1, tokenCount)
+        let inputTokens = cppPromptTokens ?? 0
+
+        let tokensPerSecond: Double
+        if let cppTps = cppTokensPerSecond {
+            tokensPerSecond = cppTps
+        } else {
+            let totalTimeSec = latencyMs / 1000.0
+            tokensPerSecond = totalTimeSec > 0 ? Double(outputTokens) / totalTimeSec : 0
+        }
+
+        let (responseText, thinkingContent) = ThinkingContentParser.extract(from: fullText)
 
         return LLMGenerationResult(
-            text: fullText,
-            thinkingContent: nil,
-            inputTokens: 0,
+            text: responseText,
+            thinkingContent: thinkingContent,
+            inputTokens: inputTokens,
             tokensUsed: outputTokens,
             modelUsed: modelId,
             latencyMs: latencyMs,

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+TextGeneration.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+TextGeneration.swift
@@ -309,7 +309,7 @@ private final class LLMStreamCallbackContext: @unchecked Sendable {
 
 // MARK: - Thinking Content Parser
 
-private enum ThinkingContentParser {
+enum ThinkingContentParser {
     /// Extracts `<think>...</think>` content from generated text.
     /// - Returns: Tuple of (responseText, thinkingContent). If no tags found, responseText = original text, thinkingContent = nil.
     static func extract(from text: String) -> (text: String, thinking: String?) {
@@ -320,10 +320,16 @@ private enum ThinkingContentParser {
         }
         let thinkingContent = String(text[startRange.upperBound..<endRange.lowerBound])
             .trimmingCharacters(in: .whitespacesAndNewlines)
-        let responseText = String(text[endRange.upperBound...])
+        // Include any text before <think> and after </think>
+        let textBefore = String(text[..<startRange.lowerBound])
             .trimmingCharacters(in: .whitespacesAndNewlines)
+        let textAfter = String(text[endRange.upperBound...])
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let responseText = [textBefore, textAfter]
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
         return (
-            text: responseText.isEmpty ? text : responseText,
+            text: responseText,
             thinking: thinkingContent.isEmpty ? nil : thinkingContent
         )
     }

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+TextGeneration.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+TextGeneration.swift
@@ -107,7 +107,10 @@ public extension RunAnywhere {
             framework: "llamacpp",
             tokensPerSecond: tokensPerSecond,
             timeToFirstTokenMs: nil,
-            thinkingTokens: thinkingContent.map { _ in outputTokens } ?? 0,
+            thinkingTokens: thinkingContent.map { thinking in
+                let ratio = Double(thinking.count) / Double(max(1, rawText.count))
+                return Int(Double(outputTokens) * ratio)
+            } ?? 0,
             responseTokens: outputTokens
         )
     }
@@ -226,7 +229,10 @@ public extension RunAnywhere {
                 }
 
                 if streamResult != RAC_SUCCESS {
-                    Unmanaged<LLMStreamCallbackContext>.fromOpaque(contextPtr).release()
+                    // NOTE: Do not release contextPtr here. The C++ layer always invokes
+                    // errorCallback before returning non-SUCCESS, and errorCallback consumes
+                    // the retained reference via takeRetainedValue(). Releasing here would
+                    // cause a double-release.
                     let error = SDKError.llm(.generationFailed, "Stream generation failed: \(streamResult)")
                     continuation.finish(throwing: error)
                     await collector.markFailed(error)
@@ -252,8 +258,9 @@ private enum LLMStreamCallbacks {
 
     static func create() -> Callbacks {
         let tokenCallback: TokenFn = { tokenPtr, userData -> rac_bool_t in
+            // Cancellation is handled by an atomic flag in llm_component.cpp — no Swift Task
+            // context exists on this C callback thread, so Task.isCancelled would always be false.
             guard let tokenPtr = tokenPtr, let userData = userData else { return RAC_TRUE }
-            if Task.isCancelled { return RAC_FALSE }
             let ctx = Unmanaged<LLMStreamCallbackContext>.fromOpaque(userData).takeUnretainedValue()
             let token = String(cString: tokenPtr)
             Task {
@@ -309,10 +316,10 @@ private final class LLMStreamCallbackContext: @unchecked Sendable {
 
 // MARK: - Thinking Content Parser
 
-enum ThinkingContentParser {
+public enum ThinkingContentParser {
     /// Extracts `<think>...</think>` content from generated text.
     /// - Returns: Tuple of (responseText, thinkingContent). If no tags found, responseText = original text, thinkingContent = nil.
-    static func extract(from text: String) -> (text: String, thinking: String?) {
+    public static func extract(from text: String) -> (text: String, thinking: String?) {
         guard let startRange = text.range(of: "<think>"),
               let endRange = text.range(of: "</think>"),
               startRange.upperBound <= endRange.lowerBound else {
@@ -332,6 +339,26 @@ enum ThinkingContentParser {
             text: responseText,
             thinking: thinkingContent.isEmpty ? nil : thinkingContent
         )
+    }
+
+    /// Strips all `<think>...</think>` blocks (including multiple blocks) and trailing unclosed
+    /// `<think>` tags from the given text, returning only the response portion.
+    /// - Parameter text: Raw text potentially containing thinking blocks.
+    /// - Returns: Text with all thinking blocks removed, trimmed of surrounding whitespace.
+    public static func strip(from text: String) -> String {
+        var result = text
+        // Remove all complete <think>...</think> blocks
+        while let startRange = result.range(of: "<think>"),
+              let endRange = result.range(of: "</think>"),
+              startRange.upperBound <= endRange.lowerBound {
+            result.removeSubrange(startRange.lowerBound..<endRange.upperBound)
+        }
+        // Drop any trailing unclosed <think> ... (still streaming)
+        if let trailingStart = result.range(of: "<think>", options: .backwards),
+           result.range(of: "</think>", range: trailingStart.upperBound..<result.endIndex) == nil {
+            result = String(result[result.startIndex..<trailingStart.lowerBound])
+        }
+        return result.trimmingCharacters(in: .whitespacesAndNewlines)
     }
 }
 
@@ -457,7 +484,10 @@ private actor LLMStreamingMetricsCollector {
             framework: "llamacpp",
             tokensPerSecond: tokensPerSecond,
             timeToFirstTokenMs: timeToFirstTokenMs,
-            thinkingTokens: 0,
+            thinkingTokens: thinkingContent.map { thinking in
+                let ratio = Double(thinking.count) / Double(max(1, fullText.count))
+                return Int(Double(outputTokens) * ratio)
+            } ?? 0,
             responseTokens: outputTokens
         )
     }

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+ToolCalling.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+ToolCalling.swift
@@ -206,12 +206,15 @@ public extension RunAnywhere {
             allToolResults.append(result)
 
             fullPrompt = buildFollowUpPrompt(
-                prompt: prompt,
+                prompt: cleanPrompt,
                 systemPrompt: systemPrompt,
                 toolCall: toolCall,
                 result: result,
                 keepToolsAvailable: opts.keepToolsAvailable
             )
+            if hasNoThink {
+                fullPrompt = "\(noThinkPrefix)\(fullPrompt)"
+            }
         }
 
         return ToolCallingResult(

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+ToolCalling.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+ToolCalling.swift
@@ -168,8 +168,17 @@ public extension RunAnywhere {
         let registeredTools = await ToolRegistry.shared.getAll()
         let tools = opts.tools ?? registeredTools
 
+        // Extract /no_think prefix before building the full prompt so it stays
+        // at the beginning where the C++ inference layer expects it.
+        let noThinkPrefix = "/no_think\n"
+        let hasNoThink = prompt.hasPrefix(noThinkPrefix)
+        let cleanPrompt = hasNoThink ? String(prompt.dropFirst(noThinkPrefix.count)) : prompt
+
         let systemPrompt = buildToolSystemPrompt(tools: tools, options: opts)
-        var fullPrompt = systemPrompt.isEmpty ? prompt : "\(systemPrompt)\n\nUser: \(prompt)"
+        var fullPrompt = systemPrompt.isEmpty ? cleanPrompt : "\(systemPrompt)\n\nUser: \(cleanPrompt)"
+        if hasNoThink {
+            fullPrompt = "\(noThinkPrefix)\(fullPrompt)"
+        }
 
         var allToolCalls: [ToolCall] = []
         var allToolResults: [ToolResult] = []

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/TTS/RunAnywhere+TTS.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/TTS/RunAnywhere+TTS.swift
@@ -95,6 +95,7 @@ public extension RunAnywhere {
 
         // Synthesize (C++ emits events)
         var ttsResult = rac_tts_result_t()
+        defer { rac_tts_result_free(&ttsResult) }
         let synthesizeResult = text.withCString { textPtr in
             rac_tts_component_synthesize(handle, textPtr, &cOptions, &ttsResult)
         }
@@ -157,7 +158,6 @@ public extension RunAnywhere {
 
         let voiceId = await CppBridge.TTS.shared.currentVoiceId ?? "unknown"
         let startTime = Date()
-        var totalAudioData = Data()
 
         // Build C options
         var cOptions = rac_tts_options_t()
@@ -166,8 +166,8 @@ public extension RunAnywhere {
         cOptions.volume = options.volume
         cOptions.sample_rate = Int32(options.sampleRate)
 
-        // Create callback context
-        let context = TTSStreamContext(onChunk: onAudioChunk, totalData: &totalAudioData)
+        // Create callback context - owns its own Data
+        let context = TTSStreamContext(onChunk: onAudioChunk)
         let contextPtr = Unmanaged.passRetained(context).toOpaque()
 
         let streamResult = text.withCString { textPtr in
@@ -180,13 +180,14 @@ public extension RunAnywhere {
                     let ctx = Unmanaged<TTSStreamContext>.fromOpaque(userData).takeUnretainedValue()
                     let chunk = Data(bytes: audioPtr, count: audioSize)
                     ctx.onChunk(chunk)
-                    ctx.totalData.pointee.append(chunk)
+                    ctx.totalData.append(chunk)
                 },
                 contextPtr
             )
         }
 
-        Unmanaged<TTSStreamContext>.fromOpaque(contextPtr).release()
+        let finalContext = Unmanaged<TTSStreamContext>.fromOpaque(contextPtr).takeRetainedValue()
+        let totalAudioData = finalContext.totalData
 
         guard streamResult == RAC_SUCCESS else {
             throw SDKError.tts(.processingFailed, "Streaming synthesis failed: \(streamResult)")
@@ -309,10 +310,9 @@ public extension RunAnywhere {
 
 private final class TTSStreamContext: @unchecked Sendable {
     let onChunk: (Data) -> Void
-    var totalData: UnsafeMutablePointer<Data>
+    var totalData: Data = Data()
 
-    init(onChunk: @escaping (Data) -> Void, totalData: UnsafeMutablePointer<Data>) {
+    init(onChunk: @escaping (Data) -> Void) {
         self.onChunk = onChunk
-        self.totalData = totalData
     }
 }

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceAgent.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceAgent.swift
@@ -257,8 +257,12 @@ public extension RunAnywhere {
             rac_voice_agent_synthesize_speech(handle, textPtr, &audioPtr, &audioSize)
         }
 
-        guard result == RAC_SUCCESS, let ptr = audioPtr, audioSize > 0 else {
+        guard result == RAC_SUCCESS else {
             throw SDKError.voiceAgent(.processingFailed, "Speech synthesis failed: \(result)")
+        }
+
+        guard let ptr = audioPtr, audioSize > 0 else {
+            return Data()
         }
 
         let audioData = Data(bytes: ptr, count: audioSize)

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceAgent.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceAgent.swift
@@ -257,6 +257,12 @@ public extension RunAnywhere {
             rac_voice_agent_synthesize_speech(handle, textPtr, &audioPtr, &audioSize)
         }
 
+        defer {
+            if let ptr = audioPtr {
+                rac_free(ptr)
+            }
+        }
+
         guard result == RAC_SUCCESS else {
             throw SDKError.voiceAgent(.processingFailed, "Speech synthesis failed: \(result)")
         }
@@ -266,8 +272,6 @@ public extension RunAnywhere {
         }
 
         let audioData = Data(bytes: ptr, count: audioSize)
-        free(ptr)
-
         return audioData
     }
 

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceSession.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceSession.swift
@@ -122,6 +122,12 @@ public actor VoiceSessionHandle {
     /// Resume listening after a completed turn (for push-to-talk when continuousMode is false)
     public func resumeListening() async {
         guard isRunning else { return }
+        // Idempotency guard: if capture is already active, don't stack a second
+        // audio-level monitoring task (see QEF-20).
+        guard !audioCapture.isRecording else {
+            logger.debug("resumeListening() called but already listening; skipping")
+            return
+        }
         try? await startListening()
     }
 
@@ -227,8 +233,14 @@ public actor VoiceSessionHandle {
             emit(.transcribed(text: transcription))
 
             // Step 2: Generate LLM response (apply /no_think prefix if needed)
+            // Only inject `/no_think` when the currently loaded LLM actually supports
+            // thinking — otherwise ordinary models receive a stray slash command
+            // (see QEF-21).
             let effectivePrompt: String
-            if !config.thinkingModeEnabled {
+            let loadedSupportsThinking = await RunAnywhere.currentLLMModel?.supportsThinking ?? false
+            if !config.thinkingModeEnabled,
+               loadedSupportsThinking,
+               !transcription.hasPrefix("/no_think") {
                 effectivePrompt = "/no_think\n\(transcription)"
             } else {
                 effectivePrompt = transcription
@@ -251,22 +263,33 @@ public actor VoiceSessionHandle {
                     emit(.speaking)
                     do {
                         try await audioPlayback.play(ttsAudio)
-                    } catch is AudioPlaybackError {
-                        logger.info("TTS playback interrupted by user")
+                    } catch let error as AudioPlaybackError {
+                        // Only swallow user-initiated interrupts; propagate real
+                        // failures so they reach the outer catch (QEF-22).
+                        switch error {
+                        case .playbackInterrupted:
+                            logger.info("TTS playback interrupted by user")
+                        default:
+                            throw error
+                        }
                     }
                 }
             }
+
+            // Success path: only emit turnCompleted when the whole pipeline
+            // finished without throwing (QEF-2). On error, the outer catch
+            // below emits .error and we skip turnCompleted so the UI state
+            // isn't overwritten.
+            emit(.turnCompleted(
+                transcript: transcription,
+                response: cleanedResponse,
+                thinkingContent: thinkingContent,
+                audio: synthesizedAudio
+            ))
         } catch {
             logger.error("Processing failed: \(error)")
             emit(.error(error.localizedDescription))
         }
-
-        emit(.turnCompleted(
-            transcript: transcription,
-            response: cleanedResponse,
-            thinkingContent: thinkingContent,
-            audio: synthesizedAudio
-        ))
 
         // Resume listening if continuous mode
         if config.continuousMode && isRunning {

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceSession.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceSession.swift
@@ -108,6 +108,10 @@ public actor VoiceSessionHandle {
         eventContinuation?.finish()
     }
 
+    public func interruptPlayback() {
+        audioPlayback.stop()
+    }
+
     /// Force process current audio (push-to-talk)
     public func sendNow() async {
         guard isRunning else { return }
@@ -196,43 +200,68 @@ public actor VoiceSessionHandle {
 
         emit(.processing)
 
-        do {
-            let result = try await RunAnywhere.processVoiceTurn(audio)
+        var transcription = ""
+        var cleanedResponse = ""
+        var thinkingContent: String?
+        var synthesizedAudio: Data?
 
-            guard result.speechDetected else {
-                logger.info("No speech detected")
+        do {
+            // Step 1: Transcribe audio
+            transcription = try await RunAnywhere.voiceAgentTranscribe(audio)
+
+            guard !transcription.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+                logger.info("No speech detected (empty transcription)")
+                emit(.turnCompleted(transcript: "", response: "", thinkingContent: nil, audio: nil))
                 if config.continuousMode && isRunning {
                     try? await startListening()
                 }
                 return
             }
 
-            // Emit intermediate results
-            if let transcript = result.transcription {
-                emit(.transcribed(text: transcript))
+            emit(.transcribed(text: transcription))
+
+            // Step 2: Generate LLM response (apply /no_think prefix if needed)
+            let effectivePrompt: String
+            if !config.thinkingModeEnabled {
+                effectivePrompt = "/no_think\n\(transcription)"
+            } else {
+                effectivePrompt = transcription
             }
 
-            if let response = result.response {
-                emit(.responded(text: response))
+            let rawResponse = try await RunAnywhere.voiceAgentGenerateResponse(effectivePrompt)
+
+            // Step 3: Parse out <think> tags from response before TTS
+            let parsed = ThinkingContentParser.extract(from: rawResponse)
+            cleanedResponse = parsed.text
+            thinkingContent = parsed.thinking
+
+            emit(.responded(text: cleanedResponse, thinkingContent: thinkingContent))
+
+            // Step 4: Synthesize speech from cleaned response (no think tags spoken)
+            if config.autoPlayTTS, !cleanedResponse.isEmpty {
+                let ttsAudio = try await RunAnywhere.voiceAgentSynthesizeSpeech(cleanedResponse)
+                synthesizedAudio = ttsAudio
+
+                if !ttsAudio.isEmpty {
+                    emit(.speaking)
+                    do {
+                        try await audioPlayback.play(ttsAudio)
+                    } catch is AudioPlaybackError {
+                        logger.info("TTS playback interrupted by user")
+                    }
+                }
             }
-
-            // Play TTS if enabled
-            if config.autoPlayTTS, let ttsAudio = result.synthesizedAudio, !ttsAudio.isEmpty {
-                emit(.speaking)
-                try await audioPlayback.play(ttsAudio)
-            }
-
-            // Emit complete result
-            emit(.turnCompleted(
-                transcript: result.transcription ?? "",
-                response: result.response ?? "",
-                audio: result.synthesizedAudio
-            ))
-
         } catch {
             logger.error("Processing failed: \(error)")
             emit(.error(error.localizedDescription))
         }
+
+        emit(.turnCompleted(
+            transcript: transcription,
+            response: cleanedResponse,
+            thinkingContent: thinkingContent,
+            audio: synthesizedAudio
+        ))
 
         // Resume listening if continuous mode
         if config.continuousMode && isRunning {

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceSession.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceSession.swift
@@ -228,12 +228,11 @@ public actor VoiceSessionHandle {
                 effectivePrompt = transcription
             }
 
-            let rawResponse = try await RunAnywhere.voiceAgentGenerateResponse(effectivePrompt)
-
-            // Step 3: Parse out <think> tags from response before TTS
-            let parsed = ThinkingContentParser.extract(from: rawResponse)
-            cleanedResponse = parsed.text
-            thinkingContent = parsed.thinking
+            let options = LLMGenerationOptions(maxTokens: config.maxTokens ?? 100)
+            let result = try await RunAnywhere.generate(effectivePrompt, options: options)
+            // generate() already runs ThinkingContentParser internally
+            cleanedResponse = result.text
+            thinkingContent = result.thinkingContent
 
             emit(.responded(text: cleanedResponse, thinkingContent: thinkingContent))
 

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceSession.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceSession.swift
@@ -119,6 +119,12 @@ public actor VoiceSessionHandle {
         await processCurrentAudio()
     }
 
+    /// Resume listening after a completed turn (for push-to-talk when continuousMode is false)
+    public func resumeListening() async {
+        guard isRunning else { return }
+        try? await startListening()
+    }
+
     // MARK: - Private
 
     private func emit(_ event: VoiceSessionEvent) {

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/VoiceAgentTypes.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/VoiceAgentTypes.swift
@@ -23,6 +23,9 @@ public struct VoiceAgentResult: Sendable {
     /// Generated response text from LLM
     public var response: String?
 
+    /// Thinking content extracted from `<think>...</think>` tags (nil if none)
+    public var thinkingContent: String?
+
     /// Synthesized audio data from TTS
     public var synthesizedAudio: Data?
 
@@ -31,11 +34,13 @@ public struct VoiceAgentResult: Sendable {
         speechDetected: Bool = false,
         transcription: String? = nil,
         response: String? = nil,
+        thinkingContent: String? = nil,
         synthesizedAudio: Data? = nil
     ) {
         self.speechDetected = speechDetected
         self.transcription = transcription
         self.response = response
+        self.thinkingContent = thinkingContent
         self.synthesizedAudio = synthesizedAudio
     }
 
@@ -185,14 +190,14 @@ public enum VoiceSessionEvent: Sendable {
     /// Got transcription from STT
     case transcribed(text: String)
 
-    /// Got response from LLM
-    case responded(text: String)
+    /// Got response from LLM (with optional thinking content)
+    case responded(text: String, thinkingContent: String? = nil)
 
     /// Playing TTS audio
     case speaking
 
-    /// Complete turn result
-    case turnCompleted(transcript: String, response: String, audio: Data?)
+    /// Complete turn result (with optional thinking content)
+    case turnCompleted(transcript: String, response: String, thinkingContent: String? = nil, audio: Data?)
 
     /// Session stopped
     case stopped
@@ -217,16 +222,21 @@ public struct VoiceSessionConfig: Sendable {
     /// Whether to auto-resume listening after TTS playback
     public var continuousMode: Bool
 
+    /// Whether thinking mode is enabled for the LLM.
+    public var thinkingModeEnabled: Bool
+
     public init(
         silenceDuration: TimeInterval = 1.5,
         speechThreshold: Float = 0.1,
         autoPlayTTS: Bool = true,
-        continuousMode: Bool = true
+        continuousMode: Bool = true,
+        thinkingModeEnabled: Bool = false
     ) {
         self.silenceDuration = silenceDuration
         self.speechThreshold = speechThreshold
         self.autoPlayTTS = autoPlayTTS
         self.continuousMode = continuousMode
+        self.thinkingModeEnabled = thinkingModeEnabled
     }
 
     /// Default configuration

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/VoiceAgentTypes.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/VoiceAgentTypes.swift
@@ -225,18 +225,23 @@ public struct VoiceSessionConfig: Sendable {
     /// Whether thinking mode is enabled for the LLM.
     public var thinkingModeEnabled: Bool
 
+    /// Maximum tokens for LLM generation (nil uses SDK default of 100)
+    public var maxTokens: Int?
+
     public init(
         silenceDuration: TimeInterval = 1.5,
         speechThreshold: Float = 0.1,
         autoPlayTTS: Bool = true,
         continuousMode: Bool = true,
-        thinkingModeEnabled: Bool = false
+        thinkingModeEnabled: Bool = false,
+        maxTokens: Int? = nil
     ) {
         self.silenceDuration = silenceDuration
         self.speechThreshold = speechThreshold
         self.autoPlayTTS = autoPlayTTS
         self.continuousMode = continuousMode
         self.thinkingModeEnabled = thinkingModeEnabled
+        self.maxTokens = maxTokens
     }
 
     /// Default configuration

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/RunAnywhere.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/RunAnywhere.swift
@@ -136,7 +136,7 @@ public enum RunAnywhere {
 
     /// Reset SDK state (for testing purposes)
     /// Clears all initialization state and cached data
-    public static func reset() {
+    public static func reset() async {
         let logger = SDKLogger(category: "RunAnywhere.Reset")
         logger.info("Resetting SDK state...")
 
@@ -147,7 +147,7 @@ public enum RunAnywhere {
         currentEnvironment = nil
 
         // Shutdown all C++ bridges and state
-        CppBridge.shutdown()
+        await CppBridge.shutdown()
         CppBridge.State.shutdown()
 
         logger.info("SDK state reset completed")


### PR DESCRIPTION
## Summary

Revives the work from #454 (by @VyasGuru), which was closed without comment on 2026-04-14 — apparently by accident. Rebased cleanly onto current `main`, merge conflicts resolved, macOS build + tests verified.

All 7 original commits preserved with @VyasGuru's authorship.

## What's Included

### Swift SDK

**Thinking mode end-to-end:**
- `ThinkingContentParser` enum that extracts `<think>...</think>` from generated text — used in both streaming and non-streaming paths
- Thinking content propagated through `LLMGenerationResult`, `VoiceSessionEvent.responded(text:thinkingContent:)`, and `.turnCompleted(transcript:response:thinkingContent:audio:)`
- `/no_think` prefix preservation in `RunAnywhere+ToolCalling.swift` (extracts prefix, injects tool system prompt, re-applies prefix so the C++ inference layer still sees it at the start)

**Streaming pipeline improvements:**
- C++ streaming metrics (prompt tokens, completion tokens, TPS, TTFT) now piped to Swift via the completion callback, so `LLMStreamingMetricsCollector` reports real C++ numbers instead of wall-clock estimates
- `Task.isCancelled` check in the stream token callback so SwiftUI-initiated cancellations stop generation promptly
- `passRetained`/`takeRetainedValue` pairing for `LLMStreamCallbackContext` to avoid leaks on error paths

**Voice session:**
- `VoiceSessionHandle.interruptPlayback()` — stops TTS playback mid-utterance for push-to-talk UX
- `VoiceSessionHandle.resumeListening()` — restart listening after a completed turn when `continuousMode == false`
- `VoiceSessionConfig.thinkingModeEnabled` + `maxTokens` — per-session control
- TTS playback interruption is caught as `AudioPlaybackError` and logged instead of bubbling up

**Lifetime + memory hygiene:**
- `TTSStreamContext` owns its own `Data` — no more `UnsafeMutablePointer<Data>` gymnastics, no more dangling-pointer risk at end of scope
- `defer { rac_tts_result_free(&ttsResult) }` in `RunAnywhere+TTS.synthesize` — fixes a leak on error paths
- `AudioPlaybackManager.stop()` now checks `audioPlayer != nil` instead of `isPlaying` — safer when the player exists but `isPlaying` just transitioned to false (prior race could skip cleanup)
- `RunAnywhere.voiceAgentSynthesizeSpeech` returns empty `Data` when no audio is produced instead of throwing (useful for silent prompts)
- `CppBridge.shutdown` now destroys all 6 component singletons (LLM, STT, TTS, VAD, VoiceAgent, VLM) in one pass

### C++ Commons

**Tool-calling robustness (`tool_calling.cpp`):**
- **Flat-args fallback** — handles LLM output of the form `{"tool": "calculate", "expression": "5 * 100"}` where the model didn't wrap args in a standard `"arguments"` key. Previously this was rejected as "no arguments found"; now the parser collects remaining non-tool-name keys as flat arguments. Real correctness fix affecting calculator tool calls.
- **Scalar value extraction in `extract_json_value`** — parser now handles numbers, booleans, `null`, not only strings and objects. Previously dropped non-string scalars silently.
- **Memory leak fix in `extract_json_string`** — no longer leaks the intermediate `std::string` when the output malloc succeeds but is followed by an early return.

**LLM component (`llm_component.cpp`):**
- `rac_llm_component.cancel_requested` — `std::atomic<bool>` flag readable by the streaming token callback without holding `component->mtx`. Fixes the cancellation deadlock where `cancel()` needed to acquire the mutex that `generate_stream()` was holding.
- Monotonic-clock generation-ID generator replaces RNG — no RNG contention in the hot path.

**Stop-sequence detection (`llamacpp_backend.cpp`):**
- UTF-8-boundary-safe truncation of the sliding `stop_window`: back up past any trailing continuation bytes (`(b & 0xC0) == 0x80`) before flushing, so we never cut mid-codepoint
- **Fixes a subtle bug where `stop_window` grew unboundedly during generation** — previously when the window exceeded `MAX_STOP_LEN` we flushed a prefix via callback but never erased it, so each subsequent flush would re-send overlapping bytes. Now erases the flushed portion after a successful callback.

### iOS Example App

- Thinking Mode toggle in `CombinedSettingsView`, UI badge in `ChatInterfaceView`, per-model support, persistence across launches
- `LLMViewModel.loadedModelSupportsThinking` state + `applyThinkingModePrefix(to:)` that prepends `/no_think\n` when the loaded model supports thinking but the user has it disabled
- `SettingsViewModel` subscribes to SDK events to detect thinking support for any model load (chat, voice, or RAG)
- Camera scene-phase lifecycle in `VLMCameraView` — stops capture on background/inactive, re-starts on active (real iOS correctness bug)
- `DemoLoRAAdapter.swift`: Abliterated LoRA adapter entry for Qwen 2.5 0.5B base + example prompts
- `ModelSelectionRows.swift`: LoRA tags visible in model sheet
- `ModelListViewModel.swift`: Qwen 2.5 0.5B link updated to the official Qwen URL
- RAG view updated with thinking mode support and thinking-aware prompts
- `VoiceAssistantView` / `VoiceAgentViewModel`: interruption/resume wiring, thinking events, batch transcription path

## What Was Dropped During Rebase

| File | Reason |
|------|--------|
| `sdk/runanywhere-swift/Sources/RunAnywhere/Infrastructure/Download/Utilities/ArchiveUtility.swift` | Accepted main's **delete** — functionality moved to C++ libarchive in main's commit `0dc46c101` ("replacing the archive logic and moving to cpp"). The PR's modifications to the Swift version were obsolete. |
| `llamacpp_backend.cpp` naming churn (`LOGI` macro alias, unnamed constants `2`/`8`) | Took main's newer versions: named constants (`kMinThreads`, `kMaxThreads`, …) and direct `RAC_LOG_INFO("LLM.LlamaCpp", ...)` calls. |
| `scanner_state`/`old_partial_size` rename | Took main's `utf8_scanner`/`scan_start` — same logic, main has an explanatory comment. |

## Merge Conflict Resolution Notes

Three conflicts, all resolved carefully (not mechanically):

1. **`llm_component.cpp`** — kept BOTH main's `ctx.full_text.reserve(2048)` (streaming pre-allocation perf) AND the PR's `ctx.cancel_flag = &component->cancel_requested` (atomic cancel wiring). They don't conflict semantically, only on adjacent lines.

2. **`llamacpp_backend.cpp` scanner persistence** — took main's variable names and retained the existing "persist scanner across iterations" comment.

3. **`llamacpp_backend.cpp` stop_window truncation** — took the PR's UTF-8-safe logic (because main's version has the unbounded-growth bug described above), adapted to main's logging style.

## Verification

```bash
cmake -B build -DRAC_BUILD_TESTS=ON -DRAC_BUILD_BACKENDS=OFF
cmake --build build -j 8
# 100%, no new warnings or errors (only pre-existing ones from main)

./build/tests/test_core                  # 13/13 PASSED
./build/tests/test_extraction            # 22/22 PASSED
./build/tests/test_download_orchestrator # 16/16 PASSED
# Total: 51/51 passing, 0 regressions
```

## Test Plan

- [x] commons library builds cleanly on macOS
- [x] All 51 existing unit tests pass
- [x] All 7 cherry-picked commits preserve @VyasGuru's authorship
- [x] No residual merge-conflict markers
- [ ] iOS example app builds + launches
- [ ] Thinking-mode toggle persists across app launches
- [ ] Chat shows thinking badge when a thinking-capable model is loaded
- [ ] `/no_think` prefix actually suppresses thinking on Qwen models
- [ ] Voice agent: push-to-talk with `interruptPlayback` / `resumeListening`
- [ ] Calculator tool call with flat args: `{"tool": "calculate", "expression": "5 * 100"}`
- [ ] Camera app lifecycle — stops on background, resumes on foreground
- [ ] Abliterated LoRA adapter loads and runs on Qwen 2.5 0.5B base

Closes / supersedes #454 (which was closed without comment on 2026-04-14).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Thinking Mode: toggle in settings, model-aware “Thinking” badge, prompt prefix behavior, and UI to view/hide model reasoning.
  * New LoRA adapter with example prompts and LoRA compatibility indicator in model list.
  * Voice: interrupt playback, resume listening, refined mic tap/long-press behavior.

* **Improvements**
  * Safer streaming and cancellation, more accurate metrics, more robust TTS/teardown and voice handling, improved camera lifecycle/resume, refined scrolling/typing behavior, stricter calculator validation, and more reliable tool/result parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR revives #454, landing thinking-mode end-to-end, memory/lifetime fixes, the atomic cancel-flag that breaks the streaming deadlock, and UTF-8-safe stop_window truncation. Four P1 issues need resolution: scalar type loss in the tool-calling flat-args path, a shutdown race in `CppBridge`, `turnCompleted` firing after errors, and an `@AppStorage`/`SettingsViewModel` sync gap silently ignoring thinking-badge toggles.

<h3>Confidence Score: 3/5</h3>

Not safe to merge: three SDK-level bugs and one app-level state sync bug need resolution first.

Four P1 findings: scalar-to-string coercion breaks non-string tool parameters; shutdown Task races with Telemetry/Events teardown; turnCompleted after errors masks failures; @AppStorage sync gap silently ignores thinking-badge toggles during generation.

sdk/runanywhere-commons/src/features/llm/tool_calling.cpp, sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/CppBridge.swift, sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceSession.swift, examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-commons/src/features/llm/tool_calling.cpp | Flat-args fallback re-serializes scalar values as strings, breaking tool calls with numeric/boolean parameters. |
| sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/CppBridge.swift | Component destroys dispatched in fire-and-forget Task, racing with immediate Telemetry/Events teardown. |
| sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceSession.swift | Rewrites voice turn pipeline; turnCompleted emitted unconditionally after do-catch, overwriting error UI state. |
| sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+TextGeneration.swift | Wires C++ streaming metrics, fixes memory pairing, adds ThinkingContentParser; Task.isCancelled in C callback is a harmless no-op. |
| sdk/runanywhere-commons/src/backends/llamacpp/llamacpp_backend.cpp | UTF-8 boundary-safe stop_window truncation and incremental Utf8State scanner fix the unbounded-growth bug. |
| sdk/runanywhere-commons/src/features/llm/llm_component.cpp | Atomic cancel flag fixes streaming deadlock; monotonic ID and real token count are clean improvements. |
| examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift | Adds thinking badge; @AppStorage binding out of sync with SettingsViewModel.shared.thinkingModeEnabled. |
| examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/SettingsViewModel.swift | Converts to shared singleton, fixes temperature 0.0 loading, adds SDK event subscription for thinking capability. |
| sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/TTS/RunAnywhere+TTS.swift | TTSStreamContext owns its Data; defer frees ttsResult on all paths. |
| examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Vision/VLMCameraView.swift | Adds scene-phase lifecycle to stop/restart camera on background/active transitions. |
| examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAgentViewModel.swift | Adds interruptSpeaking/resumeListening and push-to-talk UX. |
| examples/ios/RunAnywhereAI/RunAnywhereAI/Helpers/AdaptiveLayout.swift | Refactors AdaptiveMicButton to extract micContent and adds onLongPress gesture. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/CppBridge.swift`, line 182-194 ([link](https://github.com/runanywhereai/runanywhere-sdks/blob/5f3ba5100fe5809d8db996c1a777ee1d23c88c01/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/CppBridge.swift#L182-L194)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Fire-and-forget Task races with synchronous shutdown**

   Component destroys run concurrently while `Telemetry.shutdown()` and `Events.unregister()` execute immediately. Destroy callbacks that emit events land on already-torn-down subsystems.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/CppBridge.swift
   Line: 182-194

   Comment:
   **Fire-and-forget Task races with synchronous shutdown**

   Component destroys run concurrently while `Telemetry.shutdown()` and `Events.unregister()` execute immediately. Destroy callbacks that emit events land on already-torn-down subsystems.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: sdk/runanywhere-commons/src/features/llm/tool_calling.cpp
Line: 721-728

Comment:
**Numeric/boolean scalar values coerced to strings in flat-args JSON**

The reassembly code wraps all non-object values in double quotes, turning `"level":50` into `"level":"50"`. Tool handlers expecting numeric types will receive strings and may fail.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/CppBridge.swift
Line: 182-194

Comment:
**Fire-and-forget Task races with synchronous shutdown**

Component destroys run concurrently while `Telemetry.shutdown()` and `Events.unregister()` execute immediately. Destroy callbacks that emit events land on already-torn-down subsystems.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/VoiceAgent/RunAnywhere+VoiceSession.swift
Line: 249-260

Comment:
**`turnCompleted` fires unconditionally after errors**

Moved outside the do-catch, `emit(.turnCompleted(...))` fires on both success and failure, overwriting the `.error` UI state with `.connected / "Ready"` and hiding failures from users.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift
Line: 33-34

Comment:
**Thinking badge and `SettingsViewModel` drift out of sync**

The badge uses `@AppStorage("thinkingModeEnabled")` but `LLMViewModel.applyThinkingModePrefix` reads `SettingsViewModel.shared.thinkingModeEnabled`. Badge writes to UserDefaults but SettingsViewModel has no KVO observer, so the stale value is used during generation.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+TextGeneration.swift
Line: 256

Comment:
**`Task.isCancelled` is always `false` in a C callback thread**

No Swift Task is active on the C++ callback thread, so this check is a no-op. Cancellation is handled by the atomic flag in `llm_component.cpp`.

```suggestion
            guard let tokenPtr = tokenPtr, let userData = userData else { return RAC_TRUE }
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
Line: 574-587

Comment:
**Duplicate `<think>` stripping that diverges from `ThinkingContentParser`**

Three separate implementations exist with inconsistent multi-block handling. Consider delegating to the SDK-level `ThinkingContentParser` rather than duplicating.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["lora tags in. model sheet"](https://github.com/runanywhereai/runanywhere-sdks/commit/5f3ba5100fe5809d8db996c1a777ee1d23c88c01) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28403434)</sub>

> Greptile also left **5 inline comments** on this PR.

<!-- /greptile_comment -->