### PR TITLE
fix(spm): sync Package.swift checksums to v0.19.13 binaries

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -335,17 +335,17 @@ func binaryTargets() -> [Target] {
             .binaryTarget(
                 name: "RACommonsBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RACommons-ios-v\(sdkVersion).zip",
-                checksum: "189bcf6cf844d1df1ce51ebdf396f7b7ec24aeb5c9c3965e70c5e3851a0d8fb3"
+                checksum: "a1caaf12186c896b49bfccc7348a71c3b3428b282e5ac3f5a3181a022b5401da"
             ),
             .binaryTarget(
                 name: "RABackendLlamaCPPBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RABackendLLAMACPP-ios-v\(sdkVersion).zip",
-                checksum: "283632cd5fc8c76bbafc42a0dcfbd8a2039591e022c33eadf18fcab336ec006c"
+                checksum: "7ff978fbc87726423c682298f04354c7c11dfbfe9403b51f63d49df9c92e097a"
             ),
             .binaryTarget(
                 name: "RABackendONNXBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RABackendONNX-ios-v\(sdkVersion).zip",
-                checksum: "64404b1b53f82399a9053a323d05b22c6a9e153d7ecefc25f9d9e67d67996a53"
+                checksum: "0f8575559ac96a9a7b872bb3adca3608acef38fdec1ab8ccf9b0716a8d627c6c"
             ),
         ]
 


### PR DESCRIPTION
Post-release follow-up: update Package.swift on main with v0.19.13's actual binary checksums so CodeQL Swift autobuild on main passes.

No version bump (no new release). Consumers pinning to `from: "0.19.13"` still see stale checksums on the tag itself; they'd need v0.19.14+ or pin to branch main.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated binary component checksums to ensure integrity and compatibility of production dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR updates the three binary target checksums in `Package.swift` on `main` to match the actual v0.19.13 release artifacts, fixing CodeQL Swift autobuild failures on `main`. No other logic is changed.

- **P1 — tag not updated**: The `v0.19.13` tag was published with stale checksums and is not being patched here. Consumers using the standard `from: "0.19.13"` SPM constraint will continue to hit checksum-mismatch failures until a `v0.19.14` patch release is cut. The PR description documents this limitation, but it means the published, advertised release tag remains broken for all external consumers.

<h3>Confidence Score: 4/5</h3>

Safe to merge for the stated goal (fix CodeQL on main), but the v0.19.13 tag remains broken for external SPM consumers until a patch release is cut.

The change itself is correct — checksums on main now match the published binaries. Score is 4 rather than 5 because the P1 finding (broken published tag) represents a real, current defect affecting external consumers, even though it predates this PR. A follow-up v0.19.14 patch release is needed.

Package.swift — the remote binary URL checksums and the acknowledged discrepancy between main and the v0.19.13 tag.

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| Package.swift | Checksums updated on main to match v0.19.13 release binaries, but the v0.19.13 tag itself remains stale — SPM consumers using `from: "0.19.13"` will still see checksum failures. |

</details>



<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `Package.swift`, line 11-12 ([link](https://github.com/runanywhereai/runanywhere-sdks/blob/3ebae86014588d8c06a548540c6c14aeb017de1d/Package.swift#L11-L12)) 

   <a href="#"><img alt="P1" src="https://greptile-static-assets.s3.amazonaws.com/badges/p1.svg?v=7" align="top"></a> **Tag not updated — SPM consumers broken on v0.19.13**

   The PR description acknowledges that the `v0.19.13` tag still has the stale checksums, so any consumer using `from: "0.19.13"` (the typical SPM pattern) will continue to get checksum-mismatch errors at resolution time. The fix on `main` only benefits CodeQL and consumers who explicitly pin `main`. Unless a `v0.19.14` patch release is cut soon, this leaves the published tag in a permanently broken state — the comment in line 12 of the README still advertises `from: "0.17.0"` but the actual latest tag is not consumable. Consider cutting a `v0.19.14` patch that carries these corrected checksums so the tag itself is usable.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: Package.swift
   Line: 11-12

   Comment:
   **Tag not updated — SPM consumers broken on v0.19.13**

   The PR description acknowledges that the `v0.19.13` tag still has the stale checksums, so any consumer using `from: "0.19.13"` (the typical SPM pattern) will continue to get checksum-mismatch errors at resolution time. The fix on `main` only benefits CodeQL and consumers who explicitly pin `main`. Unless a `v0.19.14` patch release is cut soon, this leaves the published tag in a permanently broken state — the comment in line 12 of the README still advertises `from: "0.17.0"` but the actual latest tag is not consumable. Consider cutting a `v0.19.14` patch that carries these corrected checksums so the tag itself is usable.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
This is a comment left during a code review.
Path: Package.swift
Line: 11-12

Comment:
**Tag not updated — SPM consumers broken on v0.19.13**

The PR description acknowledges that the `v0.19.13` tag still has the stale checksums, so any consumer using `from: "0.19.13"` (the typical SPM pattern) will continue to get checksum-mismatch errors at resolution time. The fix on `main` only benefits CodeQL and consumers who explicitly pin `main`. Unless a `v0.19.14` patch release is cut soon, this leaves the published tag in a permanently broken state — the comment in line 12 of the README still advertises `from: "0.17.0"` but the actual latest tag is not consumable. Consider cutting a `v0.19.14` patch that carries these corrected checksums so the tag itself is usable.

How can I resolve this? If you propose a fix, please make it concise.

---

This is a comment left during a code review.
Path: Package.swift
Line: 336-349

Comment:
**Binary artifact URLs labeled `-ios-` despite containing macOS slices**

The comment on line 332 says "All xcframeworks include iOS + macOS slices (v0.19.0+)", yet the release asset URLs all use the `-ios-` infix (e.g. `RACommons-ios-v0.19.13.zip`). If these zips genuinely contain multi-platform xcframeworks, the naming is misleading and could cause confusion for future maintainers. No code action needed if the names match what is actually published on the release, but worth verifying/documenting why the `-ios-` naming is retained.

How can I resolve this? If you propose a fix, please make it concise.
`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(spm): sync Package.swift checksums t..."](https://github.com/runanywhereai/runanywhere-sdks/commit/3ebae86014588d8c06a548540c6c14aeb017de1d) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=28966718)</sub>

> Greptile also left **1 inline comment** on this PR.

<!-- /greptile_comment -->