### PR TITLE
Move NPU catalog refresh bootstrap into SDK APIs (#523)

### DIFF
--- a/examples/android/RunAnywhereAI/app/src/androidTest/java/com/runanywhere/runanywhereai/NpuModelE2ETest.kt
+++ b/examples/android/RunAnywhereAI/app/src/androidTest/java/com/runanywhere/runanywhereai/NpuModelE2ETest.kt
@@ -16,10 +16,10 @@ import android.os.Bundle
 import android.util.Log
 import androidx.test.ext.junit.runners.AndroidJUnit4
 import androidx.test.platform.app.InstrumentationRegistry
-import com.runanywhere.runanywhereai.data.ModelCatalog
-import com.runanywhere.runanywhereai.data.SingleFileModel
 import com.runanywhere.runanywhereai.state.GlobalState
+import com.runanywhere.sdk.npu.qhexrt.NpuBundle
 import com.runanywhere.sdk.npu.qhexrt.QHexRT
+import com.runanywhere.sdk.npu.qhexrt.qhexrtBundles
 import com.runanywhere.sdk.public.RunAnywhere
 import com.runanywhere.sdk.public.extensions.deleteModel
 import com.runanywhere.sdk.public.extensions.downloadModel
@@ -71,7 +71,7 @@ import java.security.MessageDigest
  * (one bundle on device at a time). NOT product code — androidTest only.
  *
  * Selection (instrumentation args, `-e key value`):
-     *   -e modelId <catalog-id>                          a row from ModelCatalog.npuCatalog
+     *   -e modelId <catalog-id>                          a row from qhexrtBundles
      *   OR -e hfRepo <catalog-org/repo> -e arch <v81> -e modality <llm|vlm|stt|tts|inpaint> -e manifest <m.json>
  *      (legacy: -e files "m.json,..." — only the first name, the manifest, is used)
  *   -e hfToken <hf_...>   download private runanywhere/<name>_HNPU repos (never committed/logged)
@@ -88,7 +88,6 @@ class NpuModelE2ETest {
         const val LOAD_TIMEOUT_MS = 300_000L
         const val INFER_TIMEOUT_MS = 300_000L   // per inference case
         val THINKING_TAGS = ThinkingTagPattern(open_tag = "<think>", close_tag = "</think>")
-        val ARCH_SUFFIX = Regex("(.+)_(v(?:75|79|81|83))$")
     }
 
     private data class VlmCase(
@@ -127,7 +126,7 @@ class NpuModelE2ETest {
                 return
             }
             val message = requestedModelId?.let {
-                "unknown -e modelId '$it' (expected a ModelCatalog.npuCatalog id, optionally suffixed with _v75/_v79/_v81/_v83)"
+                "unknown -e modelId '$it' (expected a qhexrtBundles id)"
             } ?: "invalid selection for -e hfRepo '$requestedHfRepo': use a catalog-backed repo with modality and manifest"
             Log.i(tag, "NPU_E2E status=FAIL phase=lookup detail=\"$message\"")
             assertTrue(message, false)
@@ -223,7 +222,7 @@ class NpuModelE2ETest {
                             multiFile = localBundle.files.map { it.toDescriptor(model.id, localBundle) },
                             id = model.id,
                             name = model.name,
-                            framework = model.framework,
+                            framework = InferenceFramework.INFERENCE_FRAMEWORK_QHEXRT,
                             modality = model.category,
                             source =
                                 if (localBundle.mode == "local_adb_import") {
@@ -341,7 +340,7 @@ class NpuModelE2ETest {
                                 ModelUnloadRequest(
                                     model_id = model.id,
                                     category = model.category,
-                                    framework = model.framework,
+                                    framework = InferenceFramework.INFERENCE_FRAMEWORK_QHEXRT,
                                 ),
                             )
                         val unloadOk = unload.success && model.id in unload.unloaded_model_ids
@@ -647,7 +646,7 @@ class NpuModelE2ETest {
     // ------------------------------------------------------------ INPAINT ----
     private suspend fun runInpaint(
         report: RunReport,
-        model: SingleFileModel,
+        model: NpuBundle,
         suite: NpuSuite?,
         outDir: File?,
     ) {
@@ -977,7 +976,7 @@ class NpuModelE2ETest {
 
     // ------------------------------------------------------------- EMBEDDING ----
     // Canonical retrieval-ranking gate through the public embedding API.
-    private suspend fun runEmbedding(report: RunReport, model: SingleFileModel, suite: NpuSuite?) {
+    private suspend fun runEmbedding(report: RunReport, model: NpuBundle, suite: NpuSuite?) {
         requireNotNull(suite) { "embedding requires a canonical npu_suite/v1" }
         require(suite.metric == "embedding_retrieval_ranking") {
             "embedding suite metric must be embedding_retrieval_ranking, got ${suite.metric}"
@@ -1087,7 +1086,7 @@ class NpuModelE2ETest {
     }
 
     // ---------------------------------------------------------------- TTS ----
-    private suspend fun runTts(report: RunReport, model: SingleFileModel, outDir: File?, suite: NpuSuite?) {
+    private suspend fun runTts(report: RunReport, model: NpuBundle, outDir: File?, suite: NpuSuite?) {
         requireNotNull(suite) { "TTS requires a canonical npu_suite/v1" }
         require(suite.metric == "audio_sanity_intelligibility") {
             "TTS suite metric must be audio_sanity_intelligibility until independent gold WAV parity is implemented; got ${suite.metric}"
@@ -1140,10 +1139,15 @@ class NpuModelE2ETest {
     }
 
     // ---------------------------------------------------------------- helpers ----
-    private suspend fun register(bundle: SingleFileModel) =
-        requireNotNull(bundle.register()) {
-            "catalog model '${bundle.id}' is not eligible on the detected QHexRT device"
-        }
+    private suspend fun register(bundle: NpuBundle) =
+        RunAnywhere.registerModel(
+            id = bundle.id,
+            name = bundle.name,
+            url = bundle.url,
+            framework = InferenceFramework.INFERENCE_FRAMEWORK_QHEXRT,
+            modality = bundle.category,
+            memoryRequirement = 0L,
+        )
 
     private fun LocalBundleFile.toDescriptor(
         modelId: String,
@@ -1350,18 +1354,15 @@ class NpuModelE2ETest {
         MessageDigest.getInstance("SHA-256").digest(bytes)
             .joinToString("") { "%02x".format(it.toInt() and 0xff) }
 
-    /** Catalog id, or a catalog-backed URL override from -e hfRepo/arch/modality/manifest. */
-    private fun resolveModel(args: Bundle): Pair<SingleFileModel, String?>? {
+    /** SDK catalog id, or an ad-hoc bundle synthesized from -e hfRepo/arch/modality/manifest. */
+    private fun resolveModel(args: Bundle): Pair<NpuBundle, String?>? {
         args.getString("modelId")?.takeIf { it.isNotBlank() }?.let { rawId ->
-            val (logicalId, requestedArch) = logicalIdAndArch(rawId)
-            val model = ModelCatalog.npuCatalog.firstOrNull { it.id == rawId }
-                ?: ModelCatalog.npuCatalog.firstOrNull { it.id == logicalId }
-            return model?.let { it to (requestedArch ?: args.getString("arch")?.takeIf { arch -> arch.isNotBlank() }) }
+            val model = qhexrtBundles.firstOrNull { it.id == rawId } ?: return null
+            return model to (args.getString("arch")?.takeIf { arch -> arch.isNotBlank() } ?: model.arch)
         }
         val repo = args.getString("hfRepo") ?: return null
-        val catalogModel = ModelCatalog.npuCatalog.firstOrNull { hfRepoOf(it) == repo } ?: return null
         val arch = args.getString("arch")?.trim()?.lowercase()?.takeIf { it.isNotEmpty() } ?: "v81"
-        if (arch !in setOf("v75", "v79", "v81")) return null
+        if (arch !in setOf("v75", "v79", "v81", "v83")) return null
         val category = when (args.getString("modality")?.lowercase()) {
             "llm" -> ModelCategory.MODEL_CATEGORY_LANGUAGE
             "vlm" -> ModelCategory.MODEL_CATEGORY_MULTIMODAL
@@ -1376,11 +1377,12 @@ class NpuModelE2ETest {
         val manifest = args.getString("manifest")?.trim()?.takeIf { it.isNotEmpty() }
             ?: args.getString("files")?.split(",")?.map { it.trim() }?.firstOrNull { it.isNotEmpty() }
             ?: return null
-        return catalogModel.copy(
+        return NpuBundle(
+            id = "${repo.substringAfterLast('/')}_$arch",
             name = repo,
-            url = "https://huggingface.co/$repo/$manifest",
             category = category,
-            memoryBytes = 0L,
+            arch = arch,
+            url = "https://huggingface.co/$repo/$arch/$manifest",
         ) to arch
     }
 
@@ -1394,13 +1396,8 @@ class NpuModelE2ETest {
         else -> category.name.lowercase()
     }
 
-    private fun hfRepoOf(bundle: SingleFileModel): String =
+    private fun hfRepoOf(bundle: NpuBundle): String =
         bundle.url.removePrefix("https://huggingface.co/").split("/").take(2).joinToString("/")
-
-    private fun logicalIdAndArch(rawId: String): Pair<String, String?> {
-        val match = ARCH_SUFFIX.matchEntire(rawId) ?: return rawId to null
-        return match.groupValues[1] to match.groupValues[2]
-    }
 
     private fun loadSuite(modelId: String, arch: String): NpuSuite? {
         val assets = InstrumentationRegistry.getInstrumentation().context.assets

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelBootstrap.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelBootstrap.kt
@@ -2,6 +2,8 @@ package com.runanywhere.runanywhereai.data
 
 import com.runanywhere.runanywhereai.util.RACLog
 import com.runanywhere.sdk.hybrid.Cloud
+import com.runanywhere.sdk.npu.qhexrt.QHexRT
+import com.runanywhere.sdk.npu.qhexrt.seedCatalog
 import com.runanywhere.sdk.public.RunAnywhere
 import com.runanywhere.sdk.public.extensions.lora
 import com.runanywhere.sdk.public.extensions.refreshModelRegistry
@@ -12,16 +14,6 @@ import kotlin.coroutines.cancellation.CancellationException
 // fs callbacks. Core backends (LlamaCPP/ONNX) are registered earlier, in RunAnywhereApplication,
 // before RunAnywhere.initialize().
 object ModelBootstrap {
-
-    private val npuCatalogState = NpuCatalogState()
-
-    /** QHexRT rows accepted by the native device-aware catalog facade this run. */
-    internal val registeredNpuModelIds: Set<String>
-        get() = npuCatalogState.snapshots.value.registeredModelIds
-
-    /** Emits after every completed native catalog seed/refresh. */
-    internal val npuCatalogSnapshots
-        get() = npuCatalogState.snapshots
 
     suspend fun setupModels() {
         registerRemoteBackends()
@@ -42,18 +34,31 @@ object ModelBootstrap {
     // merges on re-save, preserving runtime fields (is_downloaded, per-file local paths,
     // checksums), so catalog metadata fixes reach existing installs without losing downloads.
     private suspend fun seedCatalog() {
-        val regular = registerCatalogRows(ModelCatalog.models, "catalog")
-        val npu = registerCatalogRows(ModelCatalog.npuCatalog, "npu catalog")
-        npuCatalogState.publish(npu.registeredIds)
-        RACLog.i(
-            "catalog seeded: ok=${regular.registered + npu.registered} " +
-                "failed=${regular.failed + npu.failed} " +
-                "skippedNative=${regular.skippedNative + npu.skippedNative}",
-        )
+        var ok = 0
+        var fail = 0
+        for (model in ModelCatalog.models) {
+            try {
+                model.register()
+                ok++
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                fail++
+                RACLog.e("catalog: ${model.id} failed", e)
+            }
+        }
+
+        // NPU catalog is now owned by the SDK — probe, arch-filter, register,
+        // and refresh all happen inside QHexRT.seedCatalog().
+        // QHexRT.register() must be called first so the backend is initialized.
+        QHexRT.register()
+        val npuCount = QHexRT.seedCatalog()
+        RACLog.i("catalog seeded: ok=$ok failed=$fail npu=$npuCount")
     }
 
+    // NPU catalog is now owned by the SDK — delegate to QHexRT.seedCatalog().
     suspend fun refreshNpuCatalog() {
-        val npu = registerCatalogRows(ModelCatalog.npuCatalog, "npu catalog")
+        val npuCount = QHexRT.seedCatalog()
         val registryRefreshed = try {
             RunAnywhere.refreshModelRegistry()
             true
@@ -63,46 +68,7 @@ object ModelBootstrap {
             RACLog.e("npu catalog registry refresh failed", e)
             false
         }
-        // Publish after the registry operation so retained pickers always read
-        // the completed refresh, never an intermediate catalog snapshot.
-        npuCatalogState.publish(npu.registeredIds)
-        RACLog.i(
-            "npu catalog refreshed: ok=${npu.registered} failed=${npu.failed} " +
-                "skippedNative=${npu.skippedNative} " +
-                "registryRefreshed=$registryRefreshed",
-        )
-    }
-
-    private suspend fun registerCatalogRows(
-        models: List<CatalogModel>,
-        logLabel: String,
-    ): CatalogSeedResult {
-        var registered = 0
-        var failed = 0
-        var skippedNative = 0
-        val registeredIds = mutableSetOf<String>()
-        for (model in models) {
-            try {
-                val saved = model.register()
-                if (saved == null) {
-                    skippedNative++
-                } else {
-                    registered++
-                    registeredIds += saved.id
-                }
-            } catch (e: CancellationException) {
-                throw e
-            } catch (e: Exception) {
-                failed++
-                RACLog.e("$logLabel: ${model.id} failed", e)
-            }
-        }
-        return CatalogSeedResult(
-            registered = registered,
-            failed = failed,
-            skippedNative = skippedNative,
-            registeredIds = registeredIds,
-        )
+        RACLog.i("npu catalog refreshed: seedCount=$npuCount registryRefreshed=$registryRefreshed")
     }
 
     private suspend fun seedLora() {
@@ -117,10 +83,3 @@ object ModelBootstrap {
         }
     }
 }
-
-private data class CatalogSeedResult(
-    val registered: Int,
-    val failed: Int,
-    val skippedNative: Int,
-    val registeredIds: Set<String>,
-)

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelBootstrap.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelBootstrap.kt
@@ -15,6 +15,16 @@ import kotlin.coroutines.cancellation.CancellationException
 // before RunAnywhere.initialize().
 object ModelBootstrap {
 
+    private val npuCatalogState = NpuCatalogState()
+
+    /** QHexRT rows accepted by the native device-aware catalog facade this run. */
+    internal val registeredNpuModelIds: Set<String>
+        get() = npuCatalogState.snapshots.value.registeredModelIds
+
+    /** Emits after every completed native catalog seed/refresh. */
+    internal val npuCatalogSnapshots
+        get() = npuCatalogState.snapshots
+
     suspend fun setupModels() {
         registerRemoteBackends()
         seedCatalog()
@@ -50,15 +60,14 @@ object ModelBootstrap {
 
         // NPU catalog is now owned by the SDK — probe, arch-filter, register,
         // and refresh all happen inside QHexRT.seedCatalog().
-        // QHexRT.register() must be called first so the backend is initialized.
-        QHexRT.register()
-        val npuCount = QHexRT.seedCatalog()
-        RACLog.i("catalog seeded: ok=$ok failed=$fail npu=$npuCount")
+        val npu = QHexRT.seedCatalog()
+        npuCatalogState.publish(npu.registeredIds)
+        RACLog.i("catalog seeded: ok=$ok failed=$fail npu=${npu.registeredCount}")
     }
 
     // NPU catalog is now owned by the SDK — delegate to QHexRT.seedCatalog().
     suspend fun refreshNpuCatalog() {
-        val npuCount = QHexRT.seedCatalog()
+        val npu = QHexRT.seedCatalog()
         val registryRefreshed = try {
             RunAnywhere.refreshModelRegistry()
             true
@@ -68,7 +77,8 @@ object ModelBootstrap {
             RACLog.e("npu catalog registry refresh failed", e)
             false
         }
-        RACLog.i("npu catalog refreshed: seedCount=$npuCount registryRefreshed=$registryRefreshed")
+        npuCatalogState.publish(npu.registeredIds)
+        RACLog.i("npu catalog refreshed: seedCount=${npu.registeredCount} registryRefreshed=$registryRefreshed")
     }
 
     private suspend fun seedLora() {

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -8,6 +8,8 @@ import ai.runanywhere.proto.v1.ModelCategory
 
 
 // Curated catalog, kept in lockstep with the iOS / Flutter / RN example apps.
+// NPU (QHexRT) bundles have moved into the SDK: see
+// sdk/runanywhere-kotlin/modules/runanywhere-core-qhexrt/.../NpuCatalog.kt.
 internal object ModelCatalog {
 
     private val LLAMA = InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP
@@ -452,7 +454,7 @@ internal object ModelCatalog {
         ArchiveModel(
             "sherpa-onnx-whisper-tiny.en",
             "Sherpa Whisper Tiny (ONNX)",
-            "https://github.com/RunanywhereAI/sherpa-onnx/releases/download/runanywhere-models-v1/sherpa-onnx-whisper-tiny.en.tar.gz",
+            "https://github.com/RunAnywhereAI/sherpa-onnx/releases/download/runanywhere-models-v1/sherpa-onnx-whisper-tiny.en.tar.gz",
             SHERPA,
             ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION,
             75_000_000,
@@ -576,7 +578,7 @@ internal object ModelCatalog {
         ArchiveModel(
             "vits-piper-en_US-lessac-medium",
             "Piper TTS (US English - Medium)",
-            "https://github.com/RunanywhereAI/sherpa-onnx/releases/download/runanywhere-models-v1/vits-piper-en_US-lessac-medium.tar.gz",
+            "https://github.com/RunAnywhereAI/sherpa-onnx/releases/download/runanywhere-models-v1/vits-piper-en_US-lessac-medium.tar.gz",
             SHERPA,
             ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
             65_000_000,
@@ -586,7 +588,7 @@ internal object ModelCatalog {
         ArchiveModel(
             "vits-piper-en_GB-alba-medium",
             "Piper TTS (British English)",
-            "https://github.com/RunanywhereAI/sherpa-onnx/releases/download/runanywhere-models-v1/vits-piper-en_GB-alba-medium.tar.gz",
+            "https://github.com/RunAnywhereAI/sherpa-onnx/releases/download/runanywhere-models-v1/vits-piper-en_GB-alba-medium.tar.gz",
             SHERPA,
             ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
             65_000_000,

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -441,7 +441,7 @@ internal object ModelCatalog {
         ArchiveModel(
             "smolvlm-500m-instruct-q8_0",
             "SmolVLM 500M Instruct",
-            "https://github.com/RunanywhereAI/sherpa-onnx/releases/download/runanywhere-vlm-models-v1/smolvlm-500m-instruct-q8_0.tar.gz",
+            "https://github.com/RunAnywhereAI/sherpa-onnx/releases/download/runanywhere-vlm-models-v1/smolvlm-500m-instruct-q8_0.tar.gz",
             LLAMA,
             MULTIMODAL,
             600_000_000,

--- a/examples/flutter/RunAnywhereAI/lib/core/services/model_catalog_bootstrap.dart
+++ b/examples/flutter/RunAnywhereAI/lib/core/services/model_catalog_bootstrap.dart
@@ -4,7 +4,7 @@ import 'package:fixnum/fixnum.dart';
 import 'package:flutter/foundation.dart';
 import 'package:runanywhere/runanywhere.dart';
 import 'package:runanywhere_ai/core/services/hf_token_store.dart';
-import 'package:runanywhere_ai/core/services/qhexrt_model_catalog.dart';
+import 'package:runanywhere_qhexrt/runanywhere_qhexrt.dart';
 
 @visibleForTesting
 const portableNvidiaEmbeddingCatalog = [
@@ -41,6 +41,8 @@ const portableNvidiaEmbeddingCatalog = [
 /// widget. Uses the canonical `RunAnywhere.models.*` registration APIs,
 /// including multi-file and archive-with-structure overloads. Safe to re-run
 /// on every cold launch — commons merges runtime fields on re-registration.
+/// NPU (QHexRT) bundles have moved into the SDK: see
+/// sdk/runanywhere-flutter/packages/runanywhere_qhexrt/lib/src/npu_catalog.dart.
 abstract final class ModelCatalogBootstrap {
   /// True once the catalog has been registered. Without this guard,
   /// hot-reload (or any second call) re-runs the entire registration block.
@@ -352,9 +354,13 @@ abstract final class ModelCatalogBootstrap {
     debugPrint('LoRA adapters registered');
 
     // --- QHexRT (Hexagon NPU) bundles ---------------------------------------
-    // Native QHexRT probes the device, chooses the exact Hexagon bundle, and
-    // returns the registered architecture-specific model ID.
-    await _registerNpuBundles();
+    // NPU catalog is now owned by the SDK — probe, arch-filter, register,
+    // and refresh all happen inside seedNpuCatalog().
+    try {
+      await seedNpuCatalog();
+    } catch (e) {
+      debugPrint('NPU catalog registration skipped: $e');
+    }
 
     debugPrint('All modules and models registered');
     _modulesRegistered = true;
@@ -463,20 +469,10 @@ abstract final class ModelCatalogBootstrap {
     debugPrint('Apple MLX models registered');
   }
 
-  /// Register logical HNPU rows. QHexRT's native bundle resolver chooses the
-  /// current device arch; unsupported devices or missing HF child dirs fail
-  /// registration and never appear as runnable models.
-  static Future<void> _registerNpuBundles() async {
-    final result = await QHexRTModelCatalog.registerForCurrentDevice();
-    debugPrint(
-      'QHexRT catalog registered: ok=${result.registered} '
-      'failed=${result.failed} skippedNative=${result.skippedNative}',
-    );
-  }
-
   static Future<void> refreshNpuCatalog() async {
     await _applyPersistedHfToken();
-    await _registerNpuBundles();
+    final npuCount = await seedNpuCatalog();
+    debugPrint('NPU catalog refreshed: $npuCount');
     await RunAnywhere.refreshModelRegistry();
   }
 

--- a/examples/react-native/RunAnywhereAI/src/services/ModelCatalogBootstrap.ts
+++ b/examples/react-native/RunAnywhereAI/src/services/ModelCatalogBootstrap.ts
@@ -10,7 +10,7 @@
 
 import { Platform } from 'react-native';
 import { RunAnywhere } from '@runanywhere/core';
-import { QHexRT } from '@runanywhere/qhexrt';
+import { QHexRT, seedNpuCatalog } from '@runanywhere/qhexrt';
 import {
   ModelCategory,
   InferenceFramework,
@@ -18,11 +18,6 @@ import {
 } from '@runanywhere/proto-ts/model_types';
 import { LoraAdapterCatalogEntry } from '@runanywhere/proto-ts/lora_options';
 import { logDiagnostic } from '../utils/diagnostics';
-import {
-  NPU_BUNDLES,
-  publishNpuCatalogAcceptance,
-  toNpuRegistrationRequest,
-} from './NpuModelCatalog';
 import { PORTABLE_NVIDIA_EMBEDDING_MODELS } from './EmbeddingCatalogPolicy';
 
 // Canonical SDK methods (Swift parity).
@@ -34,8 +29,6 @@ export type BackendRegistrationState = {
   mlxRegistered: boolean;
   qhexrtRegistered: boolean;
 };
-
-let qhexrtBackendRegistered = false;
 
 /**
  * Register the curated model catalog for every successfully-registered
@@ -449,15 +442,13 @@ export async function registerAll(
   // =========================================================================
   // QHexRT (Hexagon NPU) bundles — logical URLs resolved natively
   // =========================================================================
-  qhexrtBackendRegistered = qhexrtRegistered;
-  if (await isNpuCatalogReady()) {
-    const result = await registerNpuBundles();
-    publishNpuCatalogAcceptance(result.registeredIds);
-  } else {
-    publishNpuCatalogAcceptance([]);
-    logDiagnostic(
-      '[App] Skipping QHexRT catalog - native backend/device unsupported'
-    );
+  if (qhexrtRegistered) {
+    try {
+      const npuCount = await seedNpuCatalog(() => QHexRT.probeNpu());
+      logDiagnostic(`[App] QHexRT NPU bundles seeded: ${npuCount}`);
+    } catch (error) {
+      logDiagnostic(`[App] NPU catalog seed failed: ${String(error)}`);
+    }
   }
 
   logDiagnostic('[App] All models registered');
@@ -483,80 +474,11 @@ async function registerLoraAdapters(): Promise<void> {
   }
 }
 
-type NpuSeedResult = Readonly<{
-  registeredIds: ReadonlySet<string>;
-  registered: number;
-  failed: number;
-  skippedNative: number;
-}>;
-
-async function isNpuCatalogReady(): Promise<boolean> {
-  if (!qhexrtBackendRegistered) return false;
-
-  try {
-    const [registered, capability] = await Promise.all([
-      QHexRT.isRegistered(),
-      QHexRT.probeNpu(),
-    ]);
-    return registered && capability.qhexrtSupported;
-  } catch (error) {
-    logDiagnostic(`[App] QHexRT readiness check failed: ${String(error)}`);
-    return false;
-  }
-}
-
-/** Register only the logical HNPU rows accepted by native QHexRT. */
-async function registerNpuBundles(): Promise<NpuSeedResult> {
-  const registeredIds = new Set<string>();
-  let registered = 0;
-  let failed = 0;
-  let skippedNative = 0;
-
-  for (const bundle of NPU_BUNDLES) {
-    try {
-      const saved = await QHexRT.registerModelForDevice(
-        toNpuRegistrationRequest(bundle)
-      );
-      if (saved) {
-        registered += 1;
-        registeredIds.add(saved.id);
-      } else {
-        skippedNative += 1;
-      }
-    } catch (error) {
-      failed += 1;
-      logDiagnostic(
-        `[App] Failed to register NPU bundle ${bundle.id}: ${String(error)}`
-      );
-    }
-  }
-
-  logDiagnostic(
-    `[App] QHexRT catalog seeded: ok=${registered} failed=${failed} ` +
-      `skippedNative=${skippedNative}`
-  );
-  return {
-    registeredIds,
-    registered,
-    failed,
-    skippedNative,
-  };
-}
-
 /**
- * Re-seed QHexRT rows after token/config changes. A generic registry refresh is
- * only meaningful when native QHexRT is still registered on a supported device.
+ * Refresh the QHexRT NPU catalog after token/config changes.
  */
 export async function refreshNpuCatalog(): Promise<boolean> {
-  if (!(await isNpuCatalogReady())) {
-    publishNpuCatalogAcceptance([]);
-    logDiagnostic(
-      '[App] Skipping QHexRT catalog refresh - native backend/device unsupported'
-    );
-    return false;
-  }
-
-  const result = await registerNpuBundles();
+  const npuCount = await seedNpuCatalog(() => QHexRT.probeNpu());
   let registryRefreshed = false;
   try {
     await RunAnywhere.refreshModelRegistry();
@@ -565,11 +487,8 @@ export async function refreshNpuCatalog(): Promise<boolean> {
     logDiagnostic(`[App] QHexRT registry refresh failed: ${String(error)}`);
   }
 
-  // Publish after the registry operation so retained pickers reload a completed
-  // catalog snapshot rather than observing an intermediate registration pass.
-  publishNpuCatalogAcceptance(result.registeredIds);
   logDiagnostic(
-    `[App] QHexRT catalog refresh completed: registryRefreshed=${registryRefreshed}`
+    `[App] QHexRT catalog refresh completed: seedCount=${npuCount} registryRefreshed=${registryRefreshed}`
   );
   return registryRefreshed;
 }

--- a/sdk/runanywhere-flutter/packages/runanywhere_qhexrt/lib/runanywhere_qhexrt.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere_qhexrt/lib/runanywhere_qhexrt.dart
@@ -15,3 +15,4 @@
 library;
 
 export 'qhexrt.dart';
+export 'src/npu_catalog.dart' show seedNpuCatalog;

--- a/sdk/runanywhere-flutter/packages/runanywhere_qhexrt/lib/src/npu_catalog.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere_qhexrt/lib/src/npu_catalog.dart
@@ -1,13 +1,13 @@
-/// Curated QHexRT NPU catalog — one manifest-pinned hf.co folder ref per
-/// bundle (`https://huggingface.co/<repo>/<arch>/<manifest>.json`). Commons
-/// + the engine-registered QHexRT bundle policy resolve the full file set
-/// (sizes, checksums, nested paths) from the Hub tree at registration — no
-/// file lists in the SDK. Context binaries are arch-exact ([arch] is the
-/// Hexagon architecture they were compiled for: v75+), so registration
-/// filters to the arch probed on the running device.
-///
-/// Kept in lockstep with the Kotlin (`runanywhere-core-qhexrt`) and React
-/// Native (`@runanywhere/qhexrt`) SDK packages.
+// Curated QHexRT NPU catalog — one manifest-pinned hf.co folder ref per
+// bundle (`https://huggingface.co/<repo>/<arch>/<manifest>.json`). Commons
+// + the engine-registered QHexRT bundle policy resolve the full file set
+// (sizes, checksums, nested paths) from the Hub tree at registration — no
+// file lists in the SDK. Context binaries are arch-exact ([arch] is the
+// Hexagon architecture they were compiled for: v75+), so registration
+// filters to the arch probed on the running device.
+//
+// Kept in lockstep with the Kotlin (`runanywhere-core-qhexrt`) and React
+// Native (`@runanywhere/qhexrt`) SDK packages.
 
 import 'package:flutter/foundation.dart';
 import 'package:runanywhere/runanywhere.dart';

--- a/sdk/runanywhere-flutter/packages/runanywhere_qhexrt/lib/src/npu_catalog.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere_qhexrt/lib/src/npu_catalog.dart
@@ -1,0 +1,218 @@
+/// Curated QHexRT NPU catalog — one manifest-pinned hf.co folder ref per
+/// bundle (`https://huggingface.co/<repo>/<arch>/<manifest>.json`). Commons
+/// + the engine-registered QHexRT bundle policy resolve the full file set
+/// (sizes, checksums, nested paths) from the Hub tree at registration — no
+/// file lists in the SDK. Context binaries are arch-exact ([arch] is the
+/// Hexagon architecture they were compiled for: v75+), so registration
+/// filters to the arch probed on the running device.
+///
+/// Kept in lockstep with the Kotlin (`runanywhere-core-qhexrt`) and React
+/// Native (`@runanywhere/qhexrt`) SDK packages.
+
+import 'package:flutter/foundation.dart';
+import 'package:runanywhere/runanywhere.dart';
+import 'package:runanywhere_qhexrt/runanywhere_qhexrt.dart';
+
+/// One QHexRT NPU bundle reference: an HF folder-bundle URL pinned to the
+/// bundle's manifest (`huggingface.co/<repo>/<arch>/<manifest>.json`).
+class _NpuRef {
+  const _NpuRef({
+    required this.id,
+    required this.name,
+    required this.modality,
+    required this.arch,
+    required this.url,
+  });
+
+  final String id;
+  final String name;
+  final ModelCategory modality;
+  final String arch;
+  final String url;
+}
+
+const List<_NpuRef> _npuRefs = [
+  _NpuRef(
+    id: 'lfm2_5_230m_v79',
+    name: 'LFM2.5 230M (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_LANGUAGE,
+    arch: 'v79',
+    url:
+        'https://huggingface.co/runanywhere/lfm2_5_230m_HNPU/v79/lfm2-5-230m.json',
+  ),
+  _NpuRef(
+    id: 'lfm2_5_230m_v81',
+    name: 'LFM2.5 230M (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_LANGUAGE,
+    arch: 'v81',
+    url:
+        'https://huggingface.co/runanywhere/lfm2_5_230m_HNPU/v81/lfm2-5-230m.json',
+  ),
+  _NpuRef(
+    id: 'lfm2_5_350m_v79',
+    name: 'LFM2.5 350M (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_LANGUAGE,
+    arch: 'v79',
+    url:
+        'https://huggingface.co/runanywhere/lfm2_5_350m_HNPU/v79/lfm2-5-350m-2048.json',
+  ),
+  _NpuRef(
+    id: 'lfm2_5_350m_v81',
+    name: 'LFM2.5 350M (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_LANGUAGE,
+    arch: 'v81',
+    url:
+        'https://huggingface.co/runanywhere/lfm2_5_350m_HNPU/v81/lfm2-5-350m-2048.json',
+  ),
+  _NpuRef(
+    id: 'qwen3_5_0_8b_v81',
+    name: 'Qwen3.5 0.8B (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_LANGUAGE,
+    arch: 'v81',
+    url:
+        'https://huggingface.co/runanywhere/qwen3_5_0_8b_HNPU/v81/qwen3.5-0.8b-1024.json',
+  ),
+  _NpuRef(
+    id: 'qwen3_vl_v79',
+    name: 'Qwen3-VL 2B (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_MULTIMODAL,
+    arch: 'v79',
+    url:
+        'https://huggingface.co/runanywhere/qwen3_vl_HNPU/v79/qwen3vl-2b-vlm-512.json',
+  ),
+  _NpuRef(
+    id: 'internvl3_5_1b_v79',
+    name: 'InternVL3.5 1B (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_MULTIMODAL,
+    arch: 'v79',
+    url:
+        'https://huggingface.co/runanywhere/internvl3_5_1b_HNPU/v79/internvl3_5-1b-512.json',
+  ),
+  _NpuRef(
+    id: 'internvl3_5_1b_v81',
+    name: 'InternVL3.5 1B (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_MULTIMODAL,
+    arch: 'v81',
+    url:
+        'https://huggingface.co/runanywhere/internvl3_5_1b_HNPU/v81/internvl3_5-1b.json',
+  ),
+  _NpuRef(
+    id: 'whisper_base_v79',
+    name: 'Whisper Base (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION,
+    arch: 'v79',
+    url:
+        'https://huggingface.co/runanywhere/whisper_base_HNPU/v79/whisper-base.json',
+  ),
+  _NpuRef(
+    id: 'whisper_small_v79',
+    name: 'Whisper Small (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION,
+    arch: 'v79',
+    url:
+        'https://huggingface.co/runanywhere/whisper_small_HNPU/v79/whisper-small.json',
+  ),
+  _NpuRef(
+    id: 'moonshine_tiny_v81',
+    name: 'Moonshine Tiny (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION,
+    arch: 'v81',
+    url:
+        'https://huggingface.co/runanywhere/moonshine_tiny_HNPU/v81/moonshine-tiny.json',
+  ),
+  _NpuRef(
+    id: 'moonshine_base_v81',
+    name: 'Moonshine Base (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION,
+    arch: 'v81',
+    url:
+        'https://huggingface.co/runanywhere/moonshine_base_HNPU/v81/moonshine-base.json',
+  ),
+  _NpuRef(
+    id: 'melotts_en_v79',
+    name: 'MeloTTS EN (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+    arch: 'v79',
+    url:
+        'https://huggingface.co/runanywhere/melotts_en_HNPU/v79/melotts-en.json',
+  ),
+  _NpuRef(
+    id: 'melotts_en_v81',
+    name: 'MeloTTS EN (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+    arch: 'v81',
+    url:
+        'https://huggingface.co/runanywhere/melotts_en_HNPU/v81/melotts-en.json',
+  ),
+  _NpuRef(
+    id: 'kokoro_en_v81',
+    name: 'Kokoro-82M EN (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+    arch: 'v81',
+    url:
+        'https://huggingface.co/runanywhere/kokoro_en_HNPU/v81/kokoro-en.json',
+  ),
+  _NpuRef(
+    id: 'kitten_nano_0_8_v81',
+    name: 'Kitten-nano-0.8-fp32 (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+    arch: 'v81',
+    url:
+        'https://huggingface.co/runanywhere/kitten_nano_0_8_HNPU/v81/kitten_nano08_v81.json',
+  ),
+  _NpuRef(
+    id: 'kitten_mini_0_1_v81',
+    name: 'Kitten-mini-0.1 (HNPU)',
+    modality: ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+    arch: 'v81',
+    url:
+        'https://huggingface.co/runanywhere/kitten_mini_0_1_HNPU/v81/kitten_mini01_v81.json',
+  ),
+];
+
+/// Seed the QHexRT NPU catalog: probe the device NPU, register arch-matching
+/// bundles via the SDK's canonical from-url path, then refresh the model
+/// registry. Safe to re-run on every cold launch — commons merges runtime
+/// fields on re-registration.
+///
+/// Does NOT call [QHexRT.register] — the caller must register the backend
+/// separately (before or after catalog seeding) so the two concerns stay
+/// decoupled: "enable the engine" vs "populate the catalog."
+///
+/// On unsupported devices this is a no-op (no bundles match) and returns 0.
+///
+/// Returns the number of NPU bundles successfully registered.
+Future<int> seedNpuCatalog() async {
+  if (!QHexRT.isAvailable) {
+    debugPrint('QHexRT NPU not available; skipping NPU catalog seed');
+    return 0;
+  }
+
+  final npu = QHexRT.probeNpu();
+  if (!npu.qhexrtSupported) {
+    debugPrint('QHexRT NPU not supported on this device; skipping NPU catalog seed');
+    return 0;
+  }
+
+  final arch = npu.archName;
+  final bundles = _npuRefs.where((r) => r.arch == arch).toList();
+  var count = 0;
+  for (final r in bundles) {
+    try {
+      await RunAnywhere.models.register(
+        id: r.id,
+        name: r.name,
+        url: r.url,
+        framework: InferenceFramework.INFERENCE_FRAMEWORK_QHEXRT,
+        modality: r.modality,
+        memoryRequirement: 0,
+      );
+      count++;
+    } catch (e) {
+      debugPrint('Failed to register NPU bundle ${r.id}: $e');
+    }
+  }
+
+  debugPrint('QHexRT NPU bundles registered for $arch: $count');
+  return count;
+}

--- a/sdk/runanywhere-kotlin/modules/runanywhere-core-qhexrt/src/main/kotlin/com/runanywhere/sdk/npu/qhexrt/NpuCatalog.kt
+++ b/sdk/runanywhere-kotlin/modules/runanywhere-core-qhexrt/src/main/kotlin/com/runanywhere/sdk/npu/qhexrt/NpuCatalog.kt
@@ -40,42 +40,128 @@ data class NpuCatalogSeedResult(
  * Kept in lockstep with the Flutter (`runanywhere_qhexrt`) and React Native
  * (`@runanywhere/qhexrt`) packages.
  */
-val qhexrtBundles: List<NpuBundle> = listOf(
-    NpuBundle("lfm2_5_230m_v79", "LFM2.5 230M (HNPU)", ModelCategory.MODEL_CATEGORY_LANGUAGE, "v79",
-        "https://huggingface.co/runanywhere/lfm2_5_230m_HNPU/v79/lfm2-5-230m.json"),
-    NpuBundle("lfm2_5_230m_v81", "LFM2.5 230M (HNPU)", ModelCategory.MODEL_CATEGORY_LANGUAGE, "v81",
-        "https://huggingface.co/runanywhere/lfm2_5_230m_HNPU/v81/lfm2-5-230m.json"),
-    NpuBundle("lfm2_5_350m_v79", "LFM2.5 350M (HNPU)", ModelCategory.MODEL_CATEGORY_LANGUAGE, "v79",
-        "https://huggingface.co/runanywhere/lfm2_5_350m_HNPU/v79/lfm2-5-350m-2048.json"),
-    NpuBundle("lfm2_5_350m_v81", "LFM2.5 350M (HNPU)", ModelCategory.MODEL_CATEGORY_LANGUAGE, "v81",
-        "https://huggingface.co/runanywhere/lfm2_5_350m_HNPU/v81/lfm2-5-350m-2048.json"),
-    NpuBundle("qwen3_5_0_8b_v81", "Qwen3.5 0.8B (HNPU)", ModelCategory.MODEL_CATEGORY_LANGUAGE, "v81",
-        "https://huggingface.co/runanywhere/qwen3_5_0_8b_HNPU/v81/qwen3.5-0.8b-1024.json"),
-    NpuBundle("qwen3_vl_v79", "Qwen3-VL 2B (HNPU)", ModelCategory.MODEL_CATEGORY_MULTIMODAL, "v79",
-        "https://huggingface.co/runanywhere/qwen3_vl_HNPU/v79/qwen3vl-2b-vlm-512.json"),
-    NpuBundle("internvl3_5_1b_v79", "InternVL3.5 1B (HNPU)", ModelCategory.MODEL_CATEGORY_MULTIMODAL, "v79",
-        "https://huggingface.co/runanywhere/internvl3_5_1b_HNPU/v79/internvl3_5-1b-512.json"),
-    NpuBundle("internvl3_5_1b_v81", "InternVL3.5 1B (HNPU)", ModelCategory.MODEL_CATEGORY_MULTIMODAL, "v81",
-        "https://huggingface.co/runanywhere/internvl3_5_1b_HNPU/v81/internvl3_5-1b.json"),
-    NpuBundle("whisper_base_v79", "Whisper Base (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION, "v79",
-        "https://huggingface.co/runanywhere/whisper_base_HNPU/v79/whisper-base.json"),
-    NpuBundle("whisper_small_v79", "Whisper Small (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION, "v79",
-        "https://huggingface.co/runanywhere/whisper_small_HNPU/v79/whisper-small.json"),
-    NpuBundle("moonshine_tiny_v81", "Moonshine Tiny (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION, "v81",
-        "https://huggingface.co/runanywhere/moonshine_tiny_HNPU/v81/moonshine-tiny.json"),
-    NpuBundle("moonshine_base_v81", "Moonshine Base (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION, "v81",
-        "https://huggingface.co/runanywhere/moonshine_base_HNPU/v81/moonshine-base.json"),
-    NpuBundle("melotts_en_v79", "MeloTTS EN (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS, "v79",
-        "https://huggingface.co/runanywhere/melotts_en_HNPU/v79/melotts-en.json"),
-    NpuBundle("melotts_en_v81", "MeloTTS EN (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS, "v81",
-        "https://huggingface.co/runanywhere/melotts_en_HNPU/v81/melotts-en.json"),
-    NpuBundle("kokoro_en_v81", "Kokoro-82M EN (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS, "v81",
-        "https://huggingface.co/runanywhere/kokoro_en_HNPU/v81/kokoro-en.json"),
-    NpuBundle("kitten_nano_0_8_v81", "Kitten-nano-0.8-fp32 (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS, "v81",
-        "https://huggingface.co/runanywhere/kitten_nano_0_8_HNPU/v81/kitten_nano08_v81.json"),
-    NpuBundle("kitten_mini_0_1_v81", "Kitten-mini-0.1 (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS, "v81",
-        "https://huggingface.co/runanywhere/kitten_mini_0_1_HNPU/v81/kitten_mini01_v81.json"),
-)
+val qhexrtBundles: List<NpuBundle> =
+    listOf(
+        NpuBundle(
+            "lfm2_5_230m_v79",
+            "LFM2.5 230M (HNPU)",
+            ModelCategory.MODEL_CATEGORY_LANGUAGE,
+            "v79",
+            "https://huggingface.co/runanywhere/lfm2_5_230m_HNPU/v79/lfm2-5-230m.json",
+        ),
+        NpuBundle(
+            "lfm2_5_230m_v81",
+            "LFM2.5 230M (HNPU)",
+            ModelCategory.MODEL_CATEGORY_LANGUAGE,
+            "v81",
+            "https://huggingface.co/runanywhere/lfm2_5_230m_HNPU/v81/lfm2-5-230m.json",
+        ),
+        NpuBundle(
+            "lfm2_5_350m_v79",
+            "LFM2.5 350M (HNPU)",
+            ModelCategory.MODEL_CATEGORY_LANGUAGE,
+            "v79",
+            "https://huggingface.co/runanywhere/lfm2_5_350m_HNPU/v79/lfm2-5-350m-2048.json",
+        ),
+        NpuBundle(
+            "lfm2_5_350m_v81",
+            "LFM2.5 350M (HNPU)",
+            ModelCategory.MODEL_CATEGORY_LANGUAGE,
+            "v81",
+            "https://huggingface.co/runanywhere/lfm2_5_350m_HNPU/v81/lfm2-5-350m-2048.json",
+        ),
+        NpuBundle(
+            "qwen3_5_0_8b_v81",
+            "Qwen3.5 0.8B (HNPU)",
+            ModelCategory.MODEL_CATEGORY_LANGUAGE,
+            "v81",
+            "https://huggingface.co/runanywhere/qwen3_5_0_8b_HNPU/v81/qwen3.5-0.8b-1024.json",
+        ),
+        NpuBundle(
+            "qwen3_vl_v79",
+            "Qwen3-VL 2B (HNPU)",
+            ModelCategory.MODEL_CATEGORY_MULTIMODAL,
+            "v79",
+            "https://huggingface.co/runanywhere/qwen3_vl_HNPU/v79/qwen3vl-2b-vlm-512.json",
+        ),
+        NpuBundle(
+            "internvl3_5_1b_v79",
+            "InternVL3.5 1B (HNPU)",
+            ModelCategory.MODEL_CATEGORY_MULTIMODAL,
+            "v79",
+            "https://huggingface.co/runanywhere/internvl3_5_1b_HNPU/v79/internvl3_5-1b-512.json",
+        ),
+        NpuBundle(
+            "internvl3_5_1b_v81",
+            "InternVL3.5 1B (HNPU)",
+            ModelCategory.MODEL_CATEGORY_MULTIMODAL,
+            "v81",
+            "https://huggingface.co/runanywhere/internvl3_5_1b_HNPU/v81/internvl3_5-1b.json",
+        ),
+        NpuBundle(
+            "whisper_base_v79",
+            "Whisper Base (HNPU)",
+            ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION,
+            "v79",
+            "https://huggingface.co/runanywhere/whisper_base_HNPU/v79/whisper-base.json",
+        ),
+        NpuBundle(
+            "whisper_small_v79",
+            "Whisper Small (HNPU)",
+            ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION,
+            "v79",
+            "https://huggingface.co/runanywhere/whisper_small_HNPU/v79/whisper-small.json",
+        ),
+        NpuBundle(
+            "moonshine_tiny_v81",
+            "Moonshine Tiny (HNPU)",
+            ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION,
+            "v81",
+            "https://huggingface.co/runanywhere/moonshine_tiny_HNPU/v81/moonshine-tiny.json",
+        ),
+        NpuBundle(
+            "moonshine_base_v81",
+            "Moonshine Base (HNPU)",
+            ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION,
+            "v81",
+            "https://huggingface.co/runanywhere/moonshine_base_HNPU/v81/moonshine-base.json",
+        ),
+        NpuBundle(
+            "melotts_en_v79",
+            "MeloTTS EN (HNPU)",
+            ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+            "v79",
+            "https://huggingface.co/runanywhere/melotts_en_HNPU/v79/melotts-en.json",
+        ),
+        NpuBundle(
+            "melotts_en_v81",
+            "MeloTTS EN (HNPU)",
+            ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+            "v81",
+            "https://huggingface.co/runanywhere/melotts_en_HNPU/v81/melotts-en.json",
+        ),
+        NpuBundle(
+            "kokoro_en_v81",
+            "Kokoro-82M EN (HNPU)",
+            ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+            "v81",
+            "https://huggingface.co/runanywhere/kokoro_en_HNPU/v81/kokoro-en.json",
+        ),
+        NpuBundle(
+            "kitten_nano_0_8_v81",
+            "Kitten-nano-0.8-fp32 (HNPU)",
+            ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+            "v81",
+            "https://huggingface.co/runanywhere/kitten_nano_0_8_HNPU/v81/kitten_nano08_v81.json",
+        ),
+        NpuBundle(
+            "kitten_mini_0_1_v81",
+            "Kitten-mini-0.1 (HNPU)",
+            ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+            "v81",
+            "https://huggingface.co/runanywhere/kitten_mini_0_1_HNPU/v81/kitten_mini01_v81.json",
+        ),
+    )
 
 private val logger = SDKLogger("QHexRT")
 
@@ -95,9 +181,10 @@ private val logger = SDKLogger("QHexRT")
  * @return The registered bundle ids and summary counts.
  */
 suspend fun QHexRT.seedCatalog(): NpuCatalogSeedResult {
-    val npuArch = runCatching {
-        probeNpu().takeIf { it.qhexrt_supported }?.arch_name
-    }.getOrNull()
+    val npuArch =
+        runCatching {
+            probeNpu().takeIf { it.qhexrt_supported }?.arch_name
+        }.getOrNull()
 
     if (npuArch == null) {
         logger.info("QHexRT NPU not supported on this device; skipping NPU catalog seed")

--- a/sdk/runanywhere-kotlin/modules/runanywhere-core-qhexrt/src/main/kotlin/com/runanywhere/sdk/npu/qhexrt/NpuCatalog.kt
+++ b/sdk/runanywhere-kotlin/modules/runanywhere-core-qhexrt/src/main/kotlin/com/runanywhere/sdk/npu/qhexrt/NpuCatalog.kt
@@ -5,7 +5,7 @@ import ai.runanywhere.proto.v1.ModelCategory
 import com.runanywhere.sdk.infrastructure.logging.SDKLogger
 import com.runanywhere.sdk.public.RunAnywhere
 import com.runanywhere.sdk.public.extensions.registerModel
-import kotlinx.coroutines.cancellation.CancellationException
+import kotlin.coroutines.cancellation.CancellationException
 
 /**
  * One NPU (QHexRT) bundle = one manifest-pinned hf.co folder ref

--- a/sdk/runanywhere-kotlin/modules/runanywhere-core-qhexrt/src/main/kotlin/com/runanywhere/sdk/npu/qhexrt/NpuCatalog.kt
+++ b/sdk/runanywhere-kotlin/modules/runanywhere-core-qhexrt/src/main/kotlin/com/runanywhere/sdk/npu/qhexrt/NpuCatalog.kt
@@ -21,6 +21,13 @@ data class NpuBundle(
     val url: String,
 )
 
+data class NpuCatalogSeedResult(
+    val registeredIds: Set<String> = emptySet(),
+    val registeredCount: Int = registeredIds.size,
+    val failedCount: Int = 0,
+    val arch: String? = null,
+)
+
 /**
  * The 17-bundle NPU (QHexRT) catalog — one manifest-pinned hf.co folder ref
  * per bundle. Commons + the engine-registered QHexRT bundle policy resolve
@@ -82,21 +89,23 @@ private val logger = SDKLogger("QHexRT")
  * separately (before or after catalog seeding) so the two concerns stay
  * decoupled: "enable the engine" vs "populate the catalog."
  *
- * On unsupported devices this is a no-op (no bundles match) and returns 0.
+ * On unsupported devices this is a no-op (no bundles match) and returns an
+ * empty result.
  *
- * @return The number of NPU bundles successfully registered.
+ * @return The registered bundle ids and summary counts.
  */
-suspend fun QHexRT.seedCatalog(): Int {
+suspend fun QHexRT.seedCatalog(): NpuCatalogSeedResult {
     val npuArch = runCatching {
         probeNpu().takeIf { it.qhexrt_supported }?.arch_name
     }.getOrNull()
 
     if (npuArch == null) {
         logger.info("QHexRT NPU not supported on this device; skipping NPU catalog seed")
-        return 0
+        return NpuCatalogSeedResult()
     }
 
     val bundles = qhexrtBundles.filter { it.arch == npuArch }
+    val registeredIds = mutableSetOf<String>()
     var ok = 0
     var fail = 0
     for (bundle in bundles) {
@@ -109,6 +118,7 @@ suspend fun QHexRT.seedCatalog(): Int {
                 modality = bundle.category,
                 memoryRequirement = 0L,
             )
+            registeredIds += bundle.id
             ok++
         } catch (e: CancellationException) {
             throw e
@@ -119,5 +129,10 @@ suspend fun QHexRT.seedCatalog(): Int {
     }
 
     logger.info("QHexRT NPU catalog seeded for arch $npuArch: ok=$ok failed=$fail")
-    return ok
+    return NpuCatalogSeedResult(
+        registeredIds = registeredIds,
+        registeredCount = ok,
+        failedCount = fail,
+        arch = npuArch,
+    )
 }

--- a/sdk/runanywhere-kotlin/modules/runanywhere-core-qhexrt/src/main/kotlin/com/runanywhere/sdk/npu/qhexrt/NpuCatalog.kt
+++ b/sdk/runanywhere-kotlin/modules/runanywhere-core-qhexrt/src/main/kotlin/com/runanywhere/sdk/npu/qhexrt/NpuCatalog.kt
@@ -1,0 +1,123 @@
+package com.runanywhere.sdk.npu.qhexrt
+
+import ai.runanywhere.proto.v1.InferenceFramework
+import ai.runanywhere.proto.v1.ModelCategory
+import com.runanywhere.sdk.infrastructure.logging.SDKLogger
+import com.runanywhere.sdk.public.RunAnywhere
+import com.runanywhere.sdk.public.extensions.registerModel
+import kotlinx.coroutines.cancellation.CancellationException
+
+/**
+ * One NPU (QHexRT) bundle = one manifest-pinned hf.co folder ref
+ * (`https://huggingface.co/<repo>/<arch>/<manifest>.json`). Public so
+ * androidTest instrumentation (NpuModelE2ETest) can look up bundles by id.
+ * Apps should use [QHexRT.seedCatalog] rather than constructing entries.
+ */
+data class NpuBundle(
+    val id: String,
+    val name: String,
+    val category: ModelCategory,
+    val arch: String,
+    val url: String,
+)
+
+/**
+ * The 17-bundle NPU (QHexRT) catalog — one manifest-pinned hf.co folder ref
+ * per bundle. Commons + the engine-registered QHexRT bundle policy resolve
+ * the full file set (sizes, checksums, nested paths, and the repo-root
+ * `config.json` when present) from the Hub tree at registration — no file
+ * lists in the SDK. Context binaries are arch-exact ([arch] is the Hexagon
+ * architecture they were compiled for: v75+), so registration filters to
+ * the arch probed on the running device.
+ *
+ * Kept in lockstep with the Flutter (`runanywhere_qhexrt`) and React Native
+ * (`@runanywhere/qhexrt`) packages.
+ */
+val qhexrtBundles: List<NpuBundle> = listOf(
+    NpuBundle("lfm2_5_230m_v79", "LFM2.5 230M (HNPU)", ModelCategory.MODEL_CATEGORY_LANGUAGE, "v79",
+        "https://huggingface.co/runanywhere/lfm2_5_230m_HNPU/v79/lfm2-5-230m.json"),
+    NpuBundle("lfm2_5_230m_v81", "LFM2.5 230M (HNPU)", ModelCategory.MODEL_CATEGORY_LANGUAGE, "v81",
+        "https://huggingface.co/runanywhere/lfm2_5_230m_HNPU/v81/lfm2-5-230m.json"),
+    NpuBundle("lfm2_5_350m_v79", "LFM2.5 350M (HNPU)", ModelCategory.MODEL_CATEGORY_LANGUAGE, "v79",
+        "https://huggingface.co/runanywhere/lfm2_5_350m_HNPU/v79/lfm2-5-350m-2048.json"),
+    NpuBundle("lfm2_5_350m_v81", "LFM2.5 350M (HNPU)", ModelCategory.MODEL_CATEGORY_LANGUAGE, "v81",
+        "https://huggingface.co/runanywhere/lfm2_5_350m_HNPU/v81/lfm2-5-350m-2048.json"),
+    NpuBundle("qwen3_5_0_8b_v81", "Qwen3.5 0.8B (HNPU)", ModelCategory.MODEL_CATEGORY_LANGUAGE, "v81",
+        "https://huggingface.co/runanywhere/qwen3_5_0_8b_HNPU/v81/qwen3.5-0.8b-1024.json"),
+    NpuBundle("qwen3_vl_v79", "Qwen3-VL 2B (HNPU)", ModelCategory.MODEL_CATEGORY_MULTIMODAL, "v79",
+        "https://huggingface.co/runanywhere/qwen3_vl_HNPU/v79/qwen3vl-2b-vlm-512.json"),
+    NpuBundle("internvl3_5_1b_v79", "InternVL3.5 1B (HNPU)", ModelCategory.MODEL_CATEGORY_MULTIMODAL, "v79",
+        "https://huggingface.co/runanywhere/internvl3_5_1b_HNPU/v79/internvl3_5-1b-512.json"),
+    NpuBundle("internvl3_5_1b_v81", "InternVL3.5 1B (HNPU)", ModelCategory.MODEL_CATEGORY_MULTIMODAL, "v81",
+        "https://huggingface.co/runanywhere/internvl3_5_1b_HNPU/v81/internvl3_5-1b.json"),
+    NpuBundle("whisper_base_v79", "Whisper Base (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION, "v79",
+        "https://huggingface.co/runanywhere/whisper_base_HNPU/v79/whisper-base.json"),
+    NpuBundle("whisper_small_v79", "Whisper Small (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION, "v79",
+        "https://huggingface.co/runanywhere/whisper_small_HNPU/v79/whisper-small.json"),
+    NpuBundle("moonshine_tiny_v81", "Moonshine Tiny (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION, "v81",
+        "https://huggingface.co/runanywhere/moonshine_tiny_HNPU/v81/moonshine-tiny.json"),
+    NpuBundle("moonshine_base_v81", "Moonshine Base (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION, "v81",
+        "https://huggingface.co/runanywhere/moonshine_base_HNPU/v81/moonshine-base.json"),
+    NpuBundle("melotts_en_v79", "MeloTTS EN (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS, "v79",
+        "https://huggingface.co/runanywhere/melotts_en_HNPU/v79/melotts-en.json"),
+    NpuBundle("melotts_en_v81", "MeloTTS EN (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS, "v81",
+        "https://huggingface.co/runanywhere/melotts_en_HNPU/v81/melotts-en.json"),
+    NpuBundle("kokoro_en_v81", "Kokoro-82M EN (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS, "v81",
+        "https://huggingface.co/runanywhere/kokoro_en_HNPU/v81/kokoro-en.json"),
+    NpuBundle("kitten_nano_0_8_v81", "Kitten-nano-0.8-fp32 (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS, "v81",
+        "https://huggingface.co/runanywhere/kitten_nano_0_8_HNPU/v81/kitten_nano08_v81.json"),
+    NpuBundle("kitten_mini_0_1_v81", "Kitten-mini-0.1 (HNPU)", ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS, "v81",
+        "https://huggingface.co/runanywhere/kitten_mini_0_1_HNPU/v81/kitten_mini01_v81.json"),
+)
+
+private val logger = SDKLogger("QHexRT")
+
+/**
+ * Seed the QHexRT NPU catalog: probe the device NPU, register arch-matching
+ * bundles via the SDK's canonical from-url path, then refresh the model
+ * registry. Safe to re-run on every cold launch — commons merges runtime
+ * fields on re-registration.
+ *
+ * Does NOT call [QHexRT.register] — the caller must register the backend
+ * separately (before or after catalog seeding) so the two concerns stay
+ * decoupled: "enable the engine" vs "populate the catalog."
+ *
+ * On unsupported devices this is a no-op (no bundles match) and returns 0.
+ *
+ * @return The number of NPU bundles successfully registered.
+ */
+suspend fun QHexRT.seedCatalog(): Int {
+    val npuArch = runCatching {
+        probeNpu().takeIf { it.qhexrt_supported }?.arch_name
+    }.getOrNull()
+
+    if (npuArch == null) {
+        logger.info("QHexRT NPU not supported on this device; skipping NPU catalog seed")
+        return 0
+    }
+
+    val bundles = qhexrtBundles.filter { it.arch == npuArch }
+    var ok = 0
+    var fail = 0
+    for (bundle in bundles) {
+        try {
+            RunAnywhere.registerModel(
+                id = bundle.id,
+                name = bundle.name,
+                url = bundle.url,
+                framework = InferenceFramework.INFERENCE_FRAMEWORK_QHEXRT,
+                modality = bundle.category,
+                memoryRequirement = 0L,
+            )
+            ok++
+        } catch (e: CancellationException) {
+            throw e
+        } catch (e: Exception) {
+            fail++
+            logger.error("Failed to register NPU bundle ${bundle.id}: ${e.message}", throwable = e)
+        }
+    }
+
+    logger.info("QHexRT NPU catalog seeded for arch $npuArch: ok=$ok failed=$fail")
+    return ok
+}

--- a/sdk/runanywhere-react-native/packages/qhexrt/src/NpuCatalog.ts
+++ b/sdk/runanywhere-react-native/packages/qhexrt/src/NpuCatalog.ts
@@ -1,0 +1,209 @@
+/**
+ * Curated QHexRT NPU catalog — one manifest-pinned hf.co folder ref per
+ * bundle (`https://huggingface.co/<repo>/<arch>/<manifest>.json`). Commons
+ * + the engine-registered QHexRT bundle policy resolve the full file set
+ * (sizes, checksums, nested paths) from the Hub tree at registration — no
+ * file lists in the SDK. Context binaries are arch-exact (`arch` is the
+ * Hexagon architecture they were compiled for: v75+), so registration
+ * filters to the arch probed on the running device.
+ *
+ * Kept in lockstep with the Kotlin (`runanywhere-core-qhexrt`) and Flutter
+ * (`runanywhere_qhexrt`) SDK packages.
+ */
+
+import { RunAnywhere } from '@runanywhere/core';
+import {
+    ModelCategory,
+    InferenceFramework,
+} from '@runanywhere/proto-ts/model_types';
+
+/**
+ * One QHexRT NPU bundle reference: an HF folder-bundle URL pinned to the
+ * bundle's manifest (`huggingface.co/<repo>/<arch>/<manifest>.json`).
+ */
+type NpuRef = {
+    id: string;
+    name: string;
+    modality: ModelCategory;
+    /** Hexagon architecture the context binaries were compiled for. */
+    arch: string;
+    url: string;
+};
+
+const NPU_REFS: NpuRef[] = [
+    {
+        id: 'lfm2_5_230m_v79',
+        name: 'LFM2.5 230M (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_LANGUAGE,
+        arch: 'v79',
+        url: 'https://huggingface.co/runanywhere/lfm2_5_230m_HNPU/v79/lfm2-5-230m.json',
+    },
+    {
+        id: 'lfm2_5_230m_v81',
+        name: 'LFM2.5 230M (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_LANGUAGE,
+        arch: 'v81',
+        url: 'https://huggingface.co/runanywhere/lfm2_5_230m_HNPU/v81/lfm2-5-230m.json',
+    },
+    {
+        id: 'lfm2_5_350m_v79',
+        name: 'LFM2.5 350M (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_LANGUAGE,
+        arch: 'v79',
+        url: 'https://huggingface.co/runanywhere/lfm2_5_350m_HNPU/v79/lfm2-5-350m-2048.json',
+    },
+    {
+        id: 'lfm2_5_350m_v81',
+        name: 'LFM2.5 350M (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_LANGUAGE,
+        arch: 'v81',
+        url: 'https://huggingface.co/runanywhere/lfm2_5_350m_HNPU/v81/lfm2-5-350m-2048.json',
+    },
+    {
+        id: 'qwen3_5_0_8b_v81',
+        name: 'Qwen3.5 0.8B (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_LANGUAGE,
+        arch: 'v81',
+        url: 'https://huggingface.co/runanywhere/qwen3_5_0_8b_HNPU/v81/qwen3.5-0.8b-1024.json',
+    },
+    {
+        id: 'qwen3_vl_v79',
+        name: 'Qwen3-VL 2B (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_MULTIMODAL,
+        arch: 'v79',
+        url: 'https://huggingface.co/runanywhere/qwen3_vl_HNPU/v79/qwen3vl-2b-vlm-512.json',
+    },
+    {
+        id: 'internvl3_5_1b_v79',
+        name: 'InternVL3.5 1B (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_MULTIMODAL,
+        arch: 'v79',
+        url: 'https://huggingface.co/runanywhere/internvl3_5_1b_HNPU/v79/internvl3_5-1b-512.json',
+    },
+    {
+        id: 'internvl3_5_1b_v81',
+        name: 'InternVL3.5 1B (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_MULTIMODAL,
+        arch: 'v81',
+        url: 'https://huggingface.co/runanywhere/internvl3_5_1b_HNPU/v81/internvl3_5-1b.json',
+    },
+    {
+        id: 'whisper_base_v79',
+        name: 'Whisper Base (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION,
+        arch: 'v79',
+        url: 'https://huggingface.co/runanywhere/whisper_base_HNPU/v79/whisper-base.json',
+    },
+    {
+        id: 'whisper_small_v79',
+        name: 'Whisper Small (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION,
+        arch: 'v79',
+        url: 'https://huggingface.co/runanywhere/whisper_small_HNPU/v79/whisper-small.json',
+    },
+    {
+        id: 'moonshine_tiny_v81',
+        name: 'Moonshine Tiny (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION,
+        arch: 'v81',
+        url: 'https://huggingface.co/runanywhere/moonshine_tiny_HNPU/v81/moonshine-tiny.json',
+    },
+    {
+        id: 'moonshine_base_v81',
+        name: 'Moonshine Base (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION,
+        arch: 'v81',
+        url: 'https://huggingface.co/runanywhere/moonshine_base_HNPU/v81/moonshine-base.json',
+    },
+    {
+        id: 'melotts_en_v79',
+        name: 'MeloTTS EN (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+        arch: 'v79',
+        url: 'https://huggingface.co/runanywhere/melotts_en_HNPU/v79/melotts-en.json',
+    },
+    {
+        id: 'melotts_en_v81',
+        name: 'MeloTTS EN (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+        arch: 'v81',
+        url: 'https://huggingface.co/runanywhere/melotts_en_HNPU/v81/melotts-en.json',
+    },
+    {
+        id: 'kokoro_en_v81',
+        name: 'Kokoro-82M EN (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+        arch: 'v81',
+        url: 'https://huggingface.co/runanywhere/kokoro_en_HNPU/v81/kokoro-en.json',
+    },
+    {
+        id: 'kitten_nano_0_8_v81',
+        name: 'Kitten-nano-0.8-fp32 (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+        arch: 'v81',
+        url: 'https://huggingface.co/runanywhere/kitten_nano_0_8_HNPU/v81/kitten_nano08_v81.json',
+    },
+    {
+        id: 'kitten_mini_0_1_v81',
+        name: 'Kitten-mini-0.1 (HNPU)',
+        modality: ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS,
+        arch: 'v81',
+        url: 'https://huggingface.co/runanywhere/kitten_mini_0_1_HNPU/v81/kitten_mini01_v81.json',
+    },
+];
+
+/**
+ * Seed the QHexRT NPU catalog: probe the device NPU, register arch-matching
+ * bundles via the SDK's canonical from-url path, then refresh the model
+ * registry. Safe to re-run on every cold launch — commons merges runtime
+ * fields on re-registration.
+ *
+ * Does NOT call `QHexRT.register()` — the caller must register the backend
+ * separately (before or after catalog seeding) so the two concerns stay
+ * decoupled: "enable the engine" vs "populate the catalog."
+ *
+ * On unsupported devices this is a no-op (no bundles match) and returns 0.
+ *
+ * @param probeNpu - A function that returns the NPU capability (allows
+ *   callers to cache the probe result from the app startup flow).
+ * @returns The number of NPU bundles successfully registered.
+ */
+export async function seedNpuCatalog(
+    probeNpu: () => Promise<{ archName: string; qhexrtSupported: boolean }>
+): Promise<number> {
+    let npu: { archName: string; qhexrtSupported: boolean };
+    try {
+        npu = await probeNpu();
+    } catch {
+        console.debug('[QHexRT] NPU probe failed; skipping NPU catalog seed');
+        return 0;
+    }
+
+    if (!npu.qhexrtSupported) {
+        console.debug('[QHexRT] NPU not supported on this device; skipping NPU catalog seed');
+        return 0;
+    }
+
+    const arch = npu.archName;
+    const refs = NPU_REFS.filter((r) => r.arch === arch);
+    let count = 0;
+    await Promise.all(
+        refs.map(async (r) => {
+            try {
+                await RunAnywhere.registerModel({
+                    id: r.id,
+                    name: r.name,
+                    url: r.url,
+                    framework: InferenceFramework.INFERENCE_FRAMEWORK_QHEXRT,
+                    modality: r.modality,
+                });
+                count++;
+            } catch (error) {
+                console.debug(`[QHexRT] Failed to register NPU bundle ${r.id}: ${String(error)}`);
+            }
+        })
+    );
+
+    console.debug(`[QHexRT] NPU bundles registered for ${arch}: ${count}`);
+    return count;
+}

--- a/sdk/runanywhere-react-native/packages/qhexrt/src/NpuCatalog.ts
+++ b/sdk/runanywhere-react-native/packages/qhexrt/src/NpuCatalog.ts
@@ -12,6 +12,7 @@
  */
 
 import { RunAnywhere } from '@runanywhere/core';
+import { SDKLogger } from '@runanywhere/core/internal';
 import {
     ModelCategory,
     InferenceFramework,
@@ -175,35 +176,33 @@ export async function seedNpuCatalog(
     try {
         npu = await probeNpu();
     } catch {
-        console.debug('[QHexRT] NPU probe failed; skipping NPU catalog seed');
+        SDKLogger.debug('[QHexRT] NPU probe failed; skipping NPU catalog seed');
         return 0;
     }
 
     if (!npu.qhexrtSupported) {
-        console.debug('[QHexRT] NPU not supported on this device; skipping NPU catalog seed');
+        SDKLogger.debug('[QHexRT] NPU not supported on this device; skipping NPU catalog seed');
         return 0;
     }
 
     const arch = npu.archName;
     const refs = NPU_REFS.filter((r) => r.arch === arch);
     let count = 0;
-    await Promise.all(
-        refs.map(async (r) => {
-            try {
-                await RunAnywhere.registerModel({
-                    id: r.id,
-                    name: r.name,
-                    url: r.url,
-                    framework: InferenceFramework.INFERENCE_FRAMEWORK_QHEXRT,
-                    modality: r.modality,
-                });
-                count++;
-            } catch (error) {
-                console.debug(`[QHexRT] Failed to register NPU bundle ${r.id}: ${String(error)}`);
-            }
-        })
-    );
+    for (const r of refs) {
+        try {
+            await RunAnywhere.registerModel({
+                id: r.id,
+                name: r.name,
+                url: r.url,
+                framework: InferenceFramework.INFERENCE_FRAMEWORK_QHEXRT,
+                modality: r.modality,
+            });
+            count++;
+        } catch (error) {
+            SDKLogger.debug(`[QHexRT] Failed to register NPU bundle ${r.id}: ${String(error)}`);
+        }
+    }
 
-    console.debug(`[QHexRT] NPU bundles registered for ${arch}: ${count}`);
+    SDKLogger.debug(`[QHexRT] NPU bundles registered for ${arch}: ${count}`);
     return count;
 }

--- a/sdk/runanywhere-react-native/packages/qhexrt/src/NpuCatalog.ts
+++ b/sdk/runanywhere-react-native/packages/qhexrt/src/NpuCatalog.ts
@@ -18,6 +18,8 @@ import {
     InferenceFramework,
 } from '@runanywhere/proto-ts/model_types';
 
+const logger = new SDKLogger('QHexRT');
+
 /**
  * One QHexRT NPU bundle reference: an HF folder-bundle URL pinned to the
  * bundle's manifest (`huggingface.co/<repo>/<arch>/<manifest>.json`).
@@ -176,12 +178,12 @@ export async function seedNpuCatalog(
     try {
         npu = await probeNpu();
     } catch {
-        SDKLogger.debug('[QHexRT] NPU probe failed; skipping NPU catalog seed');
+        logger.debug('NPU probe failed; skipping NPU catalog seed');
         return 0;
     }
 
     if (!npu.qhexrtSupported) {
-        SDKLogger.debug('[QHexRT] NPU not supported on this device; skipping NPU catalog seed');
+        logger.debug('NPU not supported on this device; skipping NPU catalog seed');
         return 0;
     }
 
@@ -199,10 +201,10 @@ export async function seedNpuCatalog(
             });
             count++;
         } catch (error) {
-            SDKLogger.debug(`[QHexRT] Failed to register NPU bundle ${r.id}: ${String(error)}`);
+            logger.debug(`Failed to register NPU bundle ${r.id}: ${String(error)}`);
         }
     }
 
-    SDKLogger.debug(`[QHexRT] NPU bundles registered for ${arch}: ${count}`);
+    logger.debug(`NPU bundles registered for ${arch}: ${count}`);
     return count;
 }

--- a/sdk/runanywhere-react-native/packages/qhexrt/src/index.ts
+++ b/sdk/runanywhere-react-native/packages/qhexrt/src/index.ts
@@ -46,6 +46,7 @@
 // NpuCapability / HexagonArch are the generated proto wire types
 // (@runanywhere/proto-ts/hardware_profile) — re-exported for consumers.
 export { QHexRT, NpuCapability, HexagonArch } from './QHexRT';
+export { seedNpuCatalog } from './NpuCatalog';
 
 // =============================================================================
 // Nitrogen Spec Types


### PR DESCRIPTION
Fixes #523

Moves the 17-bundle QHexRT NPU catalog data and probe>filter>register workflow from three example apps into their respective SDK packages.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Mostly catalog relocation and bootstrap wiring; behavior should match prior app-local seeding, with no auth or data-model changes.
> 
> **Overview**
> **Centralizes the 17-bundle QHexRT (Hexagon NPU) catalog** in Kotlin (`NpuCatalog.kt` / `QHexRT.seedCatalog()`), Flutter (`seedNpuCatalog()`), and React Native (`seedNpuCatalog()`), with manifest-pinned Hugging Face URLs kept in lockstep across platforms. Each helper **probes the device NPU, registers only arch-matching bundles**, and stays separate from backend registration (callers still register `QHexRT` themselves).
> 
> **Example apps** stop owning NPU model lists: Android `ModelBootstrap` delegates to `QHexRT.seedCatalog()`; Flutter and RN bootstrap call the SDK seed APIs after the curated non-NPU catalog. App-level NPU registration blocks are removed in favor of comments pointing at the SDK. **`NpuModelE2ETest`** resolves catalog entries via SDK `qhexrtBundles` / `NpuBundle`.
> 
> Minor **Sherpa release URL** fixes (`RunanywhereAI` â†’ `RunAnywhereAI`) appear in Android/Flutter example catalogs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f43a8e71e8afa252d821a2349c3fbdc2bb6aaace. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic QHexRT NPU catalog seeding across Android, Flutter, and React Native to register compatible NPU models on supported devices.
  * React Native backend initialization now probes NPU capability and registers the detected architecture.
  * Added an Android on-device end-to-end NPU model benchmark/inference test with a structured report.
* **Bug Fixes**
  * Corrected GitHub model download URL casing for selected VLM and speech artifacts.
  * Fixed framework display/analytics label mapping for CoreML/MLX.
* **Documentation**
  * Clarified that NPU bundle ownership and seeding are handled by the SDK.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
