### PR TITLE
[codex] feat(android): add Qwen 3.5 0.8B to VLM catalog

### DIFF
--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -169,6 +169,19 @@ internal object ModelCatalog {
                 ),
             ),
         ),
+        MultiFileModel(
+            "qwen3.5-0.8b-q4_k_m", "Qwen 3.5 0.8B", LLAMA, MULTIMODAL, 786_962_240,
+            files = listOf(
+                ModelFile(
+                    "https://huggingface.co/bartowski/Qwen_Qwen3.5-0.8B-GGUF/resolve/main/Qwen_Qwen3.5-0.8B-Q4_K_M.gguf",
+                    "Qwen_Qwen3.5-0.8B-Q4_K_M.gguf"
+                ),
+                ModelFile(
+                    "https://huggingface.co/bartowski/Qwen_Qwen3.5-0.8B-GGUF/resolve/main/mmproj-Qwen_Qwen3.5-0.8B-bf16.gguf",
+                    "mmproj-Qwen_Qwen3.5-0.8B-bf16.gguf"
+                ),
+            ),
+        ),
         ArchiveModel(
             "smolvlm-500m-instruct-q8_0",
             "SmolVLM 500M Instruct",


### PR DESCRIPTION
## Description

Adds Qwen 3.5 0.8B Q4_K_M to the Android sample's curated VLM catalog, with the matching BF16 multimodal projector as a required companion artifact.

The entry uses the existing `MultiFileModel` path and is classified as llama.cpp + multimodal, so it appears in the existing Vision model picker without SDK, JNI, or native-code changes. The exact combined download size is `786,962,240` bytes.

This complements merged PR #445, which added text-only Qwen 3.5 catalog entries on iOS; it does not duplicate the Android multimodal model/projector requested here.

Fixes #463

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

Catalog-only validation performed:
- Both Hugging Face artifact URLs resolve successfully.
- Content lengths verified: `579,615,840` + `207,346,400` = `786,962,240` bytes.
- `git diff --check` passes.
- No changed Kotlin line exceeds the repository's 250-character limit.
- Cursor Bugbot and CodeRabbit completed with no actionable findings.
- `:app:assembleDebug --max-workers=2 --no-daemon` was attempted, but this Windows environment has no Android SDK or staged sample AARs; device/build validation remains unchecked below.

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Playground:**
- [ ] Tested on target platform
- [ ] Verified no regressions in existing Playground projects

**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels
**SDKs:**
- [ ] `Swift SDK`
- [ ] `Kotlin SDK`
- [ ] `Flutter SDK`
- [ ] `React Native SDK`
- [ ] `Web SDK`
- [ ] `Commons`

**Sample Apps:**
- [ ] `iOS Sample`
- [x] `Android Sample`
- [ ] `Flutter Sample`
- [ ] `React Native Sample`
- [ ] `Web Sample`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (not needed; catalog-only change)

## Screenshots
Not applicable; this adds a model option to the existing picker without changing its layout.