### PR TITLE
fix(ios): guard Metal residency set with supportsResidencySets check

### DIFF
--- a/engines/llamacpp/CMakeLists.txt
+++ b/engines/llamacpp/CMakeLists.txt
@@ -30,6 +30,18 @@ if(NOT RAC_LLAMACPP_GIT_REPOSITORY)
 endif()
 message(STATUS "llama.cpp source: ${RAC_LLAMACPP_GIT_REPOSITORY} @ ${RAC_LLAMACPP_VERSION}")
 
+# Keep the cross-platform armv7 compatibility patch first. On iOS, chain the
+# Metal residency-set capability guard after it instead of replacing it.
+set(LLAMACPP_PATCH_COMMAND
+    ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_LIST_DIR}/patch_ggml_armv7.cmake"
+)
+if(RAC_PLATFORM_IOS)
+    list(APPEND LLAMACPP_PATCH_COMMAND
+        COMMAND git apply --3way --unidiff-zero --ignore-whitespace
+                "${CMAKE_CURRENT_LIST_DIR}/patches/001-metal-residency-set-guard.patch"
+    )
+endif()
+
 FetchContent_Declare(
     llamacpp
     GIT_REPOSITORY ${RAC_LLAMACPP_GIT_REPOSITORY}
@@ -38,7 +50,7 @@ FetchContent_Declare(
     GIT_PROGRESS   TRUE
     # Fix the ggml arch/arm/quants.c armv7 build break (raw AArch64-only vqtbl1q_u8 -> portable wrapper).
     # Idempotent + no-op when the pattern/file is absent, so it is safe on every arch and future llama.cpp bump.
-    PATCH_COMMAND ${CMAKE_COMMAND} -P "${CMAKE_CURRENT_LIST_DIR}/patch_ggml_armv7.cmake"
+    PATCH_COMMAND ${LLAMACPP_PATCH_COMMAND}
 )
 
 # Configure llama.cpp build options

--- a/engines/llamacpp/patches/001-metal-residency-set-guard.patch
+++ b/engines/llamacpp/patches/001-metal-residency-set-guard.patch
@@ -1,0 +1,34 @@
+From: RunAnywhere SDK <dev@runanywhere.ai>
+Date: Tue, 8 Jul 2026 10:30:00 +0530
+Subject: [PATCH] ggml-metal: guard residency sets by GPU family
+
+Metal exposes MTLResidencySet APIs on iOS 18, including on devices whose
+GPUs cannot create residency sets. Calling newResidencySetWithDescriptor:
+on those devices triggers a Metal assertion:
+
+  -[MTLDebugDevice newResidencySetWithDescriptor:error:]:2785:
+  failed assertion 'device does not support residency sets.'
+
+Apple's Metal feature tables list residency sets for Apple GPU family 6
+and newer. A13 devices are Apple6 and support the feature; A12 devices
+are Apple5 and do not. Gate residency-set use with supportsFamily:
+MTLGPUFamilyApple6 so the API remains disabled on A12 and older GPUs.
+
+Fixes: https://github.com/RunanywhereAI/runanywhere-sdks/issues/480
+---
+ ggml/src/ggml-metal/ggml-metal-device.m | 7 +++++--
+ 1 file changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/ggml/src/ggml-metal/ggml-metal-device.m b/ggml/src/ggml-metal/ggml-metal-device.m
+index 9065bfb8c384e15cc5ba9494327b13e3eda05bb5..4709229e1c674e5fd8a254a1bfab3db33b34aa9a 100644
+--- a/ggml/src/ggml-metal/ggml-metal-device.m
++++ b/ggml/src/ggml-metal/ggml-metal-device.m
+@@ -827 +827 @@ ggml_metal_device_t ggml_metal_device_init(int device) {
+-            dev->props.use_residency_sets = true;
++            dev->props.use_residency_sets = false;
+@@ -829 +829,4 @@ ggml_metal_device_t ggml_metal_device_init(int device) {
+-            dev->props.use_residency_sets = getenv("GGML_METAL_NO_RESIDENCY") == nil;
++            if ([dev->mtl_device supportsFamily:MTLGPUFamilyApple6]) {
++                dev->props.use_residency_sets = getenv("GGML_METAL_NO_RESIDENCY") == nil;
++            }
++            // Apple5 (A12) and older GPUs do not support residency sets.


### PR DESCRIPTION
Fixes #480

## Summary

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Metal patch affects all iOS llama.cpp fetches; adaptive context changes KV-cache behavior on inference paths and new exported ABI surface, though unsupported backends return NOT_SUPPORTED.
> 
> **Overview**
> **iOS llama.cpp Metal crash (issue #480):** On iOS builds only, `FetchContent` now applies `001-metal-residency-set-guard.patch` so `use_residency_sets` stays off unless `[device supportsResidencySets]` is true, avoiding `MTLResidencySet` SIGABRT on A12/A13 devices running iOS 18.
> 
> **Adaptive LLM context:** New component and lifecycle-owned C APIs (`rac_llm_component_*` and `rac_llm_*_lifecycle` / `rac_llm_generate_from_context_proto`) delegate to existing service vtable ops for incremental KV context (system prompt seed, append, generate without clearing cache, clear). Implementations live in `llm_module.cpp` with a shared `call_lifecycle_op` helper for the proto lifecycle path. **`RACommons.exports`** adds the new symbols for dynamic Apple linking.
> 
> **Swift SDK:** `CppBridge.LLM` binds the lifecycle symbols via `NativeProtoABI`, and **`RunAnywhere+TextGeneration`** adds public `injectSystemPrompt`, `appendContext`, `generateFromContext`, and `clearContext` for RAG-style flows on the loaded on-device model.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e148de5e6a3479d289f9f024d2f408a66735c436. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added LLM adaptive-context capabilities to inject a reusable system prompt, append additional context, generate from the accumulated context, and clear adaptive context.
  * Available via both component-based and lifecycle-managed interfaces, with new Swift async APIs for seamless access.

* **Bug Fixes**
  * Improved iOS Metal behavior by applying the residency-set guard only on supported Apple GPU families, reducing incorrect residency handling on older or incompatible devices.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
