### PR TITLE
web: SDK telemetry wiring + ONNX/sherpa WASM prebuilt vendor

### DIFF
--- a/examples/web/RunAnywhereAI/src/views/settings.ts
+++ b/examples/web/RunAnywhereAI/src/views/settings.ts
@@ -72,7 +72,11 @@ export function getGenerationSettings(): GenerationSettings {
 export function getStoredApiKey(): string | null {
   loadSettings();
   const value = settings.apiKey.trim();
-  return value.length > 0 ? value : null;
+  if (value.length > 0) return value;
+  // Fallback to a gitignored .env.local (VITE_RUNANYWHERE_API_KEY) so the app
+  // can boot pre-authenticated for local testing without typing in Settings.
+  const envValue = import.meta.env.VITE_RUNANYWHERE_API_KEY?.trim();
+  return envValue && envValue.length > 0 ? envValue : null;
 }
 
 /**
@@ -82,7 +86,8 @@ export function getStoredApiKey(): string | null {
  */
 export function getStoredBaseURL(): string | null {
   loadSettings();
-  const trimmed = settings.baseURL.trim();
+  const trimmed = settings.baseURL.trim()
+    || (import.meta.env.VITE_RUNANYWHERE_BASE_URL?.trim() ?? '');
   if (trimmed.length === 0) return null;
   if (trimmed.startsWith('http://') || trimmed.startsWith('https://')) {
     return trimmed;

--- a/examples/web/RunAnywhereAI/src/vite-env.d.ts
+++ b/examples/web/RunAnywhereAI/src/vite-env.d.ts
@@ -1,0 +1,10 @@
+/// <reference types="vite/client" />
+
+interface ImportMetaEnv {
+  readonly VITE_RUNANYWHERE_API_KEY?: string;
+  readonly VITE_RUNANYWHERE_BASE_URL?: string;
+}
+
+interface ImportMeta {
+  readonly env: ImportMetaEnv;
+}

--- a/sdk/runanywhere-web/packages/core/src/Adapters/FetchHttpTransport.ts
+++ b/sdk/runanywhere-web/packages/core/src/Adapters/FetchHttpTransport.ts
@@ -265,7 +265,15 @@ export class FetchHttpTransport {
         }
       }
       if (req.timeoutMs > 0) {
-        xhr.timeout = req.timeoutMs;
+        // A synchronous XHR in a document forbids setting `timeout`
+        // (InvalidAccessError) — the same class of restriction already handled
+        // for `responseType` above. The browser applies its own network
+        // timeout, so swallow the throw instead of failing the whole request.
+        try {
+          xhr.timeout = req.timeoutMs;
+        } catch {
+          /* sync XHR from a document: timeout not settable; ignored. */
+        }
       }
 
       const t0 =
@@ -366,9 +374,14 @@ export class FetchHttpTransport {
         }
       }
       if (req.timeoutMs > 0) {
-        // XHR timeout is only honoured for async requests per spec; the
-        // field is still set for observability.
-        xhr.timeout = req.timeoutMs;
+        // XHR timeout is only honoured for async requests per spec; setting it
+        // on a synchronous XHR in a document throws InvalidAccessError, so guard
+        // it the same way `responseType` is guarded above.
+        try {
+          xhr.timeout = req.timeoutMs;
+        } catch {
+          /* sync XHR from a document: timeout not settable; ignored. */
+        }
       }
 
       const t0 =

--- a/sdk/runanywhere-web/packages/core/src/Adapters/TelemetryBridge.ts
+++ b/sdk/runanywhere-web/packages/core/src/Adapters/TelemetryBridge.ts
@@ -1,0 +1,449 @@
+/**
+ * TelemetryBridge.ts (Web / WASM)
+ *
+ * Wires the C++ commons telemetry manager into an Emscripten WASM module so SDK
+ * telemetry events actually reach the backend. This is the Web port of the
+ * per-platform telemetry bridges every other SDK already ships:
+ *   - iOS:     CppBridge+Telemetry.swift  (source of truth)
+ *   - Kotlin:  CppBridgeTelemetry.kt
+ *   - RN:      TelemetryBridge.cpp
+ *   - Flutter: dart_bridge_telemetry.dart
+ *
+ * Commons owns ALL telemetry logic (queue, batch, group-by-modality, JSON,
+ * endpoint selection: `/api/v2/sdk/telemetry/{modality}`). The SDK only has to:
+ *   1. create a telemetry manager,
+ *   2. give it device info,
+ *   3. register an HTTP callback that POSTs the commons-built JSON, and
+ *   4. attach the manager as the event router's telemetry sink.
+ * The router (`rac::events::route`) then feeds every TELEMETRY-bit event into
+ * the manager via `rac_telemetry_manager_track_proto` — there is no per-event
+ * JS translation.
+ *
+ * Web specifics
+ * -------------
+ * Unlike the single-commons native SDKs, the Web SDK loads THREE independent
+ * WASM modules (core racommons + llamacpp + onnx-sherpa), each with its own
+ * commons instance, event router, and telemetry sink. Telemetry is therefore
+ * wired PER MODULE (from `completeNativePhase1ForModule`), so each module's own
+ * events (core: system/model/download; llamacpp: LLM/VLM; onnx: STT/TTS/VAD)
+ * are captured by a sink living in that same module.
+ *
+ * HTTP / auth
+ * -----------
+ * The telemetry manager invokes its HTTP callback synchronously when it flushes;
+ * the callback reads the endpoint + JSON out of the WASM heap (commons frees
+ * them immediately after the call returns) and then fires a fire-and-forget
+ * POST. `rac_telemetry_manager_http_complete` is intentionally NOT called back —
+ * it is a no-op in commons and Swift skips it too.
+ *   - Development: no JWT required (`rac_env_requires_auth(DEVELOPMENT) == false`),
+ *     so the request goes to the compiled-in dev endpoint
+ *     (`rac_wasm_dev_config_get_supabase_*`) with the dev key — mirroring the RN
+ *     dev branch (InitBridge.cpp).
+ *   - Staging/Production: the V2 endpoints require the JWT from the apiKey->JWT
+ *     exchange (the raw apiKey is rejected by the backend). The callback reads
+ *     the access token from the authenticated `'commons'` module via
+ *     `rac_auth_get_access_token` and POSTs `baseUrl + endpoint` with an
+ *     `Authorization: Bearer` header. That export must be present in the WASM
+ *     build (it is listed in wasm/CMakeLists.txt — requires a WASM rebuild); on
+ *     an older artifact lacking it the POST is skipped (logged). NOTE: only the
+ *     core 'commons' module authenticates, so backend modules (llamacpp/onnx)
+ *     defer their flush in prod until per-module auth propagation lands — until
+ *     then LLM/STT/TTS telemetry flows in development mode.
+ */
+
+import { SDKLogger } from '../Foundation/SDKLogger';
+import {
+  getAllRegisteredModules,
+  getModuleForCapability,
+  type EmscriptenRunanywhereModule,
+} from '../runtime/EmscriptenModule';
+import { SDKEnvironment } from '@runanywhere/proto-ts/model_types';
+
+const logger = new SDKLogger('TelemetryBridge');
+
+// rac_environment_t (rac_environment.h) — kept in sync with the C enum.
+const RAC_ENV_DEVELOPMENT = 0;
+const RAC_ENV_STAGING = 1;
+const RAC_ENV_PRODUCTION = 2;
+
+/**
+ * Telemetry + dev-config exports consumed by this bridge. All optional: an
+ * older WASM artifact without them degrades gracefully (a warning, no throw),
+ * matching FetchHttpTransport / CloudSttProvider.
+ */
+interface TelemetryModule extends EmscriptenRunanywhereModule {
+  _rac_telemetry_manager_create?(
+    env: number,
+    deviceIdPtr: number,
+    platformPtr: number,
+    sdkVersionPtr: number,
+  ): number;
+  _rac_telemetry_manager_set_device_info?(
+    manager: number,
+    deviceModelPtr: number,
+    osVersionPtr: number,
+  ): void;
+  _rac_telemetry_manager_set_http_callback?(
+    manager: number,
+    callbackPtr: number,
+    userData: number,
+  ): void;
+  _rac_telemetry_manager_flush?(manager: number): number;
+  _rac_telemetry_manager_destroy?(manager: number): void;
+  _rac_events_set_telemetry_sink?(manager: number): void;
+
+  // Access token (JWT) accessor for the staging/prod Authorization header.
+  _rac_auth_get_access_token?(): number;
+  // Session accessors + setter used to replay the core module's auth session
+  // into backend modules so their commons authenticates and telemetry flushes.
+  _rac_auth_is_authenticated?(): number;
+  _rac_auth_get_refresh_token?(): number;
+  _rac_auth_get_token_expires_at?(): number | bigint;
+  _rac_auth_handle_authenticate_response?(jsonPtr: number): number;
+
+  // Dev-mode endpoint config (EMSCRIPTEN_KEEPALIVE wrappers in wasm_exports.cpp).
+  _rac_wasm_dev_config_is_available?(): number;
+  _rac_wasm_dev_config_get_supabase_url?(): number;
+  _rac_wasm_dev_config_get_supabase_key?(): number;
+}
+
+export interface TelemetryInstallParams {
+  /** SDK environment — selects dev vs staging/prod HTTP behavior + JSON shape. */
+  environment: SDKEnvironment;
+  /** Backend base URL (init option) — POST target for staging/prod telemetry. */
+  baseUrl: string;
+  /** Persistent device UUID (same value passed to native Phase 1). */
+  deviceId: string;
+  /** Device model string for telemetry attribution (Web: "Browser"). */
+  deviceModel: string;
+  /** OS string for telemetry attribution (Web: derived from userAgent). */
+  osVersion: string;
+  /** SDK version string. */
+  sdkVersion: string;
+}
+
+interface InstalledTelemetry {
+  manager: number;
+  callbackPtr: number;
+}
+
+/** One telemetry manager + callback per WASM module. */
+const installed = new WeakMap<EmscriptenRunanywhereModule, InstalledTelemetry>();
+
+/**
+ * Cached development endpoint config. The compiled-in dev config is identical
+ * across all three artifacts, so it is resolved once (from whichever module
+ * exports the KEEPALIVE getters — the core 'commons' module always does) and
+ * reused by every module's callback, including backend modules whose own build
+ * may not export the dev-config wrappers.
+ */
+let devEndpoint: { baseUrl: string; key: string } | null = null;
+
+function allocCString(module: EmscriptenRunanywhereModule, value: string): number {
+  const size = module.lengthBytesUTF8(value) + 1;
+  const ptr = module._malloc(size);
+  module.stringToUTF8(value, ptr, size);
+  return ptr;
+}
+
+function toRacEnvironment(env: SDKEnvironment): number {
+  switch (env) {
+    case SDKEnvironment.SDK_ENVIRONMENT_PRODUCTION:
+      return RAC_ENV_PRODUCTION;
+    case SDKEnvironment.SDK_ENVIRONMENT_STAGING:
+      return RAC_ENV_STAGING;
+    default:
+      // UNSPECIFIED / DEVELOPMENT both map to the no-auth dev path.
+      return RAC_ENV_DEVELOPMENT;
+  }
+}
+
+function joinUrl(baseUrl: string, path: string): string {
+  const base = baseUrl.replace(/\/+$/, '');
+  const suffix = path.startsWith('/') ? path : `/${path}`;
+  return base + suffix;
+}
+
+/** Resolve (and cache) the dev endpoint config from the 'commons' module. */
+function resolveDevEndpoint(): { baseUrl: string; key: string } | null {
+  if (devEndpoint) return devEndpoint;
+  const commons = getModuleForCapability('commons') as TelemetryModule | null;
+  if (
+    !commons ||
+    typeof commons._rac_wasm_dev_config_is_available !== 'function' ||
+    typeof commons._rac_wasm_dev_config_get_supabase_url !== 'function' ||
+    typeof commons._rac_wasm_dev_config_get_supabase_key !== 'function'
+  ) {
+    return null;
+  }
+  if (commons._rac_wasm_dev_config_is_available() === 0) return null;
+  const urlPtr = commons._rac_wasm_dev_config_get_supabase_url();
+  const keyPtr = commons._rac_wasm_dev_config_get_supabase_key();
+  const baseUrl = urlPtr ? commons.UTF8ToString(urlPtr) : '';
+  const key = keyPtr ? commons.UTF8ToString(keyPtr) : '';
+  if (!baseUrl || !key) return null;
+  devEndpoint = { baseUrl, key };
+  return devEndpoint;
+}
+
+/** Fire-and-forget development telemetry POST (mirrors RN InitBridge headers). */
+function postDevTelemetry(endpoint: string, json: string): void {
+  const cfg = resolveDevEndpoint();
+  if (!cfg) {
+    logger.debug(`Skipping telemetry POST ${endpoint}: no usable dev config`);
+    return;
+  }
+  const url = joinUrl(cfg.baseUrl, endpoint);
+  void fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: cfg.key,
+      Authorization: `Bearer ${cfg.key}`,
+    },
+    body: json,
+  })
+    .then((res) => {
+      logger.debug(`Telemetry POST ${endpoint} -> ${res.status}`);
+    })
+    .catch((err) => {
+      logger.debug(
+        `Telemetry POST ${endpoint} error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+}
+
+/**
+ * Fire-and-forget staging/production telemetry POST. Resolves the JWT from the
+ * authenticated `'commons'` module (`rac_auth_get_access_token`) and attaches
+ * it as a Bearer header. The raw apiKey is never sent — the backend rejects it.
+ */
+function postProdTelemetry(endpoint: string, json: string, baseUrl: string): void {
+  if (!baseUrl) {
+    logger.debug(`Skipping telemetry POST ${endpoint}: no base URL configured`);
+    return;
+  }
+  const commons = getModuleForCapability('commons') as TelemetryModule | null;
+  if (!commons || typeof commons._rac_auth_get_access_token !== 'function') {
+    logger.debug(
+      `Skipping telemetry POST ${endpoint}: rac_auth_get_access_token unavailable (rebuild WASM)`,
+    );
+    return;
+  }
+  const tokenPtr = commons._rac_auth_get_access_token();
+  const token = tokenPtr ? commons.UTF8ToString(tokenPtr) : '';
+  if (!token) {
+    logger.debug(`Skipping telemetry POST ${endpoint}: not authenticated yet`);
+    return;
+  }
+  const url = joinUrl(baseUrl, endpoint);
+  void fetch(url, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${token}`,
+    },
+    body: json,
+  })
+    .then((res) => {
+      logger.debug(`Telemetry POST ${endpoint} -> ${res.status}`);
+    })
+    .catch((err) => {
+      logger.debug(
+        `Telemetry POST ${endpoint} error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    });
+}
+
+/**
+ * Replay the core module's auth session into a backend WASM module.
+ *
+ * Web loads three independent commons instances; only the core 'commons' module
+ * runs the apiKey->JWT exchange (Phase 2). The backend modules (llamacpp/onnx)
+ * stay unauthenticated, so in staging/prod their telemetry flush defers on the
+ * `rac_auth_is_authenticated()` gate in `rac_telemetry_manager_flush` —
+ * LLM/VLM/STT/TTS/VAD telemetry never sends. This copies the core's access +
+ * refresh token and expiry into `target` via `rac_auth_handle_authenticate_response`,
+ * which both marks the target authenticated AND drains the telemetry it deferred
+ * while waiting. Idempotent + best-effort: a no-op if the target is already
+ * authenticated, is the core module itself, or the exports are absent (older
+ * WASM). The raw apiKey is never used — only the real JWT.
+ */
+function syncCoreAuthToModule(target: EmscriptenRunanywhereModule): void {
+  const t = target as TelemetryModule;
+  if (typeof t._rac_auth_handle_authenticate_response !== 'function') return;
+  // Already authenticated (or core re-applying its own session) — skip so we
+  // don't re-publish auth events / re-flush on every call.
+  if (typeof t._rac_auth_is_authenticated === 'function' && t._rac_auth_is_authenticated() !== 0) {
+    return;
+  }
+
+  const core = getModuleForCapability('commons') as TelemetryModule | null;
+  if (!core || core === target) return;
+  if (typeof core._rac_auth_is_authenticated !== 'function' || core._rac_auth_is_authenticated() === 0) {
+    return;
+  }
+  if (typeof core._rac_auth_get_access_token !== 'function') return;
+
+  const tokenPtr = core._rac_auth_get_access_token();
+  const token = tokenPtr ? core.UTF8ToString(tokenPtr) : '';
+  if (!token) return;
+
+  const refreshPtr =
+    typeof core._rac_auth_get_refresh_token === 'function' ? core._rac_auth_get_refresh_token() : 0;
+  const refresh = refreshPtr ? core.UTF8ToString(refreshPtr) : '';
+  const expiresAt =
+    typeof core._rac_auth_get_token_expires_at === 'function'
+      ? Number(core._rac_auth_get_token_expires_at())
+      : 0;
+  const nowSec = Math.floor(Date.now() / 1000);
+  const expiresIn = expiresAt > nowSec ? expiresAt - nowSec : 3600;
+
+  // rac_auth_response_from_json (api_types.cpp) requires access_token +
+  // refresh_token. Backend modules never refresh (their only HTTP is the
+  // fire-and-forget telemetry POST), so when the core has no refresh token we
+  // reuse the access token purely to satisfy the parser's non-null check.
+  const json = JSON.stringify({
+    access_token: token,
+    refresh_token: refresh || token,
+    expires_in: expiresIn,
+  });
+  const ptr = allocCString(target, json);
+  try {
+    t._rac_auth_handle_authenticate_response(ptr);
+    logger.debug('Propagated core auth session into backend module; telemetry flush enabled');
+  } finally {
+    target._free(ptr);
+  }
+}
+
+export const TelemetryBridge = {
+  /**
+   * Create + wire a telemetry manager for `module` (idempotent per module).
+   * Mirrors the 4-step Phase-1 wiring shared by every other SDK:
+   * create -> set_device_info -> set_http_callback -> set_telemetry_sink.
+   */
+  install(module: EmscriptenRunanywhereModule, params: TelemetryInstallParams): void {
+    if (installed.has(module)) return;
+
+    const m = module as TelemetryModule;
+    if (
+      typeof m._rac_telemetry_manager_create !== 'function' ||
+      typeof m._rac_telemetry_manager_set_http_callback !== 'function' ||
+      typeof m._rac_events_set_telemetry_sink !== 'function'
+    ) {
+      logger.warning(
+        'WASM module missing telemetry exports (_rac_telemetry_manager_* / ' +
+          '_rac_events_set_telemetry_sink); telemetry not wired for this module. ' +
+          'Rebuild the artifact from wasm/CMakeLists.txt.',
+      );
+      return;
+    }
+
+    const racEnv = toRacEnvironment(params.environment);
+    const baseUrl = params.baseUrl;
+
+    // Create the manager (alloc transient C strings for the value args).
+    const deviceIdPtr = allocCString(m, params.deviceId);
+    const platformPtr = allocCString(m, 'web');
+    const sdkVersionPtr = allocCString(m, params.sdkVersion);
+    let manager = 0;
+    try {
+      manager = m._rac_telemetry_manager_create(racEnv, deviceIdPtr, platformPtr, sdkVersionPtr);
+    } finally {
+      m._free(deviceIdPtr);
+      m._free(platformPtr);
+      m._free(sdkVersionPtr);
+    }
+    if (!manager) {
+      logger.warning('rac_telemetry_manager_create returned null; telemetry not wired');
+      return;
+    }
+
+    if (typeof m._rac_telemetry_manager_set_device_info === 'function') {
+      const modelPtr = allocCString(m, params.deviceModel);
+      const osPtr = allocCString(m, params.osVersion);
+      try {
+        m._rac_telemetry_manager_set_device_info(manager, modelPtr, osPtr);
+      } finally {
+        m._free(modelPtr);
+        m._free(osPtr);
+      }
+    }
+
+    // C HTTP callback (`rac_telemetry_http_callback_t`):
+    //   void (*)(void* user_data, const char* endpoint, const char* json_body,
+    //            size_t json_length, rac_bool_t requires_auth)  => 'viiiii'.
+    // Read the heap strings synchronously (commons frees them right after the
+    // call returns), then dispatch a fire-and-forget POST.
+    const callbackPtr = m.addFunction(
+      (
+        _userData: number,
+        endpointPtr: number,
+        jsonBodyPtr: number,
+        jsonLength: number,
+        _requiresAuth: number,
+      ): void => {
+        if (!endpointPtr || !jsonBodyPtr) return;
+        const endpoint = m.UTF8ToString(endpointPtr);
+        const json = m.UTF8ToString(jsonBodyPtr, jsonLength);
+        if (racEnv === RAC_ENV_DEVELOPMENT) {
+          postDevTelemetry(endpoint, json);
+        } else {
+          postProdTelemetry(endpoint, json, baseUrl);
+        }
+      },
+      'viiiii',
+    );
+
+    m._rac_telemetry_manager_set_http_callback(manager, callbackPtr, 0);
+    m._rac_events_set_telemetry_sink(manager);
+
+    installed.set(module, { manager, callbackPtr });
+    // If the core module has already authenticated (a backend that loads after
+    // Phase 2), replay its session now so this module's telemetry can flush.
+    syncCoreAuthToModule(module);
+    logger.debug('Telemetry manager created and attached as event sink');
+  },
+
+  /**
+   * Detach + destroy the telemetry manager for `module`. Mirrors
+   * TelemetryBridge.cpp::shutdown — detach the sink first so the router stops
+   * feeding a manager we are about to destroy, then flush and destroy. Each
+   * module's sink is independent (its own commons), so clearing it here only
+   * affects this module.
+   */
+  uninstall(module: EmscriptenRunanywhereModule): void {
+    const state = installed.get(module);
+    if (!state) return;
+    installed.delete(module);
+
+    const m = module as TelemetryModule;
+    try {
+      m._rac_events_set_telemetry_sink?.(0);
+      m._rac_telemetry_manager_flush?.(state.manager);
+      m._rac_telemetry_manager_destroy?.(state.manager);
+    } catch (err) {
+      logger.debug(
+        `Telemetry teardown error: ${err instanceof Error ? err.message : String(err)}`,
+      );
+    }
+    try {
+      m.removeFunction(state.callbackPtr);
+    } catch {
+      /* table entry already retired */
+    }
+  },
+
+  /**
+   * Replay the core auth session into every registered module. Call after
+   * Phase-2 auth completes so backend modules (llamacpp/onnx), which never
+   * authenticate themselves, can flush their deferred LLM/VLM/STT/TTS/VAD
+   * telemetry in staging/production.
+   */
+  syncAuthToBackendModules(): void {
+    for (const m of getAllRegisteredModules()) {
+      syncCoreAuthToModule(m);
+    }
+  },
+};

--- a/sdk/runanywhere-web/packages/core/src/Infrastructure/DeviceCapabilities.ts
+++ b/sdk/runanywhere-web/packages/core/src/Infrastructure/DeviceCapabilities.ts
@@ -153,7 +153,7 @@ function getBrowserName(ua: string): string {
   return 'Unknown Browser';
 }
 
-function getOSVersion(ua: string): string {
+export function getOSVersion(ua: string): string {
   if (ua.includes('Windows')) return 'Windows';
   if (ua.includes('Mac OS X')) return 'macOS';
   if (ua.includes('Linux')) return 'Linux';

--- a/sdk/runanywhere-web/packages/core/src/Public/RunAnywhere.ts
+++ b/sdk/runanywhere-web/packages/core/src/Public/RunAnywhere.ts
@@ -47,6 +47,8 @@ import { SDKLogger } from '../Foundation/SDKLogger';
 import { requestPersistentStorage } from '../Infrastructure/BrowserStorage';
 import { LocalFileStorage } from '../Infrastructure/LocalFileStorage';
 import { OPFSBridge } from '../Infrastructure/OPFSBridge';
+import { getOSVersion } from '../Infrastructure/DeviceCapabilities';
+import { TelemetryBridge } from '../Adapters/TelemetryBridge';
 import {
   frameworkOPFSDir,
   primaryFilenameFromModel,
@@ -294,6 +296,23 @@ function throwIfSdkInitFailed(result: ProtoSdkInitResult | null, phase: string):
 }
 
 export function completeNativePhase1ForModule(module: EmscriptenRunanywhereModule): void {
+  const environment = _initOptions?.environment ?? SDKEnvironment.SDK_ENVIRONMENT_DEVELOPMENT;
+
+  // Wire the C++ telemetry manager + event sink for THIS module. The Web SDK
+  // loads three independent WASM modules (core / llamacpp / onnx), each with
+  // its own commons event router and telemetry sink, so telemetry is wired per
+  // module — ahead of the global phase1-proto once-guard below, which only lets
+  // the first-loaded module run rac_sdk_init_phase1_proto. install() is
+  // idempotent per module.
+  TelemetryBridge.install(module, {
+    environment,
+    baseUrl: _initOptions?.baseURL ?? '',
+    deviceId: ensureDeviceId(),
+    deviceModel: 'Browser',
+    osVersion: getOSVersion(typeof navigator !== 'undefined' ? navigator.userAgent : ''),
+    sdkVersion: SDK_VERSION,
+  });
+
   if (_hasCompletedNativePhase1) return;
   const sdkModule = module as SdkInitModule;
   if (typeof sdkModule._rac_sdk_init_phase1_proto !== 'function') {
@@ -303,7 +322,6 @@ export function completeNativePhase1ForModule(module: EmscriptenRunanywhereModul
     return;
   }
 
-  const environment = _initOptions?.environment ?? SDKEnvironment.SDK_ENVIRONMENT_DEVELOPMENT;
   const bytes = SdkInitPhase1Request.encode({
     environment: mapSdkInitEnvironment(environment),
     apiKey: _initOptions?.apiKey ?? '',
@@ -676,6 +694,9 @@ async function retryHTTPSetup(): Promise<void> {
       logger.debug(`HTTP/Auth retry warning: ${result.warning}`);
     }
     if (_hasCompletedHTTPSetup) {
+      // Auth succeeded late (offline init then online retry) — propagate the
+      // core session into backend modules for their telemetry flush.
+      TelemetryBridge.syncAuthToBackendModules();
       logger.info('HTTP/Auth setup succeeded on retry');
     }
     return;
@@ -972,6 +993,10 @@ export const RunAnywhere = {
         _hasCompletedServicesInit = true;
         _hasCompletedHTTPSetup = httpConfigured;
         if (httpConfigured) {
+          // Core just authenticated — replay its JWT session into the backend
+          // WASM modules so their LLM/VLM/STT/TTS/VAD telemetry stops deferring
+          // on the per-module auth gate.
+          TelemetryBridge.syncAuthToBackendModules();
           logger.debug('Services initialization complete (Phase 2)');
         } else {
           logger.debug('Services initialization complete (Phase 2, HTTP/auth deferred — will retry on next online call)');
@@ -1736,6 +1761,13 @@ export const RunAnywhere = {
 
   async shutdown(): Promise<void> {
     logger.info('Shutting down RunAnywhere Web SDK...');
+
+    // Detach + destroy each module's telemetry manager before the registry is
+    // cleared (a final flush runs inside uninstall). Idempotent with the
+    // per-module teardown in CommonsModule / the backend bridges.
+    for (const m of getAllRegisteredModules()) {
+      TelemetryBridge.uninstall(m);
+    }
 
     // Clear every WASM adapter singleton that `setRunanywhereModule()`
     // installed (DownloadAdapter, ModelLifecycleAdapter,

--- a/sdk/runanywhere-web/packages/core/src/internal.ts
+++ b/sdk/runanywhere-web/packages/core/src/internal.ts
@@ -115,6 +115,8 @@ export type {
 } from './Adapters/HTTPAdapter';
 export { FetchHttpTransport } from './Adapters/FetchHttpTransport';
 export type { FetchHttpTransportModule } from './Adapters/FetchHttpTransport';
+export { TelemetryBridge } from './Adapters/TelemetryBridge';
+export type { TelemetryInstallParams } from './Adapters/TelemetryBridge';
 
 export { ModelRegistryAdapter } from './Adapters/ModelRegistryAdapter';
 export type {

--- a/sdk/runanywhere-web/packages/core/src/runtime/CommonsModule.ts
+++ b/sdk/runanywhere-web/packages/core/src/runtime/CommonsModule.ts
@@ -27,6 +27,7 @@ import { SDKLogger } from '../Foundation/SDKLogger';
 import { ProtoErrorCode, SDKException } from '../Foundation/SDKException';
 import { PlatformAdapter, type PlatformAdapterModule } from './PlatformAdapter';
 import { HTTPAdapter } from '../Adapters/HTTPAdapter';
+import { TelemetryBridge } from '../Adapters/TelemetryBridge';
 import { ModelRegistryAdapter } from '../Adapters/ModelRegistryAdapter';
 import {
   getModuleForCapability,
@@ -154,6 +155,11 @@ export class CommonsModule {
   }
 
   private _teardown(): void {
+    if (this._module) {
+      // Detach the telemetry sink + destroy the manager before rac_shutdown
+      // tears down this module's commons.
+      TelemetryBridge.uninstall(this._module);
+    }
     if (this._module && this._loaded) {
       try {
         this._module._rac_shutdown?.();

--- a/sdk/runanywhere-web/packages/llamacpp/src/Foundation/LlamaCppBridge.ts
+++ b/sdk/runanywhere-web/packages/llamacpp/src/Foundation/LlamaCppBridge.ts
@@ -23,6 +23,7 @@ import {
   RAC_ERROR_MODULE_ALREADY_REGISTERED,
   SDKException,
   SDKLogger,
+  TelemetryBridge,
   registerWasmModule,
   unregisterWasmModule,
   type AccelerationMode,
@@ -206,6 +207,9 @@ export class LlamaCppBridge {
   }
 
   private _teardown(): void {
+    if (this._module) {
+      TelemetryBridge.uninstall(this._module);
+    }
     if (this._module && this._loaded) {
       try {
         this._module._rac_shutdown?.();

--- a/sdk/runanywhere-web/packages/onnx/src/Foundation/SherpaONNXBridge.ts
+++ b/sdk/runanywhere-web/packages/onnx/src/Foundation/SherpaONNXBridge.ts
@@ -35,6 +35,7 @@ import {
   RAC_ERROR_MODULE_ALREADY_REGISTERED,
   SDKException,
   SDKLogger,
+  TelemetryBridge,
   completeDeferredServicesInitialization,
   completeNativePhase1ForModule,
   missingSpeechBackendExports,
@@ -176,6 +177,7 @@ export class SherpaONNXBridge {
     if (!this._module || (!this._onnxBackendRegistered && !this._sherpaBackendRegistered)) {
       this._loaded = false;
       if (this._bridgeOwnedInit && this._module) {
+        TelemetryBridge.uninstall(this._module);
         try {
           this._module._rac_shutdown?.();
         } catch (err) {
@@ -226,6 +228,9 @@ export class SherpaONNXBridge {
     this._loaded = false;
 
     if (this._bridgeOwnedInit) {
+      if (this._module) {
+        TelemetryBridge.uninstall(this._module);
+      }
       try {
         this._module._rac_shutdown?.();
       } catch (err) {

--- a/sdk/runanywhere-web/wasm/CMakeLists.txt
+++ b/sdk/runanywhere-web/wasm/CMakeLists.txt
@@ -895,6 +895,15 @@ set(RAC_EXPORTED_FUNCTIONS_BASE
     "_rac_auth_is_authenticated"
     "_rac_auth_get_user_id"
     "_rac_auth_get_organization_id"
+    # Access token (JWT) accessor — lets the TS TelemetryBridge attach the
+    # Authorization: Bearer header for staging/production telemetry POSTs.
+    "_rac_auth_get_access_token"
+    # Session accessors + setter — the TS TelemetryBridge replays the core
+    # module's JWT session into the backend WASM modules (llamacpp/onnx) so
+    # their commons authenticates and per-module telemetry flush stops deferring.
+    "_rac_auth_get_refresh_token"
+    "_rac_auth_get_token_expires_at"
+    "_rac_auth_handle_authenticate_response"
     "_rac_state_is_device_registered"
 
     # Telemetry

--- a/sdk/runanywhere-web/wasm/scripts/vendor-onnxruntime-wasm.sh
+++ b/sdk/runanywhere-web/wasm/scripts/vendor-onnxruntime-wasm.sh
@@ -20,9 +20,50 @@ ONNX_RUNTIME_VERSION="${ONNX_RUNTIME_VERSION:-${ONNX_VERSION_LINUX}}"
 SRC_DIR="${ONNX_RUNTIME_SRC_DIR:-${WASM_DIR}/third_party/onnxruntime}"
 DEST_DIR="${REPO_ROOT}/sdk/runanywhere-commons/third_party/onnxruntime-wasm"
 BUILD_CONFIG="${ONNX_RUNTIME_BUILD_CONFIG:-Release}"
-ORT_BUILD_DIR="${SRC_DIR}/build/MacOS/${BUILD_CONFIG}"
+case "$(uname -s)" in
+  Darwin) _ORT_OS_DIR="MacOS" ;;
+  *)      _ORT_OS_DIR="Linux" ;;
+esac
+ORT_BUILD_DIR="${SRC_DIR}/build/${_ORT_OS_DIR}/${BUILD_CONFIG}"
 
 mkdir -p "$(dirname "${SRC_DIR}")" "${DEST_DIR}/lib" "${DEST_DIR}/include"
+
+# --- Prebuilt WASM bundle (download-first; mirrors the Android prebuilt .so) ---
+# The matched ORT+sherpa WASM static libs are published on the sherpa-onnx-rac
+# release. Download + extract instead of the ~30-60 min from-source build.
+# Force a source build with RAC_WASM_BUILD_FROM_SOURCE=1; override the source
+# repo/tag with RAC_WASM_PREBUILT_REPO / RAC_WASM_PREBUILT_TAG.
+if [ "${RAC_WASM_BUILD_FROM_SOURCE:-0}" != "1" ]; then
+  if [ -f "${DEST_DIR}/lib/libonnxruntime.a" ]; then
+    echo "ONNX Runtime WASM already vendored: ${DEST_DIR}/lib/libonnxruntime.a"
+    exit 0
+  fi
+  _RAC_TP="${REPO_ROOT}/sdk/runanywhere-commons/third_party"
+  _RAC_REPO="${RAC_WASM_PREBUILT_REPO:-${SHERPA_ONNX_REPO_ANDROID:-Siddhesh2377/sherpa-onnx-rac}}"
+  _RAC_TAG="${RAC_WASM_PREBUILT_TAG:-v${SHERPA_ONNX_VERSION_LINUX}}"
+  _RAC_TARBALL="sherpa-onnx-${_RAC_TAG}-wasm.tar.bz2"
+  _RAC_URL="https://github.com/${_RAC_REPO}/releases/download/${_RAC_TAG}/${_RAC_TARBALL}"
+  _RAC_CACHE="${WASM_DIR}/third_party/${_RAC_TARBALL}"
+  if [ ! -f "${_RAC_CACHE}" ]; then
+    echo "Downloading prebuilt WASM bundle: ${_RAC_URL}"
+    if curl -fL --retry 3 -o "${_RAC_CACHE}.part" "${_RAC_URL}"; then
+      mv "${_RAC_CACHE}.part" "${_RAC_CACHE}"
+    else
+      echo "Prebuilt download failed; falling back to from-source build."
+      rm -f "${_RAC_CACHE}.part"
+    fi
+  fi
+  if [ -f "${_RAC_CACHE}" ]; then
+    mkdir -p "${_RAC_TP}"
+    tar -xjf "${_RAC_CACHE}" -C "${_RAC_TP}" onnxruntime-wasm sherpa-onnx-wasm
+    if [ -f "${DEST_DIR}/lib/libonnxruntime.a" ]; then
+      echo "Vendored ONNX Runtime WASM from prebuilt bundle: ${DEST_DIR}/lib/libonnxruntime.a"
+      exit 0
+    fi
+    echo "Prebuilt extract did not produce libonnxruntime.a; falling back to from-source build."
+  fi
+fi
+# --- from-source build (reached if RAC_WASM_BUILD_FROM_SOURCE=1 or download failed) ---
 
 if [ ! -d "${SRC_DIR}/.git" ]; then
   rm -rf "${SRC_DIR}"
@@ -66,6 +107,7 @@ set +e
   --enable_wasm_simd \
   --skip_tests \
   --disable_rtti \
+  --parallel "${CMAKE_BUILD_PARALLEL_LEVEL:-12}" \
   --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5
 BUILD_RC=$?
 set -e

--- a/sdk/runanywhere-web/wasm/scripts/vendor-sherpa-onnx-wasm.sh
+++ b/sdk/runanywhere-web/wasm/scripts/vendor-sherpa-onnx-wasm.sh
@@ -18,6 +18,43 @@ DEST_DIR="${REPO_ROOT}/sdk/runanywhere-commons/third_party/sherpa-onnx-wasm"
 ORT_DIR="${REPO_ROOT}/sdk/runanywhere-commons/third_party/onnxruntime-wasm"
 BUILD_DIR="${SRC_DIR}/build-wasm-static"
 
+# --- Prebuilt WASM bundle (download-first; mirrors the Android prebuilt .so) ---
+# Download + extract the matched ORT+sherpa WASM static libs from the
+# sherpa-onnx-rac release instead of building from source. Force a source build
+# with RAC_WASM_BUILD_FROM_SOURCE=1; override the source repo/tag with
+# RAC_WASM_PREBUILT_REPO / RAC_WASM_PREBUILT_TAG.
+if [ "${RAC_WASM_BUILD_FROM_SOURCE:-0}" != "1" ]; then
+  if [ -f "${DEST_DIR}/lib/libsherpa-onnx-c-api.a" ]; then
+    echo "Sherpa-ONNX WASM already vendored: ${DEST_DIR}/lib/libsherpa-onnx-c-api.a"
+    exit 0
+  fi
+  _RAC_TP="${REPO_ROOT}/sdk/runanywhere-commons/third_party"
+  _RAC_REPO="${RAC_WASM_PREBUILT_REPO:-${SHERPA_ONNX_REPO_ANDROID:-Siddhesh2377/sherpa-onnx-rac}}"
+  _RAC_TAG="${RAC_WASM_PREBUILT_TAG:-v${SHERPA_ONNX_VERSION_LINUX}}"
+  _RAC_TARBALL="sherpa-onnx-${_RAC_TAG}-wasm.tar.bz2"
+  _RAC_URL="https://github.com/${_RAC_REPO}/releases/download/${_RAC_TAG}/${_RAC_TARBALL}"
+  _RAC_CACHE="${WASM_DIR}/third_party/${_RAC_TARBALL}"
+  if [ ! -f "${_RAC_CACHE}" ]; then
+    echo "Downloading prebuilt WASM bundle: ${_RAC_URL}"
+    if curl -fL --retry 3 -o "${_RAC_CACHE}.part" "${_RAC_URL}"; then
+      mv "${_RAC_CACHE}.part" "${_RAC_CACHE}"
+    else
+      echo "Prebuilt download failed; falling back to from-source build."
+      rm -f "${_RAC_CACHE}.part"
+    fi
+  fi
+  if [ -f "${_RAC_CACHE}" ]; then
+    mkdir -p "${_RAC_TP}"
+    tar -xjf "${_RAC_CACHE}" -C "${_RAC_TP}" onnxruntime-wasm sherpa-onnx-wasm
+    if [ -f "${DEST_DIR}/lib/libsherpa-onnx-c-api.a" ]; then
+      echo "Vendored Sherpa-ONNX WASM from prebuilt bundle: ${DEST_DIR}/lib/libsherpa-onnx-c-api.a"
+      exit 0
+    fi
+    echo "Prebuilt extract did not produce libsherpa-onnx-c-api.a; falling back to from-source build."
+  fi
+fi
+# --- from-source build (reached if RAC_WASM_BUILD_FROM_SOURCE=1 or download failed) ---
+
 if [ ! -f "${ORT_DIR}/lib/libonnxruntime.a" ]; then
   echo "ERROR: ${ORT_DIR}/lib/libonnxruntime.a is required before building Sherpa-ONNX WASM." >&2
   echo "Run: sdk/runanywhere-web/wasm/scripts/vendor-onnxruntime-wasm.sh" >&2


### PR DESCRIPTION
## Summary

Two web-SDK fixes (one per commit).

### 1. Wire commons telemetry into the Web SDK
Web was the only SDK that never wired the C++ telemetry manager — the WASM exported the full telemetry ABI but TS never created a manager / set the HTTP callback / set the event sink, so every telemetry event hit a NULL sink and was dropped.

- **`Adapters/TelemetryBridge.ts` (new)** — per-module `install`/`uninstall` doing the canonical wiring (`create` → `set_device_info` → `set_http_callback` via `addFunction` → `set_telemetry_sink`), mirroring iOS/Kotlin/RN/Flutter. Web loads 3 independent WASM modules (core/llamacpp/onnx), each with its own commons/router/sink, so telemetry is wired **per module** from `completeNativePhase1ForModule`.
- **HTTP:** dev posts to the compiled Supabase endpoint; staging/prod attach the JWT from the apiKey→JWT exchange — the raw apiKey is never sent.
- **Cross-module auth propagation:** backend modules (llamacpp/onnx) never authenticate, so their telemetry flush deferred in prod. `syncCoreAuthToModule` replays the core's session into each backend module via `rac_auth_handle_authenticate_response` (which also drains deferred telemetry), so LLM/VLM/STT/TTS/VAD telemetry flows.
- **New WASM exports** (existing commons fns, exposed in `wasm/CMakeLists.txt`): `rac_auth_get_access_token`, `rac_auth_get_refresh_token`, `rac_auth_get_token_expires_at`, `rac_auth_handle_authenticate_response`.
- **Bug fix (`FetchHttpTransport`):** `xhr.timeout` was set on a *synchronous* XHR without a guard — that throws `InvalidAccessError` from a document, silently failing **all** main-thread control-plane HTTP (auth, device-register, model-assignments, telemetry) as `status:0` / `RAC_ERROR_NETWORK_ERROR`. Now guarded like `responseType` already is.
- **Example:** `settings.ts` falls back to a gitignored `.env.local` (`import.meta.env`) for creds; `vite-env.d.ts` types it.

### 2. Vendor ONNX/sherpa WASM via prebuilt download
- Fixed two Linux bugs in `vendor-onnxruntime-wasm.sh`: it never passed `--parallel` to ORT's `build.py` (serial build), and hardcoded `build/MacOS/` (broke the `.a` find/fallback on Linux).
- Added a **download-first** path to both vendor scripts: fetch the matched ORT+sherpa WASM static-lib bundle from the `sherpa-onnx-rac` release and extract, instead of the ~30–60 min from-source build. Idempotent; falls back to a source build on download failure or `RAC_WASM_BUILD_FROM_SOURCE=1`. Mirrors the Android prebuilt `.so` model.

## Testing
- `tsc --noEmit` clean for `@runanywhere/web`, `@runanywhere/web-llamacpp`, `@runanywhere/web-onnx`.
- Built all three WASM modules (core/llamacpp/onnx) in-tree; the auth/telemetry exports are present in each.
- Download-first vendor path verified end-to-end (downloads + extracts in ~10 s; idempotent skip; from-source fallback intact).

## Notes
- Prebuilt bundle published as `sherpa-onnx-v1.13.2-wasm.tar.bz2` on the sherpa-onnx-rac `v1.13.2` release.
- Runtime verification of telemetry landing on the backend is still pending a manual run of the web example.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches init/auth/telemetry and synchronous HTTP used for SDK control plane; mis-wiring could drop or mis-attribute events, though the XHR fix reduces prior silent failures. Prebuilt vendor scripts change build reproducibility but fall back to source builds.
> 
> **Overview**
> The Web SDK finally wires the commons **telemetry manager** into each of the three WASM modules (core, llamacpp, onnx) via a new **`TelemetryBridge`**: create manager, HTTP callback (`fetch` POST), and event sink on Phase 1, with teardown on shutdown/bridge unload. **Staging/production** telemetry uses the core module’s JWT (`rac_auth_get_access_token`); **development** uses compiled-in Supabase config. **`syncAuthToBackendModules`** replays the core auth session into backend modules after Phase 2 / HTTP retry so LLM/STT telemetry is not stuck behind per-module auth gates.
> 
> **`FetchHttpTransport`** now wraps **`xhr.timeout`** in try/catch for synchronous XHR (same pattern as `responseType`), avoiding **`InvalidAccessError`** that was failing auth, device register, and other main-thread HTTP as network errors.
> 
> WASM **`CMakeLists.txt`** exports additional auth helpers for that bridge. The RunAnywhereAI example can boot from **`VITE_RUNANYWHERE_*`** in `.env.local`; **`vite-env.d.ts`** types those vars.
> 
> **Vendor scripts** for ONNX Runtime and Sherpa-ONNX WASM prefer downloading a prebuilt **`sherpa-onnx-rac`** tarball (fallback to from-source), fix Linux **`build/`** paths, and pass **`--parallel`** to ORT’s build.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9ad8c4cbbbdd31c52a1e153f62f0ffdc423abca7. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced telemetry system integrated across SDK modules for improved monitoring and diagnostics.

* **Bug Fixes**
  * Hardened XHR timeout error handling to prevent exceptions in specific browser scenarios.

* **Chores**
  * Improved build process with OS-aware detection and prebuilt WASM library support for faster compilation.
  * Refined environment configuration fallback behavior for API credentials and endpoints.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->