### PR TITLE
RAG retrieval fixes + telemetry data-quality round

### DIFF
--- a/examples/flutter/RunAnywhereAI/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
+++ b/examples/flutter/RunAnywhereAI/android/app/src/main/java/io/flutter/plugins/GeneratedPluginRegistrant.java
@@ -56,14 +56,19 @@ public final class GeneratedPluginRegistrant {
       Log.e(TAG, "Error registering plugin image_picker_android, io.flutter.plugins.imagepicker.ImagePickerPlugin", e);
     }
     try {
+      flutterEngine.getPlugins().add(new com.github.dart_lang.jni.JniPlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin jni, com.github.dart_lang.jni.JniPlugin", e);
+    }
+    try {
+      flutterEngine.getPlugins().add(new com.github.dart_lang.jni_flutter.JniFlutterPlugin());
+    } catch (Exception e) {
+      Log.e(TAG, "Error registering plugin jni_flutter, com.github.dart_lang.jni_flutter.JniFlutterPlugin", e);
+    }
+    try {
       flutterEngine.getPlugins().add(new dev.fluttercommunity.plus.packageinfo.PackageInfoPlugin());
     } catch (Exception e) {
       Log.e(TAG, "Error registering plugin package_info_plus, dev.fluttercommunity.plus.packageinfo.PackageInfoPlugin", e);
-    }
-    try {
-      flutterEngine.getPlugins().add(new io.flutter.plugins.pathprovider.PathProviderPlugin());
-    } catch (Exception e) {
-      Log.e(TAG, "Error registering plugin path_provider_android, io.flutter.plugins.pathprovider.PathProviderPlugin", e);
     }
     try {
       flutterEngine.getPlugins().add(new com.baseflow.permissionhandler.PermissionHandlerPlugin());

--- a/examples/flutter/RunAnywhereAI/ios/Runner/GeneratedPluginRegistrant.m
+++ b/examples/flutter/RunAnywhereAI/ios/Runner/GeneratedPluginRegistrant.m
@@ -54,12 +54,6 @@
 @import package_info_plus;
 #endif
 
-#if __has_include(<path_provider_foundation/PathProviderPlugin.h>)
-#import <path_provider_foundation/PathProviderPlugin.h>
-#else
-@import path_provider_foundation;
-#endif
-
 #if __has_include(<permission_handler_apple/PermissionHandlerPlugin.h>)
 #import <permission_handler_apple/PermissionHandlerPlugin.h>
 #else
@@ -119,7 +113,6 @@
   [FlutterTimezonePlugin registerWithRegistrar:[registry registrarForPlugin:@"FlutterTimezonePlugin"]];
   [FLTImagePickerPlugin registerWithRegistrar:[registry registrarForPlugin:@"FLTImagePickerPlugin"]];
   [FPPPackageInfoPlusPlugin registerWithRegistrar:[registry registrarForPlugin:@"FPPPackageInfoPlusPlugin"]];
-  [PathProviderPlugin registerWithRegistrar:[registry registrarForPlugin:@"PathProviderPlugin"]];
   [PermissionHandlerPlugin registerWithRegistrar:[registry registrarForPlugin:@"PermissionHandlerPlugin"]];
   [RecordIosPlugin registerWithRegistrar:[registry registrarForPlugin:@"RecordIosPlugin"]];
   [RunAnywherePlugin registerWithRegistrar:[registry registrarForPlugin:@"RunAnywherePlugin"]];

--- a/sdk/runanywhere-commons/include/rac/infrastructure/telemetry/rac_telemetry_types.h
+++ b/sdk/runanywhere-commons/include/rac/infrastructure/telemetry/rac_telemetry_types.h
@@ -123,6 +123,10 @@ typedef struct rac_telemetry_payload {
     int32_t top_k;
     double retrieval_time_ms;
     const char* embedding_model;  // RAG embedding model (string → dup'd/freed)
+    int32_t query_token_count;    // estimated tokens in the query (via carrier)
+    int32_t context_tokens;       // estimated tokens in the retrieved context (via carrier)
+    rac_bool_t reranker_used;     // via carrier; gated on has_reranker_used
+    rac_bool_t has_reranker_used;
 
     // LoRA-specific fields. Strings → must be dup'd/freed in track + payload_free.
     const char* adapter_id;

--- a/sdk/runanywhere-commons/src/core/model_lifecycle_translation.cpp
+++ b/sdk/runanywhere-commons/src/core/model_lifecycle_translation.cpp
@@ -23,6 +23,7 @@
 
 #if defined(RAC_HAVE_PROTOBUF)
 #include "foundation/rac_proto_marshal_internal.h"
+#include "infrastructure/events/sdk_event_publish.h"
 #endif
 
 namespace rac::core::model_lifecycle::detail {
@@ -217,12 +218,12 @@ void populate_event_envelope(runanywhere::v1::SDKEvent* event,
 }
 
 rac_result_t publish_event(const runanywhere::v1::SDKEvent& event) {
-    const size_t size = event.ByteSizeLong();
-    std::vector<uint8_t> bytes(size);
-    if (size > 0 && !event.SerializeToArray(bytes.data(), static_cast<int>(bytes.size()))) {
-        return RAC_ERROR_ENCODING_ERROR;
-    }
-    return rac_sdk_event_publish_proto(bytes.empty() ? nullptr : bytes.data(), bytes.size());
+    // Route through the destination router instead of the PUBLIC-only
+    // rac_sdk_event_publish_proto so the envelope's LOG/TELEMETRY bits are
+    // honored. Component-lifecycle/registry arms are still filtered out of
+    // backend telemetry by the extractor (module-level kModel events already
+    // carry load/unload; mapping these too would double-count).
+    return rac::events::publish_prebuilt(event);
 }
 
 std::string json_escape(const std::string& value) {

--- a/sdk/runanywhere-commons/src/features/diffusion/diffusion_module.cpp
+++ b/sdk/runanywhere-commons/src/features/diffusion/diffusion_module.cpp
@@ -773,7 +773,9 @@ void publish_capability(runanywhere::v1::CapabilityOperationEventKind kind, cons
                         int32_t negative_prompt_length = 0, int32_t image_width = 0,
                         int32_t image_height = 0, int32_t num_inference_steps = 0,
                         double guidance_scale = 0.0, int64_t seed = 0,
-                        int64_t output_size_bytes = 0) {
+                        int64_t output_size_bytes = 0,
+                        runanywhere::v1::EventDestination destination =
+                            runanywhere::v1::EVENT_DESTINATION_ALL) {
     runanywhere::v1::SDKEvent event;
     event.set_id(event_id());
     event.set_timestamp_ms(now_ms());
@@ -781,7 +783,7 @@ void publish_capability(runanywhere::v1::CapabilityOperationEventKind kind, cons
     event.set_severity(error && error[0] != '\0' ? runanywhere::v1::ERROR_SEVERITY_ERROR
                                                  : runanywhere::v1::ERROR_SEVERITY_INFO);
     event.set_component(runanywhere::v1::SDK_COMPONENT_DIFFUSION);
-    event.set_destination(runanywhere::v1::EVENT_DESTINATION_ALL);
+    event.set_destination(destination);
     event.set_source("cpp");
     auto* cap = event.mutable_capability();
     cap->set_kind(kind);
@@ -877,8 +879,11 @@ rac_bool_t progress_trampoline(const rac_diffusion_progress_t* progress, void* u
         return RAC_FALSE;
     }
 
+    // Progress is UI-only: at default steps a single generation would otherwise
+    // land ~28 telemetry rows. Started/completed carry the backend record.
     publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_DIFFUSION_PROGRESS,
-                       "diffusion.generate", progress->progress, nullptr);
+                       "diffusion.generate", progress->progress, nullptr, 0.0, nullptr, 0, 0, 0, 0,
+                       0, 0.0, 0, 0, runanywhere::v1::EVENT_DESTINATION_PUBLIC);
 
     if (!ctx || !ctx->callback)
         return RAC_TRUE;

--- a/sdk/runanywhere-commons/src/features/embeddings/embeddings_module.cpp
+++ b/sdk/runanywhere-commons/src/features/embeddings/embeddings_module.cpp
@@ -378,7 +378,7 @@ void publish_capability(runanywhere::v1::CapabilityOperationEventKind kind, cons
                         float progress, int64_t input_count, int64_t output_count,
                         const char* error, double duration_ms = 0.0,
                         int64_t embedding_dimension = 0, const char* model_id = nullptr,
-                        const char* framework = nullptr) {
+                        const char* framework = nullptr, int64_t total_tokens = 0) {
     runanywhere::v1::SDKEvent event;
     event.set_id(event_id());
     event.set_timestamp_ms(now_ms());
@@ -418,6 +418,9 @@ void publish_capability(runanywhere::v1::CapabilityOperationEventKind kind, cons
     if (embedding_dimension > 0) {
         (*event.mutable_properties())["embedding_dimension"] =
             std::to_string(embedding_dimension);
+    }
+    if (total_tokens > 0) {
+        (*event.mutable_properties())["total_tokens"] = std::to_string(total_tokens);
     }
     publish_event(event);
 }
@@ -528,10 +531,16 @@ rac_result_t rac_embeddings_embed_batch_proto(rac_handle_t handle,
         proto.mutable_vectors(i)->set_text(texts[static_cast<size_t>(i)]);
     }
     rc = copy_proto(proto, out_result);
+    // total_tokens is a chars/4 estimate over the embedded texts.
+    int64_t batch_token_estimate = 0;
+    for (const auto& t : texts) {
+        batch_token_estimate += static_cast<int64_t>((t.size() + 3) / 4);
+    }
     publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_EMBEDDINGS_COMPLETED,
                        "embeddings.embedBatch", 1.0f, static_cast<int64_t>(texts.size()),
                        proto.vectors_size(), nullptr,
-                       static_cast<double>(result.processing_time_ms));
+                       static_cast<double>(result.processing_time_ms), 0, nullptr, nullptr,
+                       batch_token_estimate);
     rac_embeddings_result_free(&result);
     return rc;
 #endif
@@ -695,12 +704,18 @@ rac_result_t rac_embeddings_embed_batch_lifecycle_proto(const uint8_t* request_p
     }
     result.set_model_id(ref.model_id ? ref.model_id : "");
     result.set_request_id(request.request_id());
+    // total_tokens is a chars/4 estimate over the embedded texts (no tokenizer
+    // on this path).
+    int64_t embed_token_estimate = 0;
+    for (const auto& t : texts) {
+        embed_token_estimate += static_cast<int64_t>((t.size() + 3) / 4);
+    }
     publish_capability(
         runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_EMBEDDINGS_COMPLETED, "embeddings.embed",
         1.0f, static_cast<int64_t>(texts.size()), static_cast<int64_t>(result.vectors_size()),
         nullptr, static_cast<double>(now_ms() - embed_start_ms),
         raw.num_embeddings > 0 ? static_cast<int64_t>(raw.embeddings[0].dimension) : 0, ref.model_id,
-        ref.framework_name);
+        ref.framework_name, embed_token_estimate);
     rc = copy_proto(result, out_result);
     rac_embeddings_result_free(&raw);
     rac::lifecycle::release_lifecycle_embeddings(&ref);

--- a/sdk/runanywhere-commons/src/features/embeddings/embeddings_module.cpp
+++ b/sdk/runanywhere-commons/src/features/embeddings/embeddings_module.cpp
@@ -600,8 +600,8 @@ rac_result_t rac_embeddings_create_proto(const uint8_t* request_proto_bytes,
         create_result.set_max_tokens(static_cast<int32_t>(info.max_tokens));
     }
 
-    publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_EMBEDDINGS_STARTED,
-                       "embeddings.create", 1.0f, 0, 0, nullptr);
+    // No event on create: service creation is not an embed request; the
+    // unpaired STARTED here counted as a phantom embedding per create.
     return copy_proto(create_result, out_result);
 #endif
 }

--- a/sdk/runanywhere-commons/src/features/llm/llm_module.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/llm_module.cpp
@@ -689,12 +689,12 @@ extern "C" rac_result_t rac_llm_component_generate(rac_handle_t handle, const ch
     RAC_LOG_INFO("LLM.Component", "Generation completed");
 
     // Emit generation completed event
-    // Use estimated input_tokens for telemetry consistency across platforms
-    // (some backends return actual tokenized count including chat template,
-    // others return 0 - estimation ensures consistent user-facing metrics)
+    // Report the backend's real token counts — out_result falls back to a
+    // chars/4 estimate only when the backend returned 0; an estimate must
+    // never override a real count.
 #if defined(RAC_HAVE_PROTOBUF)
     emit_llm_generation_completed(
-        generation_id.c_str(), model_id, model_name, estimate_tokens(prompt),
+        generation_id.c_str(), model_id, model_name, out_result->prompt_tokens,
         out_result->completion_tokens, static_cast<double>(total_time_ms), tokens_per_second,
         /*is_streaming=*/false, /*time_to_first_token_ms=*/0, component->actual_framework,
         effective_options->temperature, effective_options->max_tokens, context_length);
@@ -1002,11 +1002,15 @@ extern "C" rac_result_t rac_llm_component_generate_stream(
         ttft_ms = static_cast<double>(ttft_duration.count());
     }
 
-    // Calculate tokens per second
+    // Tokens/sec over decode time only — including prefill (TTFT) in the
+    // denominator systematically understates generation speed.
     double tokens_per_second = 0.0;
-    if (final_result.total_time_ms > 0) {
-        tokens_per_second = static_cast<double>(final_result.completion_tokens) /
-                            (static_cast<double>(final_result.total_time_ms) / 1000.0);
+    const double decode_ms = (ttft_ms > 0.0 && ttft_ms < static_cast<double>(total_time_ms))
+                                 ? static_cast<double>(total_time_ms) - ttft_ms
+                                 : static_cast<double>(total_time_ms);
+    if (decode_ms > 0.0) {
+        tokens_per_second =
+            static_cast<double>(final_result.completion_tokens) / (decode_ms / 1000.0);
         final_result.tokens_per_second = static_cast<float>(tokens_per_second);
     }
 
@@ -1959,12 +1963,17 @@ void dispatch_terminal_once(ProtoStreamContext* ctx, const char* finish_reason,
     final_result.set_total_tokens(ctx->prompt_tokens + ctx->token_count);
     const int64_t total_time_ms = now_ms() - ctx->started_ms;
     final_result.set_total_time_ms(total_time_ms);
+    int64_t ttft_ms = 0;
     if (ctx->first_token_ms > 0) {
-        final_result.set_time_to_first_token_ms(ctx->first_token_ms - ctx->started_ms);
+        ttft_ms = ctx->first_token_ms - ctx->started_ms;
+        final_result.set_time_to_first_token_ms(ttft_ms);
     }
-    if (total_time_ms > 0 && ctx->token_count > 0) {
+    // Tokens/sec over decode time only, not prefill-inclusive wall time.
+    const int64_t decode_ms =
+        (ttft_ms > 0 && ttft_ms < total_time_ms) ? total_time_ms - ttft_ms : total_time_ms;
+    if (decode_ms > 0 && ctx->token_count > 0) {
         final_result.set_tokens_per_second(static_cast<float>(
-            static_cast<double>(ctx->token_count) / (static_cast<double>(total_time_ms) / 1000.0)));
+            static_cast<double>(ctx->token_count) / (static_cast<double>(decode_ms) / 1000.0)));
     }
     final_result.set_finish_reason(
         (finish_reason != nullptr) && finish_reason[0] != '\0' ? finish_reason : "stop");
@@ -2213,17 +2222,21 @@ rac_result_t rac_llm_generate_stream_proto(const uint8_t* request_proto_bytes,
             (options.max_tokens > 0 && ctx.token_count >= options.max_tokens) ? "length" : "stop";
         dispatch_terminal_once(&ctx, finish_reason, nullptr);
         const int64_t stream_elapsed = now_ms() - ctx.started_ms;
+        // Tokens/sec over decode time only, not prefill-inclusive wall time.
+        const int64_t stream_ttft =
+            ctx.first_token_ms > ctx.started_ms ? ctx.first_token_ms - ctx.started_ms : 0;
+        const int64_t stream_decode = (stream_ttft > 0 && stream_ttft < stream_elapsed)
+                                          ? stream_elapsed - stream_ttft
+                                          : stream_elapsed;
         publish_generation_event(
             runanywhere::v1::GENERATION_EVENT_KIND_STREAM_COMPLETED, request.prompt().c_str(),
             nullptr, ctx.response_text.c_str(), nullptr, ref.model_id, ctx.token_count,
             stream_elapsed, ctx.prompt_tokens, ref.framework_name,
-            (ctx.token_count > 0 && stream_elapsed > 0)
-                ? ctx.token_count * 1000.0 / static_cast<double>(stream_elapsed)
+            (ctx.token_count > 0 && stream_decode > 0)
+                ? ctx.token_count * 1000.0 / static_cast<double>(stream_decode)
                 : 0.0,
-            ctx.first_token_ms > ctx.started_ms
-                ? static_cast<double>(ctx.first_token_ms - ctx.started_ms)
-                : 0.0,
-            options.temperature, options.max_tokens, lifecycle_context_length(ref),
+            static_cast<double>(stream_ttft), options.temperature, options.max_tokens,
+            lifecycle_context_length(ref),
             /*is_streaming=*/true);
     }
 

--- a/sdk/runanywhere-commons/src/features/llm/streaming_metrics.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/streaming_metrics.cpp
@@ -220,10 +220,13 @@ rac_result_t rac_streaming_metrics_get_result(rac_streaming_metrics_handle_t han
             output_tokens = 1;
     }
 
-    // Tokens per second
+    // Tokens/sec over decode time only — subtracting TTFT keeps the figure a
+    // generation-speed metric instead of a prefill-diluted average.
     double tokens_per_second = 0.0;
-    if (latency_ms > 0) {
-        tokens_per_second = static_cast<double>(output_tokens) / (latency_ms / 1000.0);
+    const double decode_ms =
+        (ttft_ms > 0.0 && ttft_ms < latency_ms) ? latency_ms - ttft_ms : latency_ms;
+    if (decode_ms > 0) {
+        tokens_per_second = static_cast<double>(output_tokens) / (decode_ms / 1000.0);
     }
 
     // Populate result

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_generation_internal.h
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_generation_internal.h
@@ -88,11 +88,20 @@ inline void set_display_text_and_thinking(runanywhere::v1::ToolCallingResult* re
 }
 #endif
 
-inline void publish_generation_completed_event(const LifecycleLlmRef& ref,
-                                               const rac_llm_result_t& raw) {
+inline void publish_generation_completed_event(
+    const LifecycleLlmRef& ref, const rac_llm_result_t& raw,
+#if defined(RAC_HAVE_PROTOBUF)
+    runanywhere::v1::EventDestination destination = runanywhere::v1::EVENT_DESTINATION_UNSPECIFIED
+#else
+    int destination = 0
+#endif
+) {
 #if defined(RAC_HAVE_PROTOBUF)
     // Tool-calling generate calls still need the canonical LLM telemetry path.
     runanywhere::v1::SDKEvent llm_event;
+    if (destination != runanywhere::v1::EVENT_DESTINATION_UNSPECIFIED) {
+        llm_event.set_destination(destination);
+    }
     auto* gen = llm_event.mutable_generation();
     gen->set_kind(runanywhere::v1::GENERATION_EVENT_KIND_COMPLETED);
     if (ref.model_id != nullptr && ref.model_id[0] != '\0') {
@@ -116,13 +125,70 @@ inline void publish_generation_completed_event(const LifecycleLlmRef& ref,
 #else
     (void)ref;
     (void)raw;
+    (void)destination;
 #endif
 }
+
+// Aggregates the tool-calling loop's inner generations into ONE telemetry row
+// per logical request. Per-iteration completed events go PUBLIC-only (UI parity);
+// without this a single tool-calling request landed N unpaired "completed"
+// telemetry rows — one per loop iteration.
+struct GenerationTelemetryAgg {
+    int64_t input_tokens{0};
+    int64_t output_tokens{0};
+    double tokens_per_second{0.0};
+    int64_t time_to_first_token_ms{0};
+    uint32_t generations{0};
+    std::string model_id;
+};
+
+inline void publish_tool_loop_telemetry(const GenerationTelemetryAgg& agg) {
+#if defined(RAC_HAVE_PROTOBUF)
+    if (agg.generations == 0) {
+        return;
+    }
+    runanywhere::v1::SDKEvent event;
+    // Telemetry-only: the per-iteration PUBLIC events already served consumers.
+    event.set_destination(runanywhere::v1::EVENT_DESTINATION_TELEMETRY);
+    (*event.mutable_properties())["iterations"] = std::to_string(agg.generations);
+    auto* gen = event.mutable_generation();
+    gen->set_kind(runanywhere::v1::GENERATION_EVENT_KIND_COMPLETED);
+    if (!agg.model_id.empty()) {
+        gen->set_model_id(agg.model_id);
+    }
+    if (agg.output_tokens > 0) {
+        gen->set_tokens_count(static_cast<int32_t>(agg.output_tokens));
+        gen->set_tokens_used(static_cast<int32_t>(agg.output_tokens));
+    }
+    if (agg.input_tokens > 0) {
+        gen->set_input_tokens(static_cast<int32_t>(agg.input_tokens));
+    }
+    if (agg.tokens_per_second > 0.0) {
+        gen->set_tokens_per_second(agg.tokens_per_second);
+    }
+    if (agg.time_to_first_token_ms > 0) {
+        gen->set_time_to_first_token_ms(agg.time_to_first_token_ms);
+    }
+    (void)rac::events::publish(event, runanywhere::v1::SDK_COMPONENT_LLM,
+                               runanywhere::v1::EVENT_CATEGORY_LLM);
+#else
+    (void)agg;
+#endif
+}
+
+// Emits the aggregate on every loop exit path (success, tool failure, cancel).
+struct ToolLoopTelemetryScope {
+    GenerationTelemetryAgg agg;
+    ToolLoopTelemetryScope() = default;
+    ToolLoopTelemetryScope(const ToolLoopTelemetryScope&) = delete;
+    ToolLoopTelemetryScope& operator=(const ToolLoopTelemetryScope&) = delete;
+    ~ToolLoopTelemetryScope() { publish_tool_loop_telemetry(agg); }
+};
 
 inline bool run_generate_once(GenerationState& generation,
                               const GenerationCancelBinding& cancel_binding,
                               const std::string& prompt, std::string* out_response,
-                              rac_result_t* out_rc) {
+                              rac_result_t* out_rc, GenerationTelemetryAgg* agg = nullptr) {
     LifecycleLlmRef ref;
     rac_result_t rc = acquire_lifecycle_llm(&ref);
     if (rc != RAC_SUCCESS) {
@@ -194,7 +260,27 @@ inline bool run_generate_once(GenerationState& generation,
     if (out_response) {
         *out_response = raw.text ? raw.text : "";
     }
-    publish_generation_completed_event(ref, raw);
+    if (agg) {
+        agg->generations++;
+        agg->input_tokens += raw.prompt_tokens;
+        agg->output_tokens += raw.completion_tokens;
+        if (agg->generations == 1) {
+            agg->time_to_first_token_ms = raw.time_to_first_token_ms;
+        }
+        if (raw.tokens_per_second > 0.0f) {
+            agg->tokens_per_second = raw.tokens_per_second;
+        }
+        if (agg->model_id.empty() && ref.model_id != nullptr) {
+            agg->model_id = ref.model_id;
+        }
+#if defined(RAC_HAVE_PROTOBUF)
+        publish_generation_completed_event(ref, raw, runanywhere::v1::EVENT_DESTINATION_PUBLIC);
+#else
+        publish_generation_completed_event(ref, raw);
+#endif
+    } else {
+        publish_generation_completed_event(ref, raw);
+    }
 
     rac_llm_result_free(&raw);
     release_lifecycle_llm(&ref);

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_run_loop.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_run_loop.cpp
@@ -393,6 +393,9 @@ run_loop_impl(const uint8_t* in_request_bytes, size_t in_size,
     bool is_complete = false;
     std::string final_text;
 
+    // One telemetry row per tool-calling request; inner iterations are PUBLIC-only.
+    rac::llm::tool_calling::ToolLoopTelemetryScope loop_telemetry;
+
     while (iteration < ctx.max_iterations) {
         iteration++;
         RAC_LOG_DEBUG(kTag, "iteration %u/%u", iteration, ctx.max_iterations);
@@ -403,7 +406,8 @@ run_loop_impl(const uint8_t* in_request_bytes, size_t in_size,
             &cancel_state->active_ref_mu, &cancel_state->active_ref,
             &cancel_state->cancel_requested};
         if (!rac::llm::tool_calling::run_generate_once(
-                ctx.generation, cancel_binding, current_prompt, &response, &rc)) {
+                ctx.generation, cancel_binding, current_prompt, &response, &rc,
+                &loop_telemetry.agg)) {
             // distinguish cancel from other generate
             // failures, mirroring run_generate_loop in tool_calling_session.cpp.
             // A cancel that latched before/during generate surfaces as

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_session.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_session.cpp
@@ -440,6 +440,9 @@ validate_tool_call(const ToolCallingSession& session, const runanywhere::v1::Too
 }
 
 void run_generate_loop(ToolCallingSession& session) {
+    // One telemetry row per step invocation; inner iterations are PUBLIC-only.
+    rac::llm::tool_calling::ToolLoopTelemetryScope loop_telemetry;
+
     while (session.iteration < session.max_iterations) {
         session.iteration++;
         RAC_LOG_DEBUG(kTag, "iteration %u/%u", session.iteration, session.max_iterations);
@@ -449,7 +452,8 @@ void run_generate_loop(ToolCallingSession& session) {
         rac::llm::tool_calling::GenerationCancelBinding cancel_binding{
             &session.active_ref_mu, &session.active_ref, &session.cancel_requested};
         if (!rac::llm::tool_calling::run_generate_once(
-                session.generation, cancel_binding, session.current_prompt, &response, &rc)) {
+                session.generation, cancel_binding, session.current_prompt, &response, &rc,
+                &loop_telemetry.agg)) {
             // Distinguish cancel from other generate failures.
             // A cancel that landed before or during generate makes the session
             // terminal — emit a cancel error and mark state kCancelled so the

--- a/sdk/runanywhere-commons/src/features/rag/rac_rag_proto_abi.cpp
+++ b/sdk/runanywhere-commons/src/features/rag/rac_rag_proto_abi.cpp
@@ -93,7 +93,9 @@ void publish_capability(runanywhere::v1::CapabilityOperationEventKind kind, cons
                         float progress, int64_t input_count, int64_t output_count,
                         const char* error, double duration_ms = 0.0,
                         const char* model_id = nullptr, int64_t top_k = 0,
-                        double retrieval_time_ms = 0.0, const char* embedding_model = nullptr) {
+                        double retrieval_time_ms = 0.0, const char* embedding_model = nullptr,
+                        int32_t query_token_count = 0, int32_t context_tokens = 0,
+                        int reranker_used = -1) {
     runanywhere::v1::SDKEvent event;
     event.set_id(event_id());
     event.set_timestamp_ms(now_ms());
@@ -132,6 +134,16 @@ void publish_capability(runanywhere::v1::CapabilityOperationEventKind kind, cons
     if (embedding_model != nullptr && embedding_model[0] != '\0') {
         (*event.mutable_properties())["embedding_model"] = embedding_model;
     }
+    if (query_token_count > 0) {
+        (*event.mutable_properties())["query_token_count"] = std::to_string(query_token_count);
+    }
+    if (context_tokens > 0) {
+        (*event.mutable_properties())["context_tokens"] = std::to_string(context_tokens);
+    }
+    // -1 = unknown (omitted); 0/1 = explicit.
+    if (reranker_used >= 0) {
+        (*event.mutable_properties())["reranker_used"] = reranker_used ? "true" : "false";
+    }
     publish_event(event);
 }
 
@@ -139,6 +151,12 @@ void publish_failure(rac_result_t code, const char* operation, const char* messa
     publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_RAG_FAILED, operation, 0.0f,
                        0, 0, message && message[0] ? message : rac_error_message(code));
     (void)rac_sdk_event_publish_failure(code, message, "rag", operation, RAC_TRUE);
+}
+
+// ~4 chars per token, mirroring the LLM module's estimator. 0 stays 0 so
+// unknown/empty inputs are omitted rather than reported as 1 token.
+int32_t estimate_tokens_from_chars(size_t chars) {
+    return chars == 0 ? 0 : static_cast<int32_t>((chars + 3) / 4);
 }
 
 // ---------------------------------------------------------------------------
@@ -688,11 +706,23 @@ rac_result_t rac_rag_query_proto(rac_handle_t session, const uint8_t* query_prot
     proto.set_total_time_ms(static_cast<int64_t>(total_ms));
 
     rac_result_t rc = copy_proto(proto, out_result);
+    // Estimated token counts (chars/4): the retrieval path has no tokenizer.
+    // Context prefers the actual prompt context string; falls back to the sum
+    // of retrieved chunk texts. reranker_used=0: no reranker is wired into
+    // run_rag_query yet — false is the honest value, not unknown.
+    size_t context_chars = proto.context_used().size();
+    if (context_chars == 0) {
+        for (const auto& chunk : proto.retrieved_chunks()) {
+            context_chars += chunk.text().size();
+        }
+    }
     publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_RAG_QUERY_COMPLETED,
                        "rag.query", 1.0f, 1, proto.retrieved_chunks_size(), nullptr, total_ms,
                        s->llm_model_id.empty() ? s->embedding_model_id.c_str()
                                                : s->llm_model_id.c_str(),
-                       query_proto.top_k(), retrieval_ms, s->embedding_model_id.c_str());
+                       query_proto.top_k(), retrieval_ms, s->embedding_model_id.c_str(),
+                       estimate_tokens_from_chars(question.size()),
+                       estimate_tokens_from_chars(context_chars), /*reranker_used=*/0);
     rac_llm_result_free(&llm_result);
     return rc;
 #endif

--- a/sdk/runanywhere-commons/src/features/rag/rag_pipeline_graph.cpp
+++ b/sdk/runanywhere-commons/src/features/rag/rag_pipeline_graph.cpp
@@ -205,7 +205,6 @@ rac_result_t run_rag_query(const RAGGraphInputs& inputs, RAGTokenSink on_token,
     const BM25Index* bm25 = inputs.bm25_index;
     const size_t embed_dim = inputs.embedding_dimension;
     const size_t top_k = inputs.top_k;
-    const float sim_thresh = inputs.similarity_threshold;
     const size_t max_ctx_tokens = inputs.max_context_tokens;
     const std::string prompt_tmpl = inputs.prompt_template;
     rac_llm_options_t llm_options = inputs.llm_options;
@@ -238,7 +237,12 @@ rac_result_t run_rag_query(const RAGGraphInputs& inputs, RAGTokenSink on_token,
 
     std::vector<SearchResult> results;
     try {
-        auto dense_results = vstore->search(query_embedding, top_k, sim_thresh);
+        // Candidate gathering must not apply an absolute cosine floor: all-MiniLM
+        // scores are low/near-zero even for relevant chunks, so any floor drops
+        // real matches (a multi-chunk doc then retrieves nothing -> "no info").
+        // Gather top_k and let fusion/rerank select; the configured
+        // similarity_threshold is intentionally ignored for gathering.
+        auto dense_results = vstore->search(query_embedding, top_k, 0.0f);
         std::vector<std::pair<std::string, float>> bm25_results;
         if (bm25) {
             bm25_results = bm25->search(question, top_k);

--- a/sdk/runanywhere-commons/src/features/rag/vector_store_usearch.cpp
+++ b/sdk/runanywhere-commons/src/features/rag/vector_store_usearch.cpp
@@ -163,7 +163,11 @@ class VectorStoreUSearch::Impl {
         RAC_LOG_INFO(LOG_TAG, "USearch returned %zu matches from %zu total vectors", matches.size(),
                      index_.size());
 
-        float effective_threshold = threshold;
+        // Only apply an absolute cosine floor when the caller explicitly asks
+        // for a positive one. threshold <= 0 = accept-all, ranked by score:
+        // all-MiniLM scores are low/near-zero even for relevant chunks, so a
+        // positive floor silently drops real matches.
+        const bool apply_floor = threshold > 0.0f;
         if (threshold > 0.5f) {
             LOGW(
                 "Similarity threshold %.2f is high — dense embeddings (e.g. all-MiniLM) rarely "
@@ -182,7 +186,7 @@ class VectorStoreUSearch::Impl {
             // USearch cosine distance is 1 - cosine_similarity
             float similarity = 1.0f - distance;
 
-            if (similarity < effective_threshold) {
+            if (apply_floor && similarity < threshold) {
                 continue;
             }
 

--- a/sdk/runanywhere-commons/src/features/tts/tts_module.cpp
+++ b/sdk/runanywhere-commons/src/features/tts/tts_module.cpp
@@ -197,13 +197,15 @@ void fill_tts_output(const rac_tts_result_t& result, const char* text, const cha
 }
 
 void publish_tts_voice_event(runanywhere::v1::VoiceEventKind kind, int64_t duration_ms,
-                             rac_result_t error_code = RAC_SUCCESS) {
+                             rac_result_t error_code = RAC_SUCCESS,
+                             runanywhere::v1::EventDestination destination =
+                                 runanywhere::v1::EVENT_DESTINATION_ALL) {
     runanywhere::v1::SDKEvent event;
     event.set_timestamp_ms(rac_get_current_time_ms());
     event.set_id(generate_uuid_v4());
     event.set_category(runanywhere::v1::EVENT_CATEGORY_TTS);
     event.set_component(runanywhere::v1::SDK_COMPONENT_TTS);
-    event.set_destination(runanywhere::v1::EVENT_DESTINATION_ALL);
+    event.set_destination(destination);
     event.set_source("cpp");
     event.set_operation_id("tts.synthesize");
     event.set_severity(error_code == RAC_SUCCESS ? runanywhere::v1::ERROR_SEVERITY_INFO
@@ -949,10 +951,15 @@ extern "C" rac_result_t rac_tts_component_synthesize_proto(rac_handle_t handle, 
 
     rac_tts_options_t options = options_from_proto(proto_options, RAC_TTS_OPTIONS_DEFAULT);
     rac_tts_result_t result = {};
-    publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_STARTED, 0);
+    // PUBLIC only: rac_tts_component_synthesize (called below) emits the
+    // full-metrics started/completed/failed telemetry rows; wrapper-level
+    // events would double-count every synthesis (same fix as the STT wrapper).
+    publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_STARTED, 0, RAC_SUCCESS,
+                            runanywhere::v1::EVENT_DESTINATION_PUBLIC);
     rac_result_t rc = rac_tts_component_synthesize(handle, text, &options, &result);
     if (rc != RAC_SUCCESS) {
-        publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_FAILED, 0, rc);
+        publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_FAILED, 0, rc,
+                                runanywhere::v1::EVENT_DESTINATION_PUBLIC);
         (void)rac_sdk_event_publish_failure(rc, "TTS synthesis failed", "tts", "synthesize",
                                             RAC_TRUE);
         return rac_proto_buffer_set_error(out_result, rc, "TTS synthesis failed");
@@ -961,7 +968,8 @@ extern "C" rac_result_t rac_tts_component_synthesize_proto(rac_handle_t handle, 
     runanywhere::v1::TTSOutput output;
     fill_tts_output(result, text, voice_id, options, &output);
     publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_COMPLETED,
-                            result.duration_ms);
+                            result.duration_ms, RAC_SUCCESS,
+                            runanywhere::v1::EVENT_DESTINATION_PUBLIC);
     rac_tts_result_free(&result);
     return copy_proto_message(output, out_result);
 #endif
@@ -1040,10 +1048,13 @@ extern "C" rac_result_t rac_tts_component_synthesize_stream_proto(
         }
     };
 
-    publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_STARTED, 0);
+    // PUBLIC only: rac_tts_component_synthesize_stream emits the telemetry rows.
+    publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_STARTED, 0, RAC_SUCCESS,
+                            runanywhere::v1::EVENT_DESTINATION_PUBLIC);
     rac_result_t rc = rac_tts_component_synthesize_stream(handle, text, &options, bridge, &context);
     if (rc != RAC_SUCCESS) {
-        publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_FAILED, 0, rc);
+        publish_tts_voice_event(runanywhere::v1::VOICE_EVENT_KIND_SYNTHESIS_FAILED, 0, rc,
+                                runanywhere::v1::EVENT_DESTINATION_PUBLIC);
         (void)rac_sdk_event_publish_failure(rc, "TTS streaming synthesis failed", "tts",
                                             "synthesizeStream", RAC_TRUE);
     }

--- a/sdk/runanywhere-commons/src/infrastructure/model_management/model_assignment.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/model_management/model_assignment.cpp
@@ -203,6 +203,8 @@ static std::vector<rac_model_info_t*> parse_models_json(const char* json_str, si
             model->category = RAC_MODEL_CATEGORY_AUDIO;
         else if (category == "multimodal")
             model->category = RAC_MODEL_CATEGORY_MULTIMODAL;
+        else if (category == "embedding" || category == "embeddings")
+            model->category = RAC_MODEL_CATEGORY_EMBEDDING;
         else
             model->category = RAC_MODEL_CATEGORY_LANGUAGE;
 
@@ -1468,18 +1470,39 @@ rac_result_t rac_model_assignment_fetch(rac_bool_t force_refresh, rac_model_info
                     model->format = existing->format;
                     RAC_LOG_DEBUG(LOG_CAT, "Preserved local format for model: %s", model->id);
                 }
+                // Preserve a specialized local category over the assignment's
+                // LANGUAGE fallback. The backend payload has no embedding category
+                // and defaults unknown categories to LANGUAGE, which would drop a
+                // locally-seeded embedding model from the embedding picker.
+                if (existing->category == RAC_MODEL_CATEGORY_EMBEDDING &&
+                    model->category == RAC_MODEL_CATEGORY_LANGUAGE) {
+                    model->category = existing->category;
+                    RAC_LOG_DEBUG(LOG_CAT, "Preserved local embedding category for model: %s",
+                                  model->id);
+                }
                 // Preserve local_path if existing has one and new doesn't
                 if (existing->local_path && !model->local_path) {
                     model->local_path = strdup(existing->local_path);
                 }
-                // Preserve artifact_info if existing has more specific type
+                // Preserve artifact_info if existing has more specific type.
+                // Borrow existing's richer artifact_info ONLY across the save
+                // (which deep-copies into the registry), then restore model's own
+                // pointers. Assigning existing's struct is a shallow copy that
+                // shares heap pointers; if left in place, freeing `existing`
+                // below would leave `model` with dangling artifact_info that gets
+                // copied into the cache (use-after-free) and freed again later
+                // (double-free) -> SIGABRT.
+                rac_model_artifact_info_t model_own_artifact = model->artifact_info;
+                bool borrowed_artifact = false;
                 if (existing->artifact_info.kind != RAC_ARTIFACT_KIND_SINGLE_FILE &&
                     model->artifact_info.kind == RAC_ARTIFACT_KIND_SINGLE_FILE) {
                     model->artifact_info = existing->artifact_info;
-                    // Note: This is a shallow copy — existing must stay alive until
-                    // after rac_model_registry_save deep-copies the data.
+                    borrowed_artifact = true;
                 }
                 rac_model_registry_save(registry, model);
+                if (borrowed_artifact) {
+                    model->artifact_info = model_own_artifact;
+                }
                 rac_model_info_free(existing);
             } else {
                 rac_model_registry_save(registry, model);

--- a/sdk/runanywhere-commons/src/infrastructure/network/endpoints.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/network/endpoints.cpp
@@ -11,14 +11,12 @@
 #include "rac/infrastructure/network/rac_endpoints.h"
 
 const char* rac_endpoint_device_registration(rac_environment_t env) {
-    switch (env) {
-        case RAC_ENV_DEVELOPMENT:
-            return RAC_ENDPOINT_DEV_DEVICE_REGISTER;
-        case RAC_ENV_STAGING:
-        case RAC_ENV_PRODUCTION:
-        default:
-            return RAC_ENDPOINT_DEVICE_REGISTER;
-    }
+    // Development used to target a Supabase PostgREST path (/rest/v1/sdk_devices)
+    // that doesn't exist on the FastAPI backend — every dev registration 404'd
+    // silently, leaving "Unknown" placeholder devices and registration.failed
+    // telemetry with no error code. All environments use the real endpoint now.
+    (void)env;
+    return RAC_ENDPOINT_DEVICE_REGISTER;
 }
 
 const char* rac_endpoint_model_assignments(void) {

--- a/sdk/runanywhere-commons/src/infrastructure/storage/storage_event_publisher.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/storage/storage_event_publisher.cpp
@@ -21,6 +21,8 @@
 #include "rac/core/rac_error.h"
 #include "rac/infrastructure/events/rac_sdk_event_stream.h"
 
+#include "infrastructure/events/sdk_event_publish.h"
+
 namespace rac::storage {
 namespace {
 
@@ -95,11 +97,11 @@ runanywhere::v1::ErrorSeverity storage_event_severity(rac_result_t error_code, i
 }
 
 void publish_storage_sdk_event(const runanywhere::v1::SDKEvent& event) {
-    std::string bytes;
-    if (!event.SerializeToString(&bytes)) {
-        return;
-    }
-    (void)rac_sdk_event_publish_proto(reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size());
+    // Route through the destination router instead of the PUBLIC-only
+    // rac_sdk_event_publish_proto so LOG/TELEMETRY destination bits are
+    // honored (storage-lifecycle arms stay excluded from backend telemetry
+    // by the extractor — they'd be noise rows).
+    (void)rac::events::publish_prebuilt(event);
 }
 
 }  // namespace

--- a/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_json.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_json.cpp
@@ -318,21 +318,22 @@ rac_result_t rac_telemetry_manager_payload_to_json(const rac_telemetry_payload_t
         json.add_double("vision_encode_time_ms", payload->vision_encode_time_ms);
         json.add_string("image_resolution", payload->image_resolution);
     } else if (strcmp(modality, "rag") == 0) {
-        // retrieved_docs_count / top_k / retrieval_time_ms / embedding_model have
-        // sources today (via the properties carrier). query_token_count /
-        // reranker_used / context_tokens still need carriers.
         json.add_int("retrieved_docs_count", payload->retrieved_docs_count);
         json.add_int("top_k", payload->top_k);
         json.add_double("retrieval_time_ms", payload->retrieval_time_ms);
         json.add_string("embedding_model", payload->embedding_model);
+        // Estimated (chars/4) — the retrieval path has no tokenizer.
+        json.add_int("query_token_count", payload->query_token_count);
+        json.add_int("context_tokens", payload->context_tokens);
+        json.add_bool("reranker_used", payload->reranker_used, payload->has_reranker_used);
     } else if (strcmp(modality, "embeddings") == 0) {
-        // input_count / vectors_produced / embedding_model / embedding_dimension
-        // have sources today (dimension via the properties carrier).
-        // total_tokens / batch_size still need a carrier.
         json.add_int("input_count", payload->input_count);
         json.add_int("vectors_produced", payload->vectors_produced);
         json.add_int("embedding_dimension", payload->embedding_dimension);
         json.add_string("embedding_model", payload->model_id);
+        // Estimated (chars/4) over the embedded texts. batch_size has no
+        // independent source (input_count already carries the batch length).
+        json.add_int("total_tokens", payload->total_tokens);
     } else if (strcmp(modality, "voice") == 0) {
         // Per-turn voice-agent pipeline summary (from MetricsEvent).
         json.add_double("stt_ms", payload->voice_stt_ms);
@@ -457,57 +458,12 @@ rac_result_t rac_device_registration_to_json(const rac_device_registration_reque
     JsonBuilder json;
     json.start_object();
 
-    // For development mode (Supabase), flatten the structure to match Supabase schema
-    // For production/staging, use nested device_info structure
-    if (env == RAC_ENV_DEVELOPMENT) {
-        // Flattened structure for Supabase (matches Kotlin SDK DevDeviceRegistrationRequest)
-        const rac_device_registration_info_t* info = &request->device_info;
-
-        // Required fields (matching Supabase schema)
-        if (info->device_id) {
-            json.add_string("device_id", info->device_id);
-        }
-        if (info->platform) {
-            json.add_string("platform", info->platform);
-        }
-        if (info->os_version) {
-            json.add_string("os_version", info->os_version);
-        }
-        if (info->device_model) {
-            json.add_string("device_model", info->device_model);
-        }
-        if (request->sdk_version) {
-            json.add_string("sdk_version", request->sdk_version);
-        }
-        if (has_client_info(request->client_info)) {
-            add_client_info_fields(json, request->client_info);
-        }
-
-        // Optional fields
-        if (request->build_token) {
-            json.add_string("build_token", request->build_token);
-        }
-        if (info->total_memory > 0) {
-            json.add_int("total_memory", info->total_memory);
-        }
-        if (info->architecture) {
-            json.add_string("architecture", info->architecture);
-        }
-        if (info->chip_name) {
-            json.add_string("chip_name", info->chip_name);
-        }
-        if (info->form_factor) {
-            json.add_string("form_factor", info->form_factor);
-        }
-        // has_neural_engine is always set (rac_bool_t), so we can always include it
-        json.add_bool("has_neural_engine", info->has_neural_engine, RAC_TRUE);
-        // Add last_seen_at timestamp for UPSERT to update existing records
-        if (request->last_seen_at_ms > 0) {
-            json.add_timestamp("last_seen_at", request->last_seen_at_ms);
-        }
-    } else {
-        // Nested structure for production/staging
-        // Matches backend schemas/device.py DeviceInfo schema
+    // One payload shape for every environment. The old development branch
+    // emitted a flattened Supabase-era structure for an endpoint that no
+    // longer exists; dev now posts to /api/v1/devices/register like prod.
+    (void)env;
+    {
+        // Nested structure matching backend schemas/device.py DeviceInfo
         const rac_device_registration_info_t* info = &request->device_info;
 
         json.add_string("device_id", info->device_id);

--- a/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_json.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_json.cpp
@@ -520,7 +520,11 @@ rac_result_t rac_device_registration_to_json(const rac_device_registration_reque
         json.add_string_always("device_name", info->device_name);
         json.add_string_always("platform", info->platform);
         json.add_string_always("os_version", info->os_version);
-        json.add_string_always("form_factor", info->form_factor ? info->form_factor : "phone");
+        // Unset stays null — the old fabricated defaults ("phone"/"unknown")
+        // made every desktop and web device register as a phone. Requires the
+        // backend DeviceInfo schema to accept nullable form_factor/gpu_family
+        // (deploy the backend schema change before shipping this).
+        json.add_string_or_null("form_factor", info->form_factor);
         json.add_string_always("architecture", info->architecture);
         json.add_string_always("chip_name", info->chip_name);
 
@@ -532,8 +536,7 @@ rac_result_t rac_device_registration_to_json(const rac_device_registration_reque
         json.add_bool_always("has_neural_engine", info->has_neural_engine != RAC_FALSE);
         json.add_int_always("neural_engine_cores", info->neural_engine_cores);
 
-        // GPU family with default
-        json.add_string_always("gpu_family", info->gpu_family ? info->gpu_family : "unknown");
+        json.add_string_or_null("gpu_family", info->gpu_family);
 
         // Battery info (may be unavailable - use nullable methods)
         // battery_level is a double (0.0-1.0), negative if unavailable

--- a/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_manager.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_manager.cpp
@@ -69,6 +69,9 @@ struct rac_telemetry_manager {
     static constexpr size_t BATCH_SIZE_PRODUCTION = 10;  // Flush after 10 events in production
     static constexpr int64_t BATCH_TIMEOUT_MS = 5000;    // Flush after 5 seconds in production
     static constexpr size_t MAX_QUEUE_SIZE = 256;  // Cap while flushes defer (e.g. pre-auth)
+    // Cap the poll-path HTTP queue (drop-oldest) — it was unbounded, so a
+    // platform that never drains (Flutter isolate gone) grew it without limit.
+    static constexpr size_t MAX_HTTP_QUEUE_SIZE = 64;
     int64_t last_flush_time_ms = 0;                // Track last flush time for timeout
 };
 
@@ -665,6 +668,43 @@ std::string proto_event_type_string(const SDKEvent& ev, bool& out_is_completion)
         }
         case SDKEvent::kFailure:
             return "sdk.error";
+        case SDKEvent::kCancellation: {
+            // Cancel-operation lifecycle (the terminal generation.cancelled row
+            // comes via kGeneration); previously fell to "unknown" and was
+            // silently dropped, making all cancel telemetry invisible.
+            switch (ev.cancellation().kind()) {
+                case runanywhere::v1::CANCELLATION_EVENT_KIND_REQUESTED:
+                    return "cancellation.requested";
+                case runanywhere::v1::CANCELLATION_EVENT_KIND_ACKNOWLEDGED:
+                    return "cancellation.acknowledged";
+                case runanywhere::v1::CANCELLATION_EVENT_KIND_COMPLETED:
+                    return "cancellation.completed";
+                case runanywhere::v1::CANCELLATION_EVENT_KIND_FAILED:
+                    return "cancellation.failed";
+                default:
+                    return "unknown";
+            }
+        }
+        case SDKEvent::kAuth: {
+            switch (ev.auth().kind()) {
+                case runanywhere::v1::AUTH_EVENT_KIND_REQUESTED:
+                    return "auth.requested";
+                case runanywhere::v1::AUTH_EVENT_KIND_SUCCEEDED:
+                    return "auth.succeeded";
+                case runanywhere::v1::AUTH_EVENT_KIND_FAILED:
+                    return "auth.failed";
+                case runanywhere::v1::AUTH_EVENT_KIND_TOKEN_REFRESHED:
+                    return "auth.token_refreshed";
+                case runanywhere::v1::AUTH_EVENT_KIND_TOKEN_EXPIRED:
+                    return "auth.token_expired";
+                case runanywhere::v1::AUTH_EVENT_KIND_DEVICE_REGISTERED:
+                    return "auth.device_registered";
+                case runanywhere::v1::AUTH_EVENT_KIND_DEVICE_REGISTRATION_FAILED:
+                    return "auth.device_registration_failed";
+                default:
+                    return "unknown";
+            }
+        }
         default:
             return "unknown";
     }
@@ -757,9 +797,12 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
     payload.event_type = event_type.c_str();
 
     // Oneof arms the translator has no name for (component lifecycle state
-    // transitions, cancellation envelopes, …) must not reach the backend as
-    // literal "unknown" rows — they are public/log events, not analytics.
+    // transitions, …) must not reach the backend as literal "unknown" rows.
+    // Log the drop: a silent return here previously hid whole event classes
+    // (cancellation, auth) for months.
     if (event_type == "unknown") {
+        RAC_LOG_DEBUG("Telemetry", "Dropping telemetry event with unmapped oneof arm (case=%d)",
+                      static_cast<int>(ev.event_case()));
         return RAC_SUCCESS;
     }
 
@@ -1407,6 +1450,13 @@ rac_result_t rac_telemetry_manager_flush(rac_telemetry_manager_t* manager) {
             // by Flutter, whose Dart FFI data callbacks are isolate-bound.
             {
                 std::lock_guard<std::mutex> lock(manager->http_queue_mutex);
+                while (manager->http_queue.size() >=
+                       rac_telemetry_manager::MAX_HTTP_QUEUE_SIZE) {
+                    RAC_LOG_WARNING("Telemetry",
+                                    "HTTP queue full (%zu) — dropping oldest pending batch",
+                                    manager->http_queue.size());
+                    manager->http_queue.pop_front();
+                }
                 manager->http_queue.push_back({endpoint, std::string(json, json_len), true});
             }
             manager->http_wakeup(manager->http_wakeup_user_data);

--- a/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_manager.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_manager.cpp
@@ -1180,6 +1180,21 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
                     if (em_it != ev.properties().end() && !em_it->second.empty()) {
                         payload.embedding_model = em_it->second.c_str();
                     }
+                    auto qt_it = ev.properties().find("query_token_count");
+                    if (qt_it != ev.properties().end()) {
+                        payload.query_token_count =
+                            static_cast<int32_t>(std::atoi(qt_it->second.c_str()));
+                    }
+                    auto ct_it = ev.properties().find("context_tokens");
+                    if (ct_it != ev.properties().end()) {
+                        payload.context_tokens =
+                            static_cast<int32_t>(std::atoi(ct_it->second.c_str()));
+                    }
+                    auto rr_it = ev.properties().find("reranker_used");
+                    if (rr_it != ev.properties().end()) {
+                        payload.reranker_used = rr_it->second == "true" ? RAC_TRUE : RAC_FALSE;
+                        payload.has_reranker_used = RAC_TRUE;
+                    }
                     break;
                 }
                 case runanywhere::v1::SDK_COMPONENT_EMBEDDINGS: {
@@ -1192,6 +1207,12 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
                     if (dim_it != ev.properties().end()) {
                         payload.embedding_dimension =
                             static_cast<int32_t>(std::atoi(dim_it->second.c_str()));
+                    }
+                    // total embedded tokens (chars/4 estimate from the module).
+                    auto tt_it = ev.properties().find("total_tokens");
+                    if (tt_it != ev.properties().end()) {
+                        payload.total_tokens =
+                            static_cast<int32_t>(std::atoi(tt_it->second.c_str()));
                     }
                     break;
                 }


### PR DESCRIPTION
Two RAG retrieval fixes plus the telemetry round previously reviewed in #537, rebased onto current main.

RAG:
- Candidate gathering no longer applies an absolute cosine floor. all-MiniLM scores sit low even for relevant chunks, so any floor dropped real matches and multi-chunk documents retrieved nothing. Gathering takes top_k and lets fusion/rerank select.
- The assignment merge preserves a locally-seeded embedding category instead of letting the backend's LANGUAGE fallback overwrite it, which was dropping embedding models from the picker.

Telemetry (details in #537):
- One row per user action: TTS wrapper double-emit, diffusion per-step progress rows, tool-calling's unpaired per-iteration completeds, and the embeddings phantom started are gone.
- Real token counts win over the chars/4 estimate; tokens_per_second measures decode time, not prefill-diluted wall time; unset device fields go up as null instead of "phone"/"unknown" (needs the backend nullable-schema change on development deployed first).
- Cancellation and auth events were silently dropped at an unmapped extractor arm, and two publishers bypassed the destination router. Fixed, drop path logs now.
- New carriers for always-null columns: RAG query/context token estimates and reranker_used, embeddings total_tokens.
- Dev device registration posted to a Supabase-era path that 404'd silently (about half of registrations failing with no error captured). All environments now use /api/v1/devices/register with one payload shape.
- Flutter/RN pending-HTTP queue capped at 64.

Note: the artifact_info double-free fix from #537 is not in this stack — main already carries an equivalent fix (borrow-then-restore in model_assignment.cpp).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes RAG retrieval semantics, telemetry/auth event mapping, and device registration payloads (backend schema dependency for nullable fields); model merge includes a memory-safety fix that affects registry persistence.
> 
> **Overview**
> **RAG retrieval** no longer filters dense candidates with a cosine similarity floor during gathering (pipeline and USearch treat `threshold <= 0` as rank-only). Fusion/rerank still selects from top_k, so low-scoring embedding models like all-MiniLM stop returning empty context for valid docs.
> 
> **Model registry** maps `embedding`/`embeddings` assignment categories, preserves a local **embedding** category when the backend merge would overwrite it with **LANGUAGE**, and fixes **artifact_info** shallow-borrow during merge so freed pointers are not copied into the cache.
> 
> **Telemetry and events** cut duplicate or noisy rows (TTS wrapper events → PUBLIC-only, diffusion progress → PUBLIC-only, embeddings **create** STARTED removed, tool-calling loops aggregate one TELEMETRY **completed** per request). LLM metrics prefer backend token counts and compute **tokens_per_second** over decode time excluding TTFT. RAG/embeddings JSON gains estimated token fields and **reranker_used**. Cancellation and auth SDKEvent arms are mapped instead of dropped as **unknown**; lifecycle/storage publishers use **`publish_prebuilt`** so TELEMETRY/LOG destinations apply. Pending Flutter HTTP batches cap at 64 with drop-oldest.
> 
> **Device registration** uses `/api/v1/devices/register` for all environments with one nested payload; dev no longer posts a flat Supabase shape. **form_factor** and **gpu_family** serialize as null when unset instead of **phone**/**unknown** (requires backend nullable schema).
> 
> **Flutter example**: Android registers **jni** / **jni_flutter**; iOS drops **path_provider** from generated registrant.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ac663b51dda689dab1ab22ec69d1873a4c913e11. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added richer telemetry for RAG, embeddings, language generation, tool calls, and speech synthesis.
  * Added reporting for token usage, retrieved context, reranking, first-token latency, and generation speed.
  * Added support for JNI-based Flutter integrations on Android.

* **Bug Fixes**
  * Improved RAG retrieval behavior for non-positive similarity thresholds.
  * Correctly identifies embedding models during model registration.
  * Improved device registration compatibility and telemetry payload accuracy.
  * Prevented unbounded telemetry queue growth.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->