### PR TITLE
web: model discovery, live download progress, VLM deadlock fix, RAG/vision download UI

### DIFF
--- a/examples/web/RunAnywhereAI/src/components/model-selection.ts
+++ b/examples/web/RunAnywhereAI/src/components/model-selection.ts
@@ -65,6 +65,7 @@ let toolbarText: HTMLElement | null = null;
 let getStartedOverlay: HTMLElement | null = null;
 let getStartedBtn: HTMLButtonElement | null = null;
 let catalogRegistered = false;
+let hydratedSubscribed = false;
 const listeners: Array<() => void> = [];
 
 /**
@@ -94,6 +95,30 @@ export function notifyCatalogRegistered(registeredCount: number): void {
   catalogRegistered = registeredCount > 0;
   if (catalogRegistered) {
     hydrateRowStatesFromRegistry();
+  }
+  // Cold-start hydration (RunAnywhere.hydrateModelRegistry) runs asynchronously
+  // after phase-2 and may mark models downloaded *after* this initial seed.
+  // Subscribe once so the picker, toolbar pill, and per-view consumers refresh
+  // to Downloaded/Load instead of showing Download for already-present models.
+  if (!hydratedSubscribed) {
+    hydratedSubscribed = true;
+    try {
+      RunAnywhere.events.on('models.hydrated', () => {
+        hydrateRowStatesFromRegistry();
+        if (modalEl) renderRows();
+        refreshToolbarLabel();
+        refreshOverlayVisibility();
+        for (const listener of listeners) {
+          try {
+            listener();
+          } catch (err) {
+            console.warn('[model-selection] hydrated listener threw', err);
+          }
+        }
+      });
+    } catch {
+      hydratedSubscribed = false; // EventBus unavailable; retry on next call
+    }
   }
   refreshToolbarLabel();
   refreshOverlayVisibility();

--- a/examples/web/RunAnywhereAI/src/main.ts
+++ b/examples/web/RunAnywhereAI/src/main.ts
@@ -376,6 +376,8 @@ async function initializeSDK(): Promise<void> {
       console.warn(
         '[RunAnywhere] onnx backend failed to register; STT/TTS/VAD will show feature-unavailable:',
         formatError(err),
+        '| details:',
+        (err as { proto?: { nestedMessage?: string } })?.proto?.nestedMessage ?? '(none)',
       );
     }
 

--- a/examples/web/RunAnywhereAI/src/views/documents.ts
+++ b/examples/web/RunAnywhereAI/src/views/documents.ts
@@ -56,16 +56,19 @@ export function initDocumentsTab(el: HTMLElement): TabLifecycle {
       <div class="docs-section">
         <h3>Pipeline models</h3>
         <p class="text-secondary">Choose an embedding model and an LLM model from the registry; the RAG pipeline is created with this pair.</p>
-        <div class="docs-actions" style="display:flex; gap:12px; flex-wrap:wrap;">
+        <div class="docs-actions" style="display:flex; gap:12px; flex-wrap:wrap; align-items:flex-end;">
           <label style="display:flex; flex-direction:column; gap:4px; font-size:0.8rem;">
             Embedding model
             <select id="docs-embedding-model" class="chat-input" style="min-width:220px"></select>
           </label>
+          <button class="btn btn-secondary" id="docs-embedding-download-btn">Download</button>
           <label style="display:flex; flex-direction:column; gap:4px; font-size:0.8rem;">
             LLM model
             <select id="docs-llm-model" class="chat-input" style="min-width:220px"></select>
           </label>
+          <button class="btn btn-secondary" id="docs-llm-download-btn">Download</button>
         </div>
+        <div id="docs-model-status" class="docs-status"></div>
       </div>
       <div class="docs-section">
         <h3>Indexed documents</h3>
@@ -104,8 +107,85 @@ export function initDocumentsTab(el: HTMLElement): TabLifecycle {
   container.querySelector('#docs-ask-btn')!.addEventListener('click', () => {
     void askQuestion();
   });
+  container.querySelector('#docs-embedding-download-btn')!.addEventListener('click', () => {
+    void downloadSelectedModel(selectedEmbeddingModelId, 'embedding');
+  });
+  container.querySelector('#docs-llm-download-btn')!.addEventListener('click', () => {
+    void downloadSelectedModel(selectedLlmModelId, 'LLM');
+  });
+  refreshModelButtons();
 
   return {};
+}
+
+// ---------------------------------------------------------------------------
+// Model download
+// ---------------------------------------------------------------------------
+
+function setModelStatus(msg: string): void {
+  const el = container.querySelector<HTMLElement>('#docs-model-status');
+  if (el) el.textContent = msg;
+}
+
+/** Reflect downloaded state on the two download buttons. */
+function refreshModelButtons(): void {
+  const pairs: Array<['embedding' | 'llm', string]> = [
+    ['embedding', selectedEmbeddingModelId],
+    ['llm', selectedLlmModelId],
+  ];
+  for (const [kind, modelId] of pairs) {
+    const btn = container.querySelector<HTMLButtonElement>(`#docs-${kind}-download-btn`);
+    if (!btn) continue;
+    const model = modelId ? RunAnywhere.getModel(modelId) : null;
+    const downloaded = !!(model?.isDownloaded || model?.localPath);
+    btn.disabled = isBusy || !modelId || downloaded;
+    btn.textContent = downloaded ? 'Downloaded' : 'Download';
+  }
+}
+
+async function downloadSelectedModel(
+  modelId: string,
+  label: string,
+): Promise<void> {
+  if (!modelId) {
+    setModelStatus(`Select a ${label} model first.`);
+    return;
+  }
+  const model = RunAnywhere.getModel(modelId);
+  if (!model) {
+    setModelStatus(`${label} model '${modelId}' is not registered.`);
+    return;
+  }
+  isBusy = true;
+  refreshModelButtons();
+  setModelStatus(`Downloading ${label} model ${model.name || modelId}…`);
+  try {
+    await RunAnywhere.downloadModel({
+      modelId,
+      model,
+      allowMeteredNetwork: true,
+      resumeExisting: true,
+      verifyChecksums: false,
+      validateExistingBytes: false,
+      updateRegistryOnCompletion: true,
+      storageNamespace: '',
+      availableStorageBytes: 0,
+      requiredFreeBytesAfterDownload: 0,
+      pollIntervalMs: 500,
+      onProgress: (next) => {
+        const pct = next.totalBytes > 0
+          ? Math.round((Number(next.bytesDownloaded) / Number(next.totalBytes)) * 100)
+          : 0;
+        setModelStatus(`Downloading ${label} model… ${pct}%`);
+      },
+    });
+    setModelStatus(`${label} model ready: ${model.name || modelId}.`);
+  } catch (err) {
+    setModelStatus(`${label} model download failed: ${formatError(err)}`);
+  } finally {
+    isBusy = false;
+    refreshModelButtons();
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -136,9 +216,11 @@ function populateModelPickers(): void {
 
   embeddingSelect.addEventListener('change', () => {
     selectedEmbeddingModelId = embeddingSelect.value;
+    refreshModelButtons();
   });
   llmSelect.addEventListener('change', () => {
     selectedLlmModelId = llmSelect.value;
+    refreshModelButtons();
   });
 }
 

--- a/examples/web/RunAnywhereAI/src/views/vision.ts
+++ b/examples/web/RunAnywhereAI/src/views/vision.ts
@@ -43,6 +43,9 @@ const CAPTURE_DIMENSION = 384;
 let container: HTMLElement;
 let camera: VideoCapture | null = null;
 let latestFrame: { rgbPixels: Uint8Array; width: number; height: number } | null = null;
+// Data URL preview for an image loaded from disk (null when the source is the
+// live camera). Lets the preview survive innerHTML re-renders without a camera.
+let loadedPreviewUrl: string | null = null;
 let lastResult: string | null = null;
 let status = '';
 let isBusy = false;
@@ -90,7 +93,7 @@ export function initVisionTab(el: HTMLElement): TabLifecycle {
 function renderView(): void {
   const modelLoaded = isVLMModelLoaded();
   const captureReady = camera?.isCapturing ?? false;
-  const canAnalyze = modelLoaded && captureReady && !isBusy;
+  const canAnalyze = modelLoaded && (captureReady || latestFrame !== null) && !isBusy;
 
   container.innerHTML = `
     <div class="toolbar">
@@ -120,6 +123,10 @@ function renderView(): void {
           <button class="btn btn-secondary" id="vision-capture-btn" ${captureReady && !isBusy ? '' : 'disabled'}>
             Capture frame
           </button>
+          <button class="btn btn-secondary" id="vision-load-image-btn" ${isBusy ? 'disabled' : ''}>
+            Load image…
+          </button>
+          <input type="file" id="vision-image-input" accept="image/*" hidden />
         </div>
         <div id="vision-preview" class="vision-preview"></div>
         <div id="vision-frame-meta" class="docs-status">${frameMetaLabel()}</div>
@@ -165,6 +172,11 @@ function renderView(): void {
   container
     .querySelector('#vision-capture-btn')!
     .addEventListener('click', () => captureFrame());
+  const imageInput = container.querySelector<HTMLInputElement>('#vision-image-input')!;
+  container
+    .querySelector('#vision-load-image-btn')!
+    .addEventListener('click', () => imageInput.click());
+  imageInput.addEventListener('change', () => void onImageFileSelected(imageInput));
   container
     .querySelector('#vision-analyze-btn')!
     .addEventListener('click', () => void onAnalyze());
@@ -175,9 +187,20 @@ function renderView(): void {
 
 function reattachCameraPreview(): void {
   const host = container.querySelector<HTMLElement>('#vision-preview');
-  if (!host || !camera) return;
+  if (!host) return;
   host.innerHTML = '';
-  host.appendChild(camera.videoElement);
+  if (camera) {
+    host.appendChild(camera.videoElement);
+    return;
+  }
+  if (loadedPreviewUrl) {
+    const img = document.createElement('img');
+    img.src = loadedPreviewUrl;
+    img.alt = 'Loaded image';
+    img.style.maxWidth = '100%';
+    img.style.borderRadius = '8px';
+    host.appendChild(img);
+  }
 }
 
 function frameMetaLabel(): string {
@@ -234,8 +257,87 @@ function captureFrame(): void {
     return;
   }
   latestFrame = frame;
+  loadedPreviewUrl = null;
   setStatus(`Captured ${frame.width}×${frame.height} frame.`);
   renderView();
+}
+
+// ---------------------------------------------------------------------------
+// Image from disk
+// ---------------------------------------------------------------------------
+
+async function onImageFileSelected(input: HTMLInputElement): Promise<void> {
+  const file = input.files?.[0];
+  // Reset so re-selecting the same file fires `change` again.
+  input.value = '';
+  if (!file) return;
+
+  isBusy = true;
+  setStatus('Loading image…');
+  renderView();
+  try {
+    const decoded = await decodeImageToRgbFrame(file, CAPTURE_DIMENSION);
+    // A loaded image is an alternative frame source — drop the live camera so
+    // the preview and analysis operate on the picked image.
+    stopCamera();
+    latestFrame = {
+      rgbPixels: decoded.rgbPixels,
+      width: decoded.width,
+      height: decoded.height,
+    };
+    loadedPreviewUrl = decoded.previewUrl;
+    setStatus(`Loaded ${decoded.width}×${decoded.height} image from ${file.name}.`);
+  } catch (err) {
+    setStatus(`Failed to load image: ${formatError(err)}`);
+  } finally {
+    isBusy = false;
+    renderView();
+  }
+}
+
+/**
+ * Decode an image file into the same raw-RGB frame shape the camera produces:
+ * aspect-preserving downscale so the longest side is `maxDim`, alpha stripped.
+ */
+async function decodeImageToRgbFrame(
+  file: File,
+  maxDim: number,
+): Promise<{ rgbPixels: Uint8Array; width: number; height: number; previewUrl: string }> {
+  const objectUrl = URL.createObjectURL(file);
+  try {
+    const img = await loadImageElement(objectUrl);
+    const longest = Math.max(img.naturalWidth, img.naturalHeight) || 1;
+    const scale = Math.min(1, maxDim / longest);
+    const width = Math.max(1, Math.round(img.naturalWidth * scale));
+    const height = Math.max(1, Math.round(img.naturalHeight * scale));
+
+    const canvas = document.createElement('canvas');
+    canvas.width = width;
+    canvas.height = height;
+    const ctx = canvas.getContext('2d', { willReadFrequently: true });
+    if (!ctx) throw new Error('2D canvas context unavailable');
+    ctx.drawImage(img, 0, 0, width, height);
+
+    const { data } = ctx.getImageData(0, 0, width, height); // RGBA
+    const rgbPixels = new Uint8Array(width * height * 3);
+    for (let src = 0, dst = 0; src < data.length; src += 4, dst += 3) {
+      rgbPixels[dst] = data[src];
+      rgbPixels[dst + 1] = data[src + 1];
+      rgbPixels[dst + 2] = data[src + 2];
+    }
+    return { rgbPixels, width, height, previewUrl: canvas.toDataURL('image/png') };
+  } finally {
+    URL.revokeObjectURL(objectUrl);
+  }
+}
+
+function loadImageElement(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const img = new Image();
+    img.onload = () => resolve(img);
+    img.onerror = () => reject(new Error('Could not decode the selected image'));
+    img.src = src;
+  });
 }
 
 // ---------------------------------------------------------------------------
@@ -243,12 +345,6 @@ function captureFrame(): void {
 // ---------------------------------------------------------------------------
 
 async function onAnalyze(): Promise<void> {
-  if (!camera?.isCapturing) {
-    setStatus('Start the camera first.');
-    renderView();
-    return;
-  }
-
   // Gate on the lifecycle's loaded multimodal model — iOS parity:
   // VLMViewModel.swift:58-62 checkModelStatus() (currentModel(.multimodal)).
   if (!isVLMModelLoaded()) {
@@ -259,9 +355,11 @@ async function onAnalyze(): Promise<void> {
     return;
   }
 
-  const frame = latestFrame ?? camera.captureFrame(CAPTURE_DIMENSION);
+  // Frame source: an already-captured/loaded frame, or a fresh camera grab.
+  const frame =
+    latestFrame ?? (camera?.isCapturing ? camera.captureFrame(CAPTURE_DIMENSION) : null);
   if (!frame) {
-    setStatus('Failed to capture a frame for analysis.');
+    setStatus('Capture a camera frame or load an image first.');
     renderView();
     return;
   }

--- a/sdk/runanywhere-commons/src/infrastructure/download/download_orchestrator.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/download/download_orchestrator.cpp
@@ -1320,8 +1320,330 @@ void run_proto_download_worker_async(void* user_data) {
     run_proto_download_worker(args->task, args->resume_from);
 }
 
+// =============================================================================
+// EVENT-DRIVEN ASYNC DOWNLOAD DRIVER (Emscripten / Web)
+// =============================================================================
+// The synchronous worker above buffers the whole body on the main thread when
+// the only transport is FetchHttpTransport's sync XHR — the UI freezes and the
+// poll loop never ticks until 100%. When the platform supplies the async
+// `http_download` adapter slot (the Web SDK implements it with streaming
+// fetch + ReadableStream), drive the plan event-driven instead: start a file,
+// report each chunk via the progress callback, and on completion advance to the
+// next file or finalize. Nothing blocks the main thread, so progress is live.
+//
+// This path reuses every leaf helper the synchronous worker uses
+// (set_task_progress / emit_progress / extraction / validate_downloaded_sizes /
+// resolve_completion_local_path / self_heal_registry). Only the *sequencing*
+// differs (callback continuation vs a blocking loop). The synchronous worker
+// and all native code are left untouched and remain the fallback when the slot
+// is absent.
+//
+// Integrity: the slot delivers bytes to the platform (MEMFS), never to C++, so
+// the streaming SHA-256 the synchronous path computes cannot run here. The
+// post-download size guard (validate_downloaded_sizes) plus HTTPS transport
+// integrity cover truncation/stub responses; per-byte checksum is a Web-path
+// tradeoff (the native path keeps full SHA-256).
+struct web_download_driver {
+    std::shared_ptr<proto_download_task> task;
+    int64_t total_expected = 0;
+    int64_t completed_before_file = 0;
+    size_t file_index = 0;
+    std::string final_path;
+    char* current_task_id = nullptr;  // owned C string from http_download out_task_id
+    bool cancel_abort_sent = false;
+};
+
+// Keeps each driver alive across the async callbacks (the callbacks carry only a
+// raw driver* as user_data). Erasing drops the last owner and frees the driver.
+std::map<web_download_driver*, std::shared_ptr<web_download_driver>>& web_download_registry() {
+    static std::map<web_download_driver*, std::shared_ptr<web_download_driver>> registry;
+    return registry;
+}
+
+void web_download_start_file(web_download_driver* drv);
+void web_download_finalize_all(web_download_driver* drv);
+
+// MUST be the final action on a driver in any terminal branch — frees the
+// driver, so nothing may touch `drv` afterwards.
+void web_download_finish(web_download_driver* drv) {
+    if (!drv) {
+        return;
+    }
+    if (drv->current_task_id) {
+        free(drv->current_task_id);
+        drv->current_task_id = nullptr;
+    }
+    web_download_registry().erase(drv);
+}
+
+// rac_http_progress_callback_fn: void (int64 bytes, int64 total, void* user_data).
+void web_download_on_progress(int64_t bytes_downloaded, int64_t /*total_bytes*/, void* user_data) {
+    auto* drv = static_cast<web_download_driver*>(user_data);
+    if (!drv) {
+        return;
+    }
+    const std::shared_ptr<proto_download_task>& task = drv->task;
+
+    // Cooperative cancel: abort the in-flight fetch once; on_complete then fires
+    // with RAC_ERROR_CANCELLED and emits the terminal event.
+    if (task->cancel_requested.load() && !drv->cancel_abort_sent) {
+        drv->cancel_abort_sent = true;
+        const rac_platform_adapter_t* adapter = rac_get_platform_adapter();
+        if (adapter && adapter->http_download_cancel && drv->current_task_id) {
+            adapter->http_download_cancel(drv->current_task_id, adapter->user_data);
+        }
+        return;
+    }
+
+    const int64_t downloaded = drv->completed_before_file + bytes_downloaded;
+    const proto_plan_file& file = task->files[drv->file_index];
+    set_task_progress(task, rav1::DOWNLOAD_STATE_DOWNLOADING, rav1::DOWNLOAD_STAGE_DOWNLOADING,
+                      downloaded, drv->total_expected, static_cast<int32_t>(drv->file_index),
+                      file.storage_key, "", "");
+    emit_progress(task);
+}
+
+// rac_http_complete_callback_fn: void (rac_result_t, const char* path, void* user_data).
+void web_download_on_complete(rac_result_t result, const char* /*downloaded_path*/, void* user_data) {
+    auto* drv = static_cast<web_download_driver*>(user_data);
+    if (!drv) {
+        return;
+    }
+    // Keep the task alive independently of the driver (web_download_finish frees
+    // the driver at the end of the terminal branches).
+    std::shared_ptr<proto_download_task> task = drv->task;
+    if (drv->current_task_id) {
+        free(drv->current_task_id);
+        drv->current_task_id = nullptr;
+    }
+
+    const size_t i = drv->file_index;
+    const proto_plan_file& file = task->files[i];
+
+    const bool cancelled = task->cancel_requested.load() || result == RAC_ERROR_CANCELLED;
+    if (cancelled) {
+        int64_t file_partial = file_size_or_zero(file.destination_path);
+        int64_t deleted = 0;
+        bool delete_partial = false;
+        {
+            std::lock_guard<std::mutex> lock(task->mutex);
+            delete_partial = task->delete_partial_on_cancel;
+        }
+        if (delete_partial) {
+            deleted = delete_partial_file(file.destination_path);
+            file_partial = 0;
+        }
+        {
+            std::lock_guard<std::mutex> lock(task->mutex);
+            task->last_deleted_bytes = deleted;
+            task->last_partial_bytes = drv->completed_before_file + file_partial;
+        }
+        set_task_progress(task, rav1::DOWNLOAD_STATE_CANCELLED, rav1::DOWNLOAD_STAGE_DOWNLOADING,
+                          drv->completed_before_file + file_partial, drv->total_expected,
+                          static_cast<int32_t>(i), file.storage_key, "", "download cancelled");
+        mark_task_stopped(task);
+        emit_progress(task);
+        web_download_finish(drv);
+        return;
+    }
+
+    if (result != RAC_SUCCESS) {
+        int64_t partial = drv->completed_before_file + file_size_or_zero(file.destination_path);
+        {
+            std::lock_guard<std::mutex> lock(task->mutex);
+            task->last_partial_bytes = partial;
+        }
+        set_task_progress(task, rav1::DOWNLOAD_STATE_FAILED, rav1::DOWNLOAD_STAGE_DOWNLOADING,
+                          partial, drv->total_expected, static_cast<int32_t>(i), file.storage_key,
+                          "", "download failed");
+        mark_task_stopped(task);
+        emit_progress(task);
+        web_download_finish(drv);
+        return;
+    }
+
+    // Success: extract (if archive) and advance the cumulative counter — mirrors
+    // the post-download tail of process_plan_file.
+    if (file.requires_extraction) {
+        set_task_progress(task, rav1::DOWNLOAD_STATE_EXTRACTING, rav1::DOWNLOAD_STAGE_EXTRACTING,
+                          drv->total_expected > 0 ? drv->completed_before_file + file.expected_bytes
+                                                  : 0,
+                          drv->total_expected, static_cast<int32_t>(i), file.storage_key, "", "");
+        emit_progress(task);
+
+        mkdir_p(task->model_folder_path.c_str());
+
+        rac_extraction_result_t extraction_result{};
+        rac_result_t extract_rc = rac_extract_archive_native(
+            file.destination_path.c_str(), task->model_folder_path.c_str(), nullptr, nullptr,
+            nullptr, &extraction_result);
+        if (extract_rc != RAC_SUCCESS) {
+            set_task_progress(task, rav1::DOWNLOAD_STATE_FAILED, rav1::DOWNLOAD_STAGE_EXTRACTING,
+                              drv->total_expected > 0
+                                  ? drv->completed_before_file + file.expected_bytes
+                                  : 0,
+                              drv->total_expected, static_cast<int32_t>(i), file.storage_key, "",
+                              "archive extraction failed");
+            mark_task_stopped(task);
+            emit_progress(task);
+            web_download_finish(drv);
+            return;
+        }
+
+        delete_file(file.destination_path.c_str());
+
+        char resolved_path[4096];
+        rac_result_t find_rc = rac_find_model_path_after_extraction(
+            task->model_folder_path.c_str(), task->archive_structure, task->framework, task->format,
+            resolved_path, sizeof(resolved_path));
+        drv->final_path = (find_rc == RAC_SUCCESS && resolved_path[0] != '\0')
+                              ? std::string(resolved_path)
+                              : task->model_folder_path;
+    } else {
+        drv->final_path = file.destination_path;
+    }
+
+    if (drv->total_expected > 0) {
+        drv->completed_before_file += std::max<int64_t>(file.expected_bytes, 0);
+    } else {
+        drv->completed_before_file += file_size_or_zero(drv->final_path);
+    }
+
+    drv->file_index += 1;
+    if (drv->file_index < task->files.size()) {
+        web_download_start_file(drv);
+    } else {
+        web_download_finalize_all(drv);
+    }
+}
+
+void web_download_start_file(web_download_driver* drv) {
+    const std::shared_ptr<proto_download_task>& task = drv->task;
+    const size_t i = drv->file_index;
+    const proto_plan_file& file = task->files[i];
+
+    if (task->cancel_requested.load()) {
+        set_task_progress(task, rav1::DOWNLOAD_STATE_CANCELLED, rav1::DOWNLOAD_STAGE_DOWNLOADING,
+                          drv->completed_before_file, drv->total_expected, static_cast<int32_t>(i),
+                          file.storage_key, "", "download cancelled");
+        mark_task_stopped(task);
+        emit_progress(task);
+        web_download_finish(drv);
+        return;
+    }
+
+    // A previous attempt may already have landed this file completely; skip the
+    // fetch and run the success tail directly (extraction + advance).
+    const bool already_complete =
+        file.expected_bytes > 0 && file_size_or_zero(file.destination_path) == file.expected_bytes;
+    if (already_complete) {
+        web_download_on_complete(RAC_SUCCESS, file.destination_path.c_str(), drv);
+        return;
+    }
+
+    set_task_progress(task, rav1::DOWNLOAD_STATE_DOWNLOADING, rav1::DOWNLOAD_STAGE_DOWNLOADING,
+                      drv->completed_before_file, drv->total_expected, static_cast<int32_t>(i),
+                      file.storage_key, "", "");
+    emit_progress(task);
+
+    const rac_platform_adapter_t* adapter = rac_get_platform_adapter();
+    char* task_id = nullptr;
+    rac_result_t rc = adapter->http_download(file.url.c_str(), file.destination_path.c_str(),
+                                             web_download_on_progress, web_download_on_complete, drv,
+                                             &task_id, adapter->user_data);
+    drv->current_task_id = task_id;
+    if (rc != RAC_SUCCESS) {
+        set_task_progress(task, rav1::DOWNLOAD_STATE_FAILED, rav1::DOWNLOAD_STAGE_DOWNLOADING,
+                          drv->completed_before_file, drv->total_expected, static_cast<int32_t>(i),
+                          file.storage_key, "", "failed to start download");
+        mark_task_stopped(task);
+        emit_progress(task);
+        web_download_finish(drv);
+    }
+}
+
+void web_download_finalize_all(web_download_driver* drv) {
+    const std::shared_ptr<proto_download_task>& task = drv->task;
+
+    if (task->cancel_requested.load()) {
+        set_task_progress(task, rav1::DOWNLOAD_STATE_CANCELLED, rav1::DOWNLOAD_STAGE_DOWNLOADING,
+                          drv->completed_before_file, drv->total_expected, 0, "", "",
+                          "download cancelled");
+        mark_task_stopped(task);
+        emit_progress(task);
+        web_download_finish(drv);
+        return;
+    }
+
+    const int64_t completed_bytes =
+        drv->total_expected > 0 ? drv->total_expected : drv->completed_before_file;
+
+    size_t failing_index = 0;
+    std::string sanity_error;
+    if (!validate_downloaded_sizes(task, failing_index, sanity_error)) {
+        int64_t failed_bytes = drv->total_expected > 0 ? drv->completed_before_file : 0;
+        set_task_progress(task, rav1::DOWNLOAD_STATE_FAILED, rav1::DOWNLOAD_STAGE_DOWNLOADING,
+                          failed_bytes, drv->total_expected, static_cast<int32_t>(failing_index),
+                          task->files[failing_index].storage_key, "", sanity_error);
+        mark_task_stopped(task);
+        emit_progress(task);
+        web_download_finish(drv);
+        return;
+    }
+
+    std::string completion_local_path = resolve_completion_local_path(task, drv->final_path);
+    set_task_progress(task, rav1::DOWNLOAD_STATE_COMPLETED, rav1::DOWNLOAD_STAGE_COMPLETED,
+                      completed_bytes, drv->total_expected,
+                      static_cast<int32_t>(task->files.size() - 1),
+                      task->files.empty() ? "" : task->files.back().storage_key,
+                      completion_local_path, "");
+    mark_task_stopped(task);
+    emit_progress(task);
+    self_heal_registry(task, completion_local_path);
+    web_download_finish(drv);
+}
+
+// Non-blocking entry: kick off file 0; the adapter's async callbacks drive the
+// rest. Mirrors run_proto_download_worker's telemetry-start preamble.
+void web_download_start(const std::shared_ptr<proto_download_task>& task, int64_t /*resume_from*/) {
+    auto drv = std::make_shared<web_download_driver>();
+    drv->task = task;
+    drv->total_expected = plan_total_expected(task->files);
+    web_download_registry()[drv.get()] = drv;
+
+    std::string started_model_id;
+    int64_t started_total_bytes = 0;
+    {
+        std::lock_guard<std::mutex> lock(task->mutex);
+        task->running = true;
+        if (!task->download_telemetry_started) {
+            task->download_telemetry_started = true;
+            started_model_id = task->model_id;
+            started_total_bytes = task->progress.total_bytes();
+        }
+    }
+    if (!started_model_id.empty()) {
+        rac::events::emit_model_download_started(started_model_id.c_str(), started_total_bytes,
+                                                 nullptr);
+    }
+
+    if (task->files.empty()) {
+        web_download_finalize_all(drv.get());
+        return;
+    }
+    web_download_start_file(drv.get());
+}
+
 void start_proto_download_worker(const std::shared_ptr<proto_download_task>& task,
                                  int64_t resume_from) {
+    // Prefer the async streaming slot when the platform supplies it (Web): it
+    // reports progress per chunk without blocking the main thread. Otherwise
+    // fall back to the synchronous worker on a deferred tick.
+    const rac_platform_adapter_t* adapter = rac_get_platform_adapter();
+    if (adapter && adapter->http_download) {
+        web_download_start(task, resume_from);
+        return;
+    }
     auto* args = new emscripten_proto_download_args{task, resume_from};
     emscripten_async_call(run_proto_download_worker_async, args, 0);
 }

--- a/sdk/runanywhere-web/packages/core/src/runtime/PlatformAdapter.ts
+++ b/sdk/runanywhere-web/packages/core/src/runtime/PlatformAdapter.ts
@@ -31,7 +31,13 @@ const RAC_ERROR_FILE_NOT_FOUND = -183;
 const RAC_ERROR_FILE_WRITE_FAILED = -185;
 const RAC_ERROR_PLATFORM = -180;
 const RAC_ERROR_INVALID_ARGUMENT = -259;
+const RAC_ERROR_CANCELLED = -380;
 const RAC_DIRECTORY_ENTRY_NAME_MAX = 512;
+
+// In-flight async downloads started through the `http_download` adapter slot,
+// keyed by the task id handed back to C++. Used by `http_download_cancel`.
+let httpDownloadCounter = 0;
+const httpDownloadTasks = new Map<string, AbortController>();
 
 /**
  * Structural Emscripten-module surface the adapter needs. Any RACommons
@@ -66,6 +72,8 @@ interface CallbackPtrs {
   fileListDirectory: number;
   isNonEmptyDirectory: number;
   getVendorId: number;
+  httpDownload: number;
+  httpDownloadCancel: number;
 }
 
 export class PlatformAdapter {
@@ -113,6 +121,8 @@ export class PlatformAdapter {
       fileListDirectory: this.registerFileListDirectory(),
       isNonEmptyDirectory: this.registerIsNonEmptyDirectory(),
       getVendorId: this.registerGetVendorId(),
+      httpDownload: this.registerHttpDownload(),
+      httpDownloadCancel: this.registerHttpDownloadCancel(),
     };
 
     // Runtime struct offsets — each helper must be exported by
@@ -147,10 +157,12 @@ export class PlatformAdapter {
     m.setValue(this.adapterPtr + getOffset('log'), this.callbacks.log, '*');
     m.setValue(this.adapterPtr + getOffset('now_ms'), this.callbacks.nowMs, '*');
     m.setValue(this.adapterPtr + getOffset('get_memory_info'), this.callbacks.getMemoryInfo, '*');
-    // http_download (optional) → null. The HTTPAdapter / FetchHttpTransport
-    // path takes over once setRunanywhereModule installs the module.
-    m.setValue(this.adapterPtr + getOffset('http_download'), 0, '*');
-    m.setValue(this.adapterPtr + getOffset('http_download_cancel'), 0, '*');
+    // http_download (async streaming slot). The C++ download orchestrator
+    // prefers this slot on Emscripten (event-driven, non-blocking) so progress
+    // ticks live; without it, the synchronous FetchHttpTransport path buffers
+    // the whole body on the main thread and the UI freezes at 0% until 100%.
+    m.setValue(this.adapterPtr + getOffset('http_download'), this.callbacks.httpDownload, '*');
+    m.setValue(this.adapterPtr + getOffset('http_download_cancel'), this.callbacks.httpDownloadCancel, '*');
     // extract_archive — native libarchive is compiled into WASM.
     m.setValue(this.adapterPtr + getOffset('extract_archive'), 0, '*');
     m.setValue(this.adapterPtr + getOffset('file_list_directory'), this.callbacks.fileListDirectory, '*');
@@ -427,6 +439,84 @@ export class PlatformAdapter {
       }
     }, 'iiii');
   }
+
+  /**
+   * rac_result_t (*http_download)(const char* url, const char* destination_path,
+   *     rac_http_progress_callback_fn progress_callback,
+   *     rac_http_complete_callback_fn complete_callback,
+   *     void* callback_user_data, char** out_task_id, void* user_data)
+   *
+   * Async by contract: start the transfer, return RAC_OK immediately with a
+   * task id, then stream bytes to MEMFS while calling progress_callback per
+   * chunk and complete_callback at the end. Because it returns immediately and
+   * the fetch runs on the event loop, the main thread is never blocked — the
+   * C++ download orchestrator's poll loop sees live byte counts and the UI does
+   * not freeze (unlike the synchronous FetchHttpTransport fallback).
+   */
+  private registerHttpDownload(): number {
+    const m = this.m;
+    return m.addFunction((
+      urlPtr: number,
+      destPtr: number,
+      progressCbPtr: number,
+      completeCbPtr: number,
+      cbUserData: number,
+      outTaskIdPtr: number,
+      _userData: number,
+    ) => {
+      try {
+        const url = m.UTF8ToString(urlPtr);
+        const dest = m.UTF8ToString(destPtr);
+        const taskId = `webdl_${++httpDownloadCounter}`;
+
+        // Hand the task id back to C++ as an owned C string (orchestrator frees).
+        if (outTaskIdPtr) {
+          const len = m.lengthBytesUTF8(taskId) + 1;
+          const idPtr = m._malloc(len);
+          m.stringToUTF8(taskId, idPtr, len);
+          m.setValue(outTaskIdPtr, idPtr, '*');
+        }
+
+        const controller = new AbortController();
+        httpDownloadTasks.set(taskId, controller);
+
+        // Fire-and-forget: the transfer drives itself on the event loop and
+        // reports back through the C callbacks. Errors are surfaced via
+        // complete_callback, never thrown out of this synchronous start call.
+        void runHttpDownload(m, {
+          url,
+          dest,
+          progressCbPtr,
+          completeCbPtr,
+          cbUserData,
+          controller,
+        }).finally(() => httpDownloadTasks.delete(taskId));
+
+        return RAC_OK;
+      } catch (error) {
+        logger.warning(`http_download start failed: ${error instanceof Error ? error.message : String(error)}`);
+        return RAC_ERROR_PLATFORM;
+      }
+    }, 'iiiiiiii');
+  }
+
+  /** rac_result_t (*http_download_cancel)(const char* task_id, void* user_data) */
+  private registerHttpDownloadCancel(): number {
+    const m = this.m;
+    return m.addFunction((taskIdPtr: number, _userData: number) => {
+      try {
+        const taskId = m.UTF8ToString(taskIdPtr);
+        const controller = httpDownloadTasks.get(taskId);
+        if (controller) {
+          controller.abort();
+          httpDownloadTasks.delete(taskId);
+        }
+        return RAC_OK;
+      } catch {
+        return RAC_ERROR_PLATFORM;
+      }
+    }, 'iii');
+  }
 }
 
 // ---------------------------------------------------------------------------
@@ -447,6 +537,194 @@ function readBytes(m: PlatformAdapterModule, srcPtr: number, length: number): Ui
   const out = new Uint8Array(length);
   for (let i = 0; i < length; i++) out[i] = m.getValue(srcPtr + i, 'i8') & 0xff;
   return out;
+}
+
+// ---------------------------------------------------------------------------
+// http_download slot — async streaming fetch → MEMFS with progress callbacks.
+// ---------------------------------------------------------------------------
+
+/** Emscripten FS stream-write surface needed to write chunks incrementally. */
+interface StreamingFS {
+  open(path: string, flags: string): unknown;
+  write(stream: unknown, buffer: ArrayBufferView, offset: number, length: number, position?: number): number;
+  close(stream: unknown): void;
+  mkdirTree?(path: string): void;
+  analyzePath?(path: string): { exists: boolean };
+  stat?(path: string): { size?: number };
+}
+
+function streamingFsOf(m: PlatformAdapterModule): StreamingFS | null {
+  const fs = (m as { FS?: unknown }).FS as Partial<StreamingFS> | undefined;
+  if (fs && typeof fs.open === 'function' && typeof fs.write === 'function'
+    && typeof fs.close === 'function') {
+    return fs as StreamingFS;
+  }
+  return null;
+}
+
+function memfsFileSize(fs: StreamingFS, path: string): number {
+  try {
+    if (fs.analyzePath && !fs.analyzePath(path)?.exists) return 0;
+    return fs.stat?.(path)?.size ?? 0;
+  } catch {
+    return 0;
+  }
+}
+
+/** Resolve a WASM-table entry as a callable (i64 args are passed as BigInt). */
+function wasmCallable(
+  m: PlatformAdapterModule,
+  ptr: number,
+): ((...args: Array<number | bigint>) => number) | null {
+  if (ptr === 0) return null;
+  const tbl = m as unknown as {
+    getWasmTableEntry?: (p: number) => (...args: Array<number | bigint>) => number;
+    wasmTable?: { get(p: number): (...args: Array<number | bigint>) => number };
+  };
+  if (typeof tbl.getWasmTableEntry === 'function') return tbl.getWasmTableEntry(ptr);
+  if (tbl.wasmTable && typeof tbl.wasmTable.get === 'function') return tbl.wasmTable.get(ptr);
+  return null;
+}
+
+/** Invoke rac_http_progress_callback_fn — void (int64, int64, void*). */
+function invokeProgressCallback(
+  m: PlatformAdapterModule,
+  cbPtr: number,
+  bytesDownloaded: number,
+  totalBytes: number,
+  userData: number,
+): void {
+  const callable = wasmCallable(m, cbPtr);
+  if (!callable) return;
+  try {
+    callable(BigInt(bytesDownloaded), BigInt(totalBytes), userData);
+  } catch (error) {
+    logger.warning(`http_download progress callback threw: ${error instanceof Error ? error.message : String(error)}`);
+  }
+}
+
+/** Invoke rac_http_complete_callback_fn — void (rac_result_t, const char*, void*). */
+function invokeCompleteCallback(
+  m: PlatformAdapterModule,
+  cbPtr: number,
+  result: number,
+  downloadedPath: string | null,
+  userData: number,
+): void {
+  const callable = wasmCallable(m, cbPtr);
+  if (!callable) return;
+  let pathPtr = 0;
+  try {
+    if (downloadedPath) {
+      const len = m.lengthBytesUTF8(downloadedPath) + 1;
+      pathPtr = m._malloc(len);
+      m.stringToUTF8(downloadedPath, pathPtr, len);
+    }
+    callable(result, pathPtr, userData);
+  } catch (error) {
+    logger.warning(`http_download complete callback threw: ${error instanceof Error ? error.message : String(error)}`);
+  } finally {
+    if (pathPtr) {
+      try { m._free(pathPtr); } catch { /* noop */ }
+    }
+  }
+}
+
+interface HttpDownloadArgs {
+  url: string;
+  dest: string;
+  progressCbPtr: number;
+  completeCbPtr: number;
+  cbUserData: number;
+  controller: AbortController;
+}
+
+/**
+ * Stream `url` into the MEMFS file at `dest`, reporting incremental progress.
+ * Resumes from any bytes already on disk via a Range request when the server
+ * honours it (HTTP 206); otherwise restarts from zero. Always finishes by
+ * invoking the C complete callback (success, cancel, or error) exactly once.
+ */
+async function runHttpDownload(m: PlatformAdapterModule, args: HttpDownloadArgs): Promise<void> {
+  const { url, dest, progressCbPtr, completeCbPtr, cbUserData, controller } = args;
+  const fs = streamingFsOf(m);
+  if (!fs) {
+    invokeCompleteCallback(m, completeCbPtr, RAC_ERROR_PLATFORM, null, cbUserData);
+    return;
+  }
+
+  let stream: unknown = null;
+  try {
+    const parent = dest.slice(0, dest.lastIndexOf('/')) || '/';
+    try { fs.mkdirTree?.(parent); } catch { /* dir may already exist */ }
+
+    const existing = memfsFileSize(fs, dest);
+    const headers: Record<string, string> = {};
+    if (existing > 0) headers.Range = `bytes=${existing}-`;
+
+    const response = await fetch(url, { headers, signal: controller.signal });
+
+    // 416 Range Not Satisfiable on a resume request means the file on disk is
+    // already at/past the requested offset — i.e. the download is complete.
+    // Report success without rewriting so a re-trigger of an already-present
+    // model is a no-op rather than a hard failure.
+    if (existing > 0 && response.status === 416) {
+      invokeCompleteCallback(m, completeCbPtr, RAC_OK, dest, cbUserData);
+      return;
+    }
+
+    let received = 0;
+    let position = 0;
+    if (existing > 0 && response.status === 206) {
+      // Server honoured the range — append to the partial file.
+      received = existing;
+      position = existing;
+      stream = fs.open(dest, 'r+');
+    } else {
+      if (!response.ok) throw new Error(`HTTP ${response.status}`);
+      // Fresh download (or server ignored Range) — truncate and restart.
+      stream = fs.open(dest, 'w');
+    }
+
+    const contentLength = Number(response.headers.get('Content-Length') ?? 0);
+    const totalBytes = contentLength > 0 ? received + contentLength : 0;
+
+    if (!response.body) throw new Error('response has no readable body');
+    const reader = response.body.getReader();
+
+    invokeProgressCallback(m, progressCbPtr, received, totalBytes, cbUserData);
+
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) break;
+      if (value && value.length > 0) {
+        fs.write(stream, value, 0, value.length, position);
+        position += value.length;
+        received += value.length;
+        invokeProgressCallback(m, progressCbPtr, received, totalBytes, cbUserData);
+      }
+    }
+
+    fs.close(stream);
+    stream = null;
+    invokeCompleteCallback(m, completeCbPtr, RAC_OK, dest, cbUserData);
+  } catch (error) {
+    if (stream) {
+      try { fs.close(stream); } catch { /* noop */ }
+    }
+    const aborted = controller.signal.aborted
+      || (error instanceof DOMException && error.name === 'AbortError');
+    if (!aborted) {
+      logger.warning(`http_download '${url}' failed: ${error instanceof Error ? error.message : String(error)}`);
+    }
+    invokeCompleteCallback(
+      m,
+      completeCbPtr,
+      aborted ? RAC_ERROR_CANCELLED : RAC_ERROR_PLATFORM,
+      null,
+      cbUserData,
+    );
+  }
 }
 
 interface DirectoryEntryInfo {

--- a/sdk/runanywhere-web/wasm/CMakeLists.txt
+++ b/sdk/runanywhere-web/wasm/CMakeLists.txt
@@ -457,6 +457,13 @@ set(RAC_EXPORTED_FUNCTIONS_BASE
     "_rac_framework_supports_tts"
     "_rac_model_format_extension"
 
+    # Framework <-> OPFS directory resolution. FrameworkOPFSPaths.ts needs both
+    # to compute the per-framework model folder (e.g. "LlamaCpp") on the JS side
+    # for cold-start hydration; without them frameworkOPFSDir() returns null and
+    # hydrateModelRegistry() can never re-detect downloaded models after reload.
+    "_rac_inference_framework_from_proto"
+    "_rac_framework_raw_value"
+
     # Model paths — base-dir configuration. Web has no native filesystem root,
     # but the C++ download orchestrator rejects an empty base via
     # `rac_model_paths_get_model_folder`. The TypeScript bridge installs a
@@ -1224,7 +1231,14 @@ function(rac_wasm_add_target)
     if(RAC_WASM_PTHREADS)
         list(APPEND _link_flags
             "-pthread"
-            "-sPTHREAD_POOL_SIZE=4"
+            # Pre-spawn enough workers to cover the engine's max compute thread
+            # count (get_num_threads caps at 8). VLM inference runs synchronously
+            # on the main thread; if ggml's threadpool needs to spawn a worker
+            # on-demand mid-encode, the blocked main thread can never service the
+            # Worker creation → mtmd_helper_eval_chunks deadlocks. Sizing the
+            # pool to 8 means all compute threads are already live, so no
+            # on-demand spawn happens during the blocked call.
+            "-sPTHREAD_POOL_SIZE=8"
             "-sPTHREAD_POOL_SIZE_STRICT=0"
         )
         target_compile_options(${RWT_NAME} PRIVATE "-pthread")

--- a/sdk/runanywhere-web/wasm/scripts/vendor-onnxruntime-wasm.sh
+++ b/sdk/runanywhere-web/wasm/scripts/vendor-onnxruntime-wasm.sh
@@ -20,9 +20,50 @@ ONNX_RUNTIME_VERSION="${ONNX_RUNTIME_VERSION:-${ONNX_VERSION_LINUX}}"
 SRC_DIR="${ONNX_RUNTIME_SRC_DIR:-${WASM_DIR}/third_party/onnxruntime}"
 DEST_DIR="${REPO_ROOT}/sdk/runanywhere-commons/third_party/onnxruntime-wasm"
 BUILD_CONFIG="${ONNX_RUNTIME_BUILD_CONFIG:-Release}"
-ORT_BUILD_DIR="${SRC_DIR}/build/MacOS/${BUILD_CONFIG}"
+case "$(uname -s)" in
+  Darwin) _ORT_OS_DIR="MacOS" ;;
+  *)      _ORT_OS_DIR="Linux" ;;
+esac
+ORT_BUILD_DIR="${SRC_DIR}/build/${_ORT_OS_DIR}/${BUILD_CONFIG}"
 
 mkdir -p "$(dirname "${SRC_DIR}")" "${DEST_DIR}/lib" "${DEST_DIR}/include"
+
+# --- Prebuilt WASM bundle (download-first; mirrors the Android prebuilt .so) ---
+# The matched ORT+sherpa WASM static libs are published on the sherpa-onnx-rac
+# release. Download + extract instead of the ~30-60 min from-source build.
+# Force a source build with RAC_WASM_BUILD_FROM_SOURCE=1; override the source
+# repo/tag with RAC_WASM_PREBUILT_REPO / RAC_WASM_PREBUILT_TAG.
+if [ "${RAC_WASM_BUILD_FROM_SOURCE:-0}" != "1" ]; then
+  if [ -f "${DEST_DIR}/lib/libonnxruntime.a" ]; then
+    echo "ONNX Runtime WASM already vendored: ${DEST_DIR}/lib/libonnxruntime.a"
+    exit 0
+  fi
+  _RAC_TP="${REPO_ROOT}/sdk/runanywhere-commons/third_party"
+  _RAC_REPO="${RAC_WASM_PREBUILT_REPO:-${SHERPA_ONNX_REPO_ANDROID:-Siddhesh2377/sherpa-onnx-rac}}"
+  _RAC_TAG="${RAC_WASM_PREBUILT_TAG:-v${SHERPA_ONNX_VERSION_LINUX}}"
+  _RAC_TARBALL="sherpa-onnx-${_RAC_TAG}-wasm.tar.bz2"
+  _RAC_URL="https://github.com/${_RAC_REPO}/releases/download/${_RAC_TAG}/${_RAC_TARBALL}"
+  _RAC_CACHE="${WASM_DIR}/third_party/${_RAC_TARBALL}"
+  if [ ! -f "${_RAC_CACHE}" ]; then
+    echo "Downloading prebuilt WASM bundle: ${_RAC_URL}"
+    if curl -fL --retry 3 -o "${_RAC_CACHE}.part" "${_RAC_URL}"; then
+      mv "${_RAC_CACHE}.part" "${_RAC_CACHE}"
+    else
+      echo "Prebuilt download failed; falling back to from-source build."
+      rm -f "${_RAC_CACHE}.part"
+    fi
+  fi
+  if [ -f "${_RAC_CACHE}" ]; then
+    mkdir -p "${_RAC_TP}"
+    tar -xjf "${_RAC_CACHE}" -C "${_RAC_TP}" onnxruntime-wasm sherpa-onnx-wasm
+    if [ -f "${DEST_DIR}/lib/libonnxruntime.a" ]; then
+      echo "Vendored ONNX Runtime WASM from prebuilt bundle: ${DEST_DIR}/lib/libonnxruntime.a"
+      exit 0
+    fi
+    echo "Prebuilt extract did not produce libonnxruntime.a; falling back to from-source build."
+  fi
+fi
+# --- from-source build (reached if RAC_WASM_BUILD_FROM_SOURCE=1 or download failed) ---
 
 if [ ! -d "${SRC_DIR}/.git" ]; then
   rm -rf "${SRC_DIR}"
@@ -66,6 +107,7 @@ set +e
   --enable_wasm_simd \
   --skip_tests \
   --disable_rtti \
+  --parallel "${CMAKE_BUILD_PARALLEL_LEVEL:-12}" \
   --cmake_extra_defines CMAKE_POLICY_VERSION_MINIMUM=3.5
 BUILD_RC=$?
 set -e

--- a/sdk/runanywhere-web/wasm/scripts/vendor-sherpa-onnx-wasm.sh
+++ b/sdk/runanywhere-web/wasm/scripts/vendor-sherpa-onnx-wasm.sh
@@ -18,6 +18,43 @@ DEST_DIR="${REPO_ROOT}/sdk/runanywhere-commons/third_party/sherpa-onnx-wasm"
 ORT_DIR="${REPO_ROOT}/sdk/runanywhere-commons/third_party/onnxruntime-wasm"
 BUILD_DIR="${SRC_DIR}/build-wasm-static"
 
+# --- Prebuilt WASM bundle (download-first; mirrors the Android prebuilt .so) ---
+# Download + extract the matched ORT+sherpa WASM static libs from the
+# sherpa-onnx-rac release instead of building from source. Force a source build
+# with RAC_WASM_BUILD_FROM_SOURCE=1; override the source repo/tag with
+# RAC_WASM_PREBUILT_REPO / RAC_WASM_PREBUILT_TAG.
+if [ "${RAC_WASM_BUILD_FROM_SOURCE:-0}" != "1" ]; then
+  if [ -f "${DEST_DIR}/lib/libsherpa-onnx-c-api.a" ]; then
+    echo "Sherpa-ONNX WASM already vendored: ${DEST_DIR}/lib/libsherpa-onnx-c-api.a"
+    exit 0
+  fi
+  _RAC_TP="${REPO_ROOT}/sdk/runanywhere-commons/third_party"
+  _RAC_REPO="${RAC_WASM_PREBUILT_REPO:-${SHERPA_ONNX_REPO_ANDROID:-Siddhesh2377/sherpa-onnx-rac}}"
+  _RAC_TAG="${RAC_WASM_PREBUILT_TAG:-v${SHERPA_ONNX_VERSION_LINUX}}"
+  _RAC_TARBALL="sherpa-onnx-${_RAC_TAG}-wasm.tar.bz2"
+  _RAC_URL="https://github.com/${_RAC_REPO}/releases/download/${_RAC_TAG}/${_RAC_TARBALL}"
+  _RAC_CACHE="${WASM_DIR}/third_party/${_RAC_TARBALL}"
+  if [ ! -f "${_RAC_CACHE}" ]; then
+    echo "Downloading prebuilt WASM bundle: ${_RAC_URL}"
+    if curl -fL --retry 3 -o "${_RAC_CACHE}.part" "${_RAC_URL}"; then
+      mv "${_RAC_CACHE}.part" "${_RAC_CACHE}"
+    else
+      echo "Prebuilt download failed; falling back to from-source build."
+      rm -f "${_RAC_CACHE}.part"
+    fi
+  fi
+  if [ -f "${_RAC_CACHE}" ]; then
+    mkdir -p "${_RAC_TP}"
+    tar -xjf "${_RAC_CACHE}" -C "${_RAC_TP}" onnxruntime-wasm sherpa-onnx-wasm
+    if [ -f "${DEST_DIR}/lib/libsherpa-onnx-c-api.a" ]; then
+      echo "Vendored Sherpa-ONNX WASM from prebuilt bundle: ${DEST_DIR}/lib/libsherpa-onnx-c-api.a"
+      exit 0
+    fi
+    echo "Prebuilt extract did not produce libsherpa-onnx-c-api.a; falling back to from-source build."
+  fi
+fi
+# --- from-source build (reached if RAC_WASM_BUILD_FROM_SOURCE=1 or download failed) ---
+
 if [ ! -f "${ORT_DIR}/lib/libonnxruntime.a" ]; then
   echo "ERROR: ${ORT_DIR}/lib/libonnxruntime.a is required before building Sherpa-ONNX WASM." >&2
   echo "Run: sdk/runanywhere-web/wasm/scripts/vendor-onnxruntime-wasm.sh" >&2


### PR DESCRIPTION
Web SDK testing-pass fixes found while exercising the example app end-to-end.

## Model discovery (was: every downloaded model showed "Download" after reload)
- **WASM exports**: added `_rac_inference_framework_from_proto` + `_rac_framework_raw_value` to `RAC_EXPORTED_FUNCTIONS_BASE`. Without them `frameworkOPFSDir()` returned null and `hydrateModelRegistry()` skipped every model, so OPFS-backed models never re-detected on cold start.
- **UI refresh**: the example never subscribed to the SDK `models.hydrated` event, so the picker/Storage/Docs views never re-queried after the async cold-start hydrate. `model-selection.ts` now subscribes once and refreshes consumers.

## Download progress (was: UI froze at 0% until 100%)
- Implemented the async `http_download` platform-adapter slot in `PlatformAdapter.ts` (streaming `fetch` + `ReadableStream` → MEMFS, per-chunk progress, resume via `Range`, cancel via `AbortController`, 416-on-resume treated as complete).
- Added an Emscripten-only event-driven download driver in `download_orchestrator.cpp` that uses the slot when present (native path unchanged: `#ifdef __EMSCRIPTEN__` + slot-null fallback).

## VLM inference (was: hung forever in the image encode)
- Root cause: the synchronous main-thread VLM encode requested 8 ggml threads but `PTHREAD_POOL_SIZE=4`, so on-demand worker spawn deadlocked the blocked main thread. Bumped `PTHREAD_POOL_SIZE` to 8 (covers the engine's capped max). VLM now completes.

## RAG + Vision UI
- Documents view: added Download buttons next to the embedding/LLM pickers (live `%`, reflects downloaded state). 
- Vision view: added a "Load image…" button to analyze a file from disk (not just the camera).

## ONNX/sherpa WASM vendoring
- Ported the prebuilt-download-first vendor scripts (pull the matched ORT+sherpa WASM archives from the `sherpa-onnx-rac` release) instead of the slow from-source-only path.

## Known follow-ups (not in this PR)
- ONNX backend instantiation on the local build (large-module `wasmTable` export under emcc 5.0.0) — under investigation; blocks RAG embeddings + speech end-to-end.
- VLM runs synchronously on the main thread (10–20s UI freeze) — worker-offload is scaffolded (`OffscreenRuntimeBridge`) but not wired.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core download orchestration and platform I/O on Emscripten (behavior change for all Web model downloads); WASM link/export and pthread sizing affect VLM builds. Example-only UI changes are low risk.
> 
> **Overview**
> End-to-end fixes for the Web SDK and **RunAnywhereAI** example after full-app testing.
> 
> **Model discovery after reload** exports `_rac_inference_framework_from_proto` and `_rac_framework_raw_value` so JS can resolve framework OPFS folders for `hydrateModelRegistry()`. The example subscribes once to `models.hydrated` in `model-selection.ts` so the picker and toolbar refresh when async cold-start hydration marks models as on disk.
> 
> **Download UX** wires the platform `http_download` slot in `PlatformAdapter.ts` (streaming fetch → MEMFS, live progress, Range resume, abort/cancel, HTTP 416 treated as complete). On Emscripten, `download_orchestrator.cpp` uses a new event-driven driver when that slot exists; the blocking sync worker remains the fallback. Web streaming skips per-byte SHA-256 but keeps size validation and HTTPS.
> 
> **VLM** raises `PTHREAD_POOL_SIZE` from 4 to 8 so ggml compute threads do not deadlock the main thread during synchronous encode.
> 
> **Example UI**: Documents gets per-picker **Download** buttons with `%` status; Vision adds **Load image…** (RGB decode + analyze without the camera). **ONNX/sherpa** vendor scripts prefer prebuilt WASM tarballs from `sherpa-onnx-rac`, with from-source fallback.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2bbba9287b8a260bcbc1e4ddd5e142299264c0f0. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->