### PR TITLE
Voice pipeline: real spoken-assistant turns (system prompt, brevity, memory)

### DIFF
--- a/engines/llamacpp/rac_llm_llamacpp.cpp
+++ b/engines/llamacpp/rac_llm_llamacpp.cpp
@@ -96,6 +96,25 @@ void apply_extended_sampling_options(const rac_llm_options_t* options,
     if (options->grammar != nullptr && options->grammar[0] != '\0') {
         request->grammar = options->grammar;
     }
+
+    // Multi-turn history: rac_llm_options_t.history is alternating user/assistant
+    // strings (chronological, excluding system prompt + current prompt). Render
+    // it into the chat message list so the model sees prior turns. The current
+    // prompt is appended as the final user message because build_prompt() prefers
+    // `messages` over the raw `prompt` when messages is non-empty.
+    if (options->history != nullptr && options->n_history > 0) {
+        request->messages.reserve(static_cast<size_t>(options->n_history) + 1);
+        for (int32_t i = 0; i < options->n_history; ++i) {
+            if (options->history[i] == nullptr) {
+                continue;
+            }
+            const char* role = (i % 2 == 0) ? "user" : "assistant";
+            request->messages.emplace_back(role, options->history[i]);
+        }
+        if (!request->prompt.empty()) {
+            request->messages.emplace_back("user", request->prompt);
+        }
+    }
 }
 
 }  // namespace

--- a/sdk/runanywhere-commons/src/features/voice_agent/voice_agent.cpp
+++ b/sdk/runanywhere-commons/src/features/voice_agent/voice_agent.cpp
@@ -355,9 +355,18 @@ rac_result_t rac_voice_agent_generate_response(rac_voice_agent_handle_t handle, 
         return RAC_ERROR_NOT_INITIALIZED;
     }
 
+    // Same spoken-assistant persona + brevity cap as the full voice turn so
+    // this text→text helper doesn't fall back to the model's raw (rambly)
+    // default. One-shot: no conversation history here (the d7 session path owns
+    // multi-turn memory).
+    rac_llm_options_t llm_opts = {};
+    llm_opts.max_tokens = kVoiceAgentMaxTokens;
+    llm_opts.temperature = 0.7f;
+    llm_opts.system_prompt = kVoiceAgentSystemPrompt;
+
     rac_llm_result_t llm_result = {};
     rac_result_t result =
-        rac_llm_component_generate(handle->llm_handle, prompt, nullptr, &llm_result);
+        rac_llm_component_generate(handle->llm_handle, prompt, &llm_opts, &llm_result);
 
     if (result != RAC_SUCCESS) {
         return result;

--- a/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_d7_abi.cpp
+++ b/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_d7_abi.cpp
@@ -429,13 +429,31 @@ rac_result_t d7_process_utterance(rac_voice_agent_handle_t handle, const std::st
         if (llm_ref.framework_name != nullptr)
             turn_metrics.framework = llm_ref.framework_name;
     }
+    // Build a proper voice-assistant turn: a spoken-style system prompt, a
+    // brevity cap, and the prior conversation so replies stay short, on-topic,
+    // and context-aware — instead of feeding the raw transcript with no guidance
+    // (which is why responses were rambly/useless).
+    std::vector<const char*> history_ptrs;
+    history_ptrs.reserve(handle->conversation_history.size());
+    for (const auto& entry : handle->conversation_history) {
+        history_ptrs.push_back(entry.c_str());
+    }
+    rac_llm_options_t llm_opts = {};
+    llm_opts.max_tokens = kVoiceAgentMaxTokens;
+    llm_opts.temperature = 0.7f;
+    llm_opts.system_prompt = kVoiceAgentSystemPrompt;
+    if (!history_ptrs.empty()) {
+        llm_opts.history = history_ptrs.data();
+        llm_opts.n_history = static_cast<int32_t>(history_ptrs.size());
+    }
+
     rac_llm_result_t llm = {};
     const auto t_llm = std::chrono::steady_clock::now();
     if (have_lifecycle_llm) {
         rac_llm_service_t llm_service{llm_ref.ops, llm_ref.impl, llm_ref.model_id};
-        rc = rac_llm_generate(&llm_service, stt.text, nullptr, &llm);
+        rc = rac_llm_generate(&llm_service, stt.text, &llm_opts, &llm);
     } else {
-        rc = rac_llm_component_generate(handle->llm_handle, stt.text, nullptr, &llm);
+        rc = rac_llm_component_generate(handle->llm_handle, stt.text, &llm_opts, &llm);
     }
     turn_metrics.llm_ms =
         std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_llm).count();
@@ -456,6 +474,23 @@ rac_result_t d7_process_utterance(rac_voice_agent_handle_t handle, const std::st
         return rc;
     }
     turn_metrics.response_chars = llm.text ? static_cast<int32_t>(std::strlen(llm.text)) : 0;
+
+    // Remember this turn so the next one has context. Order matters:
+    // rac_llm_options_t.history is alternating user,assistant — append the user
+    // transcript first, then the assistant reply. Bound to the most recent
+    // turns so the prompt stays within the context window.
+    if (stt.text != nullptr && stt.text[0] != '\0') {
+        handle->conversation_history.emplace_back(stt.text);
+        handle->conversation_history.emplace_back(llm.text ? llm.text : "");
+        if (handle->conversation_history.size() > kVoiceAgentMaxHistoryEntries) {
+            const size_t excess =
+                handle->conversation_history.size() - kVoiceAgentMaxHistoryEntries;
+            handle->conversation_history.erase(
+                handle->conversation_history.begin(),
+                handle->conversation_history.begin() + static_cast<std::ptrdiff_t>(excess));
+        }
+    }
+
     d7_emit_assistant_token(handle, llm.text, true, session_id, turn_id, request_id, event_callback,
                             user_data);
 

--- a/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_internal.h
+++ b/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_internal.h
@@ -19,6 +19,20 @@
 
 #include "rac/core/rac_types.h"
 
+/// Voice-assistant LLM turn defaults (commons). The voice pipeline feeds these
+/// to every LLM turn so replies are short, spoken, and context-aware instead of
+/// the model's raw default (which rambles / emits markdown for a raw transcript).
+/// Internal — no proto/ABI surface.
+inline constexpr const char* kVoiceAgentSystemPrompt =
+    "You are a helpful voice assistant. Respond in one or two short, natural, "
+    "spoken sentences. Be direct, warm, and conversational. Do not use markdown, "
+    "bullet points, code blocks, or emoji. If you are unsure or lack the "
+    "information, say so briefly instead of guessing.";
+/// Spoken replies should be short — cap generation length.
+inline constexpr int32_t kVoiceAgentMaxTokens = 200;
+/// Retained history entries (user+assistant), i.e. the most recent N/2 turns.
+inline constexpr size_t kVoiceAgentMaxHistoryEntries = 20;
+
 /// Energy-VAD utterance segmenter state for the streaming
 /// `rac_voice_agent_feed_audio_proto` ingress path. The SDK feeds raw mic
 /// frames; this state accumulates them into utterances using the same
@@ -69,6 +83,12 @@ struct rac_voice_agent {
 
     /// Streaming-ingress segmenter state (rac_voice_agent_feed_audio_proto).
     rac_voice_agent_feed_state feed;
+
+    /// Multi-turn conversation history for the LLM: alternating user/assistant
+    /// strings in chronological order (excludes the system prompt + current
+    /// turn). Fed to rac_llm_options_t.history so the agent remembers context
+    /// across turns. Bounded to kVoiceAgentMaxHistoryEntries. Guarded by `mutex`.
+    std::vector<std::string> conversation_history;
 };
 
 #endif  // RAC_FEATURES_VOICE_AGENT_VOICE_AGENT_INTERNAL_H


### PR DESCRIPTION
## Problem
The voice agent fed the raw STT transcript straight to the LLM with `nullptr` options — no system prompt, no length cap, no conversation history. Result: rambly, markdown-y, context-less ("useless") replies.

## Fix (commons — internal only, every SDK benefits)
- `voice_agent_internal.h`: spoken-assistant system prompt + `max_tokens=200` brevity cap + a `conversation_history` field on the handle.
- `voice_agent_d7_abi.cpp` (real voice session): sends system prompt + brevity + prior turns to the LLM, and records each `(user, assistant)` turn (bounded to the last ~10 turns).
- `voice_agent.cpp` (`generateResponse` helper): same persona + brevity, one-shot (no history).
- `engines/llamacpp/rac_llm_llamacpp.cpp`: `options.history` was silently ignored — now rendered into the chat-template `messages` (system + alternating user/assistant + current prompt), so multi-turn memory actually works.

No proto/ABI change.

## Testing
Built commons (arm64) + Flutter + RN, installed on device. Voice replies are now short, on-topic, and remember the previous turn instead of rambling on the bare transcript.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes core voice turn LLM behavior and prompt construction for all SDKs; bounded history could grow context usage but is capped internally.
> 
> **Overview**
> Voice LLM calls no longer pass **`nullptr` options** with a bare STT transcript. The pipeline now supplies a **spoken-assistant system prompt**, **`max_tokens` ~200**, and **temperature 0.7** on full-session turns and on the text-only **`generate_response`** helper (one-shot, no history).
> 
> The **d7 full-session path** keeps **bounded multi-turn memory** on the agent handle (alternating user/assistant strings, capped at 20 entries) and passes it through **`rac_llm_options_t.history`** after each successful turn.
> 
> **LlamaCpp** previously ignored **`options.history`**; it now maps history into **`TextGenerationRequest.messages`** (roles by index) and appends the current prompt as the final user message so chat templates see prior turns.
> 
> No public proto/ABI changes—commons-only behavior shared across SDKs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 592325a5ae68648d6a58ea0998f14f596004bdfe. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Voice responses can now take prior conversation context into account for more natural multi-turn interactions.
  * Voice agent replies now follow a more consistent assistant persona and generation limit.

* **Bug Fixes**
  * Improved handling of empty or missing conversation entries so responses are generated more reliably.
  * Conversation turns are now retained and trimmed automatically to keep recent context available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->