### PR TITLE
Cache FFI lookups in Flutter native bridge (rebase of #457)

### DIFF
--- a/examples/ios/RunAnywhereAI/Package.resolved
+++ b/examples/ios/RunAnywhereAI/Package.resolved
@@ -10,15 +10,6 @@
       }
     },
     {
-      "identity" : "bitbytedata",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tsolomko/BitByteData",
-      "state" : {
-        "revision" : "cdcdc5177ad536cfb11b95c620f926a81014b7fe",
-        "version" : "2.0.4"
-      }
-    },
-    {
       "identity" : "devicekit",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/devicekit/DeviceKit.git",
@@ -52,15 +43,6 @@
       "state" : {
         "revision" : "16cd512711375fa73f25ae5e373f596bdf4251ae",
         "version" : "8.58.0"
-      }
-    },
-    {
-      "identity" : "swcompression",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/tsolomko/SWCompression.git",
-      "state" : {
-        "revision" : "390e0b0af8dd19a600005a242a89e570ff482e09",
-        "version" : "4.8.6"
       }
     },
     {
@@ -124,15 +106,6 @@
       "state" : {
         "revision" : "664e1b5a65296cd957dfdf262cd120ca88f3b24b",
         "version" : "0.15.0"
-      }
-    },
-    {
-      "identity" : "zipfoundation",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/weichsel/ZIPFoundation.git",
-      "state" : {
-        "revision" : "22787ffb59de99e5dc1fbfe80b19c97a904ad48d",
-        "version" : "0.9.20"
       }
     }
   ],

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
@@ -21,6 +21,7 @@ import 'package:ffi/ffi.dart';
 
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
+import 'package:runanywhere/native/native_functions.dart';
 import 'package:runanywhere/native/platform_loader.dart';
 
 /// LLM component bridge for C++ interop.
@@ -78,13 +79,9 @@ class DartBridgeLLM {
     }
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final create = lib.lookupFunction<Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_llm_component_create');
-
       final handlePtr = calloc<RacHandle>();
       try {
-        final result = create(handlePtr);
+        final result = NativeFunctions.llmCreate(handlePtr);
 
         if (result != RAC_SUCCESS) {
           throw StateError(
@@ -111,11 +108,7 @@ class DartBridgeLLM {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final isLoadedFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_is_loaded');
-
-      return isLoadedFn(_handle!) == RAC_TRUE;
+      return NativeFunctions.llmIsLoaded(_handle!) == RAC_TRUE;
     } catch (e) {
       _logger.debug('isLoaded check failed: $e');
       return false;
@@ -130,11 +123,7 @@ class DartBridgeLLM {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final supportsStreamingFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_supports_streaming');
-
-      return supportsStreamingFn(_handle!) == RAC_TRUE;
+      return NativeFunctions.llmSupportsStreaming(_handle!) == RAC_TRUE;
     } catch (e) {
       return false;
     }
@@ -161,16 +150,7 @@ class DartBridgeLLM {
     final namePtr = modelName.toNativeUtf8();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final loadModelFn = lib.lookupFunction<
-          Int32 Function(
-              RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
-              Pointer<Utf8>)>('rac_llm_component_load_model');
-
-      _logger.debug(
-          'Calling rac_llm_component_load_model with handle: $_handle, path: $modelPath');
-      final result = loadModelFn(handle, pathPtr, idPtr, namePtr);
+      final result = NativeFunctions.llmLoadModel(handle, pathPtr, idPtr, namePtr);
       _logger.debug(
           'rac_llm_component_load_model returned: $result (${RacResultCode.getMessage(result)})');
 
@@ -194,11 +174,7 @@ class DartBridgeLLM {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final cleanupFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_cleanup');
-
-      cleanupFn(_handle!);
+      NativeFunctions.llmCleanup(_handle!);
       _loadedModelId = null;
       _logger.info('LLM model unloaded');
     } catch (e) {
@@ -211,11 +187,7 @@ class DartBridgeLLM {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final cancelFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_cancel');
-
-      cancelFn(_handle!);
+      NativeFunctions.llmCancel(_handle!);
       _logger.debug('LLM generation cancelled');
     } catch (e) {
       _logger.error('Failed to cancel generation: $e');
@@ -373,11 +345,7 @@ class DartBridgeLLM {
   void destroy() {
     if (_handle != null) {
       try {
-        final lib = PlatformLoader.loadCommons();
-        final destroyFn = lib.lookupFunction<Void Function(RacHandle),
-            void Function(RacHandle)>('rac_llm_component_destroy');
-
-        destroyFn(_handle!);
+        NativeFunctions.llmDestroy(_handle!);
         _handle = null;
         _loadedModelId = null;
         _logger.debug('LLM component destroyed');

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart
@@ -150,6 +150,7 @@ class DartBridgeLLM {
     final namePtr = modelName.toNativeUtf8();
 
     try {
+      _logger.debug('Calling rac_llm_component_load_model with handle=$handle');
       final result = NativeFunctions.llmLoadModel(handle, pathPtr, idPtr, namePtr);
       _logger.debug(
           'rac_llm_component_load_model returned: $result (${RacResultCode.getMessage(result)})');
@@ -454,7 +455,7 @@ void _streamingIsolateEntry(_StreamingIsolateParams params) {
     // Set systemPrompt if provided
     if (params.systemPrompt != null && params.systemPrompt!.isNotEmpty) {
       systemPromptPtr = params.systemPrompt!.toNativeUtf8();
-      optionsPtr.ref.systemPrompt = systemPromptPtr!;
+      optionsPtr.ref.systemPrompt = systemPromptPtr;
     } else {
       optionsPtr.ref.systemPrompt = nullptr;
     }
@@ -521,7 +522,7 @@ void _streamingIsolateEntry(_StreamingIsolateParams params) {
     calloc.free(promptPtr);
     calloc.free(optionsPtr);
     if (systemPromptPtr != null) {
-      calloc.free(systemPromptPtr!);
+      calloc.free(systemPromptPtr);
     }
     _isolateSendPort = null;
   }
@@ -590,7 +591,7 @@ _IsolateGenerationResult _generateInIsolate(
     // Set systemPrompt if provided
     if (systemPrompt != null && systemPrompt.isNotEmpty) {
       systemPromptPtr = systemPrompt.toNativeUtf8();
-      optionsPtr.ref.systemPrompt = systemPromptPtr!;
+      optionsPtr.ref.systemPrompt = systemPromptPtr;
     } else {
       optionsPtr.ref.systemPrompt = nullptr;
     }
@@ -626,7 +627,7 @@ _IsolateGenerationResult _generateInIsolate(
     calloc.free(optionsPtr);
     calloc.free(resultPtr);
     if (systemPromptPtr != null) {
-      calloc.free(systemPromptPtr!);
+      calloc.free(systemPromptPtr);
     }
   }
 }

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_stt.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_stt.dart
@@ -12,6 +12,7 @@ import 'package:ffi/ffi.dart';
 
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
+import 'package:runanywhere/native/native_functions.dart';
 import 'package:runanywhere/native/platform_loader.dart';
 
 /// STT component bridge for C++ interop.
@@ -48,13 +49,9 @@ class DartBridgeSTT {
     }
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final create = lib.lookupFunction<Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_stt_component_create');
-
       final handlePtr = calloc<RacHandle>();
       try {
-        final result = create(handlePtr);
+        final result = NativeFunctions.sttCreate(handlePtr);
 
         if (result != RAC_SUCCESS) {
           throw StateError(
@@ -81,11 +78,7 @@ class DartBridgeSTT {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final isLoadedFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_stt_component_is_loaded');
-
-      return isLoadedFn(_handle!) == RAC_TRUE;
+      return NativeFunctions.sttIsLoaded(_handle!) == RAC_TRUE;
     } catch (e) {
       _logger.debug('isLoaded check failed: $e');
       return false;
@@ -100,11 +93,7 @@ class DartBridgeSTT {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final supportsStreamingFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_stt_component_supports_streaming');
-
-      return supportsStreamingFn(_handle!) == RAC_TRUE;
+      return NativeFunctions.sttSupportsStreaming(_handle!) == RAC_TRUE;
     } catch (e) {
       return false;
     }
@@ -131,14 +120,7 @@ class DartBridgeSTT {
     final namePtr = modelName.toNativeUtf8();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final loadModelFn = lib.lookupFunction<
-          Int32 Function(
-              RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
-              Pointer<Utf8>)>('rac_stt_component_load_model');
-
-      final result = loadModelFn(handle, pathPtr, idPtr, namePtr);
+      final result = NativeFunctions.sttLoadModel(handle, pathPtr, idPtr, namePtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -160,11 +142,7 @@ class DartBridgeSTT {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final cleanupFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_stt_component_cleanup');
-
-      cleanupFn(_handle!);
+      NativeFunctions.sttCleanup(_handle!);
       _loadedModelId = null;
       _logger.info('STT model unloaded');
     } catch (e) {
@@ -357,11 +335,7 @@ class DartBridgeSTT {
   void destroy() {
     if (_handle != null) {
       try {
-        final lib = PlatformLoader.loadCommons();
-        final destroyFn = lib.lookupFunction<Void Function(RacHandle),
-            void Function(RacHandle)>('rac_stt_component_destroy');
-
-        destroyFn(_handle!);
+        NativeFunctions.sttDestroy(_handle!);
         _handle = null;
         _loadedModelId = null;
         _logger.debug('STT component destroyed');

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_tts.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_tts.dart
@@ -12,6 +12,7 @@ import 'package:ffi/ffi.dart';
 
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
+import 'package:runanywhere/native/native_functions.dart';
 import 'package:runanywhere/native/platform_loader.dart';
 
 /// TTS component bridge for C++ interop.
@@ -48,13 +49,9 @@ class DartBridgeTTS {
     }
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final create = lib.lookupFunction<Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_tts_component_create');
-
       final handlePtr = calloc<RacHandle>();
       try {
-        final result = create(handlePtr);
+        final result = NativeFunctions.ttsCreate(handlePtr);
 
         if (result != RAC_SUCCESS) {
           throw StateError(
@@ -81,11 +78,7 @@ class DartBridgeTTS {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final isLoadedFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_tts_component_is_loaded');
-
-      return isLoadedFn(_handle!) == RAC_TRUE;
+      return NativeFunctions.ttsIsLoaded(_handle!) == RAC_TRUE;
     } catch (e) {
       _logger.debug('isLoaded check failed: $e');
       return false;
@@ -116,14 +109,7 @@ class DartBridgeTTS {
     final namePtr = voiceName.toNativeUtf8();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final loadVoiceFn = lib.lookupFunction<
-          Int32 Function(
-              RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
-              Pointer<Utf8>)>('rac_tts_component_load_voice');
-
-      final result = loadVoiceFn(handle, pathPtr, idPtr, namePtr);
+      final result = NativeFunctions.ttsLoadVoice(handle, pathPtr, idPtr, namePtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -145,11 +131,7 @@ class DartBridgeTTS {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final cleanupFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_tts_component_cleanup');
-
-      cleanupFn(_handle!);
+      NativeFunctions.ttsCleanup(_handle!);
       _loadedVoiceId = null;
       _logger.info('TTS voice unloaded');
     } catch (e) {
@@ -162,11 +144,7 @@ class DartBridgeTTS {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final stopFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_tts_component_stop');
-
-      stopFn(_handle!);
+      NativeFunctions.ttsStop(_handle!);
       _logger.debug('TTS synthesis stopped');
     } catch (e) {
       _logger.error('Failed to stop TTS: $e');
@@ -335,11 +313,7 @@ class DartBridgeTTS {
   void destroy() {
     if (_handle != null) {
       try {
-        final lib = PlatformLoader.loadCommons();
-        final destroyFn = lib.lookupFunction<Void Function(RacHandle),
-            void Function(RacHandle)>('rac_tts_component_destroy');
-
-        destroyFn(_handle!);
+        NativeFunctions.ttsDestroy(_handle!);
         _handle = null;
         _loadedVoiceId = null;
         _logger.debug('TTS component destroyed');

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart
@@ -229,7 +229,7 @@ class DartBridgeVAD {
         handle,
         samplesPtr,
         samples.length,
-        resultPtr.cast<Void>(),
+        resultPtr,
       );
 
       if (status != RAC_SUCCESS) {

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart
@@ -329,15 +329,3 @@ class VADSpeechEndedEvent extends VADActivityEvent {
 
   const VADSpeechEndedEvent({required this.energy});
 }
-
-/// FFI struct for VAD result (matches rac_vad_result_t)
-final class RacVadResultStruct extends Struct {
-  @Int32()
-  external int isSpeech;
-
-  @Float()
-  external double energy;
-
-  @Float()
-  external double speechProbability;
-}

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart
@@ -12,6 +12,7 @@ import 'package:ffi/ffi.dart';
 
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
+import 'package:runanywhere/native/native_functions.dart';
 import 'package:runanywhere/native/platform_loader.dart';
 
 /// VAD component bridge for C++ interop.
@@ -54,14 +55,9 @@ class DartBridgeVAD {
     }
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final create = lib.lookupFunction<
-          Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_vad_component_create');
-
       final handlePtr = calloc<RacHandle>();
       try {
-        final result = create(handlePtr);
+        final result = NativeFunctions.vadCreate(handlePtr);
 
         if (result != RAC_SUCCESS) {
           throw StateError(
@@ -88,11 +84,7 @@ class DartBridgeVAD {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final isInitializedFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_is_initialized');
-
-      return isInitializedFn(_handle!) == RAC_TRUE;
+      return NativeFunctions.vadIsInitialized(_handle!) == RAC_TRUE;
     } catch (e) {
       _logger.debug('isInitialized check failed: $e');
       return false;
@@ -104,11 +96,7 @@ class DartBridgeVAD {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final isSpeechActiveFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_is_speech_active');
-
-      return isSpeechActiveFn(_handle!) == RAC_TRUE;
+      return NativeFunctions.vadIsSpeechActive(_handle!) == RAC_TRUE;
     } catch (e) {
       return false;
     }
@@ -119,11 +107,7 @@ class DartBridgeVAD {
     if (_handle == null) return 0.0;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final getThresholdFn = lib.lookupFunction<Float Function(RacHandle),
-          double Function(RacHandle)>('rac_vad_component_get_energy_threshold');
-
-      return getThresholdFn(_handle!);
+      return NativeFunctions.vadGetEnergyThreshold(_handle!);
     } catch (e) {
       return 0.0;
     }
@@ -134,13 +118,7 @@ class DartBridgeVAD {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final setThresholdFn = lib.lookupFunction<
-          Int32 Function(RacHandle, Float),
-          int Function(
-              RacHandle, double)>('rac_vad_component_set_energy_threshold');
-
-      setThresholdFn(_handle!, threshold);
+      NativeFunctions.vadSetEnergyThreshold(_handle!, threshold);
     } catch (e) {
       _logger.error('Failed to set energy threshold: $e');
     }
@@ -155,11 +133,7 @@ class DartBridgeVAD {
     final handle = getHandle();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final initializeFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_initialize');
-
-      final result = initializeFn(handle);
+      final result = NativeFunctions.vadInitialize(handle);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -179,11 +153,7 @@ class DartBridgeVAD {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final startFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_start');
-
-      final result = startFn(_handle!);
+      final result = NativeFunctions.vadStart(_handle!);
       if (result != RAC_SUCCESS) {
         throw StateError(
           'Failed to start VAD: ${RacResultCode.getMessage(result)}',
@@ -201,11 +171,7 @@ class DartBridgeVAD {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final stopFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_stop');
-
-      stopFn(_handle!);
+      NativeFunctions.vadStop(_handle!);
       _logger.debug('VAD stopped');
     } catch (e) {
       _logger.error('Failed to stop VAD: $e');
@@ -217,11 +183,7 @@ class DartBridgeVAD {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final resetFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_reset');
-
-      resetFn(_handle!);
+      NativeFunctions.vadReset(_handle!);
       _logger.debug('VAD reset');
     } catch (e) {
       _logger.error('Failed to reset VAD: $e');
@@ -233,11 +195,7 @@ class DartBridgeVAD {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final cleanupFn = lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_cleanup');
-
-      cleanupFn(_handle!);
+      NativeFunctions.vadCleanup(_handle!);
       _logger.info('VAD cleaned up');
     } catch (e) {
       _logger.error('Failed to cleanup VAD: $e');
@@ -268,14 +226,7 @@ class DartBridgeVAD {
         samplesPtr[i] = samples[i];
       }
 
-      final lib = PlatformLoader.loadCommons();
-      final processFn = lib.lookupFunction<
-          Int32 Function(
-              RacHandle, Pointer<Float>, IntPtr, Pointer<RacVadResultStruct>),
-          int Function(RacHandle, Pointer<Float>, int,
-              Pointer<RacVadResultStruct>)>('rac_vad_component_process');
-
-      final status = processFn(handle, samplesPtr, samples.length, resultPtr);
+      final status = NativeFunctions.vadProcess(handle, samplesPtr, samples.length, resultPtr);
 
       if (status != RAC_SUCCESS) {
         throw StateError(
@@ -315,11 +266,7 @@ class DartBridgeVAD {
   void destroy() {
     if (_handle != null) {
       try {
-        final lib = PlatformLoader.loadCommons();
-        final destroyFn = lib.lookupFunction<Void Function(RacHandle),
-            void Function(RacHandle)>('rac_vad_component_destroy');
-
-        destroyFn(_handle!);
+        NativeFunctions.vadDestroy(_handle!);
         _handle = null;
         _logger.debug('VAD component destroyed');
       } catch (e) {

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart
@@ -13,7 +13,6 @@ import 'package:ffi/ffi.dart';
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
 import 'package:runanywhere/native/ffi_types.dart';
 import 'package:runanywhere/native/native_functions.dart';
-import 'package:runanywhere/native/platform_loader.dart';
 
 /// VAD component bridge for C++ interop.
 ///
@@ -226,7 +225,12 @@ class DartBridgeVAD {
         samplesPtr[i] = samples[i];
       }
 
-      final status = NativeFunctions.vadProcess(handle, samplesPtr, samples.length, resultPtr);
+      final status = NativeFunctions.vadProcess(
+        handle,
+        samplesPtr,
+        samples.length,
+        resultPtr.cast<Void>(),
+      );
 
       if (status != RAC_SUCCESS) {
         throw StateError(

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -66,8 +66,6 @@ class DartBridgeVoiceAgent {
     }
 
     try {
-      final lib = PlatformLoader.loadCommons();
-
       // Use shared component handles (matches Swift approach)
       // This allows the voice agent to use already-loaded models from the
       // individual component bridges (STT, LLM, TTS, VAD)
@@ -110,7 +108,6 @@ class DartBridgeVoiceAgent {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
       final readyPtr = calloc<Int32>();
       try {
         final result = NativeFunctions.voiceAgentIsReady(_handle!, readyPtr);
@@ -128,7 +125,6 @@ class DartBridgeVoiceAgent {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
       final loadedPtr = calloc<Int32>();
       try {
         final result = NativeFunctions.voiceAgentIsSTTLoaded(_handle!, loadedPtr);
@@ -146,7 +142,6 @@ class DartBridgeVoiceAgent {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
       final loadedPtr = calloc<Int32>();
       try {
         final result = NativeFunctions.voiceAgentIsLLMLoaded(_handle!, loadedPtr);
@@ -164,7 +159,6 @@ class DartBridgeVoiceAgent {
     if (_handle == null) return false;
 
     try {
-      final lib = PlatformLoader.loadCommons();
       final loadedPtr = calloc<Int32>();
       try {
         final result = NativeFunctions.voiceAgentIsTTSLoaded(_handle!, loadedPtr);
@@ -466,7 +460,11 @@ class DartBridgeVoiceAgent {
       calloc.free(textPtr);
       // Free the audio data allocated by C++
       if (audioPtr.value != nullptr) {
-        NativeFunctions.racFree(audioPtr.value);
+        try {
+          NativeFunctions.racFree(audioPtr.value);
+        } catch (_) {
+          // `rac_free` may not exist in some native builds.
+        }
       }
       calloc.free(audioPtr);
       calloc.free(audioSizePtr);

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -65,17 +65,16 @@ class DartBridgeVoiceAgent {
       return _handle!;
     }
 
-    try {
-      // Use shared component handles (matches Swift approach)
-      // This allows the voice agent to use already-loaded models from the
-      // individual component bridges (STT, LLM, TTS, VAD)
-      final llmHandle = DartBridgeLLM.shared.getHandle();
-      final sttHandle = DartBridgeSTT.shared.getHandle();
-      final ttsHandle = DartBridgeTTS.shared.getHandle();
-      final vadHandle = DartBridgeVAD.shared.getHandle();
+    // Use shared component handles (matches Swift approach)
+    // This allows the voice agent to use already-loaded models from the
+    // individual component bridges (STT, LLM, TTS, VAD)
+    final llmHandle = DartBridgeLLM.shared.getHandle();
+    final sttHandle = DartBridgeSTT.shared.getHandle();
+    final ttsHandle = DartBridgeTTS.shared.getHandle();
+    final vadHandle = DartBridgeVAD.shared.getHandle();
 
-      _logger.debug(
-          'Creating voice agent with shared handles: LLM=$llmHandle, STT=$sttHandle, TTS=$ttsHandle, VAD=$vadHandle');
+    _logger.debug(
+        'Creating voice agent with shared handles: LLM=$llmHandle, STT=$sttHandle, TTS=$ttsHandle, VAD=$vadHandle');
 
     try {
       final handlePtr = calloc<RacVoiceAgentHandle>();
@@ -127,7 +126,8 @@ class DartBridgeVoiceAgent {
     try {
       final loadedPtr = calloc<Int32>();
       try {
-        final result = NativeFunctions.voiceAgentIsSTTLoaded(_handle!, loadedPtr);
+        final result =
+            NativeFunctions.voiceAgentIsSTTLoaded(_handle!, loadedPtr);
         return result == RAC_SUCCESS && loadedPtr.value == RAC_TRUE;
       } finally {
         calloc.free(loadedPtr);
@@ -144,7 +144,8 @@ class DartBridgeVoiceAgent {
     try {
       final loadedPtr = calloc<Int32>();
       try {
-        final result = NativeFunctions.voiceAgentIsLLMLoaded(_handle!, loadedPtr);
+        final result =
+            NativeFunctions.voiceAgentIsLLMLoaded(_handle!, loadedPtr);
         return result == RAC_SUCCESS && loadedPtr.value == RAC_TRUE;
       } finally {
         calloc.free(loadedPtr);
@@ -161,7 +162,8 @@ class DartBridgeVoiceAgent {
     try {
       final loadedPtr = calloc<Int32>();
       try {
-        final result = NativeFunctions.voiceAgentIsTTSLoaded(_handle!, loadedPtr);
+        final result =
+            NativeFunctions.voiceAgentIsTTSLoaded(_handle!, loadedPtr);
         return result == RAC_SUCCESS && loadedPtr.value == RAC_TRUE;
       } finally {
         calloc.free(loadedPtr);
@@ -181,7 +183,8 @@ class DartBridgeVoiceAgent {
     final idPtr = modelId.toNativeUtf8();
 
     try {
-      final result = NativeFunctions.voiceAgentLoadSTTModel(handle, pathPtr, idPtr);
+      final result =
+          NativeFunctions.voiceAgentLoadSTTModel(handle, pathPtr, idPtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -205,7 +208,8 @@ class DartBridgeVoiceAgent {
     final idPtr = modelId.toNativeUtf8();
 
     try {
-      final result = NativeFunctions.voiceAgentLoadLLMModel(handle, pathPtr, idPtr);
+      final result =
+          NativeFunctions.voiceAgentLoadLLMModel(handle, pathPtr, idPtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -229,7 +233,8 @@ class DartBridgeVoiceAgent {
     final idPtr = voiceId.toNativeUtf8();
 
     try {
-      final result = NativeFunctions.voiceAgentLoadTTSVoice(handle, pathPtr, idPtr);
+      final result =
+          NativeFunctions.voiceAgentLoadTTSVoice(handle, pathPtr, idPtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -254,7 +259,8 @@ class DartBridgeVoiceAgent {
     final handle = await getHandle();
 
     try {
-      final result = NativeFunctions.voiceAgentInitializeWithLoadedModels(handle);
+      final result =
+          NativeFunctions.voiceAgentInitializeWithLoadedModels(handle);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -288,8 +294,7 @@ class DartBridgeVoiceAgent {
     }
 
     // Run the heavy C++ processing in a background isolate
-    return Isolate.run(
-        () => _processVoiceTurnInIsolate(handle, audioData));
+    return Isolate.run(() => _processVoiceTurnInIsolate(handle, audioData));
   }
 
   /// Static helper for processing voice turn in an isolate.
@@ -363,7 +368,9 @@ class DartBridgeVoiceAgent {
     Uint8List audioWavData;
     if (result.synthesizedAudioSize > 0 && result.synthesizedAudio != nullptr) {
       audioWavData = Uint8List.fromList(
-        result.synthesizedAudio.cast<Uint8>().asTypedList(result.synthesizedAudioSize),
+        result.synthesizedAudio
+            .cast<Uint8>()
+            .asTypedList(result.synthesizedAudioSize),
       );
     } else {
       audioWavData = Uint8List(0);
@@ -416,7 +423,8 @@ class DartBridgeVoiceAgent {
     final resultPtr = calloc<Pointer<Utf8>>();
 
     try {
-      final status = NativeFunctions.voiceAgentGenerateResponse(handle, promptPtr, resultPtr);
+      final status = NativeFunctions.voiceAgentGenerateResponse(
+          handle, promptPtr, resultPtr);
 
       if (status != RAC_SUCCESS) {
         throw StateError(
@@ -514,6 +522,7 @@ class DartBridgeVoiceAgent {
 class VoiceTurnResult {
   final String transcription;
   final String response;
+
   /// WAV-formatted audio data ready for playback
   final Uint8List audioWavData;
   final int sttDurationMs;

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -20,6 +20,16 @@ import 'package:runanywhere/native/ffi_types.dart';
 import 'package:runanywhere/native/native_functions.dart';
 import 'package:runanywhere/native/platform_loader.dart';
 
+void _safeRacFree(Pointer<Void> ptr) {
+  if (ptr == nullptr) return;
+
+  try {
+    NativeFunctions.racFree(ptr);
+  } catch (_) {
+    // rac_free may not exist in some native builds
+  }
+}
+
 /// VoiceAgent component bridge for C++ interop.
 ///
 /// Orchestrates LLM, STT, TTS, and VAD components for voice conversations.
@@ -76,10 +86,10 @@ class DartBridgeVoiceAgent {
       // Use shared component handles (matches Swift approach)
       // This allows the voice agent to use already-loaded models from the
       // individual component bridges (STT, LLM, TTS, VAD)
-      final llmHandle = await DartBridgeLLM.shared.getHandle();
-      final sttHandle = await DartBridgeSTT.shared.getHandle();
-      final ttsHandle = await DartBridgeTTS.shared.getHandle();
-      final vadHandle = await DartBridgeVAD.shared.getHandle();
+      final llmHandle = DartBridgeLLM.shared.getHandle();
+      final sttHandle = DartBridgeSTT.shared.getHandle();
+      final ttsHandle = DartBridgeTTS.shared.getHandle();
+      final vadHandle = DartBridgeVAD.shared.getHandle();
 
       _logger.debug(
           'Creating voice agent with shared handles: LLM=$llmHandle, STT=$sttHandle, TTS=$ttsHandle, VAD=$vadHandle');
@@ -409,9 +419,7 @@ class DartBridgeVoiceAgent {
       return resultPtr.value != nullptr ? resultPtr.value.toDartString() : '';
     } finally {
       calloc.free(audioPtr);
-      if (resultPtr.value != nullptr) {
-        NativeFunctions.racFree(resultPtr.value.cast<Void>());
-      }
+      _safeRacFree(resultPtr.value.cast<Void>());
       calloc.free(resultPtr);
     }
   }
@@ -435,9 +443,7 @@ class DartBridgeVoiceAgent {
       return resultPtr.value != nullptr ? resultPtr.value.toDartString() : '';
     } finally {
       calloc.free(promptPtr);
-      if (resultPtr.value != nullptr) {
-        NativeFunctions.racFree(resultPtr.value.cast<Void>());
-      }
+      _safeRacFree(resultPtr.value.cast<Void>());
       calloc.free(resultPtr);
     }
   }
@@ -471,13 +477,7 @@ class DartBridgeVoiceAgent {
     } finally {
       calloc.free(textPtr);
       // Free the audio data allocated by C++
-      if (audioPtr.value != nullptr) {
-        try {
-          NativeFunctions.racFree(audioPtr.value);
-        } catch (_) {
-          // `rac_free` may not exist in some native builds.
-        }
-      }
+      _safeRacFree(audioPtr.value);
       calloc.free(audioPtr);
       calloc.free(audioSizePtr);
     }

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -20,9 +20,6 @@ import 'package:runanywhere/native/ffi_types.dart';
 import 'package:runanywhere/native/native_functions.dart';
 import 'package:runanywhere/native/platform_loader.dart';
 
-/// Voice agent handle type (opaque pointer to rac_voice_agent struct).
-typedef RacVoiceAgentHandle = Pointer<Void>;
-
 /// VoiceAgent component bridge for C++ interop.
 ///
 /// Orchestrates LLM, STT, TTS, and VAD components for voice conversations.
@@ -45,7 +42,8 @@ class DartBridgeVoiceAgent {
 
   // MARK: - State
 
-  RacVoiceAgentHandle? _handle;
+  RacHandle? _handle;
+  Future<RacHandle>? _initFuture;
   final _logger = SDKLogger('DartBridge.VoiceAgent');
 
   /// Event stream controller
@@ -60,10 +58,19 @@ class DartBridgeVoiceAgent {
   ///
   /// Requires LLM, STT, TTS, and VAD components to be available.
   /// Uses shared component handles (matches Swift CppBridge+VoiceAgent.swift).
-  Future<RacVoiceAgentHandle> getHandle() async {
+  Future<RacHandle> getHandle() async {
     if (_handle != null) {
       return _handle!;
     }
+
+    final initFuture = _initFuture;
+    if (initFuture != null) {
+      await initFuture;
+      return _handle!;
+    }
+
+    final completer = Completer<RacHandle>();
+    _initFuture = completer.future;
 
     // Use shared component handles (matches Swift approach)
     // This allows the voice agent to use already-loaded models from the
@@ -77,7 +84,7 @@ class DartBridgeVoiceAgent {
         'Creating voice agent with shared handles: LLM=$llmHandle, STT=$sttHandle, TTS=$ttsHandle, VAD=$vadHandle');
 
     try {
-      final handlePtr = calloc<RacVoiceAgentHandle>();
+      final handlePtr = calloc<RacHandle>();
       try {
         final result = NativeFunctions.voiceAgentCreate(
             llmHandle, sttHandle, ttsHandle, vadHandle, handlePtr);
@@ -90,12 +97,18 @@ class DartBridgeVoiceAgent {
 
         _handle = handlePtr.value;
         _logger.info('Voice agent created with shared component handles');
+        completer.complete(_handle!);
+        _initFuture = null;
         return _handle!;
       } finally {
         calloc.free(handlePtr);
       }
-    } catch (e) {
+    } catch (e, st) {
       _logger.error('Failed to create voice agent handle: $e');
+      if (!completer.isCompleted) {
+        completer.completeError(e, st);
+      }
+      _initFuture = null;
       rethrow;
     }
   }
@@ -300,7 +313,7 @@ class DartBridgeVoiceAgent {
   /// Static helper for processing voice turn in an isolate.
   /// The C++ API expects raw audio bytes (PCM16), not float samples.
   static Future<VoiceTurnResult> _processVoiceTurnInIsolate(
-    RacVoiceAgentHandle handle,
+    RacHandle handle,
     Uint8List audioData,
   ) async {
     // Allocate native memory for audio data (raw PCM16 bytes)
@@ -311,16 +324,8 @@ class DartBridgeVoiceAgent {
       // Efficient bulk copy of audio bytes
       audioPtr.asTypedList(audioData.length).setAll(0, audioData);
 
-      final lib = PlatformLoader.loadCommons();
-      final processFn = lib.lookupFunction<
-              Int32 Function(RacVoiceAgentHandle, Pointer<Void>, IntPtr,
-                  Pointer<RacVoiceAgentResultStruct>),
-              int Function(RacVoiceAgentHandle, Pointer<Void>, int,
-                  Pointer<RacVoiceAgentResultStruct>)>(
-          'rac_voice_agent_process_voice_turn');
-
-      final status =
-          processFn(handle, audioPtr.cast<Void>(), audioData.length, resultPtr);
+      final status = _processVoiceTurnFn(
+          handle, audioPtr.cast<Void>(), audioData.length, resultPtr);
 
       if (status != RAC_SUCCESS) {
         throw StateError(
@@ -329,20 +334,14 @@ class DartBridgeVoiceAgent {
       }
 
       // Parse result while still in isolate (before freeing memory)
-      return _parseVoiceTurnResultStatic(resultPtr.ref, lib);
+      return _parseVoiceTurnResultStatic(resultPtr.ref, _voiceAgentLib);
     } finally {
       // Free audio data
       calloc.free(audioPtr);
 
       // Free result struct - the C++ side allocates strings/audio that need freeing
-      final lib = PlatformLoader.loadCommons();
       try {
-        final freeFn = lib.lookupFunction<
-            Void Function(Pointer<RacVoiceAgentResultStruct>),
-            void Function(Pointer<RacVoiceAgentResultStruct>)>(
-          'rac_voice_agent_result_free',
-        );
-        freeFn(resultPtr);
+        _voiceAgentResultFreeFn?.call(resultPtr);
       } catch (e) {
         // Function may not exist, just free the struct
       }
@@ -600,3 +599,34 @@ final class RacVoiceAgentResultStruct extends Struct {
   @IntPtr()
   external int synthesizedAudioSize; // size_t (size in bytes)
 }
+
+// MARK: - Isolate-scoped FFI caches
+
+// These are intentionally top-level statics so each isolate initializes them
+// once on first use. This keeps symbol lookups out of hot paths while preserving
+// the existing isolate execution model.
+final DynamicLibrary _voiceAgentLib = PlatformLoader.loadCommons();
+
+final int Function(
+  RacHandle,
+  Pointer<Void>,
+  int,
+  Pointer<RacVoiceAgentResultStruct>,
+) _processVoiceTurnFn = _voiceAgentLib.lookupFunction<
+    Int32 Function(RacHandle, Pointer<Void>, IntPtr,
+        Pointer<RacVoiceAgentResultStruct>),
+    int Function(RacHandle, Pointer<Void>, int,
+        Pointer<RacVoiceAgentResultStruct>)>('rac_voice_agent_process_voice_turn');
+
+final void Function(Pointer<RacVoiceAgentResultStruct>)?
+    _voiceAgentResultFreeFn = (() {
+  try {
+    return _voiceAgentLib.lookupFunction<
+        Void Function(Pointer<RacVoiceAgentResultStruct>),
+        void Function(Pointer<RacVoiceAgentResultStruct>)>(
+      'rac_voice_agent_result_free',
+    );
+  } catch (_) {
+    return null;
+  }
+})();

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -106,6 +106,10 @@ class DartBridgeVoiceAgent {
         _handle = handlePtr.value;
         _logger.info('Voice agent created with shared component handles');
         completer.complete(_handle!);
+        // Clear _initFuture after completing the completer so that concurrent
+        // callers that already hold a reference to completer.future receive the
+        // value normally. New callers arriving after this line hit the
+        // `_handle != null` fast path.
         _initFuture = null;
         return _handle!;
       } finally {
@@ -214,7 +218,8 @@ class DartBridgeVoiceAgent {
       }
 
       _logger.info('Voice agent STT model loaded: $modelId');
-      _eventController.add(const VoiceAgentModelLoadedEvent(component: 'stt'));
+      _eventController.add(const VoiceAgentModelLoadedEvent(
+          component: VoiceAgentComponent.stt));
     } finally {
       calloc.free(pathPtr);
       calloc.free(idPtr);
@@ -239,7 +244,8 @@ class DartBridgeVoiceAgent {
       }
 
       _logger.info('Voice agent LLM model loaded: $modelId');
-      _eventController.add(const VoiceAgentModelLoadedEvent(component: 'llm'));
+      _eventController.add(const VoiceAgentModelLoadedEvent(
+          component: VoiceAgentComponent.llm));
     } finally {
       calloc.free(pathPtr);
       calloc.free(idPtr);
@@ -264,7 +270,8 @@ class DartBridgeVoiceAgent {
       }
 
       _logger.info('Voice agent TTS voice loaded: $voiceId');
-      _eventController.add(const VoiceAgentModelLoadedEvent(component: 'tts'));
+      _eventController.add(const VoiceAgentModelLoadedEvent(
+          component: VoiceAgentComponent.tts));
     } finally {
       calloc.free(pathPtr);
       calloc.free(idPtr);
@@ -314,16 +321,22 @@ class DartBridgeVoiceAgent {
           'Voice agent not ready. Load models and initialize first.');
     }
 
-    // Run the heavy C++ processing in a background isolate
-    return Isolate.run(() => _processVoiceTurnInIsolate(handle, audioData));
+    // Capture handle address before entering isolate — passing the raw Pointer
+    // across an isolate boundary is unsafe; pass the address and reconstruct it.
+    final handleAddress = handle.address;
+    return Isolate.run(
+        () => _processVoiceTurnInIsolate(handleAddress, audioData));
   }
 
   /// Static helper for processing voice turn in an isolate.
   /// The C++ API expects raw audio bytes (PCM16), not float samples.
+  /// Must be static/top-level for Isolate.run().
   static Future<VoiceTurnResult> _processVoiceTurnInIsolate(
-    RacHandle handle,
+    int handleAddress,
     Uint8List audioData,
   ) async {
+    final handle = RacHandle.fromAddress(handleAddress);
+
     // Allocate native memory for audio data (raw PCM16 bytes)
     final audioPtr = calloc<Uint8>(audioData.length);
     final resultPtr = calloc<RacVoiceAgentResultStruct>();
@@ -555,9 +568,12 @@ class VoiceAgentInitializedEvent extends VoiceAgentEvent {
   const VoiceAgentInitializedEvent();
 }
 
+/// Component types that can emit a model-loaded event on the voice agent.
+enum VoiceAgentComponent { stt, llm, tts }
+
 /// Voice agent model loaded.
 class VoiceAgentModelLoadedEvent extends VoiceAgentEvent {
-  final String component; // 'stt', 'llm', or 'tts'
+  final VoiceAgentComponent component;
   const VoiceAgentModelLoadedEvent({required this.component});
 }
 

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -72,18 +72,18 @@ class DartBridgeVoiceAgent {
     final completer = Completer<RacHandle>();
     _initFuture = completer.future;
 
-    // Use shared component handles (matches Swift approach)
-    // This allows the voice agent to use already-loaded models from the
-    // individual component bridges (STT, LLM, TTS, VAD)
-    final llmHandle = DartBridgeLLM.shared.getHandle();
-    final sttHandle = DartBridgeSTT.shared.getHandle();
-    final ttsHandle = DartBridgeTTS.shared.getHandle();
-    final vadHandle = DartBridgeVAD.shared.getHandle();
-
-    _logger.debug(
-        'Creating voice agent with shared handles: LLM=$llmHandle, STT=$sttHandle, TTS=$ttsHandle, VAD=$vadHandle');
-
     try {
+      // Use shared component handles (matches Swift approach)
+      // This allows the voice agent to use already-loaded models from the
+      // individual component bridges (STT, LLM, TTS, VAD)
+      final llmHandle = await DartBridgeLLM.shared.getHandle();
+      final sttHandle = await DartBridgeSTT.shared.getHandle();
+      final ttsHandle = await DartBridgeTTS.shared.getHandle();
+      final vadHandle = await DartBridgeVAD.shared.getHandle();
+
+      _logger.debug(
+          'Creating voice agent with shared handles: LLM=$llmHandle, STT=$sttHandle, TTS=$ttsHandle, VAD=$vadHandle');
+
       final handlePtr = calloc<RacHandle>();
       try {
         final result = NativeFunctions.voiceAgentCreate(
@@ -334,7 +334,7 @@ class DartBridgeVoiceAgent {
       }
 
       // Parse result while still in isolate (before freeing memory)
-      return _parseVoiceTurnResultStatic(resultPtr.ref, _voiceAgentLib);
+      return _parseVoiceTurnResultStatic(resultPtr.ref);
     } finally {
       // Free audio data
       calloc.free(audioPtr);
@@ -354,7 +354,6 @@ class DartBridgeVoiceAgent {
   /// using rac_audio_float32_to_wav, so synthesized_audio is WAV data.
   static VoiceTurnResult _parseVoiceTurnResultStatic(
     RacVoiceAgentResultStruct result,
-    DynamicLibrary lib,
   ) {
     final transcription = result.transcription != nullptr
         ? result.transcription.toDartString()
@@ -410,6 +409,9 @@ class DartBridgeVoiceAgent {
       return resultPtr.value != nullptr ? resultPtr.value.toDartString() : '';
     } finally {
       calloc.free(audioPtr);
+      if (resultPtr.value != nullptr) {
+        NativeFunctions.racFree(resultPtr.value.cast<Void>());
+      }
       calloc.free(resultPtr);
     }
   }
@@ -433,6 +435,9 @@ class DartBridgeVoiceAgent {
       return resultPtr.value != nullptr ? resultPtr.value.toDartString() : '';
     } finally {
       calloc.free(promptPtr);
+      if (resultPtr.value != nullptr) {
+        NativeFunctions.racFree(resultPtr.value.cast<Void>());
+      }
       calloc.free(resultPtr);
     }
   }

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -24,7 +24,7 @@ void _safeRacFree(Pointer<Void> ptr) {
   if (ptr == nullptr) return;
 
   try {
-    NativeFunctions.racFree(ptr);
+    NativeFunctions.racFree?.call(ptr);
   } catch (_) {
     // rac_free may not exist in some native builds
   }
@@ -73,10 +73,8 @@ class DartBridgeVoiceAgent {
       return _handle!;
     }
 
-    final initFuture = _initFuture;
-    if (initFuture != null) {
-      await initFuture;
-      return _handle!;
+    if (_initFuture != null) {
+      return _initFuture!;
     }
 
     final completer = Completer<RacHandle>();
@@ -618,10 +616,11 @@ final int Function(
   int,
   Pointer<RacVoiceAgentResultStruct>,
 ) _processVoiceTurnFn = _voiceAgentLib.lookupFunction<
-    Int32 Function(RacHandle, Pointer<Void>, IntPtr,
-        Pointer<RacVoiceAgentResultStruct>),
-    int Function(RacHandle, Pointer<Void>, int,
-        Pointer<RacVoiceAgentResultStruct>)>('rac_voice_agent_process_voice_turn');
+        Int32 Function(RacHandle, Pointer<Void>, IntPtr,
+            Pointer<RacVoiceAgentResultStruct>),
+        int Function(
+            RacHandle, Pointer<Void>, int, Pointer<RacVoiceAgentResultStruct>)>(
+    'rac_voice_agent_process_voice_turn');
 
 final void Function(Pointer<RacVoiceAgentResultStruct>)?
     _voiceAgentResultFreeFn = (() {

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
@@ -17,6 +17,7 @@ import 'package:runanywhere/native/dart_bridge_stt.dart';
 import 'package:runanywhere/native/dart_bridge_tts.dart';
 import 'package:runanywhere/native/dart_bridge_vad.dart';
 import 'package:runanywhere/native/ffi_types.dart';
+import 'package:runanywhere/native/native_functions.dart';
 import 'package:runanywhere/native/platform_loader.dart';
 
 /// Voice agent handle type (opaque pointer to rac_voice_agent struct).
@@ -78,16 +79,11 @@ class DartBridgeVoiceAgent {
       _logger.debug(
           'Creating voice agent with shared handles: LLM=$llmHandle, STT=$sttHandle, TTS=$ttsHandle, VAD=$vadHandle');
 
-      final create = lib.lookupFunction<
-          Int32 Function(RacHandle, RacHandle, RacHandle, RacHandle,
-              Pointer<RacVoiceAgentHandle>),
-          int Function(RacHandle, RacHandle, RacHandle, RacHandle,
-              Pointer<RacVoiceAgentHandle>)>('rac_voice_agent_create');
-
+    try {
       final handlePtr = calloc<RacVoiceAgentHandle>();
       try {
-        final result =
-            create(llmHandle, sttHandle, ttsHandle, vadHandle, handlePtr);
+        final result = NativeFunctions.voiceAgentCreate(
+            llmHandle, sttHandle, ttsHandle, vadHandle, handlePtr);
 
         if (result != RAC_SUCCESS) {
           throw StateError(
@@ -115,14 +111,9 @@ class DartBridgeVoiceAgent {
 
     try {
       final lib = PlatformLoader.loadCommons();
-      final isReadyFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
-          int Function(
-              RacVoiceAgentHandle, Pointer<Int32>)>('rac_voice_agent_is_ready');
-
       final readyPtr = calloc<Int32>();
       try {
-        final result = isReadyFn(_handle!, readyPtr);
+        final result = NativeFunctions.voiceAgentIsReady(_handle!, readyPtr);
         return result == RAC_SUCCESS && readyPtr.value == RAC_TRUE;
       } finally {
         calloc.free(readyPtr);
@@ -138,14 +129,9 @@ class DartBridgeVoiceAgent {
 
     try {
       final lib = PlatformLoader.loadCommons();
-      final isLoadedFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
-          int Function(RacVoiceAgentHandle,
-              Pointer<Int32>)>('rac_voice_agent_is_stt_loaded');
-
       final loadedPtr = calloc<Int32>();
       try {
-        final result = isLoadedFn(_handle!, loadedPtr);
+        final result = NativeFunctions.voiceAgentIsSTTLoaded(_handle!, loadedPtr);
         return result == RAC_SUCCESS && loadedPtr.value == RAC_TRUE;
       } finally {
         calloc.free(loadedPtr);
@@ -161,14 +147,9 @@ class DartBridgeVoiceAgent {
 
     try {
       final lib = PlatformLoader.loadCommons();
-      final isLoadedFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
-          int Function(RacVoiceAgentHandle,
-              Pointer<Int32>)>('rac_voice_agent_is_llm_loaded');
-
       final loadedPtr = calloc<Int32>();
       try {
-        final result = isLoadedFn(_handle!, loadedPtr);
+        final result = NativeFunctions.voiceAgentIsLLMLoaded(_handle!, loadedPtr);
         return result == RAC_SUCCESS && loadedPtr.value == RAC_TRUE;
       } finally {
         calloc.free(loadedPtr);
@@ -184,14 +165,9 @@ class DartBridgeVoiceAgent {
 
     try {
       final lib = PlatformLoader.loadCommons();
-      final isLoadedFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
-          int Function(RacVoiceAgentHandle,
-              Pointer<Int32>)>('rac_voice_agent_is_tts_loaded');
-
       final loadedPtr = calloc<Int32>();
       try {
-        final result = isLoadedFn(_handle!, loadedPtr);
+        final result = NativeFunctions.voiceAgentIsTTSLoaded(_handle!, loadedPtr);
         return result == RAC_SUCCESS && loadedPtr.value == RAC_TRUE;
       } finally {
         calloc.free(loadedPtr);
@@ -211,13 +187,7 @@ class DartBridgeVoiceAgent {
     final idPtr = modelId.toNativeUtf8();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final loadFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
-              Pointer<Utf8>)>('rac_voice_agent_load_stt_model');
-
-      final result = loadFn(handle, pathPtr, idPtr);
+      final result = NativeFunctions.voiceAgentLoadSTTModel(handle, pathPtr, idPtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -241,13 +211,7 @@ class DartBridgeVoiceAgent {
     final idPtr = modelId.toNativeUtf8();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final loadFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
-              Pointer<Utf8>)>('rac_voice_agent_load_llm_model');
-
-      final result = loadFn(handle, pathPtr, idPtr);
+      final result = NativeFunctions.voiceAgentLoadLLMModel(handle, pathPtr, idPtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -271,13 +235,7 @@ class DartBridgeVoiceAgent {
     final idPtr = voiceId.toNativeUtf8();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final loadFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
-              Pointer<Utf8>)>('rac_voice_agent_load_tts_voice');
-
-      final result = loadFn(handle, pathPtr, idPtr);
+      final result = NativeFunctions.voiceAgentLoadTTSVoice(handle, pathPtr, idPtr);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -302,12 +260,7 @@ class DartBridgeVoiceAgent {
     final handle = await getHandle();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final initFn = lib.lookupFunction<Int32 Function(RacVoiceAgentHandle),
-              int Function(RacVoiceAgentHandle)>(
-          'rac_voice_agent_initialize_with_loaded_models');
-
-      final result = initFn(handle);
+      final result = NativeFunctions.voiceAgentInitializeWithLoadedModels(handle);
 
       if (result != RAC_SUCCESS) {
         throw StateError(
@@ -446,14 +399,7 @@ class DartBridgeVoiceAgent {
       // Efficient bulk copy of audio bytes
       audioPtr.asTypedList(audioData.length).setAll(0, audioData);
 
-      final lib = PlatformLoader.loadCommons();
-      final transcribeFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Void>, IntPtr,
-              Pointer<Pointer<Utf8>>),
-          int Function(RacVoiceAgentHandle, Pointer<Void>, int,
-              Pointer<Pointer<Utf8>>)>('rac_voice_agent_transcribe');
-
-      final status = transcribeFn(
+      final status = NativeFunctions.voiceAgentTranscribe(
           handle, audioPtr.cast<Void>(), audioData.length, resultPtr);
 
       if (status != RAC_SUCCESS) {
@@ -476,14 +422,7 @@ class DartBridgeVoiceAgent {
     final resultPtr = calloc<Pointer<Utf8>>();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final generateFn = lib.lookupFunction<
-          Int32 Function(
-              RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
-              Pointer<Pointer<Utf8>>)>('rac_voice_agent_generate_response');
-
-      final status = generateFn(handle, promptPtr, resultPtr);
+      final status = NativeFunctions.voiceAgentGenerateResponse(handle, promptPtr, resultPtr);
 
       if (status != RAC_SUCCESS) {
         throw StateError(
@@ -507,17 +446,8 @@ class DartBridgeVoiceAgent {
     final audioSizePtr = calloc<IntPtr>();
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final synthesizeFn = lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>,
-              Pointer<Pointer<Void>>, Pointer<IntPtr>),
-          int Function(
-              RacVoiceAgentHandle,
-              Pointer<Utf8>,
-              Pointer<Pointer<Void>>,
-              Pointer<IntPtr>)>('rac_voice_agent_synthesize_speech');
-
-      final status = synthesizeFn(handle, textPtr, audioPtr, audioSizePtr);
+      final status = NativeFunctions.voiceAgentSynthesizeSpeech(
+          handle, textPtr, audioPtr, audioSizePtr);
 
       if (status != RAC_SUCCESS) {
         throw StateError(
@@ -536,14 +466,7 @@ class DartBridgeVoiceAgent {
       calloc.free(textPtr);
       // Free the audio data allocated by C++
       if (audioPtr.value != nullptr) {
-        final lib = PlatformLoader.loadCommons();
-        try {
-          final freeFn = lib.lookupFunction<Void Function(Pointer<Void>),
-              void Function(Pointer<Void>)>('rac_free');
-          freeFn(audioPtr.value);
-        } catch (_) {
-          // rac_free may not exist
-        }
+        NativeFunctions.racFree(audioPtr.value);
       }
       calloc.free(audioPtr);
       calloc.free(audioSizePtr);
@@ -557,11 +480,7 @@ class DartBridgeVoiceAgent {
     if (_handle == null) return;
 
     try {
-      final lib = PlatformLoader.loadCommons();
-      final cleanupFn = lib.lookupFunction<Int32 Function(RacVoiceAgentHandle),
-          int Function(RacVoiceAgentHandle)>('rac_voice_agent_cleanup');
-
-      cleanupFn(_handle!);
+      NativeFunctions.voiceAgentCleanup(_handle!);
       _logger.info('Voice agent cleaned up');
     } catch (e) {
       _logger.error('Failed to cleanup voice agent: $e');
@@ -572,11 +491,7 @@ class DartBridgeVoiceAgent {
   void destroy() {
     if (_handle != null) {
       try {
-        final lib = PlatformLoader.loadCommons();
-        final destroyFn = lib.lookupFunction<Void Function(RacVoiceAgentHandle),
-            void Function(RacVoiceAgentHandle)>('rac_voice_agent_destroy');
-
-        destroyFn(_handle!);
+        NativeFunctions.voiceAgentDestroy(_handle!);
         _handle = null;
         _logger.debug('Voice agent destroyed');
       } catch (e) {

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/ffi_types.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/ffi_types.dart
@@ -1039,6 +1039,18 @@ base class RacVadOnnxResultStruct extends Struct {
   external double probability;
 }
 
+/// VAD result struct matching rac_vad_result_t
+base class RacVadResultStruct extends Struct {
+  @Int32()
+  external int isSpeech;
+
+  @Float()
+  external double energy;
+
+  @Float()
+  external double speechProbability;
+}
+
 // =============================================================================
 // VLM API Types (from rac_vlm_types.h)
 // =============================================================================

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
@@ -12,6 +12,7 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:runanywhere/native/ffi_types.dart';
 import 'package:runanywhere/native/platform_loader.dart';
+import 'package:runanywhere/native/dart_bridge_vad.dart' as vad;
 
 /// Cached native function pointers for the RACommons library.
 ///
@@ -26,200 +27,174 @@ abstract class NativeFunctions {
   // LLM Component
   // ---------------------------------------------------------------------------
 
-  static final int Function(Pointer<RacHandle>) llmCreate =
-      _lib.lookupFunction<
-          Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_llm_component_create');
+  static final int Function(Pointer<RacHandle>) llmCreate = _lib.lookupFunction<
+      Int32 Function(Pointer<RacHandle>),
+      int Function(Pointer<RacHandle>)>('rac_llm_component_create');
 
   static final int Function(RacHandle) llmIsLoaded =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_is_loaded');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_llm_component_is_loaded');
 
   static final int Function(RacHandle) llmSupportsStreaming =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_supports_streaming');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_llm_component_supports_streaming');
 
-  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
-          Pointer<Utf8>) llmLoadModel =
+  static final int Function(
+          RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>) llmLoadModel =
       _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+          Int32 Function(
+              RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_llm_component_load_model');
 
   static final int Function(RacHandle) llmCleanup =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_cleanup');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_llm_component_cleanup');
 
   static final int Function(RacHandle) llmCancel =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_llm_component_cancel');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_llm_component_cancel');
 
   static final void Function(RacHandle) llmDestroy =
-      _lib.lookupFunction<
-          Void Function(RacHandle),
-          void Function(RacHandle)>('rac_llm_component_destroy');
-
+      _lib.lookupFunction<Void Function(RacHandle), void Function(RacHandle)>(
+          'rac_llm_component_destroy');
 
   // ---------------------------------------------------------------------------
   // STT Component
   // ---------------------------------------------------------------------------
 
-  static final int Function(Pointer<RacHandle>) sttCreate =
-      _lib.lookupFunction<
-          Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_stt_component_create');
+  static final int Function(Pointer<RacHandle>) sttCreate = _lib.lookupFunction<
+      Int32 Function(Pointer<RacHandle>),
+      int Function(Pointer<RacHandle>)>('rac_stt_component_create');
 
   static final int Function(RacHandle) sttIsLoaded =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_stt_component_is_loaded');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_stt_component_is_loaded');
 
   static final int Function(RacHandle) sttSupportsStreaming =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_stt_component_supports_streaming');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_stt_component_supports_streaming');
 
-  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
-          Pointer<Utf8>) sttLoadModel =
+  static final int Function(
+          RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>) sttLoadModel =
       _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+          Int32 Function(
+              RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_stt_component_load_model');
 
   static final int Function(RacHandle) sttCleanup =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_stt_component_cleanup');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_stt_component_cleanup');
 
   static final void Function(Pointer<RacSttResultStruct>) sttResultFree =
       _lib.lookupFunction<Void Function(Pointer<RacSttResultStruct>),
           void Function(Pointer<RacSttResultStruct>)>('rac_stt_result_free');
 
   static final void Function(RacHandle) sttDestroy =
-      _lib.lookupFunction<
-          Void Function(RacHandle),
-          void Function(RacHandle)>('rac_stt_component_destroy');
-
+      _lib.lookupFunction<Void Function(RacHandle), void Function(RacHandle)>(
+          'rac_stt_component_destroy');
 
   // ---------------------------------------------------------------------------
   // TTS Component
   // ---------------------------------------------------------------------------
 
-  static final int Function(Pointer<RacHandle>) ttsCreate =
-      _lib.lookupFunction<
-          Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_tts_component_create');
+  static final int Function(Pointer<RacHandle>) ttsCreate = _lib.lookupFunction<
+      Int32 Function(Pointer<RacHandle>),
+      int Function(Pointer<RacHandle>)>('rac_tts_component_create');
 
   static final int Function(RacHandle) ttsIsLoaded =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_tts_component_is_loaded');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_tts_component_is_loaded');
 
-  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
-          Pointer<Utf8>) ttsLoadVoice =
+  static final int Function(
+          RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>) ttsLoadVoice =
       _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+          Int32 Function(
+              RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_tts_component_load_voice');
 
   static final int Function(RacHandle) ttsCleanup =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_tts_component_cleanup');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_tts_component_cleanup');
 
   static final int Function(RacHandle) ttsStop =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_tts_component_stop');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_tts_component_stop');
 
   static final void Function(RacHandle) ttsDestroy =
-      _lib.lookupFunction<
-          Void Function(RacHandle),
-          void Function(RacHandle)>('rac_tts_component_destroy');
-
+      _lib.lookupFunction<Void Function(RacHandle), void Function(RacHandle)>(
+          'rac_tts_component_destroy');
 
   // ---------------------------------------------------------------------------
   // VAD Component
   // ---------------------------------------------------------------------------
 
-  static final int Function(Pointer<RacHandle>) vadCreate =
-      _lib.lookupFunction<
-          Int32 Function(Pointer<RacHandle>),
-          int Function(Pointer<RacHandle>)>('rac_vad_component_create');
+  static final int Function(Pointer<RacHandle>) vadCreate = _lib.lookupFunction<
+      Int32 Function(Pointer<RacHandle>),
+      int Function(Pointer<RacHandle>)>('rac_vad_component_create');
 
   static final int Function(RacHandle) vadIsInitialized =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_is_initialized');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_vad_component_is_initialized');
 
   static final int Function(RacHandle) vadIsSpeechActive =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_is_speech_active');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_vad_component_is_speech_active');
 
-  static final double Function(RacHandle) vadGetEnergyThreshold =
-      _lib.lookupFunction<
-          Float Function(RacHandle),
-          double Function(RacHandle)>('rac_vad_component_get_energy_threshold');
+  static final double Function(RacHandle) vadGetEnergyThreshold = _lib
+      .lookupFunction<Float Function(RacHandle), double Function(RacHandle)>(
+          'rac_vad_component_get_energy_threshold');
 
   static final int Function(RacHandle, double) vadSetEnergyThreshold =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Float),
-          int Function(RacHandle, double)>('rac_vad_component_set_energy_threshold');
+          int Function(
+              RacHandle, double)>('rac_vad_component_set_energy_threshold');
 
   static final int Function(RacHandle) vadInitialize =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_initialize');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_vad_component_initialize');
 
   static final int Function(RacHandle) vadStart =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_start');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_vad_component_start');
 
   static final int Function(RacHandle) vadStop =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_stop');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_vad_component_stop');
 
   static final int Function(RacHandle) vadReset =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_reset');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_vad_component_reset');
 
   static final int Function(RacHandle) vadCleanup =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_vad_component_cleanup');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_vad_component_cleanup');
 
   static final int Function(
-  RacHandle,
-  Pointer<Float>,
-  int,
-  Pointer<RacVadResultStruct>,
-) vadProcess =
-    _lib.lookupFunction<
-        Int32 Function(
-          RacHandle,
-          Pointer<Float>,
-          IntPtr,
-          Pointer<RacVadResultStruct>,
-        ),
-        int Function(
-          RacHandle,
-          Pointer<Float>,
-          int,
-          Pointer<RacVadResultStruct>,
-        )>('rac_vad_component_process');
+    RacHandle,
+    Pointer<Float>,
+    int,
+    Pointer<vad.RacVadResultStruct>,
+  ) vadProcess = _lib.lookupFunction<
+      Int32 Function(
+        RacHandle,
+        Pointer<Float>,
+        IntPtr,
+        Pointer<vad.RacVadResultStruct>,
+      ),
+      int Function(
+        RacHandle,
+        Pointer<Float>,
+        int,
+        Pointer<vad.RacVadResultStruct>,
+      )>('rac_vad_component_process');
 
   static final void Function(RacHandle) vadDestroy =
-      _lib.lookupFunction<
-          Void Function(RacHandle),
-          void Function(RacHandle)>('rac_vad_component_destroy');
+      _lib.lookupFunction<Void Function(RacHandle), void Function(RacHandle)>(
+          'rac_vad_component_destroy');
 
   // ---------------------------------------------------------------------------
   // VoiceAgent Component
@@ -231,102 +206,102 @@ abstract class NativeFunctions {
     RacHandle,
     RacHandle,
     Pointer<RacHandle>,
-  ) voiceAgentCreate =
-      _lib.lookupFunction<
-          Int32 Function(
-            RacHandle,
-            RacHandle,
-            RacHandle,
-            RacHandle,
-            Pointer<RacHandle>,
-          ),
-          int Function(
-            RacHandle,
-            RacHandle,
-            RacHandle,
-            RacHandle,
-            Pointer<RacHandle>,
-          )>('rac_voice_agent_create');
+  ) voiceAgentCreate = _lib.lookupFunction<
+      Int32 Function(
+        RacHandle,
+        RacHandle,
+        RacHandle,
+        RacHandle,
+        Pointer<RacHandle>,
+      ),
+      int Function(
+        RacHandle,
+        RacHandle,
+        RacHandle,
+        RacHandle,
+        Pointer<RacHandle>,
+      )>('rac_voice_agent_create');
 
   static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsReady =
       _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
           int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_ready');
 
   static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsSTTLoaded =
-      _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
-          int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_stt_loaded');
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Int32>),
+          int Function(
+              RacHandle, Pointer<Int32>)>('rac_voice_agent_is_stt_loaded');
 
   static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsLLMLoaded =
-      _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
-          int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_llm_loaded');
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Int32>),
+          int Function(
+              RacHandle, Pointer<Int32>)>('rac_voice_agent_is_llm_loaded');
 
   static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsTTSLoaded =
-      _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
-          int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_tts_loaded');
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Int32>),
+          int Function(
+              RacHandle, Pointer<Int32>)>('rac_voice_agent_is_tts_loaded');
 
-  static final int Function(
-          RacHandle, Pointer<Utf8>, Pointer<Utf8>)
+  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadSTTModel = _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_stt_model');
 
-  static final int Function(
-          RacHandle, Pointer<Utf8>, Pointer<Utf8>)
+  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadLLMModel = _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_llm_model');
 
-  static final int Function(
-          RacHandle, Pointer<Utf8>, Pointer<Utf8>)
+  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadTTSVoice = _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_tts_voice');
 
-  static final int Function(RacHandle)
-      voiceAgentInitializeWithLoadedModels = _lib.lookupFunction<
-          Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_voice_agent_initialize_with_loaded_models');
+  static final int Function(RacHandle) voiceAgentInitializeWithLoadedModels =
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_voice_agent_initialize_with_loaded_models');
 
-  static final int Function(RacHandle, Pointer<Void>, int,
-          Pointer<Pointer<Utf8>>) voiceAgentTranscribe =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Void>, IntPtr,
-              Pointer<Pointer<Utf8>>),
+  static final int Function(
+          RacHandle, Pointer<Void>, int, Pointer<Pointer<Utf8>>)
+      voiceAgentTranscribe = _lib.lookupFunction<
+          Int32 Function(
+              RacHandle, Pointer<Void>, IntPtr, Pointer<Pointer<Utf8>>),
           int Function(RacHandle, Pointer<Void>, int,
               Pointer<Pointer<Utf8>>)>('rac_voice_agent_transcribe');
 
-  static final int Function(
-          RacHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>)
+  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>)
       voiceAgentGenerateResponse = _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Utf8>,
-              Pointer<Pointer<Utf8>>),
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>),
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Pointer<Utf8>>)>('rac_voice_agent_generate_response');
 
-  static final int Function(RacHandle, Pointer<Utf8>,
-          Pointer<Pointer<Void>>, Pointer<IntPtr>) voiceAgentSynthesizeSpeech =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Utf8>,
-              Pointer<Pointer<Void>>, Pointer<IntPtr>),
-          int Function(RacHandle, Pointer<Utf8>,
-              Pointer<Pointer<Void>>, Pointer<IntPtr>)>('rac_voice_agent_synthesize_speech');
+  static final int Function(
+          RacHandle, Pointer<Utf8>, Pointer<Pointer<Void>>, Pointer<IntPtr>)
+      voiceAgentSynthesizeSpeech = _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Pointer<Void>>,
+              Pointer<IntPtr>),
+          int Function(RacHandle, Pointer<Utf8>, Pointer<Pointer<Void>>,
+              Pointer<IntPtr>)>('rac_voice_agent_synthesize_speech');
 
   static final int Function(RacHandle) voiceAgentCleanup =
-      _lib.lookupFunction<Int32 Function(RacHandle),
-          int Function(RacHandle)>('rac_voice_agent_cleanup');
+      _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
+          'rac_voice_agent_cleanup');
 
   static final void Function(RacHandle) voiceAgentDestroy =
-      _lib.lookupFunction<Void Function(RacHandle),
-          void Function(RacHandle)>('rac_voice_agent_destroy');
+      _lib.lookupFunction<Void Function(RacHandle), void Function(RacHandle)>(
+          'rac_voice_agent_destroy');
 
   static final void Function(Pointer<Void>)? racFree = (() {
-  try {
-    return _lib.lookupFunction<Void Function(Pointer<Void>),
-        void Function(Pointer<Void>)>('rac_free');
-  } catch (_) {
-    return null;
-  }
-})();
+    try {
+      return _lib.lookupFunction<Void Function(Pointer<Void>),
+          void Function(Pointer<Void>)>('rac_free');
+    } catch (_) {
+      return null;
+    }
+  })();
+}

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
@@ -20,45 +20,45 @@ import 'package:runanywhere/native/platform_loader.dart';
 /// final result = NativeFunctions.llmIsLoaded(_handle!);
 /// ```
 abstract class NativeFunctions {
-  static late final _lib = PlatformLoader.loadCommons();
+  static final _lib = PlatformLoader.loadCommons();
 
   // ---------------------------------------------------------------------------
   // LLM Component
   // ---------------------------------------------------------------------------
 
-  static late final int Function(Pointer<RacHandle>) llmCreate =
+  static final int Function(Pointer<RacHandle>) llmCreate =
       _lib.lookupFunction<
           Int32 Function(Pointer<RacHandle>),
           int Function(Pointer<RacHandle>)>('rac_llm_component_create');
 
-  static late final int Function(RacHandle) llmIsLoaded =
+  static final int Function(RacHandle) llmIsLoaded =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_llm_component_is_loaded');
 
-  static late final int Function(RacHandle) llmSupportsStreaming =
+  static final int Function(RacHandle) llmSupportsStreaming =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_llm_component_supports_streaming');
 
-  static late final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
           Pointer<Utf8>) llmLoadModel =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_llm_component_load_model');
 
-  static late final int Function(RacHandle) llmCleanup =
+  static final int Function(RacHandle) llmCleanup =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_llm_component_cleanup');
 
-  static late final int Function(RacHandle) llmCancel =
+  static final int Function(RacHandle) llmCancel =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_llm_component_cancel');
 
-  static late final int Function(
+  static final int Function(
     RacHandle,
     Pointer<Utf8>,
     Pointer<RacLlmOptionsStruct>,
@@ -69,7 +69,7 @@ abstract class NativeFunctions {
       int Function(RacHandle, Pointer<Utf8>, Pointer<RacLlmOptionsStruct>,
           Pointer<RacLlmResultStruct>)>('rac_llm_component_generate');
 
-  static late final int Function(
+  static final int Function(
     RacHandle,
     Pointer<Utf8>,
     Pointer<RacLlmOptionsStruct>,
@@ -97,7 +97,7 @@ abstract class NativeFunctions {
         Pointer<Void>,
       )>('rac_llm_component_generate_stream');
 
-  static late final void Function(RacHandle) llmDestroy =
+  static final void Function(RacHandle) llmDestroy =
       _lib.lookupFunction<
           Void Function(RacHandle),
           void Function(RacHandle)>('rac_llm_component_destroy');
@@ -107,60 +107,60 @@ abstract class NativeFunctions {
   // STT Component
   // ---------------------------------------------------------------------------
 
-  static late final int Function(Pointer<RacHandle>) sttCreate =
+  static final int Function(Pointer<RacHandle>) sttCreate =
       _lib.lookupFunction<
           Int32 Function(Pointer<RacHandle>),
           int Function(Pointer<RacHandle>)>('rac_stt_component_create');
 
-  static late final int Function(RacHandle) sttIsLoaded =
+  static final int Function(RacHandle) sttIsLoaded =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_stt_component_is_loaded');
 
-  static late final int Function(RacHandle) sttSupportsStreaming =
+  static final int Function(RacHandle) sttSupportsStreaming =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_stt_component_supports_streaming');
 
-  static late final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
           Pointer<Utf8>) sttLoadModel =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_stt_component_load_model');
 
-  static late final int Function(RacHandle) sttCleanup =
+  static final int Function(RacHandle) sttCleanup =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_stt_component_cleanup');
 
-  static late final int Function(
+  static final int Function(
     RacHandle,
     Pointer<Void>,
     int,
-    Pointer<Void>,
-    Pointer<Void>,
+    Pointer<RacSttOptionsStruct>,
+    Pointer<RacSttResultStruct>,
   ) sttTranscribe = _lib.lookupFunction<
       Int32 Function(
         RacHandle,
         Pointer<Void>,
         IntPtr,
-        Pointer<Void>,
-        Pointer<Void>,
+        Pointer<RacSttOptionsStruct>,
+        Pointer<RacSttResultStruct>,
       ),
       int Function(
         RacHandle,
         Pointer<Void>,
         int,
-        Pointer<Void>,
-        Pointer<Void>,
+        Pointer<RacSttOptionsStruct>,
+        Pointer<RacSttResultStruct>,
       )>('rac_stt_component_transcribe');
 
-  static late final void Function(Pointer<Void>) sttResultFree =
-      _lib.lookupFunction<Void Function(Pointer<Void>),
-          void Function(Pointer<Void>)>('rac_stt_result_free');
+  static final void Function(Pointer<RacSttResultStruct>) sttResultFree =
+      _lib.lookupFunction<Void Function(Pointer<RacSttResultStruct>),
+          void Function(Pointer<RacSttResultStruct>)>('rac_stt_result_free');
 
-  static late final void Function(RacHandle) sttDestroy =
+  static final void Function(RacHandle) sttDestroy =
       _lib.lookupFunction<
           Void Function(RacHandle),
           void Function(RacHandle)>('rac_stt_component_destroy');
@@ -170,53 +170,53 @@ abstract class NativeFunctions {
   // TTS Component
   // ---------------------------------------------------------------------------
 
-  static late final int Function(Pointer<RacHandle>) ttsCreate =
+  static final int Function(Pointer<RacHandle>) ttsCreate =
       _lib.lookupFunction<
           Int32 Function(Pointer<RacHandle>),
           int Function(Pointer<RacHandle>)>('rac_tts_component_create');
 
-  static late final int Function(RacHandle) ttsIsLoaded =
+  static final int Function(RacHandle) ttsIsLoaded =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_tts_component_is_loaded');
 
-  static late final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+  static final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
           Pointer<Utf8>) ttsLoadVoice =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_tts_component_load_voice');
 
-  static late final int Function(RacHandle) ttsCleanup =
+  static final int Function(RacHandle) ttsCleanup =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_tts_component_cleanup');
 
-  static late final int Function(RacHandle) ttsStop =
+  static final int Function(RacHandle) ttsStop =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_tts_component_stop');
 
-  static late final int Function(
+  static final int Function(
     RacHandle,
     Pointer<Utf8>,
-    Pointer<Void>,
-    Pointer<Void>,
+    Pointer<RacTtsOptionsStruct>,
+    Pointer<RacTtsResultStruct>,
   ) ttsSynthesize = _lib.lookupFunction<
       Int32 Function(
         RacHandle,
         Pointer<Utf8>,
-        Pointer<Void>,
-        Pointer<Void>,
+        Pointer<RacTtsOptionsStruct>,
+        Pointer<RacTtsResultStruct>,
       ),
       int Function(
         RacHandle,
         Pointer<Utf8>,
-        Pointer<Void>,
-        Pointer<Void>,
+        Pointer<RacTtsOptionsStruct>,
+        Pointer<RacTtsResultStruct>,
       )>('rac_tts_component_synthesize');
 
-  static late final void Function(RacHandle) ttsDestroy =
+  static final void Function(RacHandle) ttsDestroy =
       _lib.lookupFunction<
           Void Function(RacHandle),
           void Function(RacHandle)>('rac_tts_component_destroy');
@@ -226,64 +226,64 @@ abstract class NativeFunctions {
   // VAD Component
   // ---------------------------------------------------------------------------
 
-  static late final int Function(Pointer<RacHandle>) vadCreate =
+  static final int Function(Pointer<RacHandle>) vadCreate =
       _lib.lookupFunction<
           Int32 Function(Pointer<RacHandle>),
           int Function(Pointer<RacHandle>)>('rac_vad_component_create');
 
-  static late final int Function(RacHandle) vadIsInitialized =
+  static final int Function(RacHandle) vadIsInitialized =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_is_initialized');
 
-  static late final int Function(RacHandle) vadIsSpeechActive =
+  static final int Function(RacHandle) vadIsSpeechActive =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_is_speech_active');
 
-  static late final double Function(RacHandle) vadGetEnergyThreshold =
+  static final double Function(RacHandle) vadGetEnergyThreshold =
       _lib.lookupFunction<
           Float Function(RacHandle),
           double Function(RacHandle)>('rac_vad_component_get_energy_threshold');
 
-  static late final int Function(RacHandle, double) vadSetEnergyThreshold =
+  static final int Function(RacHandle, double) vadSetEnergyThreshold =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Float),
           int Function(RacHandle, double)>('rac_vad_component_set_energy_threshold');
 
-  static late final int Function(RacHandle) vadInitialize =
+  static final int Function(RacHandle) vadInitialize =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_initialize');
 
-  static late final int Function(RacHandle) vadStart =
+  static final int Function(RacHandle) vadStart =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_start');
 
-  static late final int Function(RacHandle) vadStop =
+  static final int Function(RacHandle) vadStop =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_stop');
 
-  static late final int Function(RacHandle) vadReset =
+  static final int Function(RacHandle) vadReset =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_reset');
 
-  static late final int Function(RacHandle) vadCleanup =
+  static final int Function(RacHandle) vadCleanup =
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_cleanup');
 
-  static late final int Function(RacHandle, Pointer<Float>, int, Pointer<Void>)
+  static final int Function(RacHandle, Pointer<Float>, int, Pointer<Void>)
       vadProcess =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Float>, IntPtr, Pointer<Void>),
           int Function(
               RacHandle, Pointer<Float>, int, Pointer<Void>)>('rac_vad_component_process');
 
-  static late final void Function(RacHandle) vadDestroy =
+  static final void Function(RacHandle) vadDestroy =
       _lib.lookupFunction<
           Void Function(RacHandle),
           void Function(RacHandle)>('rac_vad_component_destroy');
@@ -292,7 +292,7 @@ abstract class NativeFunctions {
   // VoiceAgent Component
   // ---------------------------------------------------------------------------
 
-  static late final int Function(
+  static final int Function(
     RacHandle,
     RacHandle,
     RacHandle,
@@ -315,60 +315,60 @@ abstract class NativeFunctions {
             Pointer<RacHandle>,
           )>('rac_voice_agent_create');
 
-  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsReady =
+  static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsReady =
       _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
           int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_ready');
 
-  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsSTTLoaded =
+  static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsSTTLoaded =
       _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
           int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_stt_loaded');
 
-  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsLLMLoaded =
+  static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsLLMLoaded =
       _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
           int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_llm_loaded');
 
-  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsTTSLoaded =
+  static final int Function(RacHandle, Pointer<Int32>) voiceAgentIsTTSLoaded =
       _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
           int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_tts_loaded');
 
-  static late final int Function(
+  static final int Function(
           RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadSTTModel = _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_stt_model');
 
-  static late final int Function(
+  static final int Function(
           RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadLLMModel = _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_llm_model');
 
-  static late final int Function(
+  static final int Function(
           RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadTTSVoice = _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_tts_voice');
 
-  static late final int Function(RacHandle)
+  static final int Function(RacHandle)
       voiceAgentInitializeWithLoadedModels = _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_voice_agent_initialize_with_loaded_models');
 
-  static late final int Function(RacHandle, Pointer<Void>, int, Pointer<Void>)
+  static final int Function(RacHandle, Pointer<Void>, int, Pointer<Void>)
       voiceAgentProcessVoiceTurn =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Void>, IntPtr, Pointer<Void>),
           int Function(
               RacHandle, Pointer<Void>, int, Pointer<Void>)>('rac_voice_agent_process_voice_turn');
 
-  static late final void Function(Pointer<Void>) voiceAgentResultFree =
+  static final void Function(Pointer<Void>) voiceAgentResultFree =
       _lib.lookupFunction<Void Function(Pointer<Void>),
           void Function(Pointer<Void>)>('rac_voice_agent_result_free');
 
-  static late final int Function(RacHandle, Pointer<Void>, int,
+  static final int Function(RacHandle, Pointer<Void>, int,
           Pointer<Pointer<Utf8>>) voiceAgentTranscribe =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Void>, IntPtr,
@@ -376,7 +376,7 @@ abstract class NativeFunctions {
           int Function(RacHandle, Pointer<Void>, int,
               Pointer<Pointer<Utf8>>)>('rac_voice_agent_transcribe');
 
-  static late final int Function(
+  static final int Function(
           RacHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>)
       voiceAgentGenerateResponse = _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>,
@@ -384,7 +384,7 @@ abstract class NativeFunctions {
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Pointer<Utf8>>)>('rac_voice_agent_generate_response');
 
-  static late final int Function(RacHandle, Pointer<Utf8>,
+  static final int Function(RacHandle, Pointer<Utf8>,
           Pointer<Pointer<Void>>, Pointer<IntPtr>) voiceAgentSynthesizeSpeech =
       _lib.lookupFunction<
           Int32 Function(RacHandle, Pointer<Utf8>,
@@ -392,15 +392,129 @@ abstract class NativeFunctions {
           int Function(RacHandle, Pointer<Utf8>,
               Pointer<Pointer<Void>>, Pointer<IntPtr>)>('rac_voice_agent_synthesize_speech');
 
-  static late final int Function(RacHandle) voiceAgentCleanup =
+  static final int Function(RacHandle) voiceAgentCleanup =
       _lib.lookupFunction<Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_voice_agent_cleanup');
 
-  static late final void Function(RacHandle) voiceAgentDestroy =
+  static final void Function(RacHandle) voiceAgentDestroy =
       _lib.lookupFunction<Void Function(RacHandle),
           void Function(RacHandle)>('rac_voice_agent_destroy');
 
-  static late final void Function(Pointer<Void>) racFree =
+  static final void Function(Pointer<Void>) racFree =
       _lib.lookupFunction<Void Function(Pointer<Void>),
           void Function(Pointer<Void>)>('rac_free');
+}
+
+// =============================================================================
+// FFI Structs
+// =============================================================================
+//
+// These are the native struct layouts used by a subset of component functions.
+// They are defined here (instead of `ffi_types.dart`) so that `NativeFunctions`
+// exposes correctly typed pointers without requiring other library imports.
+
+/// FFI struct for STT options (matches `rac_stt_options_t`).
+final class RacSttOptionsStruct extends Struct {
+  /// Language code (e.g., "en")
+  external Pointer<Utf8> language;
+
+  /// Whether to auto-detect language
+  @Int32()
+  external int detectLanguage;
+
+  /// Whether to add punctuation
+  @Int32()
+  external int enablePunctuation;
+
+  /// Whether to enable speaker diarization
+  @Int32()
+  external int enableDiarization;
+
+  /// Maximum number of speakers for diarization
+  @Int32()
+  external int maxSpeakers;
+
+  /// Whether to include word timestamps
+  @Int32()
+  external int enableTimestamps;
+
+  /// Audio format of input data (`rac_audio_format_enum_t`)
+  @Int32()
+  external int audioFormat;
+
+  /// Sample rate of input audio in Hz
+  @Int32()
+  external int sampleRate;
+}
+
+/// FFI struct for STT result (matches `rac_stt_result_t`).
+final class RacSttResultStruct extends Struct {
+  external Pointer<Utf8> text;
+
+  @Double()
+  external double confidence;
+
+  @Int32()
+  external int durationMs;
+
+  external Pointer<Utf8> language;
+}
+
+/// FFI struct for TTS options (matches `rac_tts_options_t`).
+final class RacTtsOptionsStruct extends Struct {
+  /// Voice to use for synthesis (can be NULL for default)
+  external Pointer<Utf8> voice;
+
+  /// Language for synthesis (BCP-47 format, e.g., "en-US")
+  external Pointer<Utf8> language;
+
+  /// Speech rate (0.0 to 2.0, 1.0 is normal)
+  @Float()
+  external double rate;
+
+  /// Speech pitch (0.0 to 2.0, 1.0 is normal)
+  @Float()
+  external double pitch;
+
+  /// Speech volume (0.0 to 1.0)
+  @Float()
+  external double volume;
+
+  /// Audio format for output (`rac_audio_format_enum_t`)
+  @Int32()
+  external int audioFormat;
+
+  /// Sample rate for output audio in Hz
+  @Int32()
+  external int sampleRate;
+
+  /// Whether to use SSML markup (`rac_bool_t`)
+  @Int32()
+  external int useSsml;
+}
+
+/// FFI struct for TTS result (matches `rac_tts_result_t`).
+final class RacTtsResultStruct extends Struct {
+  /// Audio data (PCM float samples)
+  external Pointer<Void> audioData;
+
+  /// Size of audio data in bytes (size_t)
+  @IntPtr()
+  external int audioSize;
+
+  /// Audio format (`rac_audio_format_enum_t`)
+  @Int32()
+  external int audioFormat;
+
+  /// Sample rate in Hz
+  @Int32()
+  external int sampleRate;
+
+  /// Duration in milliseconds
+  @Int64()
+  external int durationMs;
+
+  /// Processing time in milliseconds
+  @Int64()
+  external int processingTimeMs;
 }

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
@@ -58,45 +58,6 @@ abstract class NativeFunctions {
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_llm_component_cancel');
 
-  static final int Function(
-    RacHandle,
-    Pointer<Utf8>,
-    Pointer<RacLlmOptionsStruct>,
-    Pointer<RacLlmResultStruct>,
-  ) llmGenerate = _lib.lookupFunction<
-      Int32 Function(RacHandle, Pointer<Utf8>, Pointer<RacLlmOptionsStruct>,
-          Pointer<RacLlmResultStruct>),
-      int Function(RacHandle, Pointer<Utf8>, Pointer<RacLlmOptionsStruct>,
-          Pointer<RacLlmResultStruct>)>('rac_llm_component_generate');
-
-  static final int Function(
-    RacHandle,
-    Pointer<Utf8>,
-    Pointer<RacLlmOptionsStruct>,
-    Pointer<NativeFunction<Int32 Function(Pointer<Utf8>, Pointer<Void>)>>,
-    Pointer<NativeFunction<Void Function(Pointer<RacLlmResultStruct>, Pointer<Void>)>>,
-    Pointer<NativeFunction<Void Function(Int32, Pointer<Utf8>, Pointer<Void>)>>,
-    Pointer<Void>,
-  ) llmGenerateStream = _lib.lookupFunction<
-      Int32 Function(
-        RacHandle,
-        Pointer<Utf8>,
-        Pointer<RacLlmOptionsStruct>,
-        Pointer<NativeFunction<Int32 Function(Pointer<Utf8>, Pointer<Void>)>>,
-        Pointer<NativeFunction<Void Function(Pointer<RacLlmResultStruct>, Pointer<Void>)>>,
-        Pointer<NativeFunction<Void Function(Int32, Pointer<Utf8>, Pointer<Void>)>>,
-        Pointer<Void>,
-      ),
-      int Function(
-        RacHandle,
-        Pointer<Utf8>,
-        Pointer<RacLlmOptionsStruct>,
-        Pointer<NativeFunction<Int32 Function(Pointer<Utf8>, Pointer<Void>)>>,
-        Pointer<NativeFunction<Void Function(Pointer<RacLlmResultStruct>, Pointer<Void>)>>,
-        Pointer<NativeFunction<Void Function(Int32, Pointer<Utf8>, Pointer<Void>)>>,
-        Pointer<Void>,
-      )>('rac_llm_component_generate_stream');
-
   static final void Function(RacHandle) llmDestroy =
       _lib.lookupFunction<
           Void Function(RacHandle),
@@ -133,28 +94,6 @@ abstract class NativeFunctions {
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_stt_component_cleanup');
-
-  static final int Function(
-    RacHandle,
-    Pointer<Void>,
-    int,
-    Pointer<RacSttOptionsStruct>,
-    Pointer<RacSttResultStruct>,
-  ) sttTranscribe = _lib.lookupFunction<
-      Int32 Function(
-        RacHandle,
-        Pointer<Void>,
-        IntPtr,
-        Pointer<RacSttOptionsStruct>,
-        Pointer<RacSttResultStruct>,
-      ),
-      int Function(
-        RacHandle,
-        Pointer<Void>,
-        int,
-        Pointer<RacSttOptionsStruct>,
-        Pointer<RacSttResultStruct>,
-      )>('rac_stt_component_transcribe');
 
   static final void Function(Pointer<RacSttResultStruct>) sttResultFree =
       _lib.lookupFunction<Void Function(Pointer<RacSttResultStruct>),
@@ -196,25 +135,6 @@ abstract class NativeFunctions {
       _lib.lookupFunction<
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_tts_component_stop');
-
-  static final int Function(
-    RacHandle,
-    Pointer<Utf8>,
-    Pointer<RacTtsOptionsStruct>,
-    Pointer<RacTtsResultStruct>,
-  ) ttsSynthesize = _lib.lookupFunction<
-      Int32 Function(
-        RacHandle,
-        Pointer<Utf8>,
-        Pointer<RacTtsOptionsStruct>,
-        Pointer<RacTtsResultStruct>,
-      ),
-      int Function(
-        RacHandle,
-        Pointer<Utf8>,
-        Pointer<RacTtsOptionsStruct>,
-        Pointer<RacTtsResultStruct>,
-      )>('rac_tts_component_synthesize');
 
   static final void Function(RacHandle) ttsDestroy =
       _lib.lookupFunction<
@@ -357,17 +277,6 @@ abstract class NativeFunctions {
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_voice_agent_initialize_with_loaded_models');
 
-  static final int Function(RacHandle, Pointer<Void>, int, Pointer<Void>)
-      voiceAgentProcessVoiceTurn =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Void>, IntPtr, Pointer<Void>),
-          int Function(
-              RacHandle, Pointer<Void>, int, Pointer<Void>)>('rac_voice_agent_process_voice_turn');
-
-  static final void Function(Pointer<Void>) voiceAgentResultFree =
-      _lib.lookupFunction<Void Function(Pointer<Void>),
-          void Function(Pointer<Void>)>('rac_voice_agent_result_free');
-
   static final int Function(RacHandle, Pointer<Void>, int,
           Pointer<Pointer<Utf8>>) voiceAgentTranscribe =
       _lib.lookupFunction<
@@ -403,118 +312,4 @@ abstract class NativeFunctions {
   static final void Function(Pointer<Void>) racFree =
       _lib.lookupFunction<Void Function(Pointer<Void>),
           void Function(Pointer<Void>)>('rac_free');
-}
-
-// =============================================================================
-// FFI Structs
-// =============================================================================
-//
-// These are the native struct layouts used by a subset of component functions.
-// They are defined here (instead of `ffi_types.dart`) so that `NativeFunctions`
-// exposes correctly typed pointers without requiring other library imports.
-
-/// FFI struct for STT options (matches `rac_stt_options_t`).
-final class RacSttOptionsStruct extends Struct {
-  /// Language code (e.g., "en")
-  external Pointer<Utf8> language;
-
-  /// Whether to auto-detect language
-  @Int32()
-  external int detectLanguage;
-
-  /// Whether to add punctuation
-  @Int32()
-  external int enablePunctuation;
-
-  /// Whether to enable speaker diarization
-  @Int32()
-  external int enableDiarization;
-
-  /// Maximum number of speakers for diarization
-  @Int32()
-  external int maxSpeakers;
-
-  /// Whether to include word timestamps
-  @Int32()
-  external int enableTimestamps;
-
-  /// Audio format of input data (`rac_audio_format_enum_t`)
-  @Int32()
-  external int audioFormat;
-
-  /// Sample rate of input audio in Hz
-  @Int32()
-  external int sampleRate;
-}
-
-/// FFI struct for STT result (matches `rac_stt_result_t`).
-final class RacSttResultStruct extends Struct {
-  external Pointer<Utf8> text;
-
-  @Double()
-  external double confidence;
-
-  @Int32()
-  external int durationMs;
-
-  external Pointer<Utf8> language;
-}
-
-/// FFI struct for TTS options (matches `rac_tts_options_t`).
-final class RacTtsOptionsStruct extends Struct {
-  /// Voice to use for synthesis (can be NULL for default)
-  external Pointer<Utf8> voice;
-
-  /// Language for synthesis (BCP-47 format, e.g., "en-US")
-  external Pointer<Utf8> language;
-
-  /// Speech rate (0.0 to 2.0, 1.0 is normal)
-  @Float()
-  external double rate;
-
-  /// Speech pitch (0.0 to 2.0, 1.0 is normal)
-  @Float()
-  external double pitch;
-
-  /// Speech volume (0.0 to 1.0)
-  @Float()
-  external double volume;
-
-  /// Audio format for output (`rac_audio_format_enum_t`)
-  @Int32()
-  external int audioFormat;
-
-  /// Sample rate for output audio in Hz
-  @Int32()
-  external int sampleRate;
-
-  /// Whether to use SSML markup (`rac_bool_t`)
-  @Int32()
-  external int useSsml;
-}
-
-/// FFI struct for TTS result (matches `rac_tts_result_t`).
-final class RacTtsResultStruct extends Struct {
-  /// Audio data (PCM float samples)
-  external Pointer<Void> audioData;
-
-  /// Size of audio data in bytes (size_t)
-  @IntPtr()
-  external int audioSize;
-
-  /// Audio format (`rac_audio_format_enum_t`)
-  @Int32()
-  external int audioFormat;
-
-  /// Sample rate in Hz
-  @Int32()
-  external int sampleRate;
-
-  /// Duration in milliseconds
-  @Int64()
-  external int durationMs;
-
-  /// Processing time in milliseconds
-  @Int64()
-  external int processingTimeMs;
 }

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
@@ -196,12 +196,25 @@ abstract class NativeFunctions {
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_cleanup');
 
-  static final int Function(RacHandle, Pointer<Float>, int, Pointer<Void>)
-      vadProcess =
-      _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Float>, IntPtr, Pointer<Void>),
-          int Function(
-              RacHandle, Pointer<Float>, int, Pointer<Void>)>('rac_vad_component_process');
+  static final int Function(
+  RacHandle,
+  Pointer<Float>,
+  int,
+  Pointer<RacVadResultStruct>,
+) vadProcess =
+    _lib.lookupFunction<
+        Int32 Function(
+          RacHandle,
+          Pointer<Float>,
+          IntPtr,
+          Pointer<RacVadResultStruct>,
+        ),
+        int Function(
+          RacHandle,
+          Pointer<Float>,
+          int,
+          Pointer<RacVadResultStruct>,
+        )>('rac_vad_component_process');
 
   static final void Function(RacHandle) vadDestroy =
       _lib.lookupFunction<
@@ -309,7 +322,11 @@ abstract class NativeFunctions {
       _lib.lookupFunction<Void Function(RacHandle),
           void Function(RacHandle)>('rac_voice_agent_destroy');
 
-  static final void Function(Pointer<Void>) racFree =
-      _lib.lookupFunction<Void Function(Pointer<Void>),
-          void Function(Pointer<Void>)>('rac_free');
-}
+  static final void Function(Pointer<Void>)? racFree = (() {
+  try {
+    return _lib.lookupFunction<Void Function(Pointer<Void>),
+        void Function(Pointer<Void>)>('rac_free');
+  } catch (_) {
+    return null;
+  }
+})();

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
@@ -1,0 +1,380 @@
+/// NativeFunctions
+///
+/// Cached FFI function lookup registry.
+///
+/// All [DynamicLibrary.lookupFunction] calls are performed once at first access
+/// via lazy static fields. Subsequent calls return the cached function pointer,
+/// avoiding repeated symbol-table searches (dlsym) on every invocation.
+library native_functions;
+
+import 'dart:ffi';
+
+import 'package:ffi/ffi.dart';
+import 'package:runanywhere/native/ffi_types.dart';
+import 'package:runanywhere/native/platform_loader.dart';
+
+/// Cached native function pointers for the RACommons library.
+///
+/// Usage:
+/// ```dart
+/// final result = NativeFunctions.llmIsLoaded(_handle!);
+/// ```
+abstract class NativeFunctions {
+  static late final _lib = PlatformLoader.loadCommons();
+
+  // ---------------------------------------------------------------------------
+  // LLM Component
+  // ---------------------------------------------------------------------------
+
+  static late final int Function(Pointer<RacHandle>) llmCreate =
+      _lib.lookupFunction<
+          Int32 Function(Pointer<RacHandle>),
+          int Function(Pointer<RacHandle>)>('rac_llm_component_create');
+
+  static late final int Function(RacHandle) llmIsLoaded =
+      _lib.lookupFunction<RacLlmComponentIsLoadedNative,
+          RacLlmComponentIsLoadedDart>('rac_llm_component_is_loaded');
+
+  static late final int Function(RacHandle) llmSupportsStreaming =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_llm_component_supports_streaming');
+
+  static late final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+          Pointer<Utf8>) llmLoadModel =
+      _lib.lookupFunction<RacLlmComponentLoadModelNative,
+          RacLlmComponentLoadModelDart>('rac_llm_component_load_model');
+
+  static late final int Function(RacHandle) llmCleanup =
+      _lib.lookupFunction<RacLlmComponentCleanupNative,
+          RacLlmComponentCleanupDart>('rac_llm_component_cleanup');
+
+  static late final int Function(RacHandle) llmCancel =
+      _lib.lookupFunction<RacLlmComponentCancelNative,
+          RacLlmComponentCancelDart>('rac_llm_component_cancel');
+
+  static late final int Function(
+    RacHandle,
+    Pointer<Utf8>,
+    Pointer<RacLlmOptionsStruct>,
+    Pointer<RacLlmResultStruct>,
+  ) llmGenerate = _lib.lookupFunction<
+      Int32 Function(RacHandle, Pointer<Utf8>, Pointer<RacLlmOptionsStruct>,
+          Pointer<RacLlmResultStruct>),
+      int Function(RacHandle, Pointer<Utf8>, Pointer<RacLlmOptionsStruct>,
+          Pointer<RacLlmResultStruct>)>('rac_llm_component_generate');
+
+  static late final int Function(
+    RacHandle,
+    Pointer<Utf8>,
+    Pointer<RacLlmOptionsStruct>,
+    Pointer<NativeFunction<Int32 Function(Pointer<Utf8>, Pointer<Void>)>>,
+    Pointer<NativeFunction<Void Function(Pointer<RacLlmResultStruct>, Pointer<Void>)>>,
+    Pointer<NativeFunction<Void Function(Int32, Pointer<Utf8>, Pointer<Void>)>>,
+    Pointer<Void>,
+  ) llmGenerateStream = _lib.lookupFunction<
+      Int32 Function(
+        RacHandle,
+        Pointer<Utf8>,
+        Pointer<RacLlmOptionsStruct>,
+        Pointer<NativeFunction<Int32 Function(Pointer<Utf8>, Pointer<Void>)>>,
+        Pointer<NativeFunction<Void Function(Pointer<RacLlmResultStruct>, Pointer<Void>)>>,
+        Pointer<NativeFunction<Void Function(Int32, Pointer<Utf8>, Pointer<Void>)>>,
+        Pointer<Void>,
+      ),
+      int Function(
+        RacHandle,
+        Pointer<Utf8>,
+        Pointer<RacLlmOptionsStruct>,
+        Pointer<NativeFunction<Int32 Function(Pointer<Utf8>, Pointer<Void>)>>,
+        Pointer<NativeFunction<Void Function(Pointer<RacLlmResultStruct>, Pointer<Void>)>>,
+        Pointer<NativeFunction<Void Function(Int32, Pointer<Utf8>, Pointer<Void>)>>,
+        Pointer<Void>,
+      )>('rac_llm_component_generate_stream');
+
+  static late final void Function(RacHandle) llmDestroy =
+      _lib.lookupFunction<RacLlmComponentDestroyNative,
+          RacLlmComponentDestroyDart>('rac_llm_component_destroy');
+
+
+  // ---------------------------------------------------------------------------
+  // STT Component
+  // ---------------------------------------------------------------------------
+
+  static late final int Function(Pointer<RacHandle>) sttCreate =
+      _lib.lookupFunction<
+          Int32 Function(Pointer<RacHandle>),
+          int Function(Pointer<RacHandle>)>('rac_stt_component_create');
+
+  static late final int Function(RacHandle) sttIsLoaded =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_stt_component_is_loaded');
+
+  static late final int Function(RacHandle) sttSupportsStreaming =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_stt_component_supports_streaming');
+
+  static late final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+          Pointer<Utf8>) sttLoadModel =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+              Pointer<Utf8>)>('rac_stt_component_load_model');
+
+  static late final int Function(RacHandle) sttCleanup =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_stt_component_cleanup');
+
+  static late final int Function(
+    RacHandle,
+    Pointer<Void>,
+    int,
+    Pointer<RacSttOptionsStruct>,
+    Pointer<RacSttResultStruct>,
+  ) sttTranscribe = _lib.lookupFunction<
+      Int32 Function(RacHandle, Pointer<Void>, IntPtr,
+          Pointer<RacSttOptionsStruct>, Pointer<RacSttResultStruct>),
+      int Function(RacHandle, Pointer<Void>, int, Pointer<RacSttOptionsStruct>,
+          Pointer<RacSttResultStruct>)>('rac_stt_component_transcribe');
+
+  static late final void Function(Pointer<Void>) sttResultFree =
+      _lib.lookupFunction<Void Function(Pointer<Void>),
+          void Function(Pointer<Void>)>('rac_stt_result_free');
+
+  static late final void Function(RacHandle) sttDestroy =
+      _lib.lookupFunction<
+          Void Function(RacHandle),
+          void Function(RacHandle)>('rac_stt_component_destroy');
+
+
+  // ---------------------------------------------------------------------------
+  // TTS Component
+  // ---------------------------------------------------------------------------
+
+  static late final int Function(Pointer<RacHandle>) ttsCreate =
+      _lib.lookupFunction<
+          Int32 Function(Pointer<RacHandle>),
+          int Function(Pointer<RacHandle>)>('rac_tts_component_create');
+
+  static late final int Function(RacHandle) ttsIsLoaded =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_tts_component_is_loaded');
+
+  static late final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+          Pointer<Utf8>) ttsLoadVoice =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+              Pointer<Utf8>)>('rac_tts_component_load_voice');
+
+  static late final int Function(RacHandle) ttsCleanup =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_tts_component_cleanup');
+
+  static late final int Function(RacHandle) ttsStop =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_tts_component_stop');
+
+  static late final int Function(
+    RacHandle,
+    Pointer<Utf8>,
+    Pointer<RacTtsOptionsStruct>,
+    Pointer<RacTtsResultStruct>,
+  ) ttsSynthesize = _lib.lookupFunction<
+      Int32 Function(RacHandle, Pointer<Utf8>, Pointer<RacTtsOptionsStruct>,
+          Pointer<RacTtsResultStruct>),
+      int Function(RacHandle, Pointer<Utf8>, Pointer<RacTtsOptionsStruct>,
+          Pointer<RacTtsResultStruct>)>('rac_tts_component_synthesize');
+
+  static late final void Function(RacHandle) ttsDestroy =
+      _lib.lookupFunction<
+          Void Function(RacHandle),
+          void Function(RacHandle)>('rac_tts_component_destroy');
+
+
+  // ---------------------------------------------------------------------------
+  // VAD Component
+  // ---------------------------------------------------------------------------
+
+  static late final int Function(Pointer<RacHandle>) vadCreate =
+      _lib.lookupFunction<
+          Int32 Function(Pointer<RacHandle>),
+          int Function(Pointer<RacHandle>)>('rac_vad_component_create');
+
+  static late final int Function(RacHandle) vadIsInitialized =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_vad_component_is_initialized');
+
+  static late final int Function(RacHandle) vadIsSpeechActive =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_vad_component_is_speech_active');
+
+  static late final double Function(RacHandle) vadGetEnergyThreshold =
+      _lib.lookupFunction<
+          Float Function(RacHandle),
+          double Function(RacHandle)>('rac_vad_component_get_energy_threshold');
+
+  static late final int Function(RacHandle, double) vadSetEnergyThreshold =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Float),
+          int Function(RacHandle, double)>('rac_vad_component_set_energy_threshold');
+
+  static late final int Function(RacHandle) vadInitialize =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_vad_component_initialize');
+
+  static late final int Function(RacHandle) vadStart =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_vad_component_start');
+
+  static late final int Function(RacHandle) vadStop =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_vad_component_stop');
+
+  static late final int Function(RacHandle) vadReset =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_vad_component_reset');
+
+  static late final int Function(RacHandle) vadCleanup =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_vad_component_cleanup');
+
+  static late final int Function(RacHandle, Pointer<Float>, int,
+          Pointer<RacVadResultStruct>) vadProcess =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Float>, IntPtr,
+              Pointer<RacVadResultStruct>),
+          int Function(RacHandle, Pointer<Float>, int,
+              Pointer<RacVadResultStruct>)>('rac_vad_component_process');
+
+  static late final void Function(RacHandle) vadDestroy =
+      _lib.lookupFunction<
+          Void Function(RacHandle),
+          void Function(RacHandle)>('rac_vad_component_destroy');
+
+  // ---------------------------------------------------------------------------
+  // VoiceAgent Component
+  // ---------------------------------------------------------------------------
+
+  static late final int Function(RacHandle, RacHandle, RacHandle, RacHandle,
+          Pointer<RacVoiceAgentHandle>) voiceAgentCreate =
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, RacHandle, RacHandle, RacHandle,
+              Pointer<RacVoiceAgentHandle>),
+          int Function(RacHandle, RacHandle, RacHandle, RacHandle,
+              Pointer<RacVoiceAgentHandle>)>('rac_voice_agent_create');
+
+  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
+      voiceAgentIsReady = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
+          int Function(
+              RacVoiceAgentHandle, Pointer<Int32>)>('rac_voice_agent_is_ready');
+
+  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
+      voiceAgentIsSTTLoaded = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
+          int Function(RacVoiceAgentHandle,
+              Pointer<Int32>)>('rac_voice_agent_is_stt_loaded');
+
+  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
+      voiceAgentIsLLMLoaded = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
+          int Function(RacVoiceAgentHandle,
+              Pointer<Int32>)>('rac_voice_agent_is_llm_loaded');
+
+  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
+      voiceAgentIsTTSLoaded = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
+          int Function(RacVoiceAgentHandle,
+              Pointer<Int32>)>('rac_voice_agent_is_tts_loaded');
+
+  static late final int Function(
+          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>)
+      voiceAgentLoadSTTModel = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+              Pointer<Utf8>)>('rac_voice_agent_load_stt_model');
+
+  static late final int Function(
+          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>)
+      voiceAgentLoadLLMModel = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+              Pointer<Utf8>)>('rac_voice_agent_load_llm_model');
+
+  static late final int Function(
+          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>)
+      voiceAgentLoadTTSVoice = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+              Pointer<Utf8>)>('rac_voice_agent_load_tts_voice');
+
+  static late final int Function(RacVoiceAgentHandle)
+      voiceAgentInitializeWithLoadedModels = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle),
+          int Function(
+              RacVoiceAgentHandle)>('rac_voice_agent_initialize_with_loaded_models');
+
+  static late final int Function(RacVoiceAgentHandle, Pointer<Void>, int,
+          Pointer<RacVoiceAgentResultStruct>) voiceAgentProcessVoiceTurn =
+      _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Void>, IntPtr,
+              Pointer<RacVoiceAgentResultStruct>),
+          int Function(RacVoiceAgentHandle, Pointer<Void>, int,
+              Pointer<RacVoiceAgentResultStruct>)>('rac_voice_agent_process_voice_turn');
+
+  static late final void Function(Pointer<RacVoiceAgentResultStruct>)
+      voiceAgentResultFree = _lib.lookupFunction<
+          Void Function(Pointer<RacVoiceAgentResultStruct>),
+          void Function(
+              Pointer<RacVoiceAgentResultStruct>)>('rac_voice_agent_result_free');
+
+  static late final int Function(RacVoiceAgentHandle, Pointer<Void>, int,
+          Pointer<Pointer<Utf8>>) voiceAgentTranscribe =
+      _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Void>, IntPtr,
+              Pointer<Pointer<Utf8>>),
+          int Function(RacVoiceAgentHandle, Pointer<Void>, int,
+              Pointer<Pointer<Utf8>>)>('rac_voice_agent_transcribe');
+
+  static late final int Function(
+          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>)
+      voiceAgentGenerateResponse = _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>,
+              Pointer<Pointer<Utf8>>),
+          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+              Pointer<Pointer<Utf8>>)>('rac_voice_agent_generate_response');
+
+  static late final int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          Pointer<Pointer<Void>>, Pointer<IntPtr>) voiceAgentSynthesizeSpeech =
+      _lib.lookupFunction<
+          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>,
+              Pointer<Pointer<Void>>, Pointer<IntPtr>),
+          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+              Pointer<Pointer<Void>>, Pointer<IntPtr>)>('rac_voice_agent_synthesize_speech');
+
+  static late final int Function(RacVoiceAgentHandle) voiceAgentCleanup =
+      _lib.lookupFunction<Int32 Function(RacVoiceAgentHandle),
+          int Function(RacVoiceAgentHandle)>('rac_voice_agent_cleanup');
+
+  static late final void Function(RacVoiceAgentHandle) voiceAgentDestroy =
+      _lib.lookupFunction<Void Function(RacVoiceAgentHandle),
+          void Function(RacVoiceAgentHandle)>('rac_voice_agent_destroy');
+
+  static late final void Function(Pointer<Void>) racFree =
+      _lib.lookupFunction<Void Function(Pointer<Void>),
+          void Function(Pointer<Void>)>('rac_free');
+}

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
@@ -12,7 +12,6 @@ import 'dart:ffi';
 import 'package:ffi/ffi.dart';
 import 'package:runanywhere/native/ffi_types.dart';
 import 'package:runanywhere/native/platform_loader.dart';
-import 'package:runanywhere/native/dart_bridge_vad.dart' as vad;
 
 /// Cached native function pointers for the RACommons library.
 ///
@@ -87,9 +86,11 @@ abstract class NativeFunctions {
       _lib.lookupFunction<Int32 Function(RacHandle), int Function(RacHandle)>(
           'rac_stt_component_cleanup');
 
-  static final void Function(Pointer<RacSttResultStruct>) sttResultFree =
-      _lib.lookupFunction<Void Function(Pointer<RacSttResultStruct>),
-          void Function(Pointer<RacSttResultStruct>)>('rac_stt_result_free');
+  // Note: rac_stt_result_free is intentionally NOT cached here. The STT
+  // transcription path runs inside Isolate.run(...), which cannot access
+  // main-isolate static state — `_transcribeInIsolate` in dart_bridge_stt.dart
+  // performs its own inline lookup so each spawned isolate resolves the
+  // symbol once. A main-isolate cache entry would be dead code.
 
   static final void Function(RacHandle) sttDestroy =
       _lib.lookupFunction<Void Function(RacHandle), void Function(RacHandle)>(
@@ -177,19 +178,19 @@ abstract class NativeFunctions {
     RacHandle,
     Pointer<Float>,
     int,
-    Pointer<vad.RacVadResultStruct>,
+    Pointer<RacVadResultStruct>,
   ) vadProcess = _lib.lookupFunction<
       Int32 Function(
         RacHandle,
         Pointer<Float>,
         IntPtr,
-        Pointer<vad.RacVadResultStruct>,
+        Pointer<RacVadResultStruct>,
       ),
       int Function(
         RacHandle,
         Pointer<Float>,
         int,
-        Pointer<vad.RacVadResultStruct>,
+        Pointer<RacVadResultStruct>,
       )>('rac_vad_component_process');
 
   static final void Function(RacHandle) vadDestroy =

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
@@ -32,8 +32,9 @@ abstract class NativeFunctions {
           int Function(Pointer<RacHandle>)>('rac_llm_component_create');
 
   static late final int Function(RacHandle) llmIsLoaded =
-      _lib.lookupFunction<RacLlmComponentIsLoadedNative,
-          RacLlmComponentIsLoadedDart>('rac_llm_component_is_loaded');
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_llm_component_is_loaded');
 
   static late final int Function(RacHandle) llmSupportsStreaming =
       _lib.lookupFunction<
@@ -42,16 +43,20 @@ abstract class NativeFunctions {
 
   static late final int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
           Pointer<Utf8>) llmLoadModel =
-      _lib.lookupFunction<RacLlmComponentLoadModelNative,
-          RacLlmComponentLoadModelDart>('rac_llm_component_load_model');
+      _lib.lookupFunction<
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>,
+              Pointer<Utf8>)>('rac_llm_component_load_model');
 
   static late final int Function(RacHandle) llmCleanup =
-      _lib.lookupFunction<RacLlmComponentCleanupNative,
-          RacLlmComponentCleanupDart>('rac_llm_component_cleanup');
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_llm_component_cleanup');
 
   static late final int Function(RacHandle) llmCancel =
-      _lib.lookupFunction<RacLlmComponentCancelNative,
-          RacLlmComponentCancelDart>('rac_llm_component_cancel');
+      _lib.lookupFunction<
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_llm_component_cancel');
 
   static late final int Function(
     RacHandle,
@@ -93,8 +98,9 @@ abstract class NativeFunctions {
       )>('rac_llm_component_generate_stream');
 
   static late final void Function(RacHandle) llmDestroy =
-      _lib.lookupFunction<RacLlmComponentDestroyNative,
-          RacLlmComponentDestroyDart>('rac_llm_component_destroy');
+      _lib.lookupFunction<
+          Void Function(RacHandle),
+          void Function(RacHandle)>('rac_llm_component_destroy');
 
 
   // ---------------------------------------------------------------------------
@@ -132,13 +138,23 @@ abstract class NativeFunctions {
     RacHandle,
     Pointer<Void>,
     int,
-    Pointer<RacSttOptionsStruct>,
-    Pointer<RacSttResultStruct>,
+    Pointer<Void>,
+    Pointer<Void>,
   ) sttTranscribe = _lib.lookupFunction<
-      Int32 Function(RacHandle, Pointer<Void>, IntPtr,
-          Pointer<RacSttOptionsStruct>, Pointer<RacSttResultStruct>),
-      int Function(RacHandle, Pointer<Void>, int, Pointer<RacSttOptionsStruct>,
-          Pointer<RacSttResultStruct>)>('rac_stt_component_transcribe');
+      Int32 Function(
+        RacHandle,
+        Pointer<Void>,
+        IntPtr,
+        Pointer<Void>,
+        Pointer<Void>,
+      ),
+      int Function(
+        RacHandle,
+        Pointer<Void>,
+        int,
+        Pointer<Void>,
+        Pointer<Void>,
+      )>('rac_stt_component_transcribe');
 
   static late final void Function(Pointer<Void>) sttResultFree =
       _lib.lookupFunction<Void Function(Pointer<Void>),
@@ -184,13 +200,21 @@ abstract class NativeFunctions {
   static late final int Function(
     RacHandle,
     Pointer<Utf8>,
-    Pointer<RacTtsOptionsStruct>,
-    Pointer<RacTtsResultStruct>,
+    Pointer<Void>,
+    Pointer<Void>,
   ) ttsSynthesize = _lib.lookupFunction<
-      Int32 Function(RacHandle, Pointer<Utf8>, Pointer<RacTtsOptionsStruct>,
-          Pointer<RacTtsResultStruct>),
-      int Function(RacHandle, Pointer<Utf8>, Pointer<RacTtsOptionsStruct>,
-          Pointer<RacTtsResultStruct>)>('rac_tts_component_synthesize');
+      Int32 Function(
+        RacHandle,
+        Pointer<Utf8>,
+        Pointer<Void>,
+        Pointer<Void>,
+      ),
+      int Function(
+        RacHandle,
+        Pointer<Utf8>,
+        Pointer<Void>,
+        Pointer<Void>,
+      )>('rac_tts_component_synthesize');
 
   static late final void Function(RacHandle) ttsDestroy =
       _lib.lookupFunction<
@@ -252,13 +276,12 @@ abstract class NativeFunctions {
           Int32 Function(RacHandle),
           int Function(RacHandle)>('rac_vad_component_cleanup');
 
-  static late final int Function(RacHandle, Pointer<Float>, int,
-          Pointer<RacVadResultStruct>) vadProcess =
+  static late final int Function(RacHandle, Pointer<Float>, int, Pointer<Void>)
+      vadProcess =
       _lib.lookupFunction<
-          Int32 Function(RacHandle, Pointer<Float>, IntPtr,
-              Pointer<RacVadResultStruct>),
-          int Function(RacHandle, Pointer<Float>, int,
-              Pointer<RacVadResultStruct>)>('rac_vad_component_process');
+          Int32 Function(RacHandle, Pointer<Float>, IntPtr, Pointer<Void>),
+          int Function(
+              RacHandle, Pointer<Float>, int, Pointer<Void>)>('rac_vad_component_process');
 
   static late final void Function(RacHandle) vadDestroy =
       _lib.lookupFunction<
@@ -269,110 +292,113 @@ abstract class NativeFunctions {
   // VoiceAgent Component
   // ---------------------------------------------------------------------------
 
-  static late final int Function(RacHandle, RacHandle, RacHandle, RacHandle,
-          Pointer<RacVoiceAgentHandle>) voiceAgentCreate =
+  static late final int Function(
+    RacHandle,
+    RacHandle,
+    RacHandle,
+    RacHandle,
+    Pointer<RacHandle>,
+  ) voiceAgentCreate =
       _lib.lookupFunction<
-          Int32 Function(RacHandle, RacHandle, RacHandle, RacHandle,
-              Pointer<RacVoiceAgentHandle>),
-          int Function(RacHandle, RacHandle, RacHandle, RacHandle,
-              Pointer<RacVoiceAgentHandle>)>('rac_voice_agent_create');
-
-  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
-      voiceAgentIsReady = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
+          Int32 Function(
+            RacHandle,
+            RacHandle,
+            RacHandle,
+            RacHandle,
+            Pointer<RacHandle>,
+          ),
           int Function(
-              RacVoiceAgentHandle, Pointer<Int32>)>('rac_voice_agent_is_ready');
+            RacHandle,
+            RacHandle,
+            RacHandle,
+            RacHandle,
+            Pointer<RacHandle>,
+          )>('rac_voice_agent_create');
 
-  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
-      voiceAgentIsSTTLoaded = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
-          int Function(RacVoiceAgentHandle,
-              Pointer<Int32>)>('rac_voice_agent_is_stt_loaded');
+  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsReady =
+      _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
+          int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_ready');
 
-  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
-      voiceAgentIsLLMLoaded = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
-          int Function(RacVoiceAgentHandle,
-              Pointer<Int32>)>('rac_voice_agent_is_llm_loaded');
+  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsSTTLoaded =
+      _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
+          int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_stt_loaded');
 
-  static late final int Function(RacVoiceAgentHandle, Pointer<Int32>)
-      voiceAgentIsTTSLoaded = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Int32>),
-          int Function(RacVoiceAgentHandle,
-              Pointer<Int32>)>('rac_voice_agent_is_tts_loaded');
+  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsLLMLoaded =
+      _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
+          int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_llm_loaded');
+
+  static late final int Function(RacHandle, Pointer<Int32>) voiceAgentIsTTSLoaded =
+      _lib.lookupFunction<Int32 Function(RacHandle, Pointer<Int32>),
+          int Function(RacHandle, Pointer<Int32>)>('rac_voice_agent_is_tts_loaded');
 
   static late final int Function(
-          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>)
+          RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadSTTModel = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_stt_model');
 
   static late final int Function(
-          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>)
+          RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadLLMModel = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_llm_model');
 
   static late final int Function(
-          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>)
+          RacHandle, Pointer<Utf8>, Pointer<Utf8>)
       voiceAgentLoadTTSVoice = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Utf8>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          Int32 Function(RacHandle, Pointer<Utf8>, Pointer<Utf8>),
+          int Function(RacHandle, Pointer<Utf8>,
               Pointer<Utf8>)>('rac_voice_agent_load_tts_voice');
 
-  static late final int Function(RacVoiceAgentHandle)
+  static late final int Function(RacHandle)
       voiceAgentInitializeWithLoadedModels = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle),
-          int Function(
-              RacVoiceAgentHandle)>('rac_voice_agent_initialize_with_loaded_models');
+          Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_voice_agent_initialize_with_loaded_models');
 
-  static late final int Function(RacVoiceAgentHandle, Pointer<Void>, int,
-          Pointer<RacVoiceAgentResultStruct>) voiceAgentProcessVoiceTurn =
+  static late final int Function(RacHandle, Pointer<Void>, int, Pointer<Void>)
+      voiceAgentProcessVoiceTurn =
       _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Void>, IntPtr,
-              Pointer<RacVoiceAgentResultStruct>),
-          int Function(RacVoiceAgentHandle, Pointer<Void>, int,
-              Pointer<RacVoiceAgentResultStruct>)>('rac_voice_agent_process_voice_turn');
+          Int32 Function(RacHandle, Pointer<Void>, IntPtr, Pointer<Void>),
+          int Function(
+              RacHandle, Pointer<Void>, int, Pointer<Void>)>('rac_voice_agent_process_voice_turn');
 
-  static late final void Function(Pointer<RacVoiceAgentResultStruct>)
-      voiceAgentResultFree = _lib.lookupFunction<
-          Void Function(Pointer<RacVoiceAgentResultStruct>),
-          void Function(
-              Pointer<RacVoiceAgentResultStruct>)>('rac_voice_agent_result_free');
+  static late final void Function(Pointer<Void>) voiceAgentResultFree =
+      _lib.lookupFunction<Void Function(Pointer<Void>),
+          void Function(Pointer<Void>)>('rac_voice_agent_result_free');
 
-  static late final int Function(RacVoiceAgentHandle, Pointer<Void>, int,
+  static late final int Function(RacHandle, Pointer<Void>, int,
           Pointer<Pointer<Utf8>>) voiceAgentTranscribe =
       _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Void>, IntPtr,
+          Int32 Function(RacHandle, Pointer<Void>, IntPtr,
               Pointer<Pointer<Utf8>>),
-          int Function(RacVoiceAgentHandle, Pointer<Void>, int,
+          int Function(RacHandle, Pointer<Void>, int,
               Pointer<Pointer<Utf8>>)>('rac_voice_agent_transcribe');
 
   static late final int Function(
-          RacVoiceAgentHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>)
+          RacHandle, Pointer<Utf8>, Pointer<Pointer<Utf8>>)
       voiceAgentGenerateResponse = _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          Int32 Function(RacHandle, Pointer<Utf8>,
               Pointer<Pointer<Utf8>>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          int Function(RacHandle, Pointer<Utf8>,
               Pointer<Pointer<Utf8>>)>('rac_voice_agent_generate_response');
 
-  static late final int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+  static late final int Function(RacHandle, Pointer<Utf8>,
           Pointer<Pointer<Void>>, Pointer<IntPtr>) voiceAgentSynthesizeSpeech =
       _lib.lookupFunction<
-          Int32 Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          Int32 Function(RacHandle, Pointer<Utf8>,
               Pointer<Pointer<Void>>, Pointer<IntPtr>),
-          int Function(RacVoiceAgentHandle, Pointer<Utf8>,
+          int Function(RacHandle, Pointer<Utf8>,
               Pointer<Pointer<Void>>, Pointer<IntPtr>)>('rac_voice_agent_synthesize_speech');
 
-  static late final int Function(RacVoiceAgentHandle) voiceAgentCleanup =
-      _lib.lookupFunction<Int32 Function(RacVoiceAgentHandle),
-          int Function(RacVoiceAgentHandle)>('rac_voice_agent_cleanup');
+  static late final int Function(RacHandle) voiceAgentCleanup =
+      _lib.lookupFunction<Int32 Function(RacHandle),
+          int Function(RacHandle)>('rac_voice_agent_cleanup');
 
-  static late final void Function(RacVoiceAgentHandle) voiceAgentDestroy =
-      _lib.lookupFunction<Void Function(RacVoiceAgentHandle),
-          void Function(RacVoiceAgentHandle)>('rac_voice_agent_destroy');
+  static late final void Function(RacHandle) voiceAgentDestroy =
+      _lib.lookupFunction<Void Function(RacHandle),
+          void Function(RacHandle)>('rac_voice_agent_destroy');
 
   static late final void Function(Pointer<Void>) racFree =
       _lib.lookupFunction<Void Function(Pointer<Void>),


### PR DESCRIPTION
Rebase of #457 onto latest main, preserving original authorship of @Reef-7 across all 12 commits.

## What this adds

Introduces `sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart` — a single `NativeFunctions` abstract class whose `static final` fields wrap every FFI symbol used by the Flutter bridge (LLM, STT, TTS, VAD, VoiceAgent). Dart lazy-initializes each `static final`, so every `DynamicLibrary.lookupFunction` / `dlsym` runs **at most once** per symbol per process (per isolate for background isolates), and every subsequent call through the bridge is a direct function-pointer invocation.

All five bridge files (`dart_bridge_llm`, `dart_bridge_stt`, `dart_bridge_tts`, `dart_bridge_vad`, `dart_bridge_voice_agent`) are migrated to call `NativeFunctions.*` instead of doing inline `lib.lookupFunction` calls per invocation.

## Concrete value vs. current main

1. **Avoids redundant dlsym per call.** Previously, every bridge method (`isLoaded`, `loadModel`, `generate`, `transcribe`, `synthesize`, …) re-invoked `PlatformLoader.loadCommons()` and `lib.lookupFunction(...)` **on every call**. For a voice agent, that means dozens of `dlsym` lookups per voice turn. Now it's one lookup per symbol, total.
2. **Removes per-call allocation of `PlatformLoader.loadCommons()` indirection.** Centralized `_lib` static.
3. **Consistent, typed registry.** Every native symbol lives in one place with its Dart/Native signature — makes signature drift vs. the C headers visible in a single file instead of scattered across five.
4. **Fixes a voice-agent initialization race** (`dart_bridge_voice_agent.dart`): `getHandle()` previously could double-initialize under concurrent first-call paths. Now wrapped in a `Completer<RacHandle>`-based `_initFuture` guard — concurrent callers await the same completion.
5. **Adds `_safeRacFree(Pointer<Void>)`** — a null-safe wrapper that tolerates the `rac_free` symbol being unavailable on older commons builds. Stops cleanup paths from crashing when the symbol is missing.
6. **Plugs pre-existing FFI memory leaks** in `transcribeAudio` and `generateResponse` (flagged by review). Result pointers are now freed in `finally` through `_safeRacFree`.
7. **Isolate safety preserved.** `processVoiceTurn`, `transcribe`, `synthesize` run in `Isolate.run(...)` and can't access main-isolate statics — they intentionally keep file-level top-level `static` lookups so each isolate initializes its own cache once per spawn.
8. **Tightens FFI signatures** to match the C structs exactly for STT/TTS (later commits in the series), removing redundant casts and deduplicating duplicate struct declarations.

No behavioral changes to public SDK surface — pure internal refactor + bug fixes.

## Known review items NOT addressed (preserved as-is from original PR)

Preserving the original commits means these Greptile-flagged items carry over:

- **Circular import**: `native_functions.dart` imports `dart_bridge_vad.dart` for `RacVadResultStruct`, which imports `native_functions.dart`. Dart resolves this without runtime error but it is a code smell. Clean fix: move `RacVadResultStruct` into `ffi_types.dart` — can be done as a follow-up.
- **Dead code**: `NativeFunctions.sttResultFree` is declared but never called (the STT isolate still does its own inline lookup for `rac_stt_result_free`). Harmless due to Dart's lazy `static final` init (the lookup never fires), but worth wiring up or removing.

## Commits (author preserved)

All 12 commits authored by @Reef-7 cherry-picked cleanly on top of current `main` (no conflicts).

## Test plan
- [ ] `cd sdk/runanywhere-flutter && dart analyze` — zero issues
- [ ] Run Flutter example app, exercise LLM generate, STT transcribe, TTS synthesize, VAD stream, and full voice agent turn
- [ ] Verify no regressions in isolate-spawned paths (voice agent `processVoiceTurn`)
- [ ] Verify graceful behavior when `rac_free` symbol is absent (older commons build)
- [ ] Decide follow-up for the two review items above (circular import + dead code)

Original PR: #457 (closed without merge on 2026-04-14)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized native bindings for core audio/ML components to reduce repeated native lookups.

* **Bug Fixes**
  * Deduplicated handle initialization to avoid concurrent-init races and improved isolate-safe processing.

* **New Features / Behavior**
  * Model-loaded events now emit a typed component identifier (stt/llm/tts).
  * VAD results include richer fields (speech flag, energy, speech probability).

* **Chores**
  * Safer native memory handling and clearer model-load debug logging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR centralizes all FFI symbol lookups into a single `NativeFunctions` abstract class, eliminating redundant `dlsym` calls on every bridge invocation across the LLM, STT, TTS, VAD, and VoiceAgent bridges. It also fixes a double-initialization race in `getHandle()` via a `Completer`-based future guard, plugs pre-existing memory leaks in `transcribeAudio` and `generateResponse` with `_safeRacFree`, and adds a null-safe wrapper for the optional `rac_free` symbol.

The two known issues (circular import between `native_functions.dart` and `dart_bridge_vad.dart`, and the dead `sttResultFree` field) are transparently disclosed and deferred to follow-up.

<h3>Confidence Score: 5/5</h3>

Safe to merge — all findings are P2 style/consistency items; the race fix, memory leak fixes, and caching logic are correct.

No P0 or P1 issues found. The Completer-based race guard in getHandle() is sound, _safeRacFree correctly handles nullable pointers and proper free ordering in finally blocks, and the isolate-scoped top-level statics preserve per-isolate safety. Remaining items — the sttResultFree non-nullable inconsistency, raw string component literals, and the two acknowledged issues (circular import, dead sttResultFree) — are all P2 cleanup that do not affect correctness or runtime stability.

native_functions.dart (sttResultFree nullable inconsistency) and dart_bridge_voice_agent.dart (raw component strings, clarifying comment on _initFuture clear)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart | New registry of cached FFI lookups; `sttResultFree` is non-nullable unlike the null-safe `racFree` pattern, and the circular import with `dart_bridge_vad.dart` is acknowledged but unresolved. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart | Race fix via Completer guard is correct; memory leaks plugged with _safeRacFree in finally blocks; isolate-scoped FFI caches properly separated as top-level statics; component event strings should be enum-typed per codebase style. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_stt.dart | Migrated all main-isolate bridge calls to NativeFunctions; _transcribeInIsolate retains inline lookups (intentional for per-isolate safety); NativeFunctions.sttResultFree is dead code here. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_llm.dart | All main-isolate lookups migrated to NativeFunctions; isolate-spawned _streamingIsolateEntry and _generateInIsolate retain inline lookups as required (PlatformLoader import still needed for these). |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_tts.dart | Clean migration to NativeFunctions with no issues identified. |
| sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_vad.dart | Clean migration to NativeFunctions; RacVadResultStruct still lives here (causing the circular import with native_functions.dart), acknowledged for follow-up. |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Caller as Caller (main isolate)
    participant VA as DartBridgeVoiceAgent
    participant NF as NativeFunctions (cached)
    participant Iso as Background Isolate
    participant C as C++ RACommons

    Note over NF: _lib = PlatformLoader.loadCommons() (lazy, once per isolate)

    Caller->>VA: getHandle()
    alt _handle already set
        VA-->>Caller: return _handle
    else first call — race protection
        VA->>VA: create Completer, set _initFuture
        VA->>NF: voiceAgentCreate(llm, stt, tts, vad, handlePtr)
        NF->>C: rac_voice_agent_create() [cached lookup]
        C-->>NF: result
        NF-->>VA: result
        VA->>VA: _handle = handlePtr.value
        VA->>VA: completer.complete(_handle!)
        VA->>VA: _initFuture = null
        VA-->>Caller: return _handle
    end

    Caller->>VA: processVoiceTurn(audioData)
    VA->>VA: isReady check via NF.voiceAgentIsReady
    VA->>Iso: Isolate.run(_processVoiceTurnInIsolate)
    Note over Iso: Initializes _voiceAgentLib & _processVoiceTurnFn (top-level statics, once per isolate)
    Iso->>C: rac_voice_agent_process_voice_turn()
    C-->>Iso: RacVoiceAgentResultStruct
    Iso->>Iso: _parseVoiceTurnResultStatic (copy to Dart)
    Iso->>C: rac_voice_agent_result_free() (free C strings/audio)
    Iso-->>Caller: VoiceTurnResult
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart`, line 217 ([link](https://github.com/runanywhereai/runanywhere-sdks/blob/a0c25aa1712da90e402b543236a78ed0bdf49782/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart#L217)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **Raw strings for `component` — prefer a typed enum**

   `VoiceAgentModelLoadedEvent` accepts `component` as a plain `String`, and the three call sites use the literals `'stt'`, `'llm'`, and `'tts'`. Per the project's CLAUDE.md style guide ("never use strings directly so that we can keep things consistent and scalable"), this field should be an enum. A typo or new component added with a different casing would be silently accepted by the type system.

   Consider:
   ```dart
   enum VoiceAgentComponent { stt, llm, tts }

   class VoiceAgentModelLoadedEvent extends VoiceAgentEvent {
     final VoiceAgentComponent component;
     const VoiceAgentModelLoadedEvent({required this.component});
   }
   ```
   Then the call sites become `VoiceAgentModelLoadedEvent(component: VoiceAgentComponent.stt)`, etc. The same pattern applies to the other two dispatch sites (`loadLLMModel` and `loadTTSVoice`).

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
   Line: 217

   Comment:
   **Raw strings for `component` — prefer a typed enum**

   `VoiceAgentModelLoadedEvent` accepts `component` as a plain `String`, and the three call sites use the literals `'stt'`, `'llm'`, and `'tts'`. Per the project's CLAUDE.md style guide ("never use strings directly so that we can keep things consistent and scalable"), this field should be an enum. A typo or new component added with a different casing would be silently accepted by the type system.

   Consider:
   ```dart
   enum VoiceAgentComponent { stt, llm, tts }

   class VoiceAgentModelLoadedEvent extends VoiceAgentEvent {
     final VoiceAgentComponent component;
     const VoiceAgentModelLoadedEvent({required this.component});
   }
   ```
   Then the call sites become `VoiceAgentModelLoadedEvent(component: VoiceAgentComponent.stt)`, etc. The same pattern applies to the other two dispatch sites (`loadLLMModel` and `loadTTSVoice`).

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

   Note: If this suggestion doesn't match your team's coding style, reply to this and let me know. I'll remember it for next time!

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: sdk/runanywhere-flutter/packages/runanywhere/lib/native/native_functions.dart
Line: 90-92

Comment:
**`sttResultFree` should be nullable like `racFree`**

`sttResultFree` is declared as a non-nullable `void Function(...)`, so if `rac_stt_result_free` is absent in an older commons build, `lookupFunction` throws the moment this field is first accessed. Compare this to `racFree` (lines 299–306) which wraps the lookup in a try-catch and returns `null` on failure. Since the PR description flags this field as a follow-up target to wire up or remove, it should use the same null-safe pattern now to avoid a surprise crash when someone does wire it up against an older build.

```suggestion
  static final void Function(Pointer<RacSttResultStruct>)? sttResultFree =
      (() {
    try {
      return _lib.lookupFunction<Void Function(Pointer<RacSttResultStruct>),
          void Function(Pointer<RacSttResultStruct>)>('rac_stt_result_free');
    } catch (_) {
      return null;
    }
  })();
```

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
Line: 217

Comment:
**Raw strings for `component` — prefer a typed enum**

`VoiceAgentModelLoadedEvent` accepts `component` as a plain `String`, and the three call sites use the literals `'stt'`, `'llm'`, and `'tts'`. Per the project's CLAUDE.md style guide ("never use strings directly so that we can keep things consistent and scalable"), this field should be an enum. A typo or new component added with a different casing would be silently accepted by the type system.

Consider:
```dart
enum VoiceAgentComponent { stt, llm, tts }

class VoiceAgentModelLoadedEvent extends VoiceAgentEvent {
  final VoiceAgentComponent component;
  const VoiceAgentModelLoadedEvent({required this.component});
}
```
Then the call sites become `VoiceAgentModelLoadedEvent(component: VoiceAgentComponent.stt)`, etc. The same pattern applies to the other two dispatch sites (`loadLLMModel` and `loadTTSVoice`).

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_voice_agent.dart
Line: 109

Comment:
**`_initFuture` cleared before success-path callers resume**

After `completer.complete(_handle!)`, pending awaiters are scheduled as microtasks but have not yet resumed. The very next line sets `_initFuture = null`. A brand-new caller arriving between those two synchronous statements is impossible in Dart's single-threaded model, but any *concurrent* caller that already holds a reference to `completer.future` is fine — it doesn't re-read `_initFuture`. The logic is correct, but is worth a clarifying comment for future readers.

```suggestion
        _handle = handlePtr.value;
        completer.complete(_handle!);
        // Clear _initFuture *after* completing the completer so that
        // concurrent callers that already hold a reference to completer.future
        // receive the value normally. New callers arriving after this line
        // will hit the `_handle != null` fast path.
        _initFuture = null;
        return _handle!;
```

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["Address review feedback from original PR..."](https://github.com/runanywhereai/runanywhere-sdks/commit/a0c25aa1712da90e402b543236a78ed0bdf49782) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28404407)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->