### PR TITLE
commons: faster model downloads (throttle progress + 256KB read buffer)

### DIFF
--- a/sdk/runanywhere-commons/src/infrastructure/download/download_orchestrator.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/download/download_orchestrator.cpp
@@ -1011,7 +1011,15 @@ struct proto_download_callback_ctx {
     int64_t total_expected = 0;
     std::string storage_key;
     std::string destination_path;
+    std::chrono::steady_clock::time_point last_emit{};
 };
+
+// Emit at most ~8 progress events/sec. The HTTP adapter delivers a callback per
+// ~8 KiB chunk; serializing + marshalling a proto across the JNI/FFI boundary on
+// every chunk dominates CPU on multi-GB bundles and throttles real throughput.
+// last_partial_bytes is still recorded every chunk (cheap, needed for resume);
+// only the emission is coalesced. The per-file finalize emits the completion event.
+constexpr auto kProgressEmitInterval = std::chrono::milliseconds(120);
 
 rac_bool_t proto_http_progress(uint64_t bytes_written, uint64_t total_bytes, void* user_data) {
     auto* ctx = static_cast<proto_download_callback_ctx*>(user_data);
@@ -1045,6 +1053,13 @@ rac_bool_t proto_http_progress(uint64_t bytes_written, uint64_t total_bytes, voi
         overall_override = static_cast<float>(
             (static_cast<double>(ctx->file_index) + file_fraction) / static_cast<double>(num_files));
     }
+    const auto now = std::chrono::steady_clock::now();
+    if (ctx->last_emit.time_since_epoch().count() != 0 &&
+        now - ctx->last_emit < kProgressEmitInterval) {
+        return RAC_TRUE;
+    }
+    ctx->last_emit = now;
+
     set_task_progress(ctx->task, rav1::DOWNLOAD_STATE_DOWNLOADING, rav1::DOWNLOAD_STAGE_DOWNLOADING,
                       downloaded, total, ctx->file_index, ctx->storage_key, "", "", overall_override);
     emit_progress(ctx->task);

--- a/sdk/runanywhere-flutter/packages/runanywhere/android/src/main/kotlin/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt
+++ b/sdk/runanywhere-flutter/packages/runanywhere/android/src/main/kotlin/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt
@@ -65,7 +65,7 @@ object OkHttpHttpTransport {
     private const val TAG = "OkHttpHttpTransport"
 
     /** Chunk size used for streaming body delivery (32 KB matches Okio's default). */
-    private const val STREAM_CHUNK_SIZE = 32 * 1024
+    private const val STREAM_CHUNK_SIZE = 256 * 1024
 
     /** Default OkHttp client. Lazily built on first use. Mirrors Swift's `sharedSession`. */
     private val defaultClient: OkHttpClient by lazy {

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt
@@ -65,7 +65,7 @@ object OkHttpHttpTransport {
     private val logger = SDKLogger("OkHttpHttpTransport")
 
     /** Chunk size used for streaming body delivery (32 KB matches Okio's default). */
-    private const val STREAM_CHUNK_SIZE = 32 * 1024
+    private const val STREAM_CHUNK_SIZE = 256 * 1024
 
     /**
      * Default OkHttp client backing the buffered `request_send` path.

--- a/sdk/runanywhere-react-native/packages/core/android/src/main/java/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt
+++ b/sdk/runanywhere-react-native/packages/core/android/src/main/java/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt
@@ -50,7 +50,7 @@ import java.util.concurrent.atomic.AtomicReference
  *   - [setHttpClient] lets hosts swap in a custom OkHttpClient
  */
 object OkHttpHttpTransport {
-    private const val STREAM_CHUNK_SIZE = 32 * 1024
+    private const val STREAM_CHUNK_SIZE = 256 * 1024
 
     /** Default OkHttp client. Lazily built on first use. Mirrors Swift's `sharedSession`. */
     private val defaultClient: OkHttpClient by lazy {


### PR DESCRIPTION
## What

Two download-throughput fixes in the native commons + Android HTTP transport.

**1. Throttle download progress emission** (`download_orchestrator.cpp`)
`proto_http_progress` fired `set_task_progress` + `emit_progress` on every adapter chunk (~8 KiB). On multi-GB NPU bundles that is hundreds of thousands of proto serializations + JNI/FFI crossings, which pins CPU and starves the transfer. Now coalesced to ~8 emissions/sec (120 ms). `last_partial_bytes` is still recorded every chunk (needed for resume); only the emission is throttled, and the per-file finalize still emits the authoritative completion event.

**2. Raise streaming read buffer 32 KB -> 256 KB** (all three Android `OkHttpHttpTransport.kt`: kotlin, flutter, react-native)
Fewer JNI crossings + disk writes + hash calls per byte downloaded.

## Why
On a real device the model download ran at ~1.8 MB/s vs ~5.8 MB/s raw from the same CDN — the gap was per-chunk emission/marshalling overhead, not the network. These two changes remove that overhead.

## Scope
4 files, +18/-3. No API or behavior change beyond progress-event cadence; download/extraction/resume semantics unchanged.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Performance-only tuning in the download hot path; resume partial-byte tracking is unchanged and terminal progress events are still emitted on file completion.
> 
> **Overview**
> Improves **model download throughput** by cutting CPU spent on progress handling and JNI crossings, without changing download, resume, or completion semantics.
> 
> In **`download_orchestrator.cpp`**, `proto_http_progress` still updates **`last_partial_bytes` on every HTTP chunk** (resume stays accurate), but **`set_task_progress` / `emit_progress` are coalesced** to about **8 events per second** (120 ms minimum interval). Per-file finalize still emits the authoritative completion progress.
> 
> On **all three Android `OkHttpHttpTransport` copies** (Kotlin SDK, Flutter, React Native), **`STREAM_CHUNK_SIZE` increases from 32 KB to 256 KB**, so fewer chunk callbacks per gigabyte downloaded.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2891979a091d284ff3bec3a9b3dc1552900fb0a4. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->