### PR TITLE
Android Kotlin SDK + example app: VLM/voice/STT/TTS fixes

### DIFF
--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ConversationStore.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ConversationStore.kt
@@ -244,8 +244,20 @@ class ConversationStore private constructor(context: Context) {
                     }
                 }
 
+            // Drop empty conversations — they accumulate from "tap Get Started
+            // → exit before sending" flows and clutter the history sheet with
+            // "0 messages" rows. Delete their on-disk files too so they don't
+            // come back next launch.
+            val (keep, drop) = loaded.partition { it.messages.isNotEmpty() }
+            drop.forEach { conv ->
+                runCatching { conversationFileURL(conv.id).delete() }
+            }
+            if (drop.isNotEmpty()) {
+                Timber.i("Pruned ${drop.size} empty conversation(s)")
+            }
+
             // Sort by update date, newest first
-            _conversations.value = loaded.sortedByDescending { it.updatedAt }
+            _conversations.value = keep.sortedByDescending { it.updatedAt }
 
             // Don't automatically set current conversation - let ChatViewModel create a new one
         } catch (e: Exception) {

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/chat/ChatScreen.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/chat/ChatScreen.kt
@@ -218,6 +218,7 @@ fun ChatScreen(
                     value = uiState.currentInput,
                     onValueChange = viewModel::updateInput,
                     onSend = viewModel::sendMessage,
+                    onStop = viewModel::stopGeneration,
                     isGenerating = uiState.isGenerating,
                     isModelLoaded = true,
                 )
@@ -1283,6 +1284,7 @@ fun ChatInputView(
     value: String,
     onValueChange: (String) -> Unit,
     onSend: () -> Unit,
+    onStop: () -> Unit,
     isGenerating: Boolean,
     isModelLoaded: Boolean,
 ) {
@@ -1331,17 +1333,18 @@ fun ChatInputView(
             maxLines = 4,
         )
 
-        // Send button -  arrow.up.circle.fill 28pt
+        // Send / Stop button - swaps to a stop icon while generating so the user
+        // can cancel mid-stream (calls RunAnywhere.cancelGeneration via ViewModel).
         IconButton(
-            onClick = onSend,
-            enabled = canSendMessage,
+            onClick = if (isGenerating) onStop else onSend,
+            enabled = if (isGenerating) true else canSendMessage,
             modifier = Modifier.size(Dimensions.buttonHeightRegular),
         ) {
             Icon(
-                imageVector = Icons.Filled.ArrowCircleUp,
-                contentDescription = "Send",
+                imageVector = if (isGenerating) Icons.Filled.StopCircle else Icons.Filled.ArrowCircleUp,
+                contentDescription = if (isGenerating) "Stop" else "Send",
                 tint =
-                    if (canSendMessage) {
+                    if (isGenerating || canSendMessage) {
                         AppColors.primaryAccent
                     } else {
                         AppColors.statusGray

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/models/ModelSelectionViewModel.kt
@@ -325,6 +325,9 @@ class ModelSelectionViewModel(
                     selectedModelId = modelId,
                     isLoadingModel = true,
                     loadingProgress = "Loading model into memory...",
+                    // Clear any stale error from a prior attempt so the success path doesn't
+                    // surface an outdated "Failed to load" dialog.
+                    error = null,
                 )
             }
 

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsScreen.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/settings/SettingsScreen.kt
@@ -263,7 +263,7 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel()) {
         ) {
             StorageOverviewRow(
                 icon = Icons.Filled.Storage,
-                label = "Total Usage",
+                label = "Device Capacity",
                 value = Formatter.formatFileSize(context, uiState.totalStorageSize),
             )
             HorizontalDivider(modifier = Modifier.padding(vertical = 4.dp))
@@ -375,7 +375,7 @@ fun SettingsScreen(viewModel: SettingsViewModel = viewModel()) {
                         color = MaterialTheme.colorScheme.onSurface,
                     )
                     Text(
-                        text = "Version 0.1",
+                        text = "Version ${com.runanywhere.runanywhereai.BuildConfig.VERSION_NAME}",
                         style = AppTypography.caption,
                         color = MaterialTheme.colorScheme.onSurfaceVariant,
                     )

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/tts/TextToSpeechViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/tts/TextToSpeechViewModel.kt
@@ -23,6 +23,7 @@ import com.runanywhere.sdk.public.extensions.synthesize
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
+import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -116,6 +117,9 @@ data class TTSUiState(
     val audioDuration: Double? = null,
     val audioSize: Int? = null,
     val sampleRate: Int? = null,
+    // Backend-reported PCM encoding. Sherpa-Piper emits AUDIO_FORMAT_PCM
+    // which is float32 by SDK convention; AUDIO_FORMAT_PCM_S16LE is int16.
+    val audioFormat: ai.runanywhere.proto.v1.AudioFormat? = null,
     val playbackProgress: Double = 0.0,
     val currentTime: Double = 0.0,
     val errorMessage: String? = null,
@@ -403,12 +407,13 @@ class TextToSpeechViewModel(
                                 audioDuration = (result.duration_ms / 1000.0),
                                 audioSize = null,
                                 sampleRate = null,
+                                audioFormat = null,
                                 processingTimeMs = processingTime,
                             )
                         }
                     } else {
                         // ONNX/Piper TTS returns audio data for playback
-                        Timber.i("✅ Speech generation complete: ${result.audio_data.toByteArray().size} bytes, duration: ${(result.duration_ms / 1000.0)}s")
+                        Timber.i("✅ Speech generation complete: ${result.audio_data.toByteArray().size} bytes, duration: ${(result.duration_ms / 1000.0)}s, format=${result.audio_format}, sampleRate=${result.sample_rate}")
 
                         generatedAudioData = result.audio_data.toByteArray()
 
@@ -419,7 +424,8 @@ class TextToSpeechViewModel(
                                 hasGeneratedAudio = true,
                                 audioDuration = (result.duration_ms / 1000.0),
                                 audioSize = result.audio_data.toByteArray().size,
-                                sampleRate = null,
+                                sampleRate = result.sample_rate.takeIf { sr -> sr > 0 },
+                                audioFormat = result.audio_format,
                                 processingTimeMs = processingTime,
                             )
                         }
@@ -510,7 +516,20 @@ class TextToSpeechViewModel(
                     }
 
                     val channelConfig = AudioFormat.CHANNEL_OUT_MONO
-                    val audioFormat = AudioFormat.ENCODING_PCM_16BIT
+
+                    // Resolve PCM encoding from the SDK-supplied format.
+                    // Sherpa-Piper emits AUDIO_FORMAT_PCM (= float32 by SDK
+                    // convention; see estimate_pcm_f32_duration_ms in C++
+                    // tts_component.cpp). AUDIO_FORMAT_PCM_S16LE is int16.
+                    // WAV-wrapped output is always int16 by the WAV spec used
+                    // here. Anything else falls back to int16.
+                    val protoFmt = _uiState.value.audioFormat
+                    val isFloat32 = !isWav &&
+                        protoFmt == ai.runanywhere.proto.v1.AudioFormat.AUDIO_FORMAT_PCM
+                    val audioFormat =
+                        if (isFloat32) AudioFormat.ENCODING_PCM_FLOAT
+                        else AudioFormat.ENCODING_PCM_16BIT
+                    Timber.i("Playback encoding=${if (isFloat32) "FLOAT32" else "PCM16"} sampleRate=$sampleRate isWav=$isWav protoFmt=$protoFmt")
 
                     val pcmData = audioData.copyOfRange(pcmOffset, audioData.size)
 
@@ -535,11 +554,26 @@ class TextToSpeechViewModel(
                             .setTransferMode(AudioTrack.MODE_STATIC)
                             .build()
 
-                    audioTrack?.write(pcmData, 0, pcmData.size)
+                    if (isFloat32) {
+                        // Decode little-endian float32 stream into a FloatArray
+                        // because AudioTrack.write(byte[]) doesn't accept
+                        // ENCODING_PCM_FLOAT — it requires the float[] overload.
+                        val byteBuffer = java.nio.ByteBuffer.wrap(pcmData)
+                            .order(java.nio.ByteOrder.LITTLE_ENDIAN)
+                        val floatCount = pcmData.size / 4
+                        val floatBuf = FloatArray(floatCount)
+                        byteBuffer.asFloatBuffer().get(floatBuf)
+                        audioTrack?.write(floatBuf, 0, floatCount, AudioTrack.WRITE_BLOCKING)
+                    } else {
+                        audioTrack?.write(pcmData, 0, pcmData.size)
+                    }
                     audioTrack?.play()
 
                     // Track playback progress (matches iOS timer pattern)
-                    val duration = _uiState.value.audioDuration ?: (pcmData.size.toDouble() / (sampleRate * 2))
+                    // Bytes-per-sample is 4 for float32 PCM, 2 for int16 PCM.
+                    val bytesPerSample = if (isFloat32) 4 else 2
+                    val duration = _uiState.value.audioDuration
+                        ?: (pcmData.size.toDouble() / (sampleRate * bytesPerSample))
                     var currentTime = 0.0
 
                     while (_uiState.value.isPlaying && audioTrack?.playState == AudioTrack.PLAYSTATE_PLAYING) {
@@ -561,13 +595,23 @@ class TextToSpeechViewModel(
                         }
                     }
 
-                    // Playback finished - stop and reset state
-                    withContext(Dispatchers.Main) {
+                    // Playback finished - stop and reset state.
+                    // NonCancellable wrapper prevents the natural-completion
+                    // call to stopPlayback() (which cancels playbackJob) from
+                    // throwing CancellationException at us mid-cleanup.
+                    withContext(NonCancellable + Dispatchers.Main) {
                         stopPlayback()
                     }
+                } catch (e: kotlinx.coroutines.CancellationException) {
+                    // Playback was cancelled (either via Stop button or via
+                    // the natural-completion path which calls
+                    // playbackJob?.cancel()). Audio already played to
+                    // completion; don't surface a red error.
+                    Timber.d("Playback coroutine cancelled (normal stop or natural end)")
+                    throw e
                 } catch (e: Exception) {
                     Timber.e(e, "Playback error: ${e.message}")
-                    withContext(Dispatchers.Main) {
+                    withContext(NonCancellable + Dispatchers.Main) {
                         _uiState.update {
                             it.copy(
                                 isPlaying = false,

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/foundation/bridge/extensions/CppBridgeModalityProto.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/foundation/bridge/extensions/CppBridgeModalityProto.kt
@@ -258,11 +258,40 @@ object CppBridgeVLMProto {
     @Synchronized
     fun loadModelById(modelId: String): Int {
         destroy()
+
+        // Resolve model + mmproj paths from registry. The C++ service path
+        // (rac_vlm_create + rac_vlm_initialize) requires explicit file paths;
+        // only the component lifecycle resolves them automatically. Mirror
+        // rac_vlm_component_load_model_by_id's behaviour here so the proto
+        // streaming bridge actually loads weights into the llama.cpp context.
+        val info = CppBridgeModelRegistry.get(modelId)
+            ?: return RunAnywhereBridge.RAC_ERROR_NOT_FOUND
+        val localPath = info.local_path.takeIf { it.isNotBlank() }
+            ?: return RunAnywhereBridge.RAC_ERROR_NOT_FOUND
+        val (modelPath, mmprojPath) = resolveVlmModelFiles(localPath)
+            ?: return RunAnywhereBridge.RAC_ERROR_NOT_FOUND
+
         val serviceHandle = RunAnywhereBridge.racVlmCreate(modelId)
         if (serviceHandle == 0L) return RunAnywhereBridge.RAC_ERROR_OPERATION_FAILED
+        val rc = RunAnywhereBridge.racVlmInitialize(serviceHandle, modelPath, mmprojPath)
+        if (rc != RunAnywhereBridge.RAC_SUCCESS) {
+            RunAnywhereBridge.racVlmDestroy(serviceHandle)
+            return rc
+        }
         handle = serviceHandle
         loadedModelId = modelId
         return RunAnywhereBridge.RAC_SUCCESS
+    }
+
+    private fun resolveVlmModelFiles(localPath: String): Pair<String, String?>? {
+        val file = java.io.File(localPath)
+        val dir = if (file.isDirectory) file else file.parentFile ?: return null
+        val ggufFiles = dir.listFiles { f -> f.isFile && f.name.endsWith(".gguf") }
+            ?.toList().orEmpty()
+        if (ggufFiles.isEmpty()) return null
+        val mmproj = ggufFiles.firstOrNull { it.name.startsWith("mmproj", ignoreCase = true) }
+        val model = ggufFiles.firstOrNull { it != mmproj } ?: return null
+        return model.absolutePath to mmproj?.absolutePath
     }
 
     @Synchronized
@@ -555,10 +584,19 @@ object CppBridgeVoiceAgentProto {
             "racVoiceAgentComponentStatesProto",
         )
 
-    fun processVoiceTurn(handle: Long, audioData: ByteArray): VoiceAgentResult =
-        decodeOrThrow(
-            VoiceAgentResult.ADAPTER,
-            RunAnywhereBridge.racVoiceAgentProcessVoiceTurnProto(handle, audioData),
-            "racVoiceAgentProcessVoiceTurnProto",
-        )
+    // Silent / no-speech audio causes the C++ voice-agent to skip the STT→LLM
+    // →TTS pipeline and return null bytes. That isn't an error — there's just
+    // nothing to say back. Map null to an empty VoiceAgentResult so callers
+    // can treat the "no speech detected" UX without catching SDKException.
+    fun processVoiceTurn(handle: Long, audioData: ByteArray): VoiceAgentResult {
+        val bytes = RunAnywhereBridge.racVoiceAgentProcessVoiceTurnProto(handle, audioData)
+            ?: return VoiceAgentResult()
+        return try {
+            VoiceAgentResult.ADAPTER.decode(bytes)
+        } catch (e: Exception) {
+            throw SDKException.operation(
+                "Failed to decode racVoiceAgentProcessVoiceTurnProto result: ${e.message}",
+            )
+        }
+    }
 }

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt
@@ -33,7 +33,9 @@ import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeEvents
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeModelLifecycleProto
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeModelPaths
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeModelRegistry
+import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeSTT
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeStorage
+import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeTTS
 import com.runanywhere.sdk.foundation.errors.SDKException
 import com.runanywhere.sdk.native.bridge.RunAnywhereBridge
 import com.runanywhere.sdk.public.RunAnywhere
@@ -930,8 +932,33 @@ private suspend fun extractArchive(
 
         val finalPath =
             if (expectedModelDir.exists() && expectedModelDir.isDirectory) {
-                // Standard case: archive root folder name matches modelId
-                expectedModelDir.absolutePath
+                // Standard case: archive root folder name matches modelId.
+                // If `parentDir` is itself the per-model directory (parentDir.name == modelId),
+                // the extracted folder ends up nested as `parentDir/modelId/<files>`. The
+                // C++ filesystem-scan only resolves models to `parentDir` (the modelId-named
+                // dir it knows about), not the nested duplicate, so STT/TTS load fails after
+                // a cold start. Flatten by hoisting the inner files up one level so the
+                // model lives directly under the modelId-named folder.
+                if (parentDir.name == modelId) {
+                    val innerFiles = expectedModelDir.listFiles()?.toList().orEmpty()
+                    var hoisted = 0
+                    innerFiles.forEach { f ->
+                        val dest = File(parentDir, f.name)
+                        if (dest.exists()) {
+                            if (dest.isDirectory) dest.deleteRecursively() else dest.delete()
+                        }
+                        if (!f.renameTo(dest)) {
+                            f.copyRecursively(dest, overwrite = true)
+                            if (f.isDirectory) f.deleteRecursively() else f.delete()
+                        }
+                        hoisted++
+                    }
+                    expectedModelDir.delete()
+                    logger.info("Flattened nested extraction: hoisted $hoisted entries up into '${parentDir.absolutePath}'")
+                    parentDir.absolutePath
+                } else {
+                    expectedModelDir.absolutePath
+                }
             } else if (newDirs.size == 1 && newFiles.isEmpty()) {
                 // Archive had a single root directory with a different name (e.g. Genie NPU
                 // tar.gz containing "llama_v3_2_1b_instruct-genie-w4-qualcomm_snapdragon_8_elite/").
@@ -1197,6 +1224,18 @@ actual suspend fun RunAnywhere.loadSTTModel(modelId: String) {
     if (!result.success) {
         throw SDKException.stt(
             result.error_message.ifBlank { "Failed to load STT model '$modelId' from $localPath" },
+        )
+    }
+    // Lifecycle and the standalone STT component bridge maintain separate
+    // backend impls. The proto-canonical `transcribe` path (CppBridgeSTTProto
+    // → racSttComponentTranscribeProto) reads from the standalone bridge's
+    // handle, so the lifecycle load above leaves it empty and synth fails
+    // with "STT model is not loaded". Mirror the load into the standalone
+    // bridge so transcribe can use it.
+    val bridgeRc = CppBridgeSTT.loadModel(localPath, modelId, model.name)
+    if (bridgeRc != 0) {
+        throw SDKException.stt(
+            "Failed to load STT model into standalone bridge: $modelId (rc=$bridgeRc)",
         )
     }
 }

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+STT.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+STT.jvmAndroid.kt
@@ -18,6 +18,7 @@ import ai.runanywhere.proto.v1.STTPartialResult
 import ai.runanywhere.proto.v1.ModelCategory as ProtoModelCategory
 import com.runanywhere.sdk.foundation.SDKLogger
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeModelLifecycleProto
+import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeSTT
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeSTTProto
 import com.runanywhere.sdk.foundation.errors.SDKException
 import com.runanywhere.sdk.public.RunAnywhere
@@ -44,6 +45,11 @@ actual suspend fun RunAnywhere.unloadSTTModel() {
     CppBridgeModelLifecycleProto.unload(
         ModelUnloadRequest(category = ProtoModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION),
     ) ?: throw SDKException.stt("Native model lifecycle unload proto API unavailable")
+    // Release the parallel standalone bridge instance loaded by loadSTTModel
+    // (see RunAnywhere+ModelManagement.jvmAndroid.kt).
+    if (CppBridgeSTT.isLoaded) {
+        CppBridgeSTT.unload()
+    }
 }
 
 actual val RunAnywhere.isSTTModelLoaded: Boolean

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+TTS.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+TTS.jvmAndroid.kt
@@ -23,6 +23,7 @@ import com.runanywhere.sdk.features.tts.TtsAudioPlayback
 import com.runanywhere.sdk.foundation.SDKLogger
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeModelLifecycleProto
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeModelRegistry
+import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeTTS
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeTTSProto
 import com.runanywhere.sdk.foundation.errors.SDKException
 import com.runanywhere.sdk.public.RunAnywhere
@@ -62,6 +63,17 @@ actual suspend fun RunAnywhere.loadTTSModel(modelId: String) {
             result.error_message.ifBlank { "Failed to load TTS model '$modelId' from $localPath" },
         )
     }
+    // Lifecycle and the standalone TTS component bridge maintain separate
+    // backend impls. The proto-canonical `synthesize` path
+    // (CppBridgeTTSProto → racTtsComponentSynthesizeProto) reads from the
+    // standalone bridge's handle; without this mirror the call returns null
+    // because no model is loaded into that handle.
+    val bridgeRc = CppBridgeTTS.loadModel(localPath, modelId, modelInfo.name)
+    if (bridgeRc != 0) {
+        throw SDKException.tts(
+            "Failed to load TTS model into standalone bridge: $modelId (rc=$bridgeRc)",
+        )
+    }
     ttsLogger.info("TTS model loaded: $modelId")
 }
 
@@ -70,6 +82,9 @@ actual suspend fun RunAnywhere.unloadTTSModel() {
         throw SDKException.notInitialized("SDK not initialized")
     }
     unloadModel(ModelUnloadRequest(category = ProtoModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS))
+    if (CppBridgeTTS.isLoaded) {
+        CppBridgeTTS.unload()
+    }
     ttsLogger.info("TTS model unloaded")
 }
 
@@ -101,6 +116,13 @@ actual suspend fun RunAnywhere.loadTTSVoice(voiceId: String) {
         ttsLogger.error(message)
         throw SDKException.tts(message)
     }
+    // Mirror into standalone bridge; see comment in loadTTSModel().
+    val bridgeRc = CppBridgeTTS.loadModel(localPath, voiceId, modelInfo.name)
+    if (bridgeRc != 0) {
+        throw SDKException.tts(
+            "Failed to load TTS voice into standalone bridge: $voiceId (rc=$bridgeRc)",
+        )
+    }
     ttsLogger.info("TTS voice loaded: $voiceId")
 }
 
@@ -109,6 +131,9 @@ actual suspend fun RunAnywhere.unloadTTSVoice() {
         throw SDKException.notInitialized("SDK not initialized")
     }
     unloadModel(ModelUnloadRequest(category = ProtoModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS))
+    if (CppBridgeTTS.isLoaded) {
+        CppBridgeTTS.unload()
+    }
 }
 
 actual val RunAnywhere.isTTSVoiceLoaded: Boolean

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+VisionLanguage.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+VisionLanguage.jvmAndroid.kt
@@ -8,6 +8,7 @@
 
 package com.runanywhere.sdk.public.extensions
 
+import ai.runanywhere.proto.v1.GenerationEventKind
 import ai.runanywhere.proto.v1.VLMGenerationOptions
 import ai.runanywhere.proto.v1.VLMImage
 import ai.runanywhere.proto.v1.VLMResult
@@ -23,6 +24,13 @@ import kotlinx.coroutines.flow.callbackFlow
 import kotlinx.coroutines.launch
 
 private val vlmLogger = SDKLogger("VLM")
+
+// rac_vlm_process_stream_proto bypasses the component-layer stripping done by
+// vlm_strip_special_tokens (vlm_component.cpp), so chat-template control tokens
+// like `<|im_end|>` leak into the per-token stream. Strip them here before
+// yielding to match the non-streaming `processImage` path's user-visible text.
+private val SPECIAL_TOKEN_REGEX = Regex("<\\|[^|]*\\|>")
+private fun stripSpecialTokens(token: String): String = SPECIAL_TOKEN_REGEX.replace(token, "")
 
 // MARK: - Simple API
 
@@ -89,16 +97,33 @@ actual fun RunAnywhere.processImageStream(
             throw SDKException.vlm("VLM model not loaded")
         }
 
-        // Run blocking JNI call on IO dispatcher; callbackFlow handles cancellation
+        // Mirrors Swift RunAnywhere+VisionLanguage processImageStream: parse
+        // proto generation events and yield per-token strings as they arrive
+        // so the UI can render token-by-token. Previously we discarded all
+        // events and only emitted the full result text once at completion.
+        val streamingOptions = (options ?: VLMGenerationOptions()).copy(
+            prompt = prompt,
+            streaming_enabled = true,
+        )
         val job =
             launch(Dispatchers.IO) {
                 try {
-                    val result =
-                        CppBridgeVLMProto.processStream(
-                            image,
-                            (options ?: VLMGenerationOptions()).copy(prompt = prompt),
-                        ) { true }
-                    trySend(result.text)
+                    CppBridgeVLMProto.processStream(image, streamingOptions) { event ->
+                        val gen = event.generation
+                        if (gen != null) {
+                            when (gen.kind) {
+                                GenerationEventKind.GENERATION_EVENT_KIND_FIRST_TOKEN_GENERATED,
+                                GenerationEventKind.GENERATION_EVENT_KIND_TOKEN_GENERATED -> {
+                                    val cleaned = stripSpecialTokens(gen.token)
+                                    if (cleaned.isNotEmpty()) {
+                                        trySend(cleaned)
+                                    }
+                                }
+                                else -> { /* streaming_update / completed / failed handled by final result */ }
+                            }
+                        }
+                        true
+                    }
                     close()
                 } catch (e: Exception) {
                     close(e)
@@ -127,6 +152,10 @@ actual suspend fun RunAnywhere.processImageStreamWithMetrics(
     }
 
     val resultDeferred = CompletableDeferred<VLMResult>()
+    val streamingOptions = (options ?: VLMGenerationOptions()).copy(
+        prompt = prompt,
+        streaming_enabled = true,
+    )
 
     val tokenStream =
         callbackFlow {
@@ -134,11 +163,20 @@ actual suspend fun RunAnywhere.processImageStreamWithMetrics(
                 launch(Dispatchers.IO) {
                     try {
                         val result =
-                            CppBridgeVLMProto.processStream(
-                                image,
-                                (options ?: VLMGenerationOptions()).copy(prompt = prompt),
-                            ) { true }
-                        trySend(result.text)
+                            CppBridgeVLMProto.processStream(image, streamingOptions) { event ->
+                                val gen = event.generation
+                                if (gen != null) {
+                                    when (gen.kind) {
+                                        GenerationEventKind.GENERATION_EVENT_KIND_FIRST_TOKEN_GENERATED,
+                                        GenerationEventKind.GENERATION_EVENT_KIND_TOKEN_GENERATED -> {
+                                            val cleaned = stripSpecialTokens(gen.token)
+                                            if (cleaned.isNotEmpty()) trySend(cleaned)
+                                        }
+                                        else -> { /* no-op */ }
+                                    }
+                                }
+                                true
+                            }
                         resultDeferred.complete(result)
                         close()
                     } catch (e: Exception) {

--- a/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+VoiceAgent.jvmAndroid.kt
+++ b/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+VoiceAgent.jvmAndroid.kt
@@ -57,14 +57,19 @@ private val voiceAgentLogger = SDKLogger.voiceAgent
 
 @Volatile private var voiceAgentInitialized: Boolean = false
 
-private fun areAllComponentsLoaded(): Boolean =
-    CppBridgeSTT.isLoaded && CppBridgeLLM.isLoaded && CppBridgeTTS.isLoaded
+// Mirrors iOS: per-modality load is tracked via the lifecycle-snapshot APIs
+// (CppBridgeModelLifecycleProto). Direct CppBridgeSTT/LLM/TTS.isLoaded only
+// reflects loads that went through those bridges, NOT loads dispatched via
+// the proto-backed RunAnywhere.loadSTTModel / loadLLMModel / loadTTSVoice
+// pathways the example apps use.
+private fun RunAnywhere.areAllComponentsLoadedReflectingLifecycle(): Boolean =
+    isSTTModelLoaded && isLLMModelLoaded && isTTSVoiceLoaded
 
-private fun getMissingComponents(): List<String> {
+private fun RunAnywhere.getMissingComponents(): List<String> {
     val missing = mutableListOf<String>()
-    if (!CppBridgeSTT.isLoaded) missing.add("STT")
-    if (!CppBridgeLLM.isLoaded) missing.add("LLM")
-    if (!CppBridgeTTS.isLoaded) missing.add("TTS")
+    if (!isSTTModelLoaded) missing.add("STT")
+    if (!isLLMModelLoaded) missing.add("LLM")
+    if (!isTTSVoiceLoaded) missing.add("TTS")
     return missing
 }
 
@@ -89,16 +94,43 @@ actual suspend fun RunAnywhere.initializeVoiceAgent(config: VoiceAgentConfig) {
 
 actual suspend fun RunAnywhere.getVoiceAgentComponentStates(): VoiceAgentComponentStates {
     if (!isInitialized) throw SDKException.notInitialized("SDK not initialized")
-    return CppBridgeVoiceAgentProto.states(CppBridgeVoiceAgent.getRawHandle())
+    // Mirrors Swift's RunAnywhere+VoiceAgent.getVoiceAgentComponentStates():
+    // when the composite voice-agent handle is uninitialized (the common
+    // case while the user is still loading individual STT/LLM/TTS models
+    // via the per-modality APIs), the C++ layer returns NOT_LOADED for
+    // everything. Fall back to the per-component lifecycle snapshots so
+    // the UI can gate Start once the three modalities are ready. Use
+    // isSTTModelLoaded / isLLMModelLoaded / isTTSVoiceLoaded which all
+    // query CppBridgeModelLifecycleProto — the same source the per-
+    // modality load APIs feed.
+    val composite = runCatching {
+        CppBridgeVoiceAgentProto.states(CppBridgeVoiceAgent.getRawHandle())
+    }.getOrNull()
+    val sttLoaded = (composite?.stt_state == ComponentLoadState.COMPONENT_LOAD_STATE_LOADED) ||
+        isSTTModelLoaded
+    val llmLoaded = (composite?.llm_state == ComponentLoadState.COMPONENT_LOAD_STATE_LOADED) ||
+        isLLMModelLoaded
+    val ttsLoaded = (composite?.tts_state == ComponentLoadState.COMPONENT_LOAD_STATE_LOADED) ||
+        isTTSVoiceLoaded
+    fun stateOf(loaded: Boolean, fallback: ComponentLoadState) =
+        if (loaded) ComponentLoadState.COMPONENT_LOAD_STATE_LOADED else fallback
+    return VoiceAgentComponentStates(
+        stt_state = stateOf(sttLoaded, composite?.stt_state ?: ComponentLoadState.COMPONENT_LOAD_STATE_NOT_LOADED),
+        llm_state = stateOf(llmLoaded, composite?.llm_state ?: ComponentLoadState.COMPONENT_LOAD_STATE_NOT_LOADED),
+        tts_state = stateOf(ttsLoaded, composite?.tts_state ?: ComponentLoadState.COMPONENT_LOAD_STATE_NOT_LOADED),
+        vad_state = composite?.vad_state ?: ComponentLoadState.COMPONENT_LOAD_STATE_NOT_LOADED,
+        ready = sttLoaded && llmLoaded && ttsLoaded,
+        any_loading = composite?.any_loading ?: false,
+    )
 }
 
 actual suspend fun RunAnywhere.isVoiceAgentReady(): Boolean =
-    isInitialized && CppBridgeVoiceAgentProto.states(CppBridgeVoiceAgent.getRawHandle()).ready
+    isInitialized && getVoiceAgentComponentStates().ready
 
 actual suspend fun RunAnywhere.initializeVoiceAgentWithLoadedModels() {
     if (!isInitialized) throw SDKException.notInitialized("SDK not initialized")
-    if (voiceAgentInitialized && areAllComponentsLoaded()) return
-    if (!areAllComponentsLoaded()) {
+    if (voiceAgentInitialized && areAllComponentsLoadedReflectingLifecycle()) return
+    if (!areAllComponentsLoadedReflectingLifecycle()) {
         val missing = getMissingComponents()
         throw SDKException.voiceAgent("Cannot initialize: Models not loaded: ${missing.joinToString(", ")}")
     }


### PR DESCRIPTION
Branched off `feat/v2-architecture` and ran a multi-pass test loop against the Android example app on a Nothing Phone (1) (arm64-v8a). Every fix below was reproduced, fixed, and re-verified on-device. Nothing here touches C++ or any other SDK — Kotlin layer + example app only.

## At a glance

- **2 commits**, **+288 / −48** across **11 files** (6 SDK, 5 example app)
- **No C++ changes**, no proto regeneration, no version bumps
- All fixes verified end-to-end on a connected device

## What was broken vs. what's fixed

| Area | Symptom on `feat/v2-architecture` | Fix |
|---|---|---|
| **VLM by-id load** | `processStream` returned null — service handle was created but GGUF weights were never mapped | Call `racVlmInitialize` after `racVlmCreate` in `CppBridgeVLMProto.loadModelById` |
| **VLM streaming** | UI jumped from empty to full text in one update at end of generation | `processImageStream` yields per-token from `GenerationEventKind.{FIRST_TOKEN_GENERATED, TOKEN_GENERATED}` instead of discarding events |
| **VLM token leak** | Final output contained literal `<\|im_end\|>` | Strip `<\|...\|>` control tokens before yielding (proto path bypassed `vlm_strip_special_tokens`) |
| **Voice agent Start button** | Always disabled — UI gated on composite component state, but composite only became READY after Start was pressed | Fall back to per-modality lifecycle snapshots (`isSTTModelLoaded`, `isLLMModelLoaded`, `isTTSVoiceLoaded`) |
| **Voice agent silent input** | `racVoiceAgentProcessVoiceTurnProto` returned null on no-speech audio → `SDKException` stack trace under the friendly UI | Treat null bytes as empty `VoiceAgentResult` |
| **Standalone STT/TTS** | `racSttComponentTranscribeProto` / `racTtsComponentSynthesizeProto returned null` because the lifecycle and the standalone bridge own separate component instances and only the lifecycle had the model | Mirror the load into `CppBridgeSTT` / `CppBridgeTTS` after the lifecycle load (and symmetric on unload) |
| **Sherpa STT/TTS cold start** | After a clean install, models failed to load because archive extraction left files at `parentDir/modelId/<files>` while the C++ filesystem scan only resolved to `parentDir` | Detect and flatten the nested-modelId case in `extractArchive` |
| **TTS pure noise** | Sherpa-Piper emits float32 PCM, but `startPlayback` hardcoded `ENCODING_PCM_16BIT` and used `write(byte[])` | Read `audio_format` + `sample_rate` from `TTSOutput`; use `ENCODING_PCM_FLOAT` + `write(float[])` for `AUDIO_FORMAT_PCM` |
| **TTS red error after success** | Playback completed, then `stopPlayback()` cancelled the playback job from inside itself → `CancellationException` caught as generic error | Wrap natural-completion cleanup in `NonCancellable`; let `CancellationException` propagate |
| **Chat: no cancel** | Send button stayed Send during streaming — long generations were uninterruptible | Send/Stop toggle wired to `RunAnywhere.cancelGeneration()` |
| **Chat: stale error dialog** | Successful re-load surfaced an old "Failed to load" dialog | Clear `error` state at the start of a load attempt |
| **History clutter** | Empty 0-message conversations accumulated from "Get Started → exit" flows | Auto-prune empty conversations on load |
| **Settings polish** | "Total Usage" actually showed device capacity; hardcoded "Version 0.1" string | Renamed label; switched to `BuildConfig.VERSION_NAME` |

## Files

**SDK** (`sdk/runanywhere-kotlin/src/jvmAndroidMain/.../`)
- `foundation/bridge/extensions/CppBridgeModalityProto.kt`
- `public/extensions/RunAnywhere+VisionLanguage.jvmAndroid.kt`
- `public/extensions/RunAnywhere+VoiceAgent.jvmAndroid.kt`
- `public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt`
- `public/extensions/RunAnywhere+STT.jvmAndroid.kt`
- `public/extensions/RunAnywhere+TTS.jvmAndroid.kt`

**Example app** (`examples/android/RunAnywhereAI/app/src/main/java/.../`)
- `data/ConversationStore.kt`
- `presentation/chat/ChatScreen.kt`
- `presentation/models/ModelSelectionViewModel.kt`
- `presentation/settings/SettingsScreen.kt`
- `presentation/tts/TextToSpeechViewModel.kt`

## Verification on-device

- **Device**: Nothing A059 (arm64-v8a, 1080×2392, 7.5 GB RAM)
- **Build chain**: `./scripts/build-core-android.sh arm64-v8a` → `./gradlew :sdk:runanywhere-kotlin:assembleDebug` → `./gradlew :app:installDebug`
- **SDK init**: Phase 1 ≈ 21 ms; total 417 ms; LlamaCPP + ONNX register cleanly; OkHttp transport registers with system trust store; Genie gracefully no-ops on non-Snapdragon
- **Chat**: streaming at ~30–34 tok/s steady-state, ~0.5 s warm TTFT; Stop button cancels mid-stream; conversation restore from history works; rapid-fire / rotation / background-foreground all clean
- **VLM**: LFM2-VL 450M streams visibly (verified with intermediate-frame screenshots), no `<\|im_end\|>` leak in final text
- **STT**: Sherpa Whisper Tiny load + transcribe both work standalone (user-confirmed)
- **TTS**: Sherpa-Piper US English Medium load + synthesize + playback all working — 364544 bytes / 4.133 s, real speech (user-confirmed)
- **Voice agent**: STT + LLM + TTS individually load → Start button enables → pipeline reaches "Listening..."
- **Edge cases**: kill mid-download / mid-generation / rotation / background → clean recovery; force-stop ↔ relaunch → no crashes

## Out of scope (deferred)

- Standalone TTS / STT live mode (`rc=-100` per chunk for offline-only Whisper) — UX gating not changed; live mode is rare in the example app.
- VLM end-of-turn token stripping at the C++ side (we strip Kotlin-side as a defensive fix; engine-side cleanup is a follow-up).
- Voice-agent end-to-end audio pipeline test with real speech (Start / Stop / state machine all work; just didn't end-to-end with a live mic).

## Test plan for reviewer

- [ ] `./scripts/build-core-android.sh arm64-v8a` succeeds (or use existing JNIs)
- [ ] `./gradlew :sdk:runanywhere-kotlin:assembleDebug` BUILD SUCCESSFUL
- [ ] `cd examples/android/RunAnywhereAI && ./gradlew :app:installDebug`
- [ ] Chat: send long prompt, hit Stop mid-stream — generation halts
- [ ] Vision: load LFM2-VL 450M, pick a photo — text streams in token-by-token, no `<\|im_end\|>` at the end
- [ ] More → TTS: pick Piper US English Medium, type text, Generate → Play — real speech, no noise, no red error
- [ ] Voice: load STT+LLM+TTS — Start button enables; tap Start, the screen advances past "Waiting for models to load..."
- [ ] Settings → Storage shows "Device Capacity"; About shows real version (e.g. `0.1.4-debug`)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches Kotlin SDK model-loading/streaming paths and audio playback encoding, which can affect core inference flows and device resource handling. Changes are targeted but span multiple modalities (VLM/voice/STT/TTS) and include on-disk extraction behavior.
> 
> **Overview**
> Fixes several Android Kotlin SDK modality issues: VLM by-id loading now initializes the native service with resolved GGUF/mmproj paths, VLM streaming now emits per-token events (with special-token stripping), and voice-agent state/turn processing is made more resilient (lifecycle-based readiness + treat null results as no-speech).
> 
> Addresses STT/TTS cold-start and component-handle mismatches by flattening nested model extraction layouts and mirroring lifecycle loads/unloads into the standalone STT/TTS bridges used by proto `transcribe`/`synthesize`.
> 
> Improves the Android example app UX and stability: chat input toggles to a Stop button to cancel generation, empty conversations are pruned from history on load, model selection clears stale errors, settings shows real app version + corrected storage label, and TTS playback now honors backend `audio_format`/`sample_rate` (including float32 PCM) with safer playback-job cleanup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 98ec51d5f8aa5dc9b6a7a793d6a93048c7826dec. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- greptile_comment -->

<h3>Greptile Summary</h3>

This PR fixes a broad set of regressions in the Kotlin Android SDK and example app: VLM streaming/token-leak, TTS float32 PCM playback, STT/TTS standalone bridge synchronization, voice-agent Start-button gating, archive extraction nesting, and several example-app UX issues. The fixes are well-scoped and thoroughly described.

One P1 concern: in `loadTTSModel`, `loadTTSVoice`, and `loadSTTModel`, if the lifecycle load succeeds but the subsequent `CppBridgeTTS`/`CppBridgeSTT` standalone bridge load fails, an exception is thrown without first unloading the lifecycle model. This leaves the TTS/STT slot occupied in the C++ component layer while reporting failure to the caller, making a clean retry impossible without an explicit manual unload.

<h3>Confidence Score: 3/5</h3>

Safe to merge with low risk in the happy path; the P1 half-loaded-state bug affects error recovery on bridge load failure, not the primary working flow.

One P1 issue (half-loaded TTS/STT state on standalone bridge failure) caps this at 4, and the pattern appearing in three separate load functions (loadTTSModel, loadTTSVoice, loadSTTModel) pulls the score to 3.

RunAnywhere+TTS.jvmAndroid.kt and RunAnywhere+ModelManagement.jvmAndroid.kt (standalone bridge error-recovery paths); CppBridgeModalityProto.kt (VLM file selection ordering)

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+TTS.jvmAndroid.kt | Mirrors TTS lifecycle load into standalone bridge for synthesize; introduces half-loaded state if bridge load fails after lifecycle succeeds (P1) |
| sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/foundation/bridge/extensions/CppBridgeModalityProto.kt | Adds VLM model path resolution and racVlmInitialize call; resolveVlmModelFiles uses unordered listFiles() for model selection (P2); voice-agent null-bytes handled gracefully |
| sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+VoiceAgent.jvmAndroid.kt | Fixes Start button always disabled by switching to per-modality lifecycle snapshots; runCatching on composite states swallows real JNI errors (P2) |
| sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+ModelManagement.jvmAndroid.kt | Fixes cold-start nested-modelId extraction path; STT standalone bridge mirror has the same half-loaded-state risk as TTS (P1 shared with TTS file) |
| sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+VisionLanguage.jvmAndroid.kt | Fixes VLM streaming to yield per-token events; adds special-token stripping regex; both processImageStream and processImageStreamWithMetrics updated consistently |
| examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/tts/TextToSpeechViewModel.kt | Fixes float32 PCM playback by reading audio_format; wraps natural-completion cleanup in NonCancellable; CancellationException is correctly re-thrown |
| examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/presentation/chat/ChatScreen.kt | Adds Send/Stop toggle wired to cancelGeneration; icon and tint logic updated cleanly |
| examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ConversationStore.kt | Auto-prunes empty conversations on load; uses runCatching for file delete (safe); correct placement before sort |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant App
    participant LifecycleProto as CppBridgeModelLifecycleProto
    participant StandaloneBridge as CppBridgeTTS / CppBridgeSTT
    participant JNI as JNI (C++ core)

    App->>LifecycleProto: loadModel(modelId, category)
    LifecycleProto->>JNI: racModelLifecycleLoadProto()
    JNI-->>LifecycleProto: success
    LifecycleProto-->>App: result.success = true

    App->>StandaloneBridge: loadModel(localPath, modelId, name)
    StandaloneBridge->>JNI: racSttComponentLoad / racTtsComponentLoad
    alt rc == 0 (success)
        JNI-->>StandaloneBridge: OK
        StandaloneBridge-->>App: 0
        Note over App: synthesize / transcribe work via StandaloneBridge
    else rc != 0 (failure — P1 risk)
        JNI-->>StandaloneBridge: error
        StandaloneBridge-->>App: rc
        App->>App: throw SDKException
        Note over LifecycleProto,JNI: Model still loaded in lifecycle slot!<br/>Retry will fail with already loaded
    end
```

<!-- greptile_failed_comments -->
<details><summary><h3>Comments Outside Diff (1)</h3></summary>

1. `sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+VoiceAgent.jvmAndroid.kt`, line 612-614 ([link](https://github.com/runanywhereai/runanywhere-sdks/blob/98ec51d5f8aa5dc9b6a7a793d6a93048c7826dec/sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+VoiceAgent.jvmAndroid.kt#L612-L614)) 

   <a href="#"><img alt="P2" src="https://greptile-static-assets.s3.amazonaws.com/badges/p2.svg?v=7" align="top"></a> **`runCatching` silently discards all exceptions from an initialized voice agent**

   Once `initializeVoiceAgent` has been called and `CppBridgeVoiceAgent.getRawHandle()` returns a valid handle, real JNI errors or `SDKException`s from `CppBridgeVoiceAgentProto.states(...)` are swallowed by `getOrNull()` and `composite` becomes `null`. The function then falls back to per-modality state, silently masking C++ errors during normal voice-agent operation. Consider narrowing the catch to the "uninitialized handle" case (e.g., check `handle == 0L` before calling) rather than catching everything.

   <details><summary>Prompt To Fix With AI</summary>

   `````markdown
   This is a comment left during a code review.
   Path: sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+VoiceAgent.jvmAndroid.kt
   Line: 612-614

   Comment:
   **`runCatching` silently discards all exceptions from an initialized voice agent**

   Once `initializeVoiceAgent` has been called and `CppBridgeVoiceAgent.getRawHandle()` returns a valid handle, real JNI errors or `SDKException`s from `CppBridgeVoiceAgentProto.states(...)` are swallowed by `getOrNull()` and `composite` becomes `null`. The function then falls back to per-modality state, silently masking C++ errors during normal voice-agent operation. Consider narrowing the catch to the "uninitialized handle" case (e.g., check `handle == 0L` before calling) rather than catching everything.

   How can I resolve this? If you propose a fix, please make it concise.
   `````
   </details>

</details>

<!-- /greptile_failed_comments -->

<details><summary>Prompt To Fix All With AI</summary>

`````markdown
Fix the following 3 code review issues. Work through them one at a time, proposing concise fixes.

---

### Issue 1 of 3
sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+TTS.jvmAndroid.kt:71-76
**Half-loaded state when standalone bridge fails after lifecycle load**

If `CppBridgeTTS.loadModel` returns a non-zero rc, this function throws — but the lifecycle load on lines 53–65 already succeeded and the model is now resident in memory. From the caller's perspective the load failed entirely, so no `unloadTTSModel` is called, leaving the lifecycle slot occupied. A subsequent retry will hit the lifecycle with a model already loaded, potentially triggering a "model already loaded" error from the C++ side, making the issue unrecoverable without an explicit unload.

The same pattern exists in `loadTTSVoice` (line 120–124) and in `RunAnywhere+ModelManagement.jvmAndroid.kt` for `loadSTTModel`. Each of these should unload the lifecycle model (`unloadModel(...)`) before rethrowing if the standalone bridge fails.

### Issue 2 of 3
sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/foundation/bridge/extensions/CppBridgeModalityProto.kt:286-294
**Non-deterministic model file selection with `listFiles()`**

`File.listFiles()` on Android (Linux ext4/F2FS) does not guarantee a consistent iteration order across JVM invocations. If a VLM model directory contains more than two `.gguf` files (e.g., a stale/partial file left from a failed download), `ggufFiles.firstOrNull { it != mmproj }` will non-deterministically select the wrong file as the main model weight on some launches — causing a VLM load failure that cannot be reproduced reliably.

A safer heuristic would be to pick the largest `.gguf` file as the main model (mmproj files are typically a fraction of the main weight size), or to sort `ggufFiles` by name before selecting.

### Issue 3 of 3
sdk/runanywhere-kotlin/src/jvmAndroidMain/kotlin/com/runanywhere/sdk/public/extensions/RunAnywhere+VoiceAgent.jvmAndroid.kt:612-614
**`runCatching` silently discards all exceptions from an initialized voice agent**

Once `initializeVoiceAgent` has been called and `CppBridgeVoiceAgent.getRawHandle()` returns a valid handle, real JNI errors or `SDKException`s from `CppBridgeVoiceAgentProto.states(...)` are swallowed by `getOrNull()` and `composite` becomes `null`. The function then falls back to per-modality state, silently masking C++ errors during normal voice-agent operation. Consider narrowing the catch to the "uninitialized handle" case (e.g., check `handle == 0L` before calling) rather than catching everything.


`````

</details>

<sub>Reviews (1): Last reviewed commit: ["fix(android-example): TTS playback (floa..."](https://github.com/runanywhereai/runanywhere-sdks/commit/98ec51d5f8aa5dc9b6a7a793d6a93048c7826dec) | [Re-trigger Greptile](https://app.greptile.com/api/retrigger?id=30706504)</sub>

> Greptile also left **2 inline comments** on this PR.

<!-- /greptile_comment -->