### PR TITLE
fix(ios): force static linkage on SPM library products to prevent wra…

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -128,6 +128,7 @@ let package = Package(
         // =================================================================
         .library(
             name: "RunAnywhere",
+            type: .static,
             targets: ["RunAnywhere"]
         ),
 
@@ -136,6 +137,7 @@ let package = Package(
         // =================================================================
         .library(
             name: "RunAnywhereONNX",
+            type: .static,
             targets: ["ONNXRuntime"]
         ),
 
@@ -144,6 +146,7 @@ let package = Package(
         // =================================================================
         .library(
             name: "RunAnywhereLlamaCPP",
+            type: .static,
             targets: ["LlamaCPPRuntime"]
         ),
 
@@ -152,6 +155,7 @@ let package = Package(
         // =================================================================
         .library(
             name: "RunAnywhereMLX",
+            type: .static,
             targets: ["MLXRuntime"]
         ),
 

--- a/sdk/runanywhere-swift/Package.swift
+++ b/sdk/runanywhere-swift/Package.swift
@@ -59,14 +59,15 @@ let package = Package(
         // -------------------------------------------------------------------
         .library(
             name: "RunAnywhere",
+            type: .static,
             targets: ["RunAnywhere"]
         ),
 
         // Individual backend products (used by the example apps that only
         // want to link a subset of the runtimes).
-        .library(name: "RunAnywhereLlamaCPP", targets: ["LlamaCPPRuntime"]),
-        .library(name: "RunAnywhereONNX", targets: ["ONNXRuntime"]),
-        .library(name: "RunAnywhereMLX", targets: ["MLXRuntime"]),
+        .library(name: "RunAnywhereLlamaCPP", type: .static, targets: ["LlamaCPPRuntime"]),
+        .library(name: "RunAnywhereONNX", type: .static, targets: ["ONNXRuntime"]),
+        .library(name: "RunAnywhereMLX", type: .static, targets: ["MLXRuntime"]),
     ],
     dependencies: [
         // SPM deps use `.upToNextMinor` (not open-ended `from:`) so a


### PR DESCRIPTION
resolve:#437
### Description
This PR resolves errors **ITMS-90057** and **ITMS-90208** during App Store Connect upload validation. 

### Root Cause
When client apps integrated the Swift targets via Swift Package Manager, Xcode evaluated the library products' default automatic linkage. In dynamic contexts, Xcode built them as dynamic wrapper framework targets (`RACommons.framework`, `RABackendLLAMACPP.framework`, and `RABackendONNX.framework`), adding them to the "Embed Frameworks" build phase. 

Because these stubs only wrapped static library files, they lacked the required metadata keys (`CFBundleSupportedPlatforms`, `MinimumOSVersion`, `CFBundleShortVersionString`) in their generated `Info.plist` files, leading to automated App Store Connect rejections.

### Proposed Solution
We explicitly declare `type: .static` on the library targets in both Package manifests. This forces Xcode to statically link the library targets and their associated `.binaryTarget` dependencies directly into the host app binary, completely bypassing the generation and copying of dynamic wrapper frameworks to the app's `Frameworks/` folder.

### Changes
*   Configured explicit `.static` linkage for `RunAnywhere`, `RunAnywhereONNX`, `RunAnywhereLlamaCPP`, and `RunAnywhereMLX` in the root [Package.swift](file:///D:/runanywhere-sdks/Package.swift).
*   Synchronized the target declarations in the Swift SDK's [Package.swift](file:///D:/runanywhere-sdks/sdk/runanywhere-swift/Package.swift).

### Verification
*   Manifest syntax checked.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Linkage behavior for all SPM consumers changes (no more dynamic SDK frameworks), which can affect embed/signing setup but is intentional to fix App Store validation; no runtime source changes.
> 
> **Overview**
> Sets **`type: .static`** on the SPM library products **`RunAnywhere`**, **`RunAnywhereONNX`**, **`RunAnywhereLlamaCPP`**, and **`RunAnywhereMLX`** in the root **`Package.swift`** and the local **`sdk/runanywhere-swift/Package.swift`**.
> 
> This changes how Xcode links those products so SDK code and binary targets are **statically linked into the host app** instead of being packaged as **dynamic wrapper frameworks** in **Embed Frameworks**, which was triggering App Store Connect **ITMS-90057** / **ITMS-90208** when those wrappers lacked required **`Info.plist`** metadata.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6e9d44b75e25927f232d530e9c4a512bf17091fc. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Summary by CodeRabbit

* **Build & Integration**
  * Updated the Swift package library products to use **static linking** for the core SDK and supported runtime modules.
  * Improves **predictability of how the libraries are integrated** when consuming the Swift package in your application.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->