### PR TITLE
telemetry: stop double counting, fake metrics, and dropped events

### DIFF
--- a/sdk/runanywhere-commons/src/core/model_lifecycle_translation.cpp
+++ b/sdk/runanywhere-commons/src/core/model_lifecycle_translation.cpp
@@ -23,6 +23,7 @@
 
 #if defined(RAC_HAVE_PROTOBUF)
 #include "foundation/rac_proto_marshal_internal.h"
+#include "infrastructure/events/sdk_event_publish.h"
 #endif
 
 namespace rac::core::model_lifecycle::detail {
@@ -217,12 +218,12 @@ void populate_event_envelope(runanywhere::v1::SDKEvent* event,
 }
 
 rac_result_t publish_event(const runanywhere::v1::SDKEvent& event) {
-    const size_t size = event.ByteSizeLong();
-    std::vector<uint8_t> bytes(size);
-    if (size > 0 && !event.SerializeToArray(bytes.data(), static_cast<int>(bytes.size()))) {
-        return RAC_ERROR_ENCODING_ERROR;
-    }
-    return rac_sdk_event_publish_proto(bytes.empty() ? nullptr : bytes.data(), bytes.size());
+    // Route through the destination router instead of the PUBLIC-only
+    // rac_sdk_event_publish_proto so the envelope's LOG/TELEMETRY bits are
+    // honored. Component-lifecycle/registry arms are still filtered out of
+    // backend telemetry by the extractor (module-level kModel events already
+    // carry load/unload; mapping these too would double-count).
+    return rac::events::publish_prebuilt(event);
 }
 
 std::string json_escape(const std::string& value) {

--- a/sdk/runanywhere-commons/src/features/diffusion/diffusion_module.cpp
+++ b/sdk/runanywhere-commons/src/features/diffusion/diffusion_module.cpp
@@ -773,7 +773,9 @@ void publish_capability(runanywhere::v1::CapabilityOperationEventKind kind, cons
                         int32_t negative_prompt_length = 0, int32_t image_width = 0,
                         int32_t image_height = 0, int32_t num_inference_steps = 0,
                         double guidance_scale = 0.0, int64_t seed = 0,
-                        int64_t output_size_bytes = 0) {
+                        int64_t output_size_bytes = 0,
+                        runanywhere::v1::EventDestination destination =
+                            runanywhere::v1::EVENT_DESTINATION_ALL) {
     runanywhere::v1::SDKEvent event;
     event.set_id(event_id());
     event.set_timestamp_ms(now_ms());
@@ -781,7 +783,7 @@ void publish_capability(runanywhere::v1::CapabilityOperationEventKind kind, cons
     event.set_severity(error && error[0] != '\0' ? runanywhere::v1::ERROR_SEVERITY_ERROR
                                                  : runanywhere::v1::ERROR_SEVERITY_INFO);
     event.set_component(runanywhere::v1::SDK_COMPONENT_DIFFUSION);
-    event.set_destination(runanywhere::v1::EVENT_DESTINATION_ALL);
+    event.set_destination(destination);
     event.set_source("cpp");
     auto* cap = event.mutable_capability();
     cap->set_kind(kind);
@@ -877,8 +879,11 @@ rac_bool_t progress_trampoline(const rac_diffusion_progress_t* progress, void* u
         return RAC_FALSE;
     }
 
+    // Progress is UI-only: at default steps a single generation would otherwise
+    // land ~28 telemetry rows. Started/completed carry the backend record.
     publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_DIFFUSION_PROGRESS,
-                       "diffusion.generate", progress->progress, nullptr);
+                       "diffusion.generate", progress->progress, nullptr, 0.0, nullptr, 0, 0, 0, 0,
+                       0, 0.0, 0, 0, runanywhere::v1::EVENT_DESTINATION_PUBLIC);
 
     if (!ctx || !ctx->callback)
         return RAC_TRUE;

--- a/sdk/runanywhere-commons/src/features/embeddings/embeddings_module.cpp
+++ b/sdk/runanywhere-commons/src/features/embeddings/embeddings_module.cpp
@@ -600,8 +600,8 @@ rac_result_t rac_embeddings_create_proto(const uint8_t* request_proto_bytes,
         create_result.set_max_tokens(static_cast<int32_t>(info.max_tokens));
     }
 
-    publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_EMBEDDINGS_STARTED,
-                       "embeddings.create", 1.0f, 0, 0, nullptr);
+    // No event on create: service creation is not an embed request; the
+    // unpaired STARTED here counted as a phantom embedding per create.
     return copy_proto(create_result, out_result);
 #endif
 }

--- a/sdk/runanywhere-commons/src/features/llm/llm_module.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/llm_module.cpp
@@ -689,12 +689,12 @@ extern "C" rac_result_t rac_llm_component_generate(rac_handle_t handle, const ch
     RAC_LOG_INFO("LLM.Component", "Generation completed");
 
     // Emit generation completed event
-    // Use estimated input_tokens for telemetry consistency across platforms
-    // (some backends return actual tokenized count including chat template,
-    // others return 0 - estimation ensures consistent user-facing metrics)
+    // Report the backend's real token counts — out_result falls back to a
+    // chars/4 estimate only when the backend returned 0; an estimate must
+    // never override a real count.
 #if defined(RAC_HAVE_PROTOBUF)
     emit_llm_generation_completed(
-        generation_id.c_str(), model_id, model_name, estimate_tokens(prompt),
+        generation_id.c_str(), model_id, model_name, out_result->prompt_tokens,
         out_result->completion_tokens, static_cast<double>(total_time_ms), tokens_per_second,
         /*is_streaming=*/false, /*time_to_first_token_ms=*/0, component->actual_framework,
         effective_options->temperature, effective_options->max_tokens, context_length);
@@ -1002,11 +1002,15 @@ extern "C" rac_result_t rac_llm_component_generate_stream(
         ttft_ms = static_cast<double>(ttft_duration.count());
     }
 
-    // Calculate tokens per second
+    // Tokens/sec over decode time only — including prefill (TTFT) in the
+    // denominator systematically understates generation speed.
     double tokens_per_second = 0.0;
-    if (final_result.total_time_ms > 0) {
-        tokens_per_second = static_cast<double>(final_result.completion_tokens) /
-                            (static_cast<double>(final_result.total_time_ms) / 1000.0);
+    const double decode_ms = (ttft_ms > 0.0 && ttft_ms < static_cast<double>(total_time_ms))
+                                 ? static_cast<double>(total_time_ms) - ttft_ms
+                                 : static_cast<double>(total_time_ms);
+    if (decode_ms > 0.0) {
+        tokens_per_second =
+            static_cast<double>(final_result.completion_tokens) / (decode_ms / 1000.0);
         final_result.tokens_per_second = static_cast<float>(tokens_per_second);
     }
 
@@ -1959,12 +1963,17 @@ void dispatch_terminal_once(ProtoStreamContext* ctx, const char* finish_reason,
     final_result.set_total_tokens(ctx->prompt_tokens + ctx->token_count);
     const int64_t total_time_ms = now_ms() - ctx->started_ms;
     final_result.set_total_time_ms(total_time_ms);
+    int64_t ttft_ms = 0;
     if (ctx->first_token_ms > 0) {
-        final_result.set_time_to_first_token_ms(ctx->first_token_ms - ctx->started_ms);
+        ttft_ms = ctx->first_token_ms - ctx->started_ms;
+        final_result.set_time_to_first_token_ms(ttft_ms);
     }
-    if (total_time_ms > 0 && ctx->token_count > 0) {
+    // Tokens/sec over decode time only, not prefill-inclusive wall time.
+    const int64_t decode_ms =
+        (ttft_ms > 0 && ttft_ms < total_time_ms) ? total_time_ms - ttft_ms : total_time_ms;
+    if (decode_ms > 0 && ctx->token_count > 0) {
         final_result.set_tokens_per_second(static_cast<float>(
-            static_cast<double>(ctx->token_count) / (static_cast<double>(total_time_ms) / 1000.0)));
+            static_cast<double>(ctx->token_count) / (static_cast<double>(decode_ms) / 1000.0)));
     }
     final_result.set_finish_reason(
         (finish_reason != nullptr) && finish_reason[0] != '\0' ? finish_reason : "stop");
@@ -2213,17 +2222,21 @@ rac_result_t rac_llm_generate_stream_proto(const uint8_t* request_proto_bytes,
             (options.max_tokens > 0 && ctx.token_count >= options.max_tokens) ? "length" : "stop";
         dispatch_terminal_once(&ctx, finish_reason, nullptr);
         const int64_t stream_elapsed = now_ms() - ctx.started_ms;
+        // Tokens/sec over decode time only, not prefill-inclusive wall time.
+        const int64_t stream_ttft =
+            ctx.first_token_ms > ctx.started_ms ? ctx.first_token_ms - ctx.started_ms : 0;
+        const int64_t stream_decode = (stream_ttft > 0 && stream_ttft < stream_elapsed)
+                                          ? stream_elapsed - stream_ttft
+                                          : stream_elapsed;
         publish_generation_event(
             runanywhere::v1::GENERATION_EVENT_KIND_STREAM_COMPLETED, request.prompt().c_str(),
             nullptr, ctx.response_text.c_str(), nullptr, ref.model_id, ctx.token_count,
             stream_elapsed, ctx.prompt_tokens, ref.framework_name,
-            (ctx.token_count > 0 && stream_elapsed > 0)
-                ? ctx.token_count * 1000.0 / static_cast<double>(stream_elapsed)
+            (ctx.token_count > 0 && stream_decode > 0)
+                ? ctx.token_count * 1000.0 / static_cast<double>(stream_decode)
                 : 0.0,
-            ctx.first_token_ms > ctx.started_ms
-                ? static_cast<double>(ctx.first_token_ms - ctx.started_ms)
-                : 0.0,
-            options.temperature, options.max_tokens, lifecycle_context_length(ref),
+            static_cast<double>(stream_ttft), options.temperature, options.max_tokens,
+            lifecycle_context_length(ref),
             /*is_streaming=*/true);
     }
 

--- a/sdk/runanywhere-commons/src/features/llm/streaming_metrics.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/streaming_metrics.cpp
@@ -220,10 +220,13 @@ rac_result_t rac_streaming_metrics_get_result(rac_streaming_metrics_handle_t han
             output_tokens = 1;
     }
 
-    // Tokens per second
+    // Tokens/sec over decode time only — subtracting TTFT keeps the figure a
+    // generation-speed metric instead of a prefill-diluted average.
     double tokens_per_second = 0.0;
-    if (latency_ms > 0) {
-        tokens_per_second = static_cast<double>(output_tokens) / (latency_ms / 1000.0);
+    const double decode_ms =
+        (ttft_ms > 0.0 && ttft_ms < latency_ms) ? latency_ms - ttft_ms : latency_ms;
+    if (decode_ms > 0) {
+        tokens_per_second = static_cast<double>(output_tokens) / (decode_ms / 1000.0);
     }
 
     // Populate result

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_generation_internal.h
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_generation_internal.h
@@ -88,11 +88,20 @@ inline void set_display_text_and_thinking(runanywhere::v1::ToolCallingResult* re
 }
 #endif
 
-inline void publish_generation_completed_event(const LifecycleLlmRef& ref,
-                                               const rac_llm_result_t& raw) {
+inline void publish_generation_completed_event(
+    const LifecycleLlmRef& ref, const rac_llm_result_t& raw,
+#if defined(RAC_HAVE_PROTOBUF)
+    runanywhere::v1::EventDestination destination = runanywhere::v1::EVENT_DESTINATION_UNSPECIFIED
+#else
+    int destination = 0
+#endif
+) {
 #if defined(RAC_HAVE_PROTOBUF)
     // Tool-calling generate calls still need the canonical LLM telemetry path.
     runanywhere::v1::SDKEvent llm_event;
+    if (destination != runanywhere::v1::EVENT_DESTINATION_UNSPECIFIED) {
+        llm_event.set_destination(destination);
+    }
     auto* gen = llm_event.mutable_generation();
     gen->set_kind(runanywhere::v1::GENERATION_EVENT_KIND_COMPLETED);
     if (ref.model_id != nullptr && ref.model_id[0] != '\0') {
@@ -116,13 +125,70 @@ inline void publish_generation_completed_event(const LifecycleLlmRef& ref,
 #else
     (void)ref;
     (void)raw;
+    (void)destination;
 #endif
 }
+
+// Aggregates the tool-calling loop's inner generations into ONE telemetry row
+// per logical request. Per-iteration completed events go PUBLIC-only (UI parity);
+// without this a single tool-calling request landed N unpaired "completed"
+// telemetry rows — one per loop iteration.
+struct GenerationTelemetryAgg {
+    int64_t input_tokens{0};
+    int64_t output_tokens{0};
+    double tokens_per_second{0.0};
+    int64_t time_to_first_token_ms{0};
+    uint32_t generations{0};
+    std::string model_id;
+};
+
+inline void publish_tool_loop_telemetry(const GenerationTelemetryAgg& agg) {
+#if defined(RAC_HAVE_PROTOBUF)
+    if (agg.generations == 0) {
+        return;
+    }
+    runanywhere::v1::SDKEvent event;
+    // Telemetry-only: the per-iteration PUBLIC events already served consumers.
+    event.set_destination(runanywhere::v1::EVENT_DESTINATION_TELEMETRY);
+    (*event.mutable_properties())["iterations"] = std::to_string(agg.generations);
+    auto* gen = event.mutable_generation();
+    gen->set_kind(runanywhere::v1::GENERATION_EVENT_KIND_COMPLETED);
+    if (!agg.model_id.empty()) {
+        gen->set_model_id(agg.model_id);
+    }
+    if (agg.output_tokens > 0) {
+        gen->set_tokens_count(static_cast<int32_t>(agg.output_tokens));
+        gen->set_tokens_used(static_cast<int32_t>(agg.output_tokens));
+    }
+    if (agg.input_tokens > 0) {
+        gen->set_input_tokens(static_cast<int32_t>(agg.input_tokens));
+    }
+    if (agg.tokens_per_second > 0.0) {
+        gen->set_tokens_per_second(agg.tokens_per_second);
+    }
+    if (agg.time_to_first_token_ms > 0) {
+        gen->set_time_to_first_token_ms(agg.time_to_first_token_ms);
+    }
+    (void)rac::events::publish(event, runanywhere::v1::SDK_COMPONENT_LLM,
+                               runanywhere::v1::EVENT_CATEGORY_LLM);
+#else
+    (void)agg;
+#endif
+}
+
+// Emits the aggregate on every loop exit path (success, tool failure, cancel).
+struct ToolLoopTelemetryScope {
+    GenerationTelemetryAgg agg;
+    ToolLoopTelemetryScope() = default;
+    ToolLoopTelemetryScope(const ToolLoopTelemetryScope&) = delete;
+    ToolLoopTelemetryScope& operator=(const ToolLoopTelemetryScope&) = delete;
+    ~ToolLoopTelemetryScope() { publish_tool_loop_telemetry(agg); }
+};
 
 inline bool run_generate_once(GenerationState& generation,
                               const GenerationCancelBinding& cancel_binding,
                               const std::string& prompt, std::string* out_response,
-                              rac_result_t* out_rc) {
+                              rac_result_t* out_rc, GenerationTelemetryAgg* agg = nullptr) {
     LifecycleLlmRef ref;
     rac_result_t rc = acquire_lifecycle_llm(&ref);
     if (rc != RAC_SUCCESS) {
@@ -194,7 +260,27 @@ inline bool run_generate_once(GenerationState& generation,
     if (out_response) {
         *out_response = raw.text ? raw.text : "";
     }
-    publish_generation_completed_event(ref, raw);
+    if (agg) {
+        agg->generations++;
+        agg->input_tokens += raw.prompt_tokens;
+        agg->output_tokens += raw.completion_tokens;
+        if (agg->generations == 1) {
+            agg->time_to_first_token_ms = raw.time_to_first_token_ms;
+        }
+        if (raw.tokens_per_second > 0.0f) {
+            agg->tokens_per_second = raw.tokens_per_second;
+        }
+        if (agg->model_id.empty() && ref.model_id != nullptr) {
+            agg->model_id = ref.model_id;
+        }
+#if defined(RAC_HAVE_PROTOBUF)
+        publish_generation_completed_event(ref, raw, runanywhere::v1::EVENT_DESTINATION_PUBLIC);
+#else
+        publish_generation_completed_event(ref, raw);
+#endif
+    } else {
+        publish_generation_completed_event(ref, raw);
+    }
 
     rac_llm_result_free(&raw);
     release_lifecycle_llm(&ref);

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_run_loop.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_run_loop.cpp
@@ -393,6 +393,9 @@ run_loop_impl(const uint8_t* in_request_bytes, size_t in_size,
     bool is_complete = false;
     std::string final_text;
 
+    // One telemetry row per tool-calling request; inner iterations are PUBLIC-only.
+    rac::llm::tool_calling::ToolLoopTelemetryScope loop_telemetry;
+
     while (iteration < ctx.max_iterations) {
         iteration++;
         RAC_LOG_DEBUG(kTag, "iteration %u/%u", iteration, ctx.max_iterations);
@@ -403,7 +406,8 @@ run_loop_impl(const uint8_t* in_request_bytes, size_t in_size,
             &cancel_state->active_ref_mu, &cancel_state->active_ref,
             &cancel_state->cancel_requested};
         if (!rac::llm::tool_calling::run_generate_once(
-                ctx.generation, cancel_binding, current_prompt, &response, &rc)) {
+                ctx.generation, cancel_binding, current_prompt, &response, &rc,
+                &loop_telemetry.agg)) {
             // distinguish cancel from other generate
             // failures, mirroring run_generate_loop in tool_calling_session.cpp.
             // A cancel that latched before/during generate surfaces as

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_session.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_session.cpp
@@ -440,6 +440,9 @@ validate_tool_call(const ToolCallingSession& session, const runanywhere::v1::Too
 }
 
 void run_generate_loop(ToolCallingSession& session) {
+    // One telemetry row per step invocation; inner iterations are PUBLIC-only.
+    rac::llm::tool_calling::ToolLoopTelemetryScope loop_telemetry;
+
     while (session.iteration < session.max_iterations) {
         session.iteration++;
         RAC_LOG_DEBUG(kTag, "iteration %u/%u", session.iteration, session.max_iterations);
@@ -449,7 +452,8 @@ void run_generate_loop(ToolCallingSession& session) {
         rac::llm::tool_calling::GenerationCancelBinding cancel_binding{
             &session.active_ref_mu, &session.active_ref, &session.cancel_requested};
         if (!rac::llm::tool_calling::run_generate_once(
-                session.generation, cancel_binding, session.current_prompt, &response, &rc)) {
+                session.generation, cancel_binding, session.current_prompt, &response, &rc,
+                &loop_telemetry.agg)) {
             // Distinguish cancel from other generate failures.
             // A cancel that landed before or during generate makes the session
             // terminal — emit a cancel error and mark state kCancelled so the

--- a/sdk/runanywhere-commons/src/features/tts/tts_module.cpp
+++ b/sdk/runanywhere-commons/src/features/tts/tts_module.cpp
@@ -197,13 +197,15 @@ void fill_tts_output(const rac_tts_result_t& result, const char* text, const cha
 }
 
 void publish_tts_voice_event(runanywhere::v1::VoiceEventKind kind, int64_t duration_ms,
-                             rac_result_t error_code = RAC_SUCCESS) {
+                             rac_result_t error_code = RAC_SUCCESS,
+                             runanywhere::v1::EventDestination destination =
+                                 runanywhere::v1::EVENT_DESTINATION_ALL) {
     runanywhere::v1::SDKEvent event;
     event.set_timestamp_ms(rac_get_current_time_ms());
     event.set_id(generate_uuid_v4());
     event.set_category(runanywhere::v1::EVENT_CATEGORY_TTS);
     event.set_component(runanywhere::v1::SDK_COMPONENT_TTS);
-    event.set_destination(runanywhere::v1::EVENT_DESTINATION_ALL);
+    event.set_destination(destination);
     event.set_source("cpp");
     event.set_operation_id("tts.synthesize");
     event.set_severity(error_code == RAC_SUCCESS ? runanywhere::v1::ERROR_SEVERITY_INFO
@@ -949,10 +951,15 @@ extern "C" rac_result_t rac_tts_component_synthesize_proto(rac_handle_t handle, 
 
     rac_tts_options_t options = options_from_proto(proto_options, RAC_TTS_OPTIONS_DEFAULT);
     rac_tts_result_t result = {};
-    publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_STARTED, 0);
+    // PUBLIC only: rac_tts_component_synthesize (called below) emits the
+    // full-metrics started/completed/failed telemetry rows; wrapper-level
+    // events would double-count every synthesis (same fix as the STT wrapper).
+    publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_STARTED, 0, RAC_SUCCESS,
+                            runanywhere::v1::EVENT_DESTINATION_PUBLIC);
     rac_result_t rc = rac_tts_component_synthesize(handle, text, &options, &result);
     if (rc != RAC_SUCCESS) {
-        publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_FAILED, 0, rc);
+        publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_FAILED, 0, rc,
+                                runanywhere::v1::EVENT_DESTINATION_PUBLIC);
         (void)rac_sdk_event_publish_failure(rc, "TTS synthesis failed", "tts", "synthesize",
                                             RAC_TRUE);
         return rac_proto_buffer_set_error(out_result, rc, "TTS synthesis failed");
@@ -961,7 +968,8 @@ extern "C" rac_result_t rac_tts_component_synthesize_proto(rac_handle_t handle, 
     runanywhere::v1::TTSOutput output;
     fill_tts_output(result, text, voice_id, options, &output);
     publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_COMPLETED,
-                            result.duration_ms);
+                            result.duration_ms, RAC_SUCCESS,
+                            runanywhere::v1::EVENT_DESTINATION_PUBLIC);
     rac_tts_result_free(&result);
     return copy_proto_message(output, out_result);
 #endif
@@ -1040,10 +1048,13 @@ extern "C" rac_result_t rac_tts_component_synthesize_stream_proto(
         }
     };
 
-    publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_STARTED, 0);
+    // PUBLIC only: rac_tts_component_synthesize_stream emits the telemetry rows.
+    publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_STARTED, 0, RAC_SUCCESS,
+                            runanywhere::v1::EVENT_DESTINATION_PUBLIC);
     rac_result_t rc = rac_tts_component_synthesize_stream(handle, text, &options, bridge, &context);
     if (rc != RAC_SUCCESS) {
-        publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_FAILED, 0, rc);
+        publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_FAILED, 0, rc,
+                                runanywhere::v1::EVENT_DESTINATION_PUBLIC);
         (void)rac_sdk_event_publish_failure(rc, "TTS streaming synthesis failed", "tts",
                                             "synthesizeStream", RAC_TRUE);
     }

--- a/sdk/runanywhere-commons/src/infrastructure/model_management/model_assignment.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/model_management/model_assignment.cpp
@@ -1475,9 +1475,17 @@ rac_result_t rac_model_assignment_fetch(rac_bool_t force_refresh, rac_model_info
                 // Preserve artifact_info if existing has more specific type
                 if (existing->artifact_info.kind != RAC_ARTIFACT_KIND_SINGLE_FILE &&
                     model->artifact_info.kind == RAC_ARTIFACT_KIND_SINGLE_FILE) {
+                    // Transfer ownership of the heap members to `model` and null
+                    // them on `existing`: `model` outlives this block (copied into
+                    // the cache, freed at the end of the fetch), so a shallow
+                    // alias here + rac_model_info_free(existing) below left
+                    // dangling pointers that were re-freed later — use-after-free
+                    // crash (bionic tagged-pointer SIGABRT) on second launch.
                     model->artifact_info = existing->artifact_info;
-                    // Note: This is a shallow copy — existing must stay alive until
-                    // after rac_model_registry_save deep-copies the data.
+                    existing->artifact_info.expected_files = nullptr;
+                    existing->artifact_info.file_descriptors = nullptr;
+                    existing->artifact_info.file_descriptor_count = 0;
+                    existing->artifact_info.strategy_id = nullptr;
                 }
                 rac_model_registry_save(registry, model);
                 rac_model_info_free(existing);

--- a/sdk/runanywhere-commons/src/infrastructure/storage/storage_event_publisher.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/storage/storage_event_publisher.cpp
@@ -21,6 +21,8 @@
 #include "rac/core/rac_error.h"
 #include "rac/infrastructure/events/rac_sdk_event_stream.h"
 
+#include "infrastructure/events/sdk_event_publish.h"
+
 namespace rac::storage {
 namespace {
 
@@ -95,11 +97,11 @@ runanywhere::v1::ErrorSeverity storage_event_severity(rac_result_t error_code, i
 }
 
 void publish_storage_sdk_event(const runanywhere::v1::SDKEvent& event) {
-    std::string bytes;
-    if (!event.SerializeToString(&bytes)) {
-        return;
-    }
-    (void)rac_sdk_event_publish_proto(reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size());
+    // Route through the destination router instead of the PUBLIC-only
+    // rac_sdk_event_publish_proto so LOG/TELEMETRY destination bits are
+    // honored (storage-lifecycle arms stay excluded from backend telemetry
+    // by the extractor — they'd be noise rows).
+    (void)rac::events::publish_prebuilt(event);
 }
 
 }  // namespace

--- a/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_json.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_json.cpp
@@ -520,7 +520,11 @@ rac_result_t rac_device_registration_to_json(const rac_device_registration_reque
         json.add_string_always("device_name", info->device_name);
         json.add_string_always("platform", info->platform);
         json.add_string_always("os_version", info->os_version);
-        json.add_string_always("form_factor", info->form_factor ? info->form_factor : "phone");
+        // Unset stays null — the old fabricated defaults ("phone"/"unknown")
+        // made every desktop and web device register as a phone. Requires the
+        // backend DeviceInfo schema to accept nullable form_factor/gpu_family
+        // (deploy the backend schema change before shipping this).
+        json.add_string_or_null("form_factor", info->form_factor);
         json.add_string_always("architecture", info->architecture);
         json.add_string_always("chip_name", info->chip_name);
 
@@ -532,8 +536,7 @@ rac_result_t rac_device_registration_to_json(const rac_device_registration_reque
         json.add_bool_always("has_neural_engine", info->has_neural_engine != RAC_FALSE);
         json.add_int_always("neural_engine_cores", info->neural_engine_cores);
 
-        // GPU family with default
-        json.add_string_always("gpu_family", info->gpu_family ? info->gpu_family : "unknown");
+        json.add_string_or_null("gpu_family", info->gpu_family);
 
         // Battery info (may be unavailable - use nullable methods)
         // battery_level is a double (0.0-1.0), negative if unavailable

--- a/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_manager.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_manager.cpp
@@ -69,6 +69,9 @@ struct rac_telemetry_manager {
     static constexpr size_t BATCH_SIZE_PRODUCTION = 10;  // Flush after 10 events in production
     static constexpr int64_t BATCH_TIMEOUT_MS = 5000;    // Flush after 5 seconds in production
     static constexpr size_t MAX_QUEUE_SIZE = 256;  // Cap while flushes defer (e.g. pre-auth)
+    // Cap the poll-path HTTP queue (drop-oldest) — it was unbounded, so a
+    // platform that never drains (Flutter isolate gone) grew it without limit.
+    static constexpr size_t MAX_HTTP_QUEUE_SIZE = 64;
     int64_t last_flush_time_ms = 0;                // Track last flush time for timeout
 };
 
@@ -665,6 +668,43 @@ std::string proto_event_type_string(const SDKEvent& ev, bool& out_is_completion)
         }
         case SDKEvent::kFailure:
             return "sdk.error";
+        case SDKEvent::kCancellation: {
+            // Cancel-operation lifecycle (the terminal generation.cancelled row
+            // comes via kGeneration); previously fell to "unknown" and was
+            // silently dropped, making all cancel telemetry invisible.
+            switch (ev.cancellation().kind()) {
+                case runanywhere::v1::CANCELLATION_EVENT_KIND_REQUESTED:
+                    return "cancellation.requested";
+                case runanywhere::v1::CANCELLATION_EVENT_KIND_ACKNOWLEDGED:
+                    return "cancellation.acknowledged";
+                case runanywhere::v1::CANCELLATION_EVENT_KIND_COMPLETED:
+                    return "cancellation.completed";
+                case runanywhere::v1::CANCELLATION_EVENT_KIND_FAILED:
+                    return "cancellation.failed";
+                default:
+                    return "unknown";
+            }
+        }
+        case SDKEvent::kAuth: {
+            switch (ev.auth().kind()) {
+                case runanywhere::v1::AUTH_EVENT_KIND_REQUESTED:
+                    return "auth.requested";
+                case runanywhere::v1::AUTH_EVENT_KIND_SUCCEEDED:
+                    return "auth.succeeded";
+                case runanywhere::v1::AUTH_EVENT_KIND_FAILED:
+                    return "auth.failed";
+                case runanywhere::v1::AUTH_EVENT_KIND_TOKEN_REFRESHED:
+                    return "auth.token_refreshed";
+                case runanywhere::v1::AUTH_EVENT_KIND_TOKEN_EXPIRED:
+                    return "auth.token_expired";
+                case runanywhere::v1::AUTH_EVENT_KIND_DEVICE_REGISTERED:
+                    return "auth.device_registered";
+                case runanywhere::v1::AUTH_EVENT_KIND_DEVICE_REGISTRATION_FAILED:
+                    return "auth.device_registration_failed";
+                default:
+                    return "unknown";
+            }
+        }
         default:
             return "unknown";
     }
@@ -757,9 +797,12 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
     payload.event_type = event_type.c_str();
 
     // Oneof arms the translator has no name for (component lifecycle state
-    // transitions, cancellation envelopes, …) must not reach the backend as
-    // literal "unknown" rows — they are public/log events, not analytics.
+    // transitions, …) must not reach the backend as literal "unknown" rows.
+    // Log the drop: a silent return here previously hid whole event classes
+    // (cancellation, auth) for months.
     if (event_type == "unknown") {
+        RAC_LOG_DEBUG("Telemetry", "Dropping telemetry event with unmapped oneof arm (case=%d)",
+                      static_cast<int>(ev.event_case()));
         return RAC_SUCCESS;
     }
 
@@ -1407,6 +1450,13 @@ rac_result_t rac_telemetry_manager_flush(rac_telemetry_manager_t* manager) {
             // by Flutter, whose Dart FFI data callbacks are isolate-bound.
             {
                 std::lock_guard<std::mutex> lock(manager->http_queue_mutex);
+                while (manager->http_queue.size() >=
+                       rac_telemetry_manager::MAX_HTTP_QUEUE_SIZE) {
+                    RAC_LOG_WARNING("Telemetry",
+                                    "HTTP queue full (%zu) — dropping oldest pending batch",
+                                    manager->http_queue.size());
+                    manager->http_queue.pop_front();
+                }
                 manager->http_queue.push_back({endpoint, std::string(json, json_len), true});
             }
             manager->http_wakeup(manager->http_wakeup_user_data);


### PR DESCRIPTION
One user action should produce one telemetry row. It didn't:

- The TTS proto wrapper emitted started/completed around an inner call that already emits them, so every synthesis counted 4 rows. Wrapper events are public-only now, same as the existing STT fix.
- Diffusion emitted a telemetry row per denoising step, about 28 per image. Progress is public-only now; started/completed stay.
- Tool calling emitted one completed row per loop iteration and never a started. The loop now aggregates into a single row with summed tokens and an iteration count.
- embeddings.create emitted a started with no completed pair. Removed.

Some metrics were lying:

- input_tokens was always a chars/4 estimate, even when the engine returned a real count. The real count wins now; the estimate is only a fallback.
- tokens_per_second divided by total wall time including prefill, which understates decode speed. It divides by decode time now.
- form_factor defaulted to "phone" and gpu_family to "unknown" on every platform. Unset fields go up as null. This needs the nullable-schema change already on the backend development branch, so deploy that first.

Some events never reached the backend at all: cancellation and auth events fell through to an unmapped "unknown" arm and were dropped without a log, and two publishers bypassed the destination router entirely. Both fixed, and the drop path logs now.

Also in here:

- Fix a use-after-free in the model assignment merge that crashed Android on second launch. artifact_info was shallow-copied out of a row that then got freed, so the same pointers were freed twice and bionic's tagged-pointer check aborted.
- Cap the Flutter/RN pending-HTTP queue at 64, drop-oldest. It was unbounded.

Not attempted: retry on failed telemetry POSTs. The http_complete callback on this branch carries no request id, so there is no way to tell which batch failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches telemetry ingestion, device registration payloads, and model registry memory ownership; backend must accept nullable device fields before shipping device JSON changes.
> 
> **Overview**
> This PR aligns SDK telemetry with **one logical action → one backend row**, fixes misleading LLM/device metrics, and closes gaps where events never reached analytics.
> 
> **Event volume and routing:** TTS proto wrappers now emit synthesis lifecycle events as **PUBLIC-only** so inner `rac_tts_component_synthesize*` rows are not duplicated. Diffusion **progress** is PUBLIC-only (~28 step rows per image removed). Tool-calling loops aggregate inner generations into a single **TELEMETRY** completed row (with iteration count); per-iteration completes stay PUBLIC. **`embeddings.create`** no longer emits a phantom STARTED. Model lifecycle and storage publishers switch from **`rac_sdk_event_publish_proto`** to **`rac::events::publish_prebuilt`** so LOG/TELEMETRY destination bits are honored.
> 
> **Metrics:** LLM completed telemetry uses **backend `prompt_tokens`** when present (estimate only as fallback). **`tokens_per_second`** is computed over **decode time** (wall time minus TTFT) across component, proto stream, and streaming metrics paths.
> 
> **Telemetry pipeline:** **`cancellation.*`** and **`auth.*`** event types are mapped instead of dropping as `"unknown"`; unmapped arms now **log** on drop. Device registration JSON sends **`form_factor`** / **`gpu_family`** as **null** when unset (requires nullable backend schema). Flutter/RN pending HTTP queue is capped at **64** with drop-oldest.
> 
> **Stability:** Model registry merge **transfers** `artifact_info` heap ownership when preserving artifact info, fixing **use-after-free** on Android second launch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7025b714af06b2c5b0f76df570d01387cabeabb8. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->