### PR TITLE
feat(llm): expose adaptive-context APIs through component layer wrappers

### DIFF
--- a/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_component.h
+++ b/sdk/runanywhere-commons/include/rac/features/llm/rac_llm_component.h
@@ -281,6 +281,89 @@ rac_result_t rac_llm_component_check_lora_compat(rac_handle_t handle, const char
                                                  char** out_error);
 
 // =============================================================================
+// ADAPTIVE CONTEXT API - KV Cache Prefix-Caching for Multi-Turn Sessions
+// =============================================================================
+
+/**
+ * @brief Inject a system prompt into the KV cache at position 0
+ *
+ * Clears existing KV cache, then seeds it with the given system prompt.
+ * Call once at session start to avoid re-tokenizing the prompt every turn.
+ *
+ * Optional — returns RAC_ERROR_NOT_SUPPORTED if the active backend does not
+ * implement adaptive context (e.g., only LlamaCPP supports it today).
+ *
+ * @param handle Component handle
+ * @param prompt System prompt text (must be non-NULL)
+ * @return RAC_SUCCESS or error code
+ */
+RAC_API rac_result_t rac_llm_component_inject_system_prompt(rac_handle_t handle, const char* prompt);
+
+/**
+ * @brief Append text to the KV cache after current content
+ *
+ * Does not clear existing KV state — accumulates context incrementally.
+ * Use after inject_system_prompt to append user turns, assistant responses,
+ * or RAG chunks without re-processing the entire conversation.
+ *
+ * @warning Callers MUST call rac_llm_component_clear_context() at session
+ *          boundaries (user switch, session end, memory pressure) to prevent
+ *          unbounded KV cache growth that will lead to OS-level OOM termination.
+ *
+ * Optional — returns RAC_ERROR_NOT_SUPPORTED if the active backend does not
+ * implement adaptive context.
+ *
+ * @param handle Component handle
+ * @param text Text to append (must be non-NULL)
+ * @return RAC_SUCCESS or error code
+ */
+RAC_API rac_result_t rac_llm_component_append_context(rac_handle_t handle, const char* text);
+
+/**
+ * @brief Generate a response from accumulated KV cache state
+ *
+ * Unlike rac_llm_component_generate(), this does NOT clear the KV cache first.
+ * Use after inject_system_prompt + append_context to generate from accumulated
+ * state, preserving the KV cache for subsequent turns.
+ *
+ * @warning This call is BLOCKING (non-streaming). It will monopolize the calling
+ *          thread for the entire decode duration (potentially several seconds on
+ *          mobile hardware). On platforms with cooperative thread pools (e.g.,
+ *          Swift async/await), callers MUST offload this to a non-cooperative
+ *          thread or accept that overlapping generation requests may deadlock.
+ *          A streaming variant (generate_stream_from_context) is planned as a
+ *          follow-up.
+ *
+ * Optional — returns RAC_ERROR_NOT_SUPPORTED if the active backend does not
+ * implement adaptive context.
+ *
+ * @param handle Component handle
+ * @param query Query/suffix text to append before generation (must be non-NULL)
+ * @param options Generation options (can be NULL for defaults)
+ * @param out_result Output: Generation result (caller must free with rac_llm_result_free)
+ * @return RAC_SUCCESS or error code
+ */
+RAC_API rac_result_t rac_llm_component_generate_from_context(rac_handle_t handle, const char* query,
+                                                              const rac_llm_options_t* options,
+                                                              rac_llm_result_t* out_result);
+
+/**
+ * @brief Clear all KV cache state
+ *
+ * Resets the LLM's context for a fresh adaptive query cycle. Call at session
+ * boundaries, on user switch, or when memory pressure is detected to prevent
+ * unbounded KV cache growth.
+ *
+ * Optional — returns RAC_ERROR_NOT_SUPPORTED if the active backend does not
+ * implement adaptive context. Returns RAC_SUCCESS if no model is loaded
+ * (no context to clear).
+ *
+ * @param handle Component handle
+ * @return RAC_SUCCESS or error code
+ */
+RAC_API rac_result_t rac_llm_component_clear_context(rac_handle_t handle);
+
+// =============================================================================
 // DESTRUCTION
 // =============================================================================
 

--- a/sdk/runanywhere-commons/src/features/llm/llm_module.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/llm_module.cpp
@@ -1191,6 +1191,98 @@ extern "C" rac_result_t rac_llm_component_check_lora_compat(rac_handle_t handle,
 }
 
 // =============================================================================
+// ADAPTIVE CONTEXT API
+// =============================================================================
+
+extern "C" rac_result_t rac_llm_component_inject_system_prompt(rac_handle_t handle,
+                                                                const char* prompt) {
+    if (!handle)
+        return RAC_ERROR_INVALID_HANDLE;
+    if (!prompt || prompt[0] == '\0')
+        return RAC_ERROR_INVALID_ARGUMENT;
+
+    auto* component = reinterpret_cast<rac_llm_component*>(handle);
+    std::lock_guard<std::mutex> lock(component->mtx);
+
+    rac_handle_t service = rac_lifecycle_get_service(component->lifecycle);
+    if (!service) {
+        RAC_LOG_ERROR("LLM.Component", "Cannot inject system prompt: no model loaded");
+        return RAC_ERROR_COMPONENT_NOT_READY;
+    }
+
+    auto* llm_service = reinterpret_cast<rac_llm_service_t*>(service);
+    if (!llm_service->ops || !llm_service->ops->inject_system_prompt)
+        return RAC_ERROR_NOT_SUPPORTED;
+    return llm_service->ops->inject_system_prompt(llm_service->impl, prompt);
+}
+
+extern "C" rac_result_t rac_llm_component_append_context(rac_handle_t handle, const char* text) {
+    if (!handle)
+        return RAC_ERROR_INVALID_HANDLE;
+    if (!text || text[0] == '\0')
+        return RAC_ERROR_INVALID_ARGUMENT;
+
+    auto* component = reinterpret_cast<rac_llm_component*>(handle);
+    std::lock_guard<std::mutex> lock(component->mtx);
+
+    rac_handle_t service = rac_lifecycle_get_service(component->lifecycle);
+    if (!service) {
+        RAC_LOG_ERROR("LLM.Component", "Cannot append context: no model loaded");
+        return RAC_ERROR_COMPONENT_NOT_READY;
+    }
+
+    auto* llm_service = reinterpret_cast<rac_llm_service_t*>(service);
+    if (!llm_service->ops || !llm_service->ops->append_context)
+        return RAC_ERROR_NOT_SUPPORTED;
+    return llm_service->ops->append_context(llm_service->impl, text);
+}
+
+extern "C" rac_result_t rac_llm_component_generate_from_context(rac_handle_t handle,
+                                                                 const char* query,
+                                                                 const rac_llm_options_t* options,
+                                                                 rac_llm_result_t* out_result) {
+    if (!handle)
+        return RAC_ERROR_INVALID_HANDLE;
+    if (!query || !out_result)
+        return RAC_ERROR_INVALID_ARGUMENT;
+
+    auto* component = reinterpret_cast<rac_llm_component*>(handle);
+    std::lock_guard<std::mutex> lock(component->mtx);
+
+    rac_handle_t service = rac_lifecycle_get_service(component->lifecycle);
+    if (!service) {
+        RAC_LOG_ERROR("LLM.Component", "Cannot generate from context: no model loaded");
+        return RAC_ERROR_COMPONENT_NOT_READY;
+    }
+
+    auto* llm_service = reinterpret_cast<rac_llm_service_t*>(service);
+    if (!llm_service->ops || !llm_service->ops->generate_from_context)
+        return RAC_ERROR_NOT_SUPPORTED;
+
+    const rac_llm_options_t* effective_options = options ? options : &component->default_options;
+    return llm_service->ops->generate_from_context(llm_service->impl, query, effective_options,
+                                                   out_result);
+}
+
+extern "C" rac_result_t rac_llm_component_clear_context(rac_handle_t handle) {
+    if (!handle)
+        return RAC_ERROR_INVALID_HANDLE;
+
+    auto* component = reinterpret_cast<rac_llm_component*>(handle);
+    std::lock_guard<std::mutex> lock(component->mtx);
+
+    rac_handle_t service = rac_lifecycle_get_service(component->lifecycle);
+    if (!service) {
+        return RAC_SUCCESS;  // No service = no context to clear
+    }
+
+    auto* llm_service = reinterpret_cast<rac_llm_service_t*>(service);
+    if (!llm_service->ops || !llm_service->ops->clear_context)
+        return RAC_ERROR_NOT_SUPPORTED;
+    return llm_service->ops->clear_context(llm_service->impl);
+}
+
+// =============================================================================
 // STATE QUERY API
 // =============================================================================
 

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+LLM.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+LLM.swift
@@ -64,6 +64,95 @@ extension CppBridge {
             rac_llm_component_cancel(handle)
         }
 
+        // MARK: - Adaptive Context (KV Cache Prefix-Caching)
+
+        /// Inject a system prompt into the KV cache at position 0.
+        ///
+        /// Clears existing KV cache, then seeds with the given prompt.
+        /// Call once at session start to avoid re-tokenizing the prompt every turn.
+        ///
+        /// - Parameter prompt: System prompt text.
+        /// - Throws: `SDKException` if no model is loaded or the backend
+        ///   does not support adaptive context.
+        public func injectSystemPrompt(_ prompt: String) async throws {
+            let handle = try await getHandle()
+            let result = rac_llm_component_inject_system_prompt(handle, prompt)
+            guard result == RAC_SUCCESS else {
+                throw SDKException(
+                    code: .processingFailed,
+                    message: "Failed to inject system prompt (rc=\(result))",
+                    category: .component
+                )
+            }
+        }
+
+        /// Append text to the KV cache after current content.
+        ///
+        /// Accumulates context incrementally without re-processing previous turns.
+        ///
+        /// - Warning: Callers **must** call ``clearContext()`` at session boundaries
+        ///   to prevent unbounded KV cache growth leading to OS-level OOM termination.
+        ///
+        /// - Parameter text: Text to append (user turn, assistant response, etc.).
+        /// - Throws: `SDKException` if no model is loaded or the backend
+        ///   does not support adaptive context.
+        public func appendContext(_ text: String) async throws {
+            let handle = try await getHandle()
+            let result = rac_llm_component_append_context(handle, text)
+            guard result == RAC_SUCCESS else {
+                throw SDKException(
+                    code: .processingFailed,
+                    message: "Failed to append context (rc=\(result))",
+                    category: .component
+                )
+            }
+        }
+
+        /// Generate a response from accumulated KV cache state.
+        ///
+        /// Unlike ``generate(_:)``, this does **not** clear the KV cache first.
+        /// Use after ``injectSystemPrompt(_:)`` + ``appendContext(_:)`` to
+        /// generate from preserved context.
+        ///
+        /// - Warning: This call is **blocking** (non-streaming). It will monopolize
+        ///   the calling cooperative thread for the entire decode duration (potentially
+        ///   several seconds). Overlapping generation requests while this call is
+        ///   in-flight will queue behind the component mutex. A streaming variant
+        ///   is planned as a follow-up.
+        ///
+        /// - Parameters:
+        ///   - query: Query/suffix text to append before generation.
+        ///   - options: Generation options, or `nil` for component defaults.
+        /// - Returns: Generation result. Caller must eventually free via
+        ///   `rac_llm_result_free`.
+        /// - Throws: `SDKException` if no model is loaded or the backend
+        ///   does not support adaptive context.
+        public func generateFromContext(
+            query: String,
+            options: UnsafePointer<rac_llm_options_t>? = nil
+        ) async throws -> rac_llm_result_t {
+            let handle = try await getHandle()
+            var result = rac_llm_result_t()
+            let status = rac_llm_component_generate_from_context(handle, query, options, &result)
+            guard status == RAC_SUCCESS else {
+                throw SDKException(
+                    code: .processingFailed,
+                    message: "Failed to generate from context (rc=\(status))",
+                    category: .component
+                )
+            }
+            return result
+        }
+
+        /// Clear all KV cache state.
+        ///
+        /// Resets the context for a fresh adaptive query cycle. Call at session
+        /// boundaries, on user switch, or when memory pressure is detected.
+        public func clearContext() async {
+            guard let handle = await inner.existingHandle() else { return }
+            rac_llm_component_clear_context(handle)
+        }
+
         // MARK: - Cleanup
 
         /// Destroy the component

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+LLM.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+LLM.swift
@@ -123,26 +123,58 @@ extension CppBridge {
         /// - Parameters:
         ///   - query: Query/suffix text to append before generation.
         ///   - options: Generation options, or `nil` for component defaults.
-        /// - Returns: Generation result. Caller must eventually free via
-        ///   `rac_llm_result_free`.
+        /// - Returns: Swift-native generation result with text and metrics.
         /// - Throws: `SDKException` if no model is loaded or the backend
         ///   does not support adaptive context.
         public func generateFromContext(
             query: String,
-            options: UnsafePointer<rac_llm_options_t>? = nil
-        ) async throws -> rac_llm_result_t {
+            options: RALLMGenerationOptions? = nil
+        ) async throws -> RALLMGenerationResult {
             let handle = try await getHandle()
-            var result = rac_llm_result_t()
-            let status = rac_llm_component_generate_from_context(handle, query, options, &result)
+            var cResult = rac_llm_result_t()
+
+            let status: rac_result_t
+            if let options = options {
+                var cOptions = rac_llm_options_t()
+                cOptions.max_tokens = options.maxTokens
+                cOptions.temperature = options.temperature
+                cOptions.top_p = options.topP
+                cOptions.top_k = options.topK
+                cOptions.repetition_penalty = options.repetitionPenalty
+                cOptions.frequency_penalty = options.frequencyPenalty
+                cOptions.presence_penalty = options.presencePenalty
+                cOptions.min_p = options.minP
+                cOptions.seed = options.seed
+                cOptions.n_threads = options.nThreads
+                cOptions.disable_thinking = options.disableThinking ? RAC_TRUE : RAC_FALSE
+                status = withUnsafePointer(to: &cOptions) { optsPtr in
+                    rac_llm_component_generate_from_context(handle, query, optsPtr, &cResult)
+                }
+            } else {
+                status = rac_llm_component_generate_from_context(handle, query, nil, &cResult)
+            }
+
+            // Always convert + free the C result, even on success
+            defer { rac_llm_result_free(&cResult) }
+
             guard status == RAC_SUCCESS else {
-                rac_llm_result_free(&result)
                 throw SDKException(
                     code: .processingFailed,
                     message: "Failed to generate from context (rc=\(status))",
                     category: .component
                 )
             }
-            return result
+
+            // Marshal C result → Swift proto result (memory is copied)
+            var swiftResult = RALLMGenerationResult()
+            swiftResult.text = cResult.text.map { String(cString: $0) } ?? ""
+            swiftResult.inputTokens = cResult.prompt_tokens
+            swiftResult.tokensGenerated = cResult.completion_tokens
+            swiftResult.totalTokens = cResult.total_tokens
+            swiftResult.generationTimeMs = Double(cResult.total_time_ms)
+            swiftResult.ttftMs = Double(cResult.time_to_first_token_ms)
+            swiftResult.tokensPerSecond = Double(cResult.tokens_per_second)
+            return swiftResult
         }
 
         /// Clear all KV cache state.

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+LLM.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+LLM.swift
@@ -135,6 +135,7 @@ extension CppBridge {
             var result = rac_llm_result_t()
             let status = rac_llm_component_generate_from_context(handle, query, options, &result)
             guard status == RAC_SUCCESS else {
+                rac_llm_result_free(&result)
                 throw SDKException(
                     code: .processingFailed,
                     message: "Failed to generate from context (rc=\(status))",

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+AdaptiveContext.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+AdaptiveContext.swift
@@ -59,6 +59,7 @@ public extension RunAnywhere {
             guard RunAnywhere.isInitialized else {
                 throw SDKException(code: .notInitialized, message: "SDK not initialized", category: .internal)
             }
+            try await RunAnywhere.ensureServicesReady()
             try await CppBridge.LLM.shared.injectSystemPrompt(prompt)
         }
 
@@ -80,6 +81,7 @@ public extension RunAnywhere {
             guard RunAnywhere.isInitialized else {
                 throw SDKException(code: .notInitialized, message: "SDK not initialized", category: .internal)
             }
+            try await RunAnywhere.ensureServicesReady()
             try await CppBridge.LLM.shared.appendContext(text)
         }
 
@@ -114,6 +116,7 @@ public extension RunAnywhere {
             guard RunAnywhere.isInitialized else {
                 throw SDKException(code: .notInitialized, message: "SDK not initialized", category: .internal)
             }
+            try await RunAnywhere.ensureServicesReady()
             return try await CppBridge.LLM.shared.generateFromContext(query: query, options: options)
         }
 

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+AdaptiveContext.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+AdaptiveContext.swift
@@ -1,0 +1,136 @@
+//
+//  RunAnywhere+AdaptiveContext.swift
+//  RunAnywhere SDK
+//
+//  Public API for adaptive-context (KV cache prefix-caching) —
+//  namespaced under `RunAnywhere.adaptiveContext.*`.
+//
+//  Delegates to the component-layer C ABI through CppBridge.LLM.
+//  See rac_llm_component.h for the underlying C documentation.
+//
+
+import CRACommons
+import Foundation
+
+// MARK: - Adaptive Context Capability Namespace
+
+public extension RunAnywhere {
+
+    /// Capability accessor for adaptive-context (KV cache prefix-caching).
+    ///
+    /// Provides multi-turn session optimization by preserving the KV cache
+    /// across conversational turns. Typical workflow:
+    ///
+    /// ```swift
+    /// // 1. Inject system prompt once at session start (~1100 tokens, ~5s)
+    /// try await RunAnywhere.adaptiveContext.injectSystemPrompt(systemPrompt)
+    ///
+    /// // 2. For each user turn, append + generate (KV cache preserved, ~ms TTFT)
+    /// try await RunAnywhere.adaptiveContext.appendContext(userMessage)
+    /// let result = try await RunAnywhere.adaptiveContext.generateFromContext(query: "")
+    ///
+    /// // 3. Clear at session end to reclaim memory
+    /// await RunAnywhere.adaptiveContext.clearContext()
+    /// ```
+    ///
+    /// - Important: Only the LlamaCPP backend supports adaptive context today.
+    ///   Other backends will return errors with code `RAC_ERROR_NOT_SUPPORTED`.
+    static var adaptiveContext: AdaptiveContext { AdaptiveContext() }
+
+    /// Stateless namespace exposing adaptive-context (KV cache) operations.
+    ///
+    /// Backed by the C ABI via `CppBridge.LLM` component-layer wrappers.
+    /// All methods are serialized through the component's internal mutex —
+    /// concurrent calls are safe but will queue sequentially.
+    struct AdaptiveContext: Sendable {
+
+        // MARK: - Context Management
+
+        /// Inject a system prompt into the KV cache at position 0.
+        ///
+        /// Clears any existing KV cache and seeds it with the given prompt.
+        /// Call once at session start to pay the prefill cost exactly once;
+        /// subsequent turns skip re-tokenization entirely.
+        ///
+        /// - Parameter prompt: System prompt text.
+        /// - Throws: ``SDKException`` if the SDK is not initialized, no model
+        ///   is loaded, or the backend does not support adaptive context.
+        public func injectSystemPrompt(_ prompt: String) async throws {
+            guard RunAnywhere.isInitialized else {
+                throw SDKException(code: .notInitialized, message: "SDK not initialized", category: .internal)
+            }
+            try await CppBridge.LLM.shared.injectSystemPrompt(prompt)
+        }
+
+        /// Append text to the KV cache after current content.
+        ///
+        /// Accumulates context incrementally without re-processing previous
+        /// turns. Use to append user messages, assistant responses, or RAG
+        /// chunks to the preserved KV cache.
+        ///
+        /// - Warning: The KV cache grows linearly with each call. Callers
+        ///   **must** call ``clearContext()`` at session boundaries (user
+        ///   switch, session end, or memory pressure) to prevent unbounded
+        ///   growth that will cause OS-level OOM (Jetsam) termination.
+        ///
+        /// - Parameter text: Text to append.
+        /// - Throws: ``SDKException`` if the SDK is not initialized, no model
+        ///   is loaded, or the backend does not support adaptive context.
+        public func appendContext(_ text: String) async throws {
+            guard RunAnywhere.isInitialized else {
+                throw SDKException(code: .notInitialized, message: "SDK not initialized", category: .internal)
+            }
+            try await CppBridge.LLM.shared.appendContext(text)
+        }
+
+        // MARK: - Generation
+
+        /// Generate a response from accumulated KV cache state.
+        ///
+        /// Unlike ``RunAnywhere/generate(prompt:options:)``, this does **not**
+        /// clear the KV cache first. The cached system prompt and appended
+        /// context are preserved, eliminating prefill latency on subsequent
+        /// turns.
+        ///
+        /// - Warning: **Blocking call.** This method monopolizes a cooperative
+        ///   thread for the entire decode duration (potentially several seconds
+        ///   on mobile hardware). Overlapping generation requests will queue
+        ///   behind the component mutex. For streaming UX in production, prefer
+        ///   ``RunAnywhere/generateStream(prompt:options:)`` with full prompt
+        ///   re-submission until a streaming-from-context variant is available.
+        ///
+        /// - Parameters:
+        ///   - query: Query or suffix text appended before generation begins.
+        ///     Pass an empty string to generate purely from accumulated cache.
+        ///   - options: Generation options, or `nil` for component defaults.
+        /// - Returns: The generation result including text, token counts, and
+        ///   timing metrics. Caller owns the result memory.
+        /// - Throws: ``SDKException`` if the SDK is not initialized, no model
+        ///   is loaded, or the backend does not support adaptive context.
+        public func generateFromContext(
+            query: String,
+            options: UnsafePointer<rac_llm_options_t>? = nil
+        ) async throws -> rac_llm_result_t {
+            guard RunAnywhere.isInitialized else {
+                throw SDKException(code: .notInitialized, message: "SDK not initialized", category: .internal)
+            }
+            return try await CppBridge.LLM.shared.generateFromContext(query: query, options: options)
+        }
+
+        // MARK: - Cleanup
+
+        /// Clear all KV cache state.
+        ///
+        /// Resets the adaptive context for a fresh session. Call at:
+        /// - Session end
+        /// - User profile switch
+        /// - Memory pressure notifications
+        /// - Before loading a different model
+        ///
+        /// Safe to call when no model is loaded (no-op).
+        public func clearContext() async {
+            guard RunAnywhere.isInitialized else { return }
+            await CppBridge.LLM.shared.clearContext()
+        }
+    }
+}

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+AdaptiveContext.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+AdaptiveContext.swift
@@ -9,7 +9,6 @@
 //  See rac_llm_component.h for the underlying C documentation.
 //
 
-import CRACommons
 import Foundation
 
 // MARK: - Adaptive Context Capability Namespace
@@ -106,13 +105,13 @@ public extension RunAnywhere {
         ///     Pass an empty string to generate purely from accumulated cache.
         ///   - options: Generation options, or `nil` for component defaults.
         /// - Returns: The generation result including text, token counts, and
-        ///   timing metrics. Caller owns the result memory.
+        ///   timing metrics.
         /// - Throws: ``SDKException`` if the SDK is not initialized, no model
         ///   is loaded, or the backend does not support adaptive context.
         public func generateFromContext(
             query: String,
-            options: UnsafePointer<rac_llm_options_t>? = nil
-        ) async throws -> rac_llm_result_t {
+            options: RALLMGenerationOptions? = nil
+        ) async throws -> RALLMGenerationResult {
             guard RunAnywhere.isInitialized else {
                 throw SDKException(code: .notInitialized, message: "SDK not initialized", category: .internal)
             }


### PR DESCRIPTION
Description
Expose the 4 adaptive-context C++ service-layer APIs (inject_system_prompt, append_context, generate_from_context, clear_context) through component-layer wrappers so Swift's CppBridge.LLM can reach them. This unblocks KV cache prefix-caching workflows that eliminate ~5s prefill penalty per conversational turn on mobile hardware.


##Type of Change
- [x] New feature

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

## Labels
- [x] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [x] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New inference paths hold the component mutex during blocking decode and allow KV cache to grow until `clear_context`; misuse can cause memory pressure or thread starvation, though unsupported backends fail closed with NOT_SUPPORTED.
> 
> **Overview**
> Adds **adaptive context** (KV cache prefix-caching) at the LLM **component** layer and surfaces it in Swift as `RunAnywhere.adaptiveContext`.
> 
> Commons gains four new `rac_llm_component_*` entry points—`inject_system_prompt`, `append_context`, `generate_from_context`, and `clear_context`—documented as optional (backends without ops return `RAC_ERROR_NOT_SUPPORTED`). `llm_module.cpp` implements them like LoRA: validate handle/args, hold the component mutex, resolve the loaded service, and dispatch through the `rac_llm_service` ops vtable.
> 
> Swift adds matching methods on `CppBridge.LLM` (with `SDKException` on failure) and a public `RunAnywhere.AdaptiveContext` namespace that checks initialization and documents the inject → append → generate → clear workflow, plus warnings about **unbounded KV growth** and **blocking** `generateFromContext` on cooperative threads.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6b90e4859ded5b52ff66c944a5dbbbc659c8849f. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an Adaptive Context API for LLM multi-turn sessions, enabling: injecting a system prompt into the KV cache, incrementally appending context, generating responses from the accumulated KV cache without clearing it first, and resetting the session by clearing cached state. Exposed via the Swift API, with backend-dependent support (may be unavailable depending on the underlying engine).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->