### PR TITLE
Telemetry field fixes and RAG streaming

### DIFF
--- a/engines/llamacpp/rac_vlm_llamacpp.cpp
+++ b/engines/llamacpp/rac_vlm_llamacpp.cpp
@@ -147,6 +147,15 @@ struct LlamaCppVLMBackend {
     int context_size = 0;
     llama_pos n_past = 0;
 
+    // Vision token count of the most recent prepare (image chunks only), carried
+    // from prepare_vlm_context() to process()/process_stream() for telemetry.
+    int32_t last_image_tokens = 0;
+    // Decoded image dimensions of the most recent prepare (0 when text-only).
+    // The caller's rac_vlm_image often carries no dims for encoded inputs, so the
+    // real resolution is only known after mtmd decodes the bitmap.
+    int32_t last_image_width = 0;
+    int32_t last_image_height = 0;
+
     // Detected model type for chat template
     VLMModelType model_type = VLMModelType::Unknown;
 
@@ -730,6 +739,9 @@ rac_result_t prepare_vlm_context(LlamaCppVLMBackend* backend, const rac_vlm_imag
         llama_memory_clear(mem, true);
     }
     backend->n_past = 0;
+    backend->last_image_tokens = 0;
+    backend->last_image_width = 0;
+    backend->last_image_height = 0;
 
     // Resolve effective model type: options override > auto-detected at load time
     VLMModelType effective_model_type = resolve_effective_model_type(backend->model_type, options);
@@ -782,6 +794,8 @@ rac_result_t prepare_vlm_context(LlamaCppVLMBackend* backend, const rac_vlm_imag
             RAC_LOG_ERROR(LOG_CAT, "Failed to load image");
             return RAC_ERROR_INVALID_INPUT;
         }
+        backend->last_image_width = static_cast<int32_t>(mtmd_bitmap_get_nx(bitmap.get()));
+        backend->last_image_height = static_cast<int32_t>(mtmd_bitmap_get_ny(bitmap.get()));
     }
 
     const rac_vlm_chat_template_t* custom_chat_template =
@@ -813,6 +827,19 @@ rac_result_t prepare_vlm_context(LlamaCppVLMBackend* backend, const rac_vlm_imag
             RAC_LOG_ERROR(LOG_CAT, "Failed to tokenize prompt with image: %d", tokenize_result);
             return RAC_ERROR_PROCESSING_FAILED;
         }
+
+        // Sum tokens across image chunks so telemetry can report the vision-token
+        // count (distinct from the text prompt tokens).
+        int32_t image_token_count = 0;
+        const size_t chunk_count = mtmd_input_chunks_size(chunks.get());
+        for (size_t ci = 0; ci < chunk_count; ci++) {
+            const mtmd_input_chunk* chunk = mtmd_input_chunks_get(chunks.get(), ci);
+            if (chunk != nullptr &&
+                mtmd_input_chunk_get_type(chunk) == MTMD_INPUT_CHUNK_TYPE_IMAGE) {
+                image_token_count += static_cast<int32_t>(mtmd_input_chunk_get_n_tokens(chunk));
+            }
+        }
+        backend->last_image_tokens = image_token_count;
 
         llama_pos new_n_past = 0;
         RAC_LOG_INFO(LOG_CAT, "[v3-prep] evaluating image/text chunks");
@@ -1265,11 +1292,14 @@ rac_result_t rac_vlm_llamacpp_process(rac_handle_t handle, const rac_vlm_image_t
     }
 
     // Shared context preparation: reset, configure sampler, build prompt,
-    // evaluate
+    // evaluate. Time it as the multimodal encode/prefill (image + prompt).
+    const auto t_start = std::chrono::steady_clock::now();
     rac_result_t prep_result = prepare_vlm_context(backend, image, prompt, options);
     if (prep_result != RAC_SUCCESS) {
         return prep_result;
     }
+    const auto t_after_prep = std::chrono::steady_clock::now();
+    auto t_first_token = t_after_prep;  // overwritten when the first token is produced
 
     // Generate response (batch mode — accumulate all tokens)
     const int max_tokens =
@@ -1370,6 +1400,9 @@ rac_result_t rac_vlm_llamacpp_process(rac_handle_t handle, const rac_vlm_image_t
         }
         prev_token = token;
 
+        if (tokens_generated == 0) {
+            t_first_token = std::chrono::steady_clock::now();
+        }
         char buf[256];
         int len = llama_token_to_piece(vocab, token, buf, sizeof(buf) - 1, 0, true);
         if (len > 0) {
@@ -1426,6 +1459,23 @@ rac_result_t rac_vlm_llamacpp_process(rac_handle_t handle, const rac_vlm_image_t
     out_result->completion_tokens = tokens_generated;
     out_result->prompt_tokens = backend->n_past - tokens_generated;
     out_result->total_tokens = backend->n_past;
+    out_result->image_tokens = backend->last_image_tokens;
+    out_result->image_width = backend->last_image_width;
+    out_result->image_height = backend->last_image_height;
+    out_result->context_length =
+        backend->ctx != nullptr ? static_cast<int32_t>(llama_n_ctx(backend->ctx))
+                                : backend->context_size;
+
+    // Timing metrics (were previously left 0 → null in telemetry).
+    const auto t_end = std::chrono::steady_clock::now();
+    using ms = std::chrono::duration<double, std::milli>;
+    const double total_ms = ms(t_end - t_start).count();
+    const double decode_ms = ms(t_end - t_after_prep).count();
+    out_result->total_time_ms = static_cast<int64_t>(total_ms);
+    out_result->image_encode_time_ms = static_cast<int64_t>(ms(t_after_prep - t_start).count());
+    out_result->time_to_first_token_ms = static_cast<int64_t>(ms(t_first_token - t_start).count());
+    out_result->tokens_per_second =
+        decode_ms > 0.0 ? static_cast<float>(tokens_generated / (decode_ms / 1000.0)) : 0.0f;
 
     RAC_LOG_INFO(LOG_CAT, "Generated %d tokens", tokens_generated);
     return RAC_SUCCESS;

--- a/examples/android/RunAnywhereAI/app/build.gradle.kts
+++ b/examples/android/RunAnywhereAI/app/build.gradle.kts
@@ -11,9 +11,16 @@ plugins {
     alias(libs.plugins.kotlin.serialization)
 }
 
+// STRICT locking is a release/CI reproducibility gate; locally (and during
+// Android Studio sync, which resolves synthetic *Copy configs and IDE-only
+// source artifacts) it only causes friction, so relax to LENIENT off-CI.
+val strictDependencyLocks = providers.environmentVariable("CI").isPresent ||
+    providers.gradleProperty("runanywhere.strictLocks").map { it.toBoolean() }.orElse(false).get() ||
+    gradle.startParameter.isWriteDependencyLocks
+
 dependencyLocking {
     lockAllConfigurations()
-    lockMode.set(LockMode.STRICT)
+    lockMode.set(if (strictDependencyLocks) LockMode.STRICT else LockMode.LENIENT)
 }
 
 // Backend config comes from CI-safe environment variables first, then the

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/rag/RagViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/rag/RagViewModel.kt
@@ -2,6 +2,7 @@ package com.runanywhere.runanywhereai.ui.screens.rag
 
 import ai.runanywhere.proto.v1.RAGConfiguration
 import ai.runanywhere.proto.v1.RAGDocument
+import ai.runanywhere.proto.v1.RAGStreamEventKind
 import android.app.Application
 import android.net.Uri
 import androidx.compose.runtime.getValue
@@ -19,17 +20,16 @@ import com.runanywhere.sdk.public.extensions.ragCancelQuery
 import com.runanywhere.sdk.public.extensions.ragCreatePipeline
 import com.runanywhere.sdk.public.extensions.ragGetStatistics
 import com.runanywhere.sdk.public.extensions.ragIngest
-import com.runanywhere.sdk.public.extensions.ragQuery
+import com.runanywhere.sdk.public.extensions.ragQueryStream
 import kotlinx.coroutines.DelicateCoroutinesApi
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.GlobalScope
 import kotlinx.coroutines.Job
-import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.ensureActive
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
-import kotlinx.coroutines.withTimeout
 import java.util.UUID
 import kotlin.coroutines.cancellation.CancellationException
 
@@ -198,27 +198,53 @@ class RagViewModel(application: Application) : AndroidViewModel(application) {
         isQuerying = true
         val requestVersion = RagQueryVersion(query = ++queryGeneration, corpus = corpusGeneration)
         job = viewModelScope.launch {
+            // Live-updating answer slot; tokens stream in, then the COMPLETED
+            // event replaces it with the final answer + cited sources. No
+            // wall-clock timeout — progress is visible as it generates.
+            val answerIndex = messages.size
+            messages += RagMessage("", isUser = false)
+            val streamed = StringBuilder()
+            var finalized = false
             try {
                 val options = RagGenerationPolicy.options(q, multiQueryEnabled)
                 val key = pipelineKey ?: error("Choose document models and add a document first.")
-                val result = withTimeout(RagGenerationPolicy.QUERY_TIMEOUT_MS) {
-                    withPipeline(key.first, key.second) {
-                        RunAnywhere.ragQuery(q, options)
+                withPipeline(key.first, key.second) {
+                    RunAnywhere.ragQueryStream(q, options).collect { event ->
+                        currentCoroutineContext().ensureActive()
+                        if (!requestVersion.isCurrent(queryGeneration, corpusGeneration)) {
+                            return@collect
+                        }
+                        when (event.kind) {
+                            RAGStreamEventKind.RAG_STREAM_EVENT_KIND_TOKEN -> {
+                                streamed.append(event.token)
+                                messages[answerIndex] = RagMessage(
+                                    text = RagAnswerNormalizer.visibleAnswer(streamed.toString()),
+                                    isUser = false,
+                                )
+                            }
+                            RAGStreamEventKind.RAG_STREAM_EVENT_KIND_COMPLETED -> {
+                                val result = event.result
+                                val sources = result?.retrieved_chunks?.map {
+                                    RagSource(
+                                        text = it.text.trim(),
+                                        score = it.similarity_score,
+                                        document = it.source_document.orEmpty(),
+                                    )
+                                } ?: emptyList()
+                                messages[answerIndex] = buildRagAnswerMessage(
+                                    rawAnswer = result?.answer ?: streamed.toString(),
+                                    sources = sources,
+                                    elapsedMs = result?.total_time_ms ?: 0L,
+                                )
+                                finalized = true
+                            }
+                            RAGStreamEventKind.RAG_STREAM_EVENT_KIND_ERROR -> {
+                                error = event.error_message?.takeIf { it.isNotBlank() }
+                                    ?: "The query failed."
+                            }
+                            else -> Unit
+                        }
                     }
-                }
-                currentCoroutineContext().ensureActive()
-                if (!requestVersion.isCurrent(queryGeneration, corpusGeneration)) return@launch
-                val sources = result.retrieved_chunks.map {
-                    RagSource(text = it.text.trim(), score = it.similarity_score, document = it.source_document.orEmpty())
-                }
-                messages += buildRagAnswerMessage(
-                    rawAnswer = result.answer,
-                    sources = sources,
-                    elapsedMs = result.total_time_ms,
-                )
-            } catch (e: TimeoutCancellationException) {
-                if (requestVersion.isCurrent(queryGeneration, corpusGeneration)) {
-                    error = "The query took too long and was stopped. Try a shorter question."
                 }
             } catch (e: CancellationException) {
                 throw e
@@ -228,6 +254,14 @@ class RagViewModel(application: Application) : AndroidViewModel(application) {
                     error = e.message ?: "The query failed."
                 }
             } finally {
+                // Drop the placeholder if nothing streamed and no final answer
+                // landed (error/cancel), so no empty bubble lingers.
+                if (!finalized && streamed.isBlank() &&
+                    answerIndex < messages.size && !messages[answerIndex].isUser &&
+                    messages[answerIndex].text.isBlank()
+                ) {
+                    messages.removeAt(answerIndex)
+                }
                 if (requestVersion.query == queryGeneration) {
                     isQuerying = false
                     job = null

--- a/examples/android/RunAnywhereAI/gradle/verification-metadata.xml
+++ b/examples/android/RunAnywhereAI/gradle/verification-metadata.xml
@@ -3,6 +3,11 @@
    <configuration>
       <verify-metadata>true</verify-metadata>
       <verify-signatures>false</verify-signatures>
+      <trusted-artifacts>
+         <trust file=".*-sources[.]jar" regex="true"/>
+         <trust file=".*-javadoc[.]jar" regex="true"/>
+         <trust group="gradle" name="gradle"/>
+      </trusted-artifacts>
    </configuration>
    <components>
       <component group="androidx.activity" name="activity" version="1.13.0">

--- a/sdk/runanywhere-commons/exports/RACommons.rag.exports
+++ b/sdk/runanywhere-commons/exports/RACommons.rag.exports
@@ -22,6 +22,7 @@ _rac_rag_clear_proto
 _rac_rag_cancel_proto
 _rac_rag_ingest_proto
 _rac_rag_query_proto
+_rac_rag_query_stream_proto
 _rac_rag_session_create_proto
 _rac_rag_session_destroy_proto
 _rac_rag_stats_proto

--- a/sdk/runanywhere-commons/include/rac/features/rag/rac_rag.h
+++ b/sdk/runanywhere-commons/include/rac/features/rag/rac_rag.h
@@ -99,9 +99,13 @@ RAC_API rac_result_t rac_rag_query_proto(rac_handle_t session, const uint8_t* qu
  * runanywhere.v1.RAGStreamEvent (TOKEN as the answer generates, then a terminal
  * COMPLETED carrying the full RAGResult, or ERROR). The bytes are owned by the
  * SDK and valid only for the duration of the call — copy if retained.
+ *
+ * Return RAC_TRUE to keep generating, RAC_FALSE to stop early (backpressure):
+ * a false return on a TOKEN event halts generation and the run ends with a
+ * terminal COMPLETED carrying the partial answer.
  */
-typedef void (*rac_rag_stream_proto_callback_fn)(const uint8_t* event_bytes, size_t event_size,
-                                                 void* user_data);
+typedef rac_bool_t (*rac_rag_stream_proto_callback_t)(const uint8_t* event_bytes,
+                                                      size_t event_size, void* user_data);
 
 /**
  * @brief Streaming variant of rac_rag_query_proto.
@@ -115,7 +119,7 @@ typedef void (*rac_rag_stream_proto_callback_fn)(const uint8_t* event_bytes, siz
 RAC_API rac_result_t rac_rag_query_stream_proto(rac_handle_t session,
                                                 const uint8_t* query_proto_bytes,
                                                 size_t query_proto_size,
-                                                rac_rag_stream_proto_callback_fn callback,
+                                                rac_rag_stream_proto_callback_t callback,
                                                 void* user_data);
 
 /**

--- a/sdk/runanywhere-commons/include/rac/features/rag/rac_rag.h
+++ b/sdk/runanywhere-commons/include/rac/features/rag/rac_rag.h
@@ -93,6 +93,32 @@ RAC_API rac_result_t rac_rag_query_proto(rac_handle_t session, const uint8_t* qu
                                          size_t query_proto_size, rac_proto_buffer_t* out_result);
 
 /**
+ * @brief Per-event callback for streaming RAG queries.
+ *
+ * Invoked synchronously on the calling thread for each serialized
+ * runanywhere.v1.RAGStreamEvent (TOKEN as the answer generates, then a terminal
+ * COMPLETED carrying the full RAGResult, or ERROR). The bytes are owned by the
+ * SDK and valid only for the duration of the call — copy if retained.
+ */
+typedef void (*rac_rag_stream_proto_callback_fn)(const uint8_t* event_bytes, size_t event_size,
+                                                 void* user_data);
+
+/**
+ * @brief Streaming variant of rac_rag_query_proto.
+ *
+ * Runs the same pipeline but forwards each generated token as a RAGStreamEvent
+ * to `callback` (no unary wait), then a terminal COMPLETED/ERROR event. Returns
+ * the pipeline status. Cancellation is via rac_rag_cancel_proto() (same as the
+ * unary path) — a cancelled run ends with an ERROR event carrying
+ * RAC_ERROR_CANCELLED.
+ */
+RAC_API rac_result_t rac_rag_query_stream_proto(rac_handle_t session,
+                                                const uint8_t* query_proto_bytes,
+                                                size_t query_proto_size,
+                                                rac_rag_stream_proto_callback_fn callback,
+                                                void* user_data);
+
+/**
  * @brief Request cancellation of the query currently running on a RAG session.
  *
  * Safe to call from a thread other than the one blocked in

--- a/sdk/runanywhere-commons/include/rac/features/vlm/rac_vlm_types.h
+++ b/sdk/runanywhere-commons/include/rac/features/vlm/rac_vlm_types.h
@@ -327,6 +327,15 @@ typedef struct rac_vlm_result {
     /** Number of vision/image tokens specifically */
     int32_t image_tokens;
 
+    /** Decoded image dimensions in pixels (0 when text-only). Populated by the
+     *  backend after the image is decoded, so telemetry can report the real
+     *  resolution even when the caller supplied encoded bytes without dims. */
+    int32_t image_width;
+    int32_t image_height;
+
+    /** Model context window (n_ctx) the generation ran with. */
+    int32_t context_length;
+
     /** Number of tokens generated */
     int32_t completion_tokens;
 

--- a/sdk/runanywhere-commons/include/rac/infrastructure/telemetry/rac_telemetry_types.h
+++ b/sdk/runanywhere-commons/include/rac/infrastructure/telemetry/rac_telemetry_types.h
@@ -64,6 +64,8 @@ typedef struct rac_telemetry_payload {
 
     // Common performance metrics
     double processing_time_ms;
+    rac_bool_t has_processing_time_ms;  // Whether a duration was actually measured
+                                        // (distinguishes a real 0 ms from "unset")
     rac_bool_t success;
     rac_bool_t has_success;  // Whether success field is set
     const char* error_message;
@@ -90,6 +92,12 @@ typedef struct rac_telemetry_payload {
     rac_bool_t is_streaming;
     rac_bool_t has_is_streaming;
     int32_t segment_index;
+    // Hybrid STT router attribution (populated only on the hybrid transcribe
+    // path; null on plain single-backend STT).
+    const char* routed_backend;    // backend/model that actually served the request
+    rac_bool_t was_fallback;       // secondary served after the primary failed
+    rac_bool_t has_was_fallback;   // whether was_fallback is meaningful
+    int32_t attempt_count;         // 1 = primary only, 2 = primary then fallback
 
     // TTS-specific fields
     int32_t character_count;
@@ -123,6 +131,8 @@ typedef struct rac_telemetry_payload {
     int32_t top_k;
     double retrieval_time_ms;
     const char* embedding_model;  // RAG embedding model (string → dup'd/freed)
+    rac_bool_t reranker_used;      // LLM-pointwise rerank enabled for the query
+    rac_bool_t has_reranker_used;  // whether reranker_used is set
 
     // LoRA-specific fields. Strings → must be dup'd/freed in track + payload_free.
     const char* adapter_id;
@@ -157,6 +167,10 @@ typedef struct rac_telemetry_payload {
     // Voice-agent per-turn fields (via properties carrier; voice_* timing above)
     int32_t transcript_chars;
     int32_t response_chars;
+    int32_t turn_index;              // 0-based turn number within the agent session
+    rac_bool_t has_turn_index;       // whether turn_index is set (0 is valid)
+    rac_bool_t voice_interrupted;    // turn ended via caller cancel / barge-out
+    rac_bool_t has_voice_interrupted;
 
     // SDK lifecycle fields
     int32_t count;

--- a/sdk/runanywhere-commons/src/features/rag/rac_rag_proto_abi.cpp
+++ b/sdk/runanywhere-commons/src/features/rag/rac_rag_proto_abi.cpp
@@ -96,7 +96,8 @@ void publish_capability(runanywhere::v1::CapabilityOperationEventKind kind, cons
                         float progress, int64_t input_count, int64_t output_count,
                         const char* error, double duration_ms = 0.0, const char* model_id = nullptr,
                         int64_t top_k = 0, double retrieval_time_ms = 0.0,
-                        const char* embedding_model = nullptr) {
+                        const char* embedding_model = nullptr,
+                        rac_result_t error_code = RAC_SUCCESS, int reranker_used = -1) {
     runanywhere::v1::SDKEvent event;
     event.set_id(event_id());
     event.set_timestamp_ms(now_ms());
@@ -121,6 +122,14 @@ void publish_capability(runanywhere::v1::CapabilityOperationEventKind kind, cons
     cap->set_output_count(output_count);
     if (error)
         cap->set_error(error);
+    // Populate the envelope SDKError so the telemetry manager records error_code on
+    // the row (the kCapability extractor reads ev.error().c_abi_code(); without this
+    // a failed RAG op landed with error_message set but error_code null).
+    if (error && error[0] && error_code != RAC_SUCCESS) {
+        auto* err = event.mutable_error();
+        err->set_message(error);
+        err->set_c_abi_code(static_cast<int32_t>(error_code));
+    }
     // CapabilityOperationEvent has no duration field; telemetry reads it from
     // the envelope properties map (see telemetry_manager kCapability extraction).
     if (duration_ms > 0.0) {
@@ -135,12 +144,17 @@ void publish_capability(runanywhere::v1::CapabilityOperationEventKind kind, cons
     if (embedding_model != nullptr && embedding_model[0] != '\0') {
         (*event.mutable_properties())["embedding_model"] = embedding_model;
     }
+    if (reranker_used >= 0) {
+        (*event.mutable_properties())["reranker_used"] = reranker_used != 0 ? "1" : "0";
+    }
     publish_event(event);
 }
 
 void publish_failure(rac_result_t code, const char* operation, const char* message) {
     publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_RAG_FAILED, operation, 0.0f,
-                       0, 0, message && message[0] ? message : rac_error_message(code));
+                       0, 0, message && message[0] ? message : rac_error_message(code),
+                       /*duration_ms=*/0.0, /*model_id=*/nullptr, /*top_k=*/0,
+                       /*retrieval_time_ms=*/0.0, /*embedding_model=*/nullptr, /*error_code=*/code);
     (void)rac_sdk_event_publish_failure(code, message, "rag", operation, RAC_TRUE);
 }
 
@@ -207,6 +221,13 @@ struct Session {
     // events report the embedding model, query events the LLM).
     std::string embedding_model_id;
     std::string llm_model_id;
+    // Resolved retrieval top_k for this session (config default). Telemetry emits
+    // the effective retrieval top_k so the query row is never null when a caller
+    // omits a per-query override.
+    size_t retrieval_top_k = 5;
+    // Whether LLM-pointwise reranking is enabled for this session (config).
+    // Stamped onto query telemetry (rag_telemetry.reranker_used).
+    bool rerank = false;
 };
 
 struct SessionRegistry {
@@ -367,6 +388,143 @@ runanywhere::v1::RAGStatistics make_stats(RAGBackend& backend) {
     return out;
 }
 
+// Shared core for the unary + streaming RAG query entry points. Runs setup →
+// retrieval + generation (per-token via on_token when non-null) → telemetry →
+// builds the RAGResult proto. On success fills *out_proto and returns
+// RAC_SUCCESS; on failure returns the status and sets *out_error for the
+// caller's error surface. Telemetry (started/completed/failed) is emitted here
+// so both entry points behave identically.
+rac_result_t execute_rag_query(const std::shared_ptr<Session>& s,
+                               const runanywhere::v1::RAGQueryOptions& query_proto,
+                               std::function<bool(const std::string&)> on_token,
+                               runanywhere::v1::RAGResult* out_proto, std::string* out_error) {
+    const std::string question = query_proto.question();
+    const std::string system_prompt =
+        query_proto.has_system_prompt() ? query_proto.system_prompt() : std::string();
+
+    // Base off RAC_LLM_OPTIONS_DEFAULT so the sampling fields RAGQueryOptions
+    // does not expose carry the proto-documented defaults instead of zero-init.
+    rac_llm_options_t opts = RAC_LLM_OPTIONS_DEFAULT;
+    opts.max_tokens = query_proto.max_tokens() > 0 ? query_proto.max_tokens() : 512;
+    opts.temperature = query_proto.temperature();
+    opts.top_p = query_proto.top_p() > 0.0f ? query_proto.top_p() : 0.9f;
+    opts.top_k = query_proto.top_k();
+    opts.disable_thinking = query_proto.disable_thinking() ? RAC_TRUE : RAC_FALSE;
+    opts.system_prompt = system_prompt.empty() ? nullptr : system_prompt.c_str();
+
+    RAGBackend::QueryOverrides overrides;
+    overrides.retrieval_top_k = query_proto.retrieval_top_k();
+    overrides.has_similarity_threshold = query_proto.has_similarity_threshold();
+    overrides.similarity_threshold = query_proto.similarity_threshold();
+    overrides.enable_multi_query = query_proto.enable_multi_query();
+    constexpr int32_t kMaxMultiQueryCount = 8;
+    if (query_proto.has_multi_query_count()) {
+        const int32_t n = query_proto.multi_query_count();
+        overrides.multi_query_count = n > kMaxMultiQueryCount ? kMaxMultiQueryCount : n;
+    } else {
+        overrides.multi_query_count = 0;
+    }
+    if (query_proto.has_scope_prefix())
+        overrides.scope_prefix = query_proto.scope_prefix();
+
+    publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_RAG_QUERY_STARTED,
+                       "rag.query", 0.0f, 1, 0, nullptr, 0.0,
+                       s->llm_model_id.empty() ? s->embedding_model_id.c_str()
+                                               : s->llm_model_id.c_str());
+
+    const auto t_start = std::chrono::high_resolution_clock::now();
+    rac_llm_result_t llm_result = {};
+    nlohmann::json metadata;
+    rac_result_t status = RAC_SUCCESS;
+    try {
+        status = s->backend->query(question, &opts, &llm_result, metadata, std::move(on_token),
+                                   &overrides);
+    } catch (const std::exception& e) {
+        LOGE("rag.query exception: %s", e.what());
+        rac_llm_result_free(&llm_result);
+        if (out_error)
+            *out_error = e.what();
+        publish_failure(RAC_ERROR_PROCESSING_FAILED, "rag.query", e.what());
+        return RAC_ERROR_PROCESSING_FAILED;
+    }
+    const auto t_end = std::chrono::high_resolution_clock::now();
+    const double total_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
+
+    if (status != RAC_SUCCESS) {
+        rac_llm_result_free(&llm_result);
+        if (out_error)
+            *out_error = rac_error_message(status);
+        publish_failure(status, "rag.query", rac_error_message(status));
+        return status;
+    }
+
+    runanywhere::v1::RAGResult& proto = *out_proto;
+    const char* raw_answer = llm_result.text ? llm_result.text : "";
+    const char* answer = nullptr;
+    size_t answer_len = 0;
+    const char* thinking = nullptr;
+    size_t thinking_len = 0;
+    std::string thinking_open_tag;
+    std::string thinking_close_tag;
+    (void)rac::llm::model_thinking_tags_from_registry(s->llm_model_id.c_str(), &thinking_open_tag,
+                                                      &thinking_close_tag);
+    if (rac_llm_extract_thinking_with_tags(
+            raw_answer, thinking_open_tag.empty() ? nullptr : thinking_open_tag.c_str(),
+            thinking_close_tag.empty() ? nullptr : thinking_close_tag.c_str(), &answer, &answer_len,
+            &thinking, &thinking_len) == RAC_SUCCESS) {
+        proto.set_answer(answer ? std::string(answer, answer_len) : std::string());
+        if (thinking && thinking_len > 0) {
+            proto.set_thinking_content(std::string(thinking, thinking_len));
+        }
+    } else if (llm_result.text) {
+        proto.set_answer(llm_result.text);
+    }
+
+    if (metadata.contains("context_used") && metadata["context_used"].is_string()) {
+        proto.set_context_used(metadata["context_used"].get<std::string>());
+    }
+
+    if (metadata.contains("sources") && metadata["sources"].is_array()) {
+        for (const auto& s_item : metadata["sources"]) {
+            auto* chunk = proto.add_retrieved_chunks();
+            if (s_item.contains("id") && s_item["id"].is_string()) {
+                chunk->set_chunk_id(s_item["id"].get<std::string>());
+            }
+            if (s_item.contains("text") && s_item["text"].is_string()) {
+                chunk->set_text(s_item["text"].get<std::string>());
+            }
+            if (s_item.contains("score") && s_item["score"].is_number()) {
+                chunk->set_similarity_score(s_item["score"].get<float>());
+            }
+            if (s_item.contains("source_document") && s_item["source_document"].is_string()) {
+                chunk->set_source_document(s_item["source_document"].get<std::string>());
+            } else if (s_item.contains("source") && s_item["source"].is_string()) {
+                chunk->set_source_document(s_item["source"].get<std::string>());
+            }
+        }
+    }
+
+    const double generation_ms = llm_result.total_time_ms;
+    const double retrieval_ms = std::max(0.0, total_ms - generation_ms);
+    proto.set_retrieval_time_ms(static_cast<int64_t>(retrieval_ms));
+    proto.set_generation_time_ms(static_cast<int64_t>(generation_ms));
+    proto.set_total_time_ms(static_cast<int64_t>(total_ms));
+
+    // Emit the EFFECTIVE retrieval top_k (per-query override, else the session
+    // config default) — not query_proto.top_k(), which is the LLM sampling top_k.
+    const int64_t effective_top_k =
+        overrides.retrieval_top_k > 0 ? static_cast<int64_t>(overrides.retrieval_top_k)
+                                      : static_cast<int64_t>(s->retrieval_top_k);
+    publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_RAG_QUERY_COMPLETED,
+                       "rag.query", 1.0f, 1, proto.retrieved_chunks_size(), nullptr, total_ms,
+                       s->llm_model_id.empty() ? s->embedding_model_id.c_str()
+                                               : s->llm_model_id.c_str(),
+                       effective_top_k, retrieval_ms, s->embedding_model_id.c_str(),
+                       /*error_code=*/RAC_SUCCESS, /*reranker_used=*/s->rerank ? 1 : 0);
+    rac_llm_result_free(&llm_result);
+    return RAC_SUCCESS;
+}
+
 #endif  // RAC_HAVE_PROTOBUF
 
 #if !defined(RAC_HAVE_PROTOBUF)
@@ -490,6 +648,8 @@ rac_result_t rac_rag_session_create_proto(const uint8_t* config_proto_bytes,
         session->embedding_model_id = embedding_model_id;
         session->llm_model_id = llm_model_id;
         RAGBackendConfig backend_config = build_backend_config(proto);
+        session->retrieval_top_k = backend_config.top_k;
+        session->rerank = backend_config.rerank;
         // Resolve the dimension without assuming 384. Some providers know it
         // at create time; providers such as QHexRT only know after inference,
         // in which case zero remains the auto sentinel and RAGBackend binds the
@@ -666,135 +826,85 @@ rac_result_t rac_rag_query_proto(rac_handle_t session, const uint8_t* query_prot
                                           "RAGQueryOptions.question is required");
     }
 
-    const std::string system_prompt =
-        query_proto.has_system_prompt() ? query_proto.system_prompt() : std::string();
-
-    // Base off RAC_LLM_OPTIONS_DEFAULT so the sampling fields RAGQueryOptions
-    // does not expose (repetition_penalty, min_p, seed, grammar, ...) carry the
-    // proto-documented disabled/default sentinels instead of a raw zero-init.
-    rac_llm_options_t opts = RAC_LLM_OPTIONS_DEFAULT;
-    opts.max_tokens = query_proto.max_tokens() > 0 ? query_proto.max_tokens() : 512;
-    // 0.0 is the documented greedy value, not an "unset" sentinel. SDK
-    // defaults materialize 0.7 explicitly, so preserve an explicit zero all
-    // the way to the provider for deterministic production RAG answers.
-    opts.temperature = query_proto.temperature();
-    opts.top_p = query_proto.top_p() > 0.0f ? query_proto.top_p() : 0.9f;
-    // commons-030-A: RAGQueryOptions.top_k (idl/rag.proto:55) was silently
-    // dropped; thread it through. 0 = disabled (engine default).
-    opts.top_k = query_proto.top_k();
-    // Thread the structured thinking-suppression flag so commons prepends the
-    // no-think directive instead of the app injecting "/no_think" into the query.
-    opts.disable_thinking = query_proto.disable_thinking() ? RAC_TRUE : RAC_FALSE;
-    opts.system_prompt = system_prompt.empty() ? nullptr : system_prompt.c_str();
-
-    // Per-query retrieval overrides from RAGQueryOptions (idl/rag.proto:180-183).
-    // Zero values fall back to the session-level RAGConfig defaults inside
-    // RAGBackend::query so legacy callers behave as before.
-    RAGBackend::QueryOverrides overrides;
-    overrides.retrieval_top_k = query_proto.retrieval_top_k();
-    overrides.has_similarity_threshold = query_proto.has_similarity_threshold();
-    overrides.similarity_threshold = query_proto.similarity_threshold();
-    overrides.enable_multi_query = query_proto.enable_multi_query();
-    // Clamp to a sane ceiling: each variant triggers an extra LLM rewrite +
-    // retrieval pass, so an unbounded value would let a caller fan out into
-    // arbitrarily many inference passes. 0 = use the session default; values
-    // <= 0 are treated as "use default" downstream (RAGBackend::query).
-    constexpr int32_t kMaxMultiQueryCount = 8;
-    if (query_proto.has_multi_query_count()) {
-        const int32_t n = query_proto.multi_query_count();
-        overrides.multi_query_count = n > kMaxMultiQueryCount ? kMaxMultiQueryCount : n;
-    } else {
-        overrides.multi_query_count = 0;
-    }
-    if (query_proto.has_scope_prefix())
-        overrides.scope_prefix = query_proto.scope_prefix();
-
-    publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_RAG_QUERY_STARTED,
-                       "rag.query", 0.0f, 1, 0, nullptr, 0.0,
-                       s->llm_model_id.empty() ? s->embedding_model_id.c_str()
-                                               : s->llm_model_id.c_str());
-
-    const auto t_start = std::chrono::high_resolution_clock::now();
-    rac_llm_result_t llm_result = {};
-    nlohmann::json metadata;
-    rac_result_t status = RAC_SUCCESS;
-    try {
-        status = s->backend->query(question, &opts, &llm_result, metadata, nullptr, &overrides);
-    } catch (const std::exception& e) {
-        LOGE("rag.query exception: %s", e.what());
-        rac_llm_result_free(&llm_result);
-        publish_failure(RAC_ERROR_PROCESSING_FAILED, "rag.query", e.what());
-        return rac_proto_buffer_set_error(out_result, RAC_ERROR_PROCESSING_FAILED, e.what());
-    }
-    const auto t_end = std::chrono::high_resolution_clock::now();
-    const double total_ms = std::chrono::duration<double, std::milli>(t_end - t_start).count();
-
+    runanywhere::v1::RAGResult proto;
+    std::string err_msg;
+    const rac_result_t status = execute_rag_query(s, query_proto, nullptr, &proto, &err_msg);
     if (status != RAC_SUCCESS) {
-        rac_llm_result_free(&llm_result);
-        publish_failure(status, "rag.query", rac_error_message(status));
-        return rac_proto_buffer_set_error(out_result, status, rac_error_message(status));
+        return rac_proto_buffer_set_error(
+            out_result, status, err_msg.empty() ? rac_error_message(status) : err_msg.c_str());
     }
+    return copy_proto(proto, out_result);
+#endif
+}
+
+rac_result_t rac_rag_query_stream_proto(rac_handle_t session, const uint8_t* query_proto_bytes,
+                                        size_t query_proto_size,
+                                        rac_rag_stream_proto_callback_fn callback, void* user_data) {
+#if !defined(RAC_HAVE_PROTOBUF)
+    (void)session;
+    (void)query_proto_bytes;
+    (void)query_proto_size;
+    (void)callback;
+    (void)user_data;
+    return RAC_ERROR_FEATURE_NOT_AVAILABLE;
+#else
+    if (!callback)
+        return RAC_ERROR_NULL_POINTER;
+    const auto s = acquire_session(session);
+    if (!s || !s->backend) {
+        publish_failure(RAC_ERROR_COMPONENT_NOT_READY, "rag.query", "RAG session is not loaded");
+        return RAC_ERROR_COMPONENT_NOT_READY;
+    }
+    if (!valid_bytes(query_proto_bytes, query_proto_size))
+        return RAC_ERROR_DECODING_ERROR;
+    runanywhere::v1::RAGQueryOptions query_proto;
+    if (!query_proto.ParseFromArray(parse_data(query_proto_bytes, query_proto_size),
+                                    static_cast<int>(query_proto_size)))
+        return RAC_ERROR_DECODING_ERROR;
+    if (query_proto.question().empty())
+        return RAC_ERROR_INVALID_ARGUMENT;
+
+    // Serializes one RAGStreamEvent and hands it to the SDK callback. Runs on the
+    // calling thread (the pipeline invokes on_token synchronously).
+    uint64_t seq = 0;
+    auto emit = [&](runanywhere::v1::RAGStreamEventKind kind, const std::string* token,
+                    const runanywhere::v1::RAGResult* result, rac_result_t err_code,
+                    const char* err_msg) {
+        runanywhere::v1::RAGStreamEvent ev;
+        ev.set_seq(seq++);
+        ev.set_timestamp_us(now_ms() * 1000);
+        ev.set_kind(kind);
+        if (token != nullptr)
+            ev.set_token(*token);
+        if (result != nullptr)
+            *ev.mutable_result() = *result;
+        if (err_msg != nullptr && err_msg[0] != '\0') {
+            ev.set_error_message(err_msg);
+            ev.set_error_code(static_cast<int32_t>(err_code));
+        }
+        std::string bytes;
+        if (ev.SerializeToString(&bytes)) {
+            callback(reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size(), user_data);
+        }
+    };
+
+    auto on_token = [&](const std::string& tok) -> bool {
+        emit(runanywhere::v1::RAG_STREAM_EVENT_KIND_TOKEN, &tok, nullptr, RAC_SUCCESS, nullptr);
+        // Cancellation is driven by rac_rag_cancel_proto() latching the pipeline's
+        // atomic; the graph stops between phases, so on_token always continues.
+        return true;
+    };
 
     runanywhere::v1::RAGResult proto;
-    const char* raw_answer = llm_result.text ? llm_result.text : "";
-    const char* answer = nullptr;
-    size_t answer_len = 0;
-    const char* thinking = nullptr;
-    size_t thinking_len = 0;
-    std::string thinking_open_tag;
-    std::string thinking_close_tag;
-    (void)rac::llm::model_thinking_tags_from_registry(s->llm_model_id.c_str(), &thinking_open_tag,
-                                                      &thinking_close_tag);
-    if (rac_llm_extract_thinking_with_tags(
-            raw_answer, thinking_open_tag.empty() ? nullptr : thinking_open_tag.c_str(),
-            thinking_close_tag.empty() ? nullptr : thinking_close_tag.c_str(), &answer, &answer_len,
-            &thinking, &thinking_len) == RAC_SUCCESS) {
-        proto.set_answer(answer ? std::string(answer, answer_len) : std::string());
-        if (thinking && thinking_len > 0) {
-            proto.set_thinking_content(std::string(thinking, thinking_len));
-        }
-    } else if (llm_result.text) {
-        proto.set_answer(llm_result.text);
+    std::string err_msg;
+    const rac_result_t status = execute_rag_query(s, query_proto, on_token, &proto, &err_msg);
+    if (status != RAC_SUCCESS) {
+        emit(runanywhere::v1::RAG_STREAM_EVENT_KIND_ERROR, nullptr, nullptr, status,
+             err_msg.empty() ? rac_error_message(status) : err_msg.c_str());
+        return status;
     }
-
-    if (metadata.contains("context_used") && metadata["context_used"].is_string()) {
-        proto.set_context_used(metadata["context_used"].get<std::string>());
-    }
-
-    if (metadata.contains("sources") && metadata["sources"].is_array()) {
-        for (const auto& s_item : metadata["sources"]) {
-            auto* chunk = proto.add_retrieved_chunks();
-            if (s_item.contains("id") && s_item["id"].is_string()) {
-                chunk->set_chunk_id(s_item["id"].get<std::string>());
-            }
-            if (s_item.contains("text") && s_item["text"].is_string()) {
-                chunk->set_text(s_item["text"].get<std::string>());
-            }
-            if (s_item.contains("score") && s_item["score"].is_number()) {
-                chunk->set_similarity_score(s_item["score"].get<float>());
-            }
-            if (s_item.contains("source_document") && s_item["source_document"].is_string()) {
-                chunk->set_source_document(s_item["source_document"].get<std::string>());
-            } else if (s_item.contains("source") && s_item["source"].is_string()) {
-                chunk->set_source_document(s_item["source"].get<std::string>());
-            }
-        }
-    }
-
-    const double generation_ms = llm_result.total_time_ms;
-    const double retrieval_ms = std::max(0.0, total_ms - generation_ms);
-    proto.set_retrieval_time_ms(static_cast<int64_t>(retrieval_ms));
-    proto.set_generation_time_ms(static_cast<int64_t>(generation_ms));
-    proto.set_total_time_ms(static_cast<int64_t>(total_ms));
-
-    rac_result_t rc = copy_proto(proto, out_result);
-    publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_RAG_QUERY_COMPLETED,
-                       "rag.query", 1.0f, 1, proto.retrieved_chunks_size(), nullptr, total_ms,
-                       s->llm_model_id.empty() ? s->embedding_model_id.c_str()
-                                               : s->llm_model_id.c_str(),
-                       query_proto.top_k(), retrieval_ms, s->embedding_model_id.c_str());
-    rac_llm_result_free(&llm_result);
-    return rc;
+    emit(runanywhere::v1::RAG_STREAM_EVENT_KIND_COMPLETED, nullptr, &proto, RAC_SUCCESS, nullptr);
+    return RAC_SUCCESS;
 #endif
 }
 

--- a/sdk/runanywhere-commons/src/features/rag/rac_rag_proto_abi.cpp
+++ b/sdk/runanywhere-commons/src/features/rag/rac_rag_proto_abi.cpp
@@ -839,7 +839,7 @@ rac_result_t rac_rag_query_proto(rac_handle_t session, const uint8_t* query_prot
 
 rac_result_t rac_rag_query_stream_proto(rac_handle_t session, const uint8_t* query_proto_bytes,
                                         size_t query_proto_size,
-                                        rac_rag_stream_proto_callback_fn callback, void* user_data) {
+                                        rac_rag_stream_proto_callback_t callback, void* user_data) {
 #if !defined(RAC_HAVE_PROTOBUF)
     (void)session;
     (void)query_proto_bytes;
@@ -867,9 +867,11 @@ rac_result_t rac_rag_query_stream_proto(rac_handle_t session, const uint8_t* que
     // Serializes one RAGStreamEvent and hands it to the SDK callback. Runs on the
     // calling thread (the pipeline invokes on_token synchronously).
     uint64_t seq = 0;
+    // Returns true to keep generating; false when the SDK callback asked to stop
+    // (backpressure / early stop). Terminal emits ignore the return.
     auto emit = [&](runanywhere::v1::RAGStreamEventKind kind, const std::string* token,
                     const runanywhere::v1::RAGResult* result, rac_result_t err_code,
-                    const char* err_msg) {
+                    const char* err_msg) -> bool {
         runanywhere::v1::RAGStreamEvent ev;
         ev.set_seq(seq++);
         ev.set_timestamp_us(now_ms() * 1000);
@@ -883,27 +885,30 @@ rac_result_t rac_rag_query_stream_proto(rac_handle_t session, const uint8_t* que
             ev.set_error_code(static_cast<int32_t>(err_code));
         }
         std::string bytes;
-        if (ev.SerializeToString(&bytes)) {
-            callback(reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size(), user_data);
-        }
+        if (!ev.SerializeToString(&bytes))
+            return true;
+        return callback(reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size(), user_data) ==
+               RAC_TRUE;
     };
 
     auto on_token = [&](const std::string& tok) -> bool {
-        emit(runanywhere::v1::RAG_STREAM_EVENT_KIND_TOKEN, &tok, nullptr, RAC_SUCCESS, nullptr);
-        // Cancellation is driven by rac_rag_cancel_proto() latching the pipeline's
-        // atomic; the graph stops between phases, so on_token always continues.
-        return true;
+        // Propagate the SDK callback's stop request: a false return halts token
+        // generation and the run ends with a terminal COMPLETED (partial answer).
+        // Cancellation via rac_rag_cancel_proto() still latches the pipeline atomic.
+        return emit(runanywhere::v1::RAG_STREAM_EVENT_KIND_TOKEN, &tok, nullptr, RAC_SUCCESS,
+                    nullptr);
     };
 
     runanywhere::v1::RAGResult proto;
     std::string err_msg;
     const rac_result_t status = execute_rag_query(s, query_proto, on_token, &proto, &err_msg);
     if (status != RAC_SUCCESS) {
-        emit(runanywhere::v1::RAG_STREAM_EVENT_KIND_ERROR, nullptr, nullptr, status,
-             err_msg.empty() ? rac_error_message(status) : err_msg.c_str());
+        (void)emit(runanywhere::v1::RAG_STREAM_EVENT_KIND_ERROR, nullptr, nullptr, status,
+                   err_msg.empty() ? rac_error_message(status) : err_msg.c_str());
         return status;
     }
-    emit(runanywhere::v1::RAG_STREAM_EVENT_KIND_COMPLETED, nullptr, &proto, RAC_SUCCESS, nullptr);
+    (void)emit(runanywhere::v1::RAG_STREAM_EVENT_KIND_COMPLETED, nullptr, &proto, RAC_SUCCESS,
+               nullptr);
     return RAC_SUCCESS;
 #endif
 }

--- a/sdk/runanywhere-commons/src/features/stt/stt_module.cpp
+++ b/sdk/runanywhere-commons/src/features/stt/stt_module.cpp
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <new>
 #include <random>
+#include <map>
 #include <string>
 #include <thread>
 #include <unordered_map>
@@ -609,9 +610,22 @@ void publish_stt_lifecycle_event(runanywhere::v1::VoiceEventKind kind, const cha
         voice.set_framework(rac::events::framework_to_proto_int(fw));
     }
     voice.set_is_streaming(is_streaming);
+    // Plain (non-hybrid) STT attribution: the model that served it, with no
+    // fallback and a single attempt. The hybrid router overrides these via its
+    // own emit; here they fill the STT row's routed_backend/was_fallback/
+    // attempt_count columns instead of leaving them null. Only on a successful
+    // transcription (a start/failure carries no routing outcome).
+    std::map<std::string, std::string> props;
+    if (kind == runanywhere::v1::VOICE_EVENT_KIND_STT_COMPLETED && model_id != nullptr &&
+        model_id[0] != '\0') {
+        props["routed_backend"] = model_id;
+        props["was_fallback"] = "0";
+        props["attempt_count"] = "1";
+    }
     rac::events::publish_with_session(runanywhere::v1::SDK_COMPONENT_STT,
                                       runanywhere::v1::EVENT_CATEGORY_STT, std::move(voice),
-                                      transcription_id);
+                                      transcription_id, runanywhere::v1::EVENT_DESTINATION_UNSPECIFIED,
+                                      props.empty() ? nullptr : &props);
 }
 
 #endif  // RAC_HAVE_PROTOBUF

--- a/sdk/runanywhere-commons/src/features/vlm/vlm_module.cpp
+++ b/sdk/runanywhere-commons/src/features/vlm/vlm_module.cpp
@@ -906,7 +906,8 @@ void publish_capability(runanywhere::v1::CapabilityOperationEventKind kind, cons
                         double tokens_per_second = 0.0, double ttft_ms = 0.0,
                         const char* framework = nullptr, double temperature = -1.0,
                         int32_t max_tokens = 0, int64_t vision_tokens = 0,
-                        double vision_encode_ms = 0.0, const char* image_resolution = nullptr) {
+                        double vision_encode_ms = 0.0, const char* image_resolution = nullptr,
+                        int32_t context_length = 0) {
     runanywhere::v1::SDKEvent event;
     populate_envelope(&event, (error != nullptr && error[0] != '\0')
                                   ? runanywhere::v1::ERROR_SEVERITY_ERROR
@@ -965,6 +966,9 @@ void publish_capability(runanywhere::v1::CapabilityOperationEventKind kind, cons
     }
     if (image_resolution != nullptr && image_resolution[0] != '\0') {
         (*event.mutable_properties())["image_resolution"] = image_resolution;
+    }
+    if (context_length > 0) {
+        (*event.mutable_properties())["context_length"] = std::to_string(context_length);
     }
     publish_event(event);
 }
@@ -1253,7 +1257,9 @@ rac_result_t rac_vlm_generate_proto(const uint8_t* request_proto_bytes, size_t r
 
     rac::vlm::clear_lifecycle_vlm_cancel(&ref);
     publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_VLM_STARTED, "vlm.generate",
-                       0.0f, 1, 0, nullptr, 0.0, ref.model_id);
+                       0.0f, 1, 0, nullptr, 0.0, ref.model_id, /*input_tokens=*/0,
+                       /*total_tokens=*/0, /*tokens_per_second=*/0.0, /*ttft_ms=*/0.0,
+                       ref.framework_name);
 
     rac_vlm_result_t raw = {};
     rc = (ref.ops && ref.ops->process) ? ref.ops->process(ref.impl, &image, prompt, &options, &raw)
@@ -1274,10 +1280,14 @@ rac_result_t rac_vlm_generate_proto(const uint8_t* request_proto_bytes, size_t r
     } else {
         rc = copy_proto(result, out_result);
     }
-    const std::string vlm_gen_res =
-        (image.width > 0 && image.height > 0)
-            ? std::to_string(image.width) + "x" + std::to_string(image.height)
-            : std::string();
+    // Prefer the decoded dimensions from the backend (the caller's rac_vlm_image
+    // carries no dims for encoded inputs); fall back to any caller-supplied dims.
+    const int32_t res_w = raw.image_width > 0 ? raw.image_width : static_cast<int32_t>(image.width);
+    const int32_t res_h =
+        raw.image_height > 0 ? raw.image_height : static_cast<int32_t>(image.height);
+    const std::string vlm_gen_res = (res_w > 0 && res_h > 0)
+                                        ? std::to_string(res_w) + "x" + std::to_string(res_h)
+                                        : std::string();
     publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_VLM_COMPLETED,
                        "vlm.generate", 1.0f, 1, result.completion_tokens(), nullptr,
                        static_cast<double>(result.processing_time_ms()), ref.model_id,
@@ -1286,7 +1296,7 @@ rac_result_t rac_vlm_generate_proto(const uint8_t* request_proto_bytes, size_t r
                        static_cast<double>(result.time_to_first_token_ms()), ref.framework_name,
                        static_cast<double>(options.temperature), options.max_tokens,
                        result.image_tokens(), static_cast<double>(result.image_encode_time_ms()),
-                       vlm_gen_res.empty() ? nullptr : vlm_gen_res.c_str());
+                       vlm_gen_res.empty() ? nullptr : vlm_gen_res.c_str(), raw.context_length);
     rac_vlm_result_free(&raw);
     free_vlm_image(&image);
     rac_free(const_cast<char*>(prompt));
@@ -1352,7 +1362,9 @@ rac_result_t rac_vlm_stream_proto(const uint8_t* request_proto_bytes, size_t req
 
     rac::vlm::clear_lifecycle_vlm_cancel(&ref);
     publish_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_VLM_STARTED, "vlm.stream",
-                       0.0f, 1, 0, nullptr, 0.0, ref.model_id);
+                       0.0f, 1, 0, nullptr, 0.0, ref.model_id, /*input_tokens=*/0,
+                       /*total_tokens=*/0, /*tokens_per_second=*/0.0, /*ttft_ms=*/0.0,
+                       ref.framework_name);
 
     GeneratedStreamCtx ctx;
     ctx.callback = callback;

--- a/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_d7_abi.cpp
+++ b/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_d7_abi.cpp
@@ -474,9 +474,10 @@ rac_result_t d7_process_utterance(rac_voice_agent_handle_t handle, const std::st
         std::string framework;
         int32_t transcript_chars = 0;
         int32_t response_chars = 0;
+        int32_t turn_index = 0;
+        bool armed = false;
         rac_result_t error_code = RAC_SUCCESS;
         std::string error_message;
-        bool armed = false;
         ~TurnMetricsGuard() {
             if (!armed)
                 return;
@@ -488,10 +489,12 @@ rac_result_t d7_process_utterance(rac_voice_agent_handle_t handle, const std::st
                 session_id.empty() ? nullptr : session_id.c_str(),
                 model_id.empty() ? nullptr : model_id.c_str(),
                 framework.empty() ? nullptr : framework.c_str(), transcript_chars, response_chars,
-                error_code, error_message.empty() ? nullptr : error_message.c_str());
+                turn_index, error_code == RAC_ERROR_CANCELLED ? RAC_TRUE : RAC_FALSE, error_code,
+                error_message.empty() ? nullptr : error_message.c_str());
         }
     } turn_metrics;
     turn_metrics.session_id = session_id;
+    turn_metrics.turn_index = handle->turn_counter.fetch_add(1, std::memory_order_relaxed);
 
     std::lock_guard<std::mutex> lock(handle->mutex);
 

--- a/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_internal.h
+++ b/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_internal.h
@@ -137,6 +137,11 @@ struct rac_voice_agent {
     /// agent remembers context across turns. Bounded to the last
     /// kVoiceAgentMaxHistoryEntries flattened entries. Guarded by `mutex`.
     std::vector<VoiceConversationTurn> conversation_history;
+
+    /// Monotonic 0-based turn counter for this agent, stamped onto each turn's
+    /// telemetry (voice_telemetry.turn_index). Atomic so it can be read without
+    /// holding `mutex`.
+    std::atomic<int32_t> turn_counter{0};
 };
 
 #endif  // RAC_FEATURES_VOICE_AGENT_VOICE_AGENT_INTERNAL_H

--- a/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_internal_helpers.cpp
+++ b/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_internal_helpers.cpp
@@ -267,6 +267,7 @@ void publish_voice_turn_metrics(double stt_ms, double llm_ms, double tts_ms, dou
                                 int64_t tokens_generated, const char* session_id,
                                 const char* model_id, const char* framework,
                                 int32_t transcript_chars, int32_t response_chars,
+                                int32_t turn_index, rac_bool_t interrupted,
                                 rac_result_t error_code, const char* error_message) {
     const bool failed = (error_code != RAC_SUCCESS);
     runanywhere::v1::SDKEvent sdk_event;
@@ -298,6 +299,11 @@ void publish_voice_turn_metrics(double stt_ms, double llm_ms, double tts_ms, dou
     if (response_chars > 0) {
         (*sdk_event.mutable_properties())["response_chars"] = std::to_string(response_chars);
     }
+    // turn_index is 0-based (0 is valid) so always carry it; interrupted flags a
+    // caller cancel / barge-out. Both ride the properties carrier (MetricsEvent
+    // has no field for them) and are read back in the telemetry kMetrics arm.
+    (*sdk_event.mutable_properties())["turn_index"] = std::to_string(turn_index);
+    (*sdk_event.mutable_properties())["interrupted"] = interrupted != RAC_FALSE ? "1" : "0";
 
     auto* vp = sdk_event.mutable_voice_pipeline();
     vp->set_timestamp_us(rac_get_current_time_ms() * 1000);

--- a/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_internal_helpers.h
+++ b/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_internal_helpers.h
@@ -141,7 +141,8 @@ void publish_voice_turn_metrics(double stt_ms, double llm_ms, double tts_ms, dou
                                 int64_t tokens_generated, const char* session_id,
                                 const char* model_id, const char* framework,
                                 int32_t transcript_chars, int32_t response_chars,
-                                rac_result_t error_code, const char* error_message);
+                                int32_t turn_index, rac_bool_t interrupted, rac_result_t error_code,
+                                const char* error_message);
 
 // Translate a proto `VoiceAgentComposeConfig` into the C ABI
 // `rac_voice_agent_config_t`. The returned config aliases string pointers

--- a/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_proto_abi.cpp
+++ b/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_proto_abi.cpp
@@ -301,6 +301,8 @@ rac_result_t rac_voice_agent_process_voice_turn_proto(rac_voice_agent_handle_t h
     rac_result_t rc = RAC_SUCCESS;
     std::string error_message;
     rac_result_t error_code = RAC_SUCCESS;
+    // Monotonic 0-based turn index for this agent, stamped onto the turn metrics.
+    const int32_t turn_index = handle->turn_counter.fetch_add(1, std::memory_order_relaxed);
 
     // Per-turn timing for the telemetry MetricsEvent, read at both exits below.
     // Declared here (function scope) so the cleanup_and_return path can publish
@@ -567,7 +569,8 @@ rac_result_t rac_voice_agent_process_voice_turn_proto(rac_voice_agent_handle_t h
                                /*session_id=*/nullptr,
                                turn_model_id.empty() ? nullptr : turn_model_id.c_str(),
                                turn_framework.empty() ? nullptr : turn_framework.c_str(),
-                               turn_transcript_chars, turn_response_chars, RAC_SUCCESS, nullptr);
+                               turn_transcript_chars, turn_response_chars, turn_index,
+                               /*interrupted=*/RAC_FALSE, RAC_SUCCESS, nullptr);
     return copy_proto_message(result, out_result);
 
 cleanup_and_return:
@@ -576,7 +579,9 @@ cleanup_and_return:
         stt_ms, llm_ms, tts_ms, ms_since(turn_start), turn_tokens,
         /*session_id=*/nullptr, turn_model_id.empty() ? nullptr : turn_model_id.c_str(),
         turn_framework.empty() ? nullptr : turn_framework.c_str(), turn_transcript_chars,
-        turn_response_chars, error_code, error_message.c_str());
+        turn_response_chars, turn_index,
+        error_code == RAC_ERROR_CANCELLED ? RAC_TRUE : RAC_FALSE, error_code,
+        error_message.c_str());
     return rac_proto_buffer_set_error(out_result, error_code, error_message.c_str());
 #endif
 }

--- a/sdk/runanywhere-commons/src/infrastructure/events/sdk_event_publish.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/events/sdk_event_publish.cpp
@@ -235,7 +235,8 @@ rac_result_t publish_with_session(runanywhere::v1::SDKComponent component,
                                   runanywhere::v1::EventCategory category,
                                   runanywhere::v1::VoiceLifecycleEvent payload,
                                   const char* session_id,
-                                  runanywhere::v1::EventDestination destination) {
+                                  runanywhere::v1::EventDestination destination,
+                                  const std::map<std::string, std::string>* extra_properties) {
     runanywhere::v1::SDKEvent event;
     *event.mutable_voice() = std::move(payload);
     if (session_id != nullptr && session_id[0] != '\0') {
@@ -243,6 +244,11 @@ rac_result_t publish_with_session(runanywhere::v1::SDKComponent component,
     }
     if (destination != runanywhere::v1::EVENT_DESTINATION_UNSPECIFIED) {
         event.set_destination(destination);
+    }
+    if (extra_properties != nullptr) {
+        for (const auto& kv : *extra_properties) {
+            (*event.mutable_properties())[kv.first] = kv.second;
+        }
     }
     return publish(event, component, category);
 }

--- a/sdk/runanywhere-commons/src/infrastructure/events/sdk_event_publish.h
+++ b/sdk/runanywhere-commons/src/infrastructure/events/sdk_event_publish.h
@@ -24,6 +24,8 @@
 
 #include <cstddef>
 #include <cstdint>
+#include <map>
+#include <string>
 
 #include "rac/core/rac_error.h"
 #include "rac/infrastructure/model_management/rac_model_types.h"
@@ -202,7 +204,8 @@ rac_result_t publish_with_session(
 rac_result_t publish_with_session(
     runanywhere::v1::SDKComponent component, runanywhere::v1::EventCategory category,
     runanywhere::v1::VoiceLifecycleEvent payload, const char* session_id,
-    runanywhere::v1::EventDestination destination = runanywhere::v1::EVENT_DESTINATION_UNSPECIFIED);
+    runanywhere::v1::EventDestination destination = runanywhere::v1::EVENT_DESTINATION_UNSPECIFIED,
+    const std::map<std::string, std::string>* extra_properties = nullptr);
 
 // ---------------------------------------------------------------------------
 // Destination router. Called by publish() after the PUBLIC proto stream has

--- a/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_json.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_json.cpp
@@ -265,7 +265,11 @@ rac_result_t rac_telemetry_manager_payload_to_json(const rac_telemetry_payload_t
     json.add_string("platform", payload->platform);
     json.add_string("sdk_version", payload->sdk_version);
 
-    json.add_double("processing_time_ms", payload->processing_time_ms);
+    // processing_time_ms: emit as a real value (including a measured 0 ms) when a
+    // duration was actually captured, else null. A plain add_double would drop a
+    // genuine 0 ms (e.g. a sub-millisecond SDK init span) as if it were unset.
+    json.add_double_or_null("processing_time_ms", payload->processing_time_ms,
+                            payload->has_processing_time_ms != RAC_FALSE);
     json.add_bool("success", payload->success, payload->has_success);
     json.add_string("error_message", payload->error_message);
     json.add_string("error_code", payload->error_code);
@@ -291,6 +295,10 @@ rac_result_t rac_telemetry_manager_payload_to_json(const rac_telemetry_payload_t
         json.add_double("confidence", payload->confidence);
         json.add_string("language", payload->language);
         json.add_int("segment_index", payload->segment_index);
+        // Hybrid STT router attribution (null on plain single-backend STT).
+        json.add_string("routed_backend", payload->routed_backend);
+        json.add_bool("was_fallback", payload->was_fallback, payload->has_was_fallback);
+        json.add_int("attempt_count", payload->attempt_count);
     } else if (strcmp(modality, "tts") == 0) {
         json.add_int("character_count", payload->character_count);
         json.add_double("characters_per_second", payload->characters_per_second);
@@ -325,6 +333,7 @@ rac_result_t rac_telemetry_manager_payload_to_json(const rac_telemetry_payload_t
         json.add_int("top_k", payload->top_k);
         json.add_double("retrieval_time_ms", payload->retrieval_time_ms);
         json.add_string("embedding_model", payload->embedding_model);
+        json.add_bool("reranker_used", payload->reranker_used, payload->has_reranker_used);
     } else if (strcmp(modality, "embeddings") == 0) {
         // input_count / vectors_produced / embedding_model / embedding_dimension
         // have sources today (dimension via the properties carrier).
@@ -341,6 +350,9 @@ rac_result_t rac_telemetry_manager_payload_to_json(const rac_telemetry_payload_t
         json.add_double("total_ms", payload->voice_total_ms);
         json.add_int("transcript_chars", payload->transcript_chars);
         json.add_int("response_chars", payload->response_chars);
+        json.add_int_or_null("turn_index", payload->turn_index,
+                             payload->has_turn_index != RAC_FALSE);
+        json.add_bool("interrupted", payload->voice_interrupted, payload->has_voice_interrupted);
     } else if (strcmp(modality, "vad") == 0) {
         json.add_double("speech_duration_ms", payload->speech_duration_ms);
         json.add_double("silence_duration_ms", payload->silence_duration_ms);

--- a/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_manager.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_manager.cpp
@@ -143,6 +143,7 @@ void free_payload_strings(rac_telemetry_payload_t& event) {
     free((void*)event.image_resolution);
     free((void*)event.scheduler);
     free((void*)event.output_format);
+    free((void*)event.routed_backend);
 }
 
 #if defined(RAC_HAVE_PROTOBUF)
@@ -380,6 +381,7 @@ rac_result_t rac_telemetry_manager_track(rac_telemetry_manager_t* manager,
     copy.image_resolution = dup_string(payload->image_resolution);
     copy.scheduler = dup_string(payload->scheduler);
     copy.output_format = dup_string(payload->output_format);
+    copy.routed_backend = dup_string(payload->routed_backend);
 
     {
         std::lock_guard<std::mutex> lock(manager->queue_mutex);
@@ -548,10 +550,18 @@ std::string proto_event_type_string(const SDKEvent& ev, bool& out_is_completion)
                 case runanywhere::v1::VOICE_EVENT_KIND_VAD_STARTED:
                     return "vad.started";
                 case runanywhere::v1::VOICE_EVENT_KIND_VAD_STOPPED:
+                    // Terminal VAD-session event — flush promptly so it is not
+                    // stranded in the queue when the screen tears down.
+                    out_is_completion = true;
                     return "vad.stopped";
                 case runanywhere::v1::VOICE_EVENT_KIND_SPEECH_STARTED:
                     return "vad.speech.started";
                 case runanywhere::v1::VOICE_EVENT_KIND_SPEECH_ENDED:
+                    // Terminal per-utterance event carrying speech_duration/silence
+                    // /segment_count. It is emitted right as VAD stops/resets, so
+                    // without an immediate flush the queued row never reaches the
+                    // backend (vad.speech.ended had 0 rows). Flag it a completion.
+                    out_is_completion = true;
                     return "vad.speech.ended";
                 case runanywhere::v1::VOICE_EVENT_KIND_VAD_PAUSED:
                     return "vad.paused";
@@ -911,6 +921,7 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
             const double dur =
                 g.duration_ms() != 0.0 ? g.duration_ms() : static_cast<double>(g.latency_ms());
             payload.processing_time_ms = dur;
+            payload.has_processing_time_ms = RAC_TRUE;
             payload.generation_time_ms = dur;
             payload.tokens_per_second = g.tokens_per_second();
             payload.time_to_first_token_ms = g.time_to_first_token_ms() != 0
@@ -949,6 +960,7 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
                                      : (!m.model_id().empty() ? m.model_id().c_str() : nullptr);
             payload.model_size_bytes = m.model_size_bytes();
             payload.processing_time_ms = static_cast<double>(m.duration_ms());
+            payload.has_processing_time_ms = RAC_TRUE;
             framework_str = framework_proto_to_string(m.framework());
             payload.framework = framework_str.c_str();
             // archive_type has no ModelEvent field; rides the properties carrier.
@@ -979,6 +991,7 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
                                          ? v.model_name().c_str()
                                          : (!v.model_id().empty() ? v.model_id().c_str() : nullptr);
                 payload.processing_time_ms = static_cast<double>(v.duration_ms());
+                payload.has_processing_time_ms = RAC_TRUE;
                 payload.audio_duration_ms = static_cast<double>(v.audio_length_ms());
                 payload.audio_size_bytes = v.audio_size_bytes();
                 payload.word_count = v.word_count();
@@ -991,6 +1004,24 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
                 payload.has_is_streaming = RAC_TRUE;
                 framework_str = framework_proto_to_string(v.framework());
                 payload.framework = framework_str.c_str();
+                // Hybrid STT router attribution rides the envelope properties
+                // carrier (VoiceLifecycleEvent has no field for it); present only
+                // on the hybrid transcribe path.
+                {
+                    auto rb_it = ev.properties().find("routed_backend");
+                    if (rb_it != ev.properties().end() && !rb_it->second.empty()) {
+                        payload.routed_backend = rb_it->second.c_str();
+                    }
+                    auto wf_it = ev.properties().find("was_fallback");
+                    if (wf_it != ev.properties().end()) {
+                        payload.was_fallback = wf_it->second == "1" ? RAC_TRUE : RAC_FALSE;
+                        payload.has_was_fallback = RAC_TRUE;
+                    }
+                    auto ac_it = ev.properties().find("attempt_count");
+                    if (ac_it != ev.properties().end()) {
+                        payload.attempt_count = std::atoi(ac_it->second.c_str());
+                    }
+                }
                 if (v.kind() == runanywhere::v1::VOICE_EVENT_KIND_STT_COMPLETED &&
                     !ev.has_error()) {
                     payload.success = RAC_TRUE;
@@ -1008,6 +1039,7 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
                 payload.output_duration_ms = static_cast<double>(v.audio_duration_ms());
                 payload.audio_size_bytes = v.audio_size_bytes_tts();
                 payload.processing_time_ms = static_cast<double>(v.processing_duration_ms());
+                payload.has_processing_time_ms = RAC_TRUE;
                 payload.characters_per_second = v.characters_per_second();
                 payload.sample_rate = v.sample_rate();
                 framework_str = framework_proto_to_string(v.framework());
@@ -1072,6 +1104,7 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
                     const double dur = std::atof(it->second.c_str());
                     if (dur > 0.0) {
                         payload.processing_time_ms = dur;
+                        payload.has_processing_time_ms = RAC_TRUE;
                     }
                 }
             }
@@ -1148,6 +1181,10 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
                     if (mt_it != ev.properties().end()) {
                         payload.max_tokens = std::atoi(mt_it->second.c_str());
                     }
+                    auto cl_it = ev.properties().find("context_length");
+                    if (cl_it != ev.properties().end()) {
+                        payload.context_length = std::atoi(cl_it->second.c_str());
+                    }
                     // Vision-specific metrics ride the properties carrier (no proto fields).
                     auto vt_it = ev.properties().find("vision_tokens");
                     if (vt_it != ev.properties().end()) {
@@ -1180,6 +1217,11 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
                     auto em_it = ev.properties().find("embedding_model");
                     if (em_it != ev.properties().end() && !em_it->second.empty()) {
                         payload.embedding_model = em_it->second.c_str();
+                    }
+                    auto rr_it = ev.properties().find("reranker_used");
+                    if (rr_it != ev.properties().end()) {
+                        payload.reranker_used = rr_it->second == "1" ? RAC_TRUE : RAC_FALSE;
+                        payload.has_reranker_used = RAC_TRUE;
                     }
                     break;
                 }
@@ -1271,6 +1313,7 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
                 payload.voice_tts_ms = m.tts_total_ms();
                 payload.voice_total_ms = m.end_to_end_ms();
                 payload.processing_time_ms = m.end_to_end_ms();
+                payload.has_processing_time_ms = RAC_TRUE;
                 // MetricsEvent has no model/framework/char fields — read them
                 // from the envelope properties carrier set by
                 // publish_voice_turn_metrics. (session_id is read at L761.)
@@ -1291,6 +1334,16 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
                 if (rc_it != ev.properties().end()) {
                     payload.response_chars = std::atoi(rc_it->second.c_str());
                 }
+                auto ti_it = ev.properties().find("turn_index");
+                if (ti_it != ev.properties().end()) {
+                    payload.turn_index = std::atoi(ti_it->second.c_str());
+                    payload.has_turn_index = RAC_TRUE;
+                }
+                auto intr_it = ev.properties().find("interrupted");
+                if (intr_it != ev.properties().end()) {
+                    payload.voice_interrupted = intr_it->second == "1" ? RAC_TRUE : RAC_FALSE;
+                    payload.has_voice_interrupted = RAC_TRUE;
+                }
                 if (!ev.has_error()) {
                     payload.success = RAC_TRUE;
                     payload.has_success = RAC_TRUE;
@@ -1309,6 +1362,9 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
             auto dur_it = ev.properties().find("duration_ms");
             if (dur_it != ev.properties().end()) {
                 payload.processing_time_ms = std::atof(dur_it->second.c_str());
+                // Record even a sub-millisecond (0 ms) init span as a measured
+                // value rather than letting add_double drop it to null.
+                payload.has_processing_time_ms = RAC_TRUE;
             }
             break;
         }
@@ -1334,7 +1390,11 @@ rac_result_t rac_telemetry_manager_track_proto(rac_telemetry_manager_t* manager,
             payload.has_success = RAC_TRUE;
         } else if (ends_with(".completed") || ends_with(".loaded") || ends_with(".deleted") ||
                    ends_with(".cleared") || ends_with(".cleaned") || ends_with(".registered") ||
-                   ends_with(".stopped")) {
+                   ends_with(".stopped") || ends_with(".succeeded") || ends_with(".authenticated") ||
+                   ends_with(".refreshed") || ends_with(".token_refreshed")) {
+            // ".succeeded"/".authenticated"/".refreshed"/".token_refreshed" cover the
+            // auth lifecycle (auth.succeeded, auth.token_refreshed) whose success flag
+            // was otherwise left null on the system row.
             payload.success = RAC_TRUE;
             payload.has_success = RAC_TRUE;
         }

--- a/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_types.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/telemetry/telemetry_types.cpp
@@ -11,6 +11,7 @@
 
 rac_telemetry_payload_t rac_telemetry_payload_default(void) {
     rac_telemetry_payload_t payload = {};
+    payload.has_processing_time_ms = RAC_FALSE;
     payload.success = RAC_FALSE;
     payload.has_success = RAC_FALSE;
     payload.is_streaming = RAC_FALSE;

--- a/sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp
+++ b/sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp
@@ -5564,6 +5564,33 @@ Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racRagQueryRequestProto
     return makeProtoCallResult(env, rc, &result, "racRagQueryRequestProto");
 }
 
+// Streaming RAG query: blocks on the calling (background) thread, invoking the
+// JVM listener with each serialized RAGStreamEvent (TOKEN..., then COMPLETED or
+// ERROR). Mirrors racLlmGenerateStreamProto. Cancellation is via racRagCancelProto
+// (rac_rag_cancel_proto latches the pipeline atomic).
+JNIEXPORT jint JNICALL
+Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racRagQueryStreamProto(
+    JNIEnv* env, jclass clazz, jlong handle, jbyteArray queryProto, jobject listener) {
+    (void)clazz;
+    JByteArrayView query(env, queryProto);
+    if (handle == 0L || !query.ok)
+        return static_cast<jint>(RAC_ERROR_NULL_POINTER);
+    using Fn = rac_result_t (*)(rac_handle_t, const uint8_t*, size_t,
+                                void (*)(const uint8_t*, size_t, void*), void*);
+    Fn streamRag = optionalNativeSymbol<Fn>("rac_rag_query_stream_proto");
+    if (streamRag == nullptr)
+        return static_cast<jint>(RAC_ERROR_FEATURE_NOT_AVAILABLE);
+    jobject globalListener = listener != nullptr ? env->NewGlobalRef(listener) : nullptr;
+    ProtoListenerUserData ctx{.listener = globalListener, .operation = "racRagQueryStreamProto"};
+    rac_result_t rc = streamRag(handleFromJLong(handle), query.u8(), query.size(),
+                                globalListener != nullptr ? proto_void_callback : nullptr,
+                                globalListener != nullptr ? &ctx : nullptr);
+    if (globalListener != nullptr) {
+        env->DeleteGlobalRef(globalListener);
+    }
+    return static_cast<jint>(rc);
+}
+
 JNIEXPORT jint JNICALL Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racRagCancelProto(
     JNIEnv* env, jclass clazz, jlong handle) {
     (void)env;

--- a/sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp
+++ b/sdk/runanywhere-commons/src/jni/runanywhere_commons_jni.cpp
@@ -5566,24 +5566,40 @@ Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racRagQueryRequestProto
 
 // Streaming RAG query: blocks on the calling (background) thread, invoking the
 // JVM listener with each serialized RAGStreamEvent (TOKEN..., then COMPLETED or
-// ERROR). Mirrors racLlmGenerateStreamProto. Cancellation is via racRagCancelProto
-// (rac_rag_cancel_proto latches the pipeline atomic).
+// ERROR). Mirrors racLlmGenerateStreamProto. Request-scoped like the unary path:
+// the request relay makes cancellation target this exact stream (via
+// racRagCancelRequestProto) instead of any query on the session, so concurrent
+// collectors cannot cancel each other. The listener returns false to stop early
+// (backpressure), forwarded through proto_bool_callback.
 JNIEXPORT jint JNICALL
-Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racRagQueryStreamProto(
-    JNIEnv* env, jclass clazz, jlong handle, jbyteArray queryProto, jobject listener) {
+Java_com_runanywhere_sdk_native_bridge_RunAnywhereBridge_racRagQueryStreamRequestProto(
+    JNIEnv* env, jclass clazz, jlong requestId, jlong handle, jbyteArray queryProto,
+    jobject listener) {
     (void)clazz;
+    if (requestId <= 0L)
+        return static_cast<jint>(RAC_ERROR_INVALID_STATE);
+    const uint64_t request_id = static_cast<uint64_t>(requestId);
+    const auto start = g_rag_request_relay.start(request_id);
+    if (start != rac::jni::RequestCancellationRelay::StartResult::kRun) {
+        return static_cast<jint>(start == rac::jni::RequestCancellationRelay::StartResult::kCancelled
+                                     ? RAC_ERROR_CANCELLED
+                                     : RAC_ERROR_INVALID_STATE);
+    }
+    rac::jni::RequestCompletionGuard completion(&g_rag_request_relay, request_id);
+
     JByteArrayView query(env, queryProto);
     if (handle == 0L || !query.ok)
         return static_cast<jint>(RAC_ERROR_NULL_POINTER);
     using Fn = rac_result_t (*)(rac_handle_t, const uint8_t*, size_t,
-                                void (*)(const uint8_t*, size_t, void*), void*);
+                                rac_bool_t (*)(const uint8_t*, size_t, void*), void*);
     Fn streamRag = optionalNativeSymbol<Fn>("rac_rag_query_stream_proto");
     if (streamRag == nullptr)
         return static_cast<jint>(RAC_ERROR_FEATURE_NOT_AVAILABLE);
     jobject globalListener = listener != nullptr ? env->NewGlobalRef(listener) : nullptr;
-    ProtoListenerUserData ctx{.listener = globalListener, .operation = "racRagQueryStreamProto"};
+    ProtoListenerUserData ctx{.listener = globalListener,
+                              .operation = "racRagQueryStreamRequestProto"};
     rac_result_t rc = streamRag(handleFromJLong(handle), query.u8(), query.size(),
-                                globalListener != nullptr ? proto_void_callback : nullptr,
+                                globalListener != nullptr ? proto_bool_callback : nullptr,
                                 globalListener != nullptr ? &ctx : nullptr);
     if (globalListener != nullptr) {
         env->DeleteGlobalRef(globalListener);

--- a/sdk/runanywhere-commons/src/router/hybrid/rac_stt_hybrid_router_proto.cpp
+++ b/sdk/runanywhere-commons/src/router/hybrid/rac_stt_hybrid_router_proto.cpp
@@ -75,6 +75,7 @@ void rac_stt_hybrid_router_proto_buffer_free(uint8_t* response_bytes) {
 #include <cmath>
 #include <cstdlib>
 #include <cstring>
+#include <map>
 #include <string>
 #include <vector>
 
@@ -125,8 +126,21 @@ void emit_hybrid_stt_telemetry(const rac_stt_result_t& result,
     if (!ok) {
         voice.set_error(rac_error_message(rc));
     }
+    // routed_backend/was_fallback/attempt_count have no VoiceLifecycleEvent proto
+    // field; carry them on the envelope properties map (same pattern as VAD
+    // silence_duration_ms / RAG top_k). The telemetry manager reads these into the
+    // STT row's dedicated columns.
+    std::map<std::string, std::string> props;
+    if (meta.chosen_model_id[0] != '\0') {
+        props["routed_backend"] = meta.chosen_model_id;
+    }
+    props["was_fallback"] = meta.was_fallback ? "1" : "0";
+    if (meta.attempt_count > 0) {
+        props["attempt_count"] = std::to_string(meta.attempt_count);
+    }
     rac::events::publish_with_session(v1::SDK_COMPONENT_STT, v1::EVENT_CATEGORY_STT,
-                                      std::move(voice), nullptr);
+                                      std::move(voice), nullptr,
+                                      v1::EVENT_DESTINATION_UNSPECIFIED, &props);
 }
 
 void parse_descriptor(const uint8_t* bytes, size_t size, rac_hybrid_model_descriptor_t& out) {

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/foundation/bridge/extensions/CppBridgeRAG.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/foundation/bridge/extensions/CppBridgeRAG.kt
@@ -84,36 +84,28 @@ object CppBridgeRAG {
         )
 
     /**
-     * Streaming query: blocks the calling thread, invoking [onEvent] with each
-     * RAGStreamEvent (TOKEN…, then COMPLETED or ERROR). [onEvent] returns false to
-     * stop early. Cancel from another thread via [cancelActiveQuery].
+     * Request-scoped streaming query: blocks the calling thread, invoking [onEvent]
+     * with each RAGStreamEvent (TOKEN…, then COMPLETED or ERROR). [onEvent] returns
+     * false to stop early (backpressure). Cancel this exact stream from another
+     * thread via [cancelQueryRequest] with the same [requestId], so concurrent
+     * collectors cannot cancel each other.
      */
-    internal fun queryStream(
-        options: RAGQueryOptions,
+    internal fun queryStreamRequest(
+        requestId: Long,
+        request: NativeRAGQueryRequest,
         onEvent: (RAGStreamEvent) -> Boolean,
     ) {
         val rc =
-            RunAnywhereBridge.racRagQueryStreamProto(
+            RunAnywhereBridge.racRagQueryStreamRequestProto(
+                requestId,
+                // The coordinator owns the lifecycle gate before this method is
+                // called, so the current handle is exactly this request's session.
                 requireSession(),
-                RAGQueryOptions.ADAPTER.encode(options),
+                request.queryProto,
                 NativeProtoProgressListener { bytes -> onEvent(RAGStreamEvent.ADAPTER.decode(bytes)) },
             )
         if (rc != RunAnywhereBridge.RAC_SUCCESS && rc != RunAnywhereBridge.RAC_ERROR_CANCELLED) {
-            throw SDKException.operation("racRagQueryStreamProto failed: $rc")
-        }
-    }
-
-    /**
-     * Plain cancel of whatever query is running on the current session (not
-     * request-scoped). Safe to call from a different thread while [queryStream]
-     * blocks; a no-op if no session is loaded.
-     */
-    internal fun cancelActiveQuery() {
-        val handle = sessionHandle
-        if (handle == 0L) return
-        val rc = RunAnywhereBridge.racRagCancelProto(handle)
-        if (rc != RunAnywhereBridge.RAC_SUCCESS && rc != RunAnywhereBridge.RAC_ERROR_CANCELLED) {
-            throw SDKException.operation("racRagCancelProto failed: $rc")
+            throw SDKException.operation("racRagQueryStreamRequestProto failed: $rc")
         }
     }
 

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/foundation/bridge/extensions/CppBridgeRAG.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/foundation/bridge/extensions/CppBridgeRAG.kt
@@ -12,7 +12,9 @@ import ai.runanywhere.proto.v1.RAGDocument
 import ai.runanywhere.proto.v1.RAGQueryOptions
 import ai.runanywhere.proto.v1.RAGResult
 import ai.runanywhere.proto.v1.RAGStatistics
+import ai.runanywhere.proto.v1.RAGStreamEvent
 import com.runanywhere.sdk.foundation.errors.SDKException
+import com.runanywhere.sdk.native.bridge.NativeProtoProgressListener
 import com.runanywhere.sdk.native.bridge.RunAnywhereBridge
 import com.runanywhere.sdk.public.types.RARAGConfiguration
 import com.runanywhere.sdk.public.types.RARAGDocument
@@ -80,6 +82,40 @@ object CppBridgeRAG {
             ),
             "racRagQueryRequestProto",
         )
+
+    /**
+     * Streaming query: blocks the calling thread, invoking [onEvent] with each
+     * RAGStreamEvent (TOKEN…, then COMPLETED or ERROR). [onEvent] returns false to
+     * stop early. Cancel from another thread via [cancelActiveQuery].
+     */
+    internal fun queryStream(
+        options: RAGQueryOptions,
+        onEvent: (RAGStreamEvent) -> Boolean,
+    ) {
+        val rc =
+            RunAnywhereBridge.racRagQueryStreamProto(
+                requireSession(),
+                RAGQueryOptions.ADAPTER.encode(options),
+                NativeProtoProgressListener { bytes -> onEvent(RAGStreamEvent.ADAPTER.decode(bytes)) },
+            )
+        if (rc != RunAnywhereBridge.RAC_SUCCESS && rc != RunAnywhereBridge.RAC_ERROR_CANCELLED) {
+            throw SDKException.operation("racRagQueryStreamProto failed: $rc")
+        }
+    }
+
+    /**
+     * Plain cancel of whatever query is running on the current session (not
+     * request-scoped). Safe to call from a different thread while [queryStream]
+     * blocks; a no-op if no session is loaded.
+     */
+    internal fun cancelActiveQuery() {
+        val handle = sessionHandle
+        if (handle == 0L) return
+        val rc = RunAnywhereBridge.racRagCancelProto(handle)
+        if (rc != RunAnywhereBridge.RAC_SUCCESS && rc != RunAnywhereBridge.RAC_ERROR_CANCELLED) {
+            throw SDKException.operation("racRagCancelProto failed: $rc")
+        }
+    }
 
     /** Cancel only the matching request-scoped JNI query wrapper. */
     internal fun cancelQueryRequest(

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/native/bridge/RunAnywhereBridge.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/native/bridge/RunAnywhereBridge.kt
@@ -1292,6 +1292,17 @@ object RunAnywhereBridge {
     /** Request-scoped query wrapper used by cancellable Kotlin calls. */
     @JvmStatic external fun racRagQueryRequestProto(requestId: Long, handle: Long, queryProto: ByteArray): ByteArray?
 
+    /**
+     * Streaming query: blocks on the calling thread, invoking [listener] with each
+     * serialized RAGStreamEvent (TOKEN…, then COMPLETED or ERROR). Returns the
+     * pipeline rac_result_t. Cancel via [racRagCancelProto].
+     */
+    @JvmStatic external fun racRagQueryStreamProto(
+        handle: Long,
+        queryProto: ByteArray,
+        listener: NativeProtoProgressListener?,
+    ): Int
+
     /** Request cancellation of the active query on this RAG session. */
     @JvmStatic external fun racRagCancelProto(handle: Long): Int
 

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/native/bridge/RunAnywhereBridge.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/native/bridge/RunAnywhereBridge.kt
@@ -1293,11 +1293,14 @@ object RunAnywhereBridge {
     @JvmStatic external fun racRagQueryRequestProto(requestId: Long, handle: Long, queryProto: ByteArray): ByteArray?
 
     /**
-     * Streaming query: blocks on the calling thread, invoking [listener] with each
-     * serialized RAGStreamEvent (TOKEN…, then COMPLETED or ERROR). Returns the
-     * pipeline rac_result_t. Cancel via [racRagCancelProto].
+     * Request-scoped streaming query: blocks on the calling thread, invoking
+     * [listener] with each serialized RAGStreamEvent (TOKEN…, then COMPLETED or
+     * ERROR). Returns the pipeline rac_result_t. [listener] returns false to stop
+     * early (backpressure). Cancel this exact stream via [racRagCancelRequestProto]
+     * with the same [requestId], so concurrent collectors cannot cancel each other.
      */
-    @JvmStatic external fun racRagQueryStreamProto(
+    @JvmStatic external fun racRagQueryStreamRequestProto(
+        requestId: Long,
         handle: Long,
         queryProto: ByteArray,
         listener: NativeProtoProgressListener?,

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/RAG/RunAnywhereRAG.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/RAG/RunAnywhereRAG.kt
@@ -14,6 +14,7 @@ import ai.runanywhere.proto.v1.InferenceFramework
 import ai.runanywhere.proto.v1.ModelCategory
 import ai.runanywhere.proto.v1.RAGQueryOptions
 import ai.runanywhere.proto.v1.RAGResult
+import ai.runanywhere.proto.v1.RAGStreamEvent
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeRAG
 import com.runanywhere.sdk.foundation.errors.SDKException
 import com.runanywhere.sdk.generated.convenience.defaults
@@ -27,6 +28,10 @@ import com.runanywhere.sdk.public.types.RARAGDocument
 import com.runanywhere.sdk.public.types.RARAGStatistics
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.channels.awaitClose
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.callbackFlow
+import kotlinx.coroutines.launch
 import java.util.concurrent.atomic.AtomicBoolean
 
 // MARK: - Pipeline Lifecycle
@@ -198,6 +203,46 @@ suspend fun RunAnywhere.ragQuery(
 
 suspend fun RunAnywhere.ragQuery(options: RAGQueryOptions): RAGResult =
     ragQuery(options.question, options)
+
+/**
+ * Streaming RAG query. Emits a [RAGStreamEvent] per generated token
+ * (kind = TOKEN) as the answer is produced, then a terminal COMPLETED event
+ * carrying the full [RAGResult] (answer + retrieved chunks), or an ERROR event.
+ *
+ * Because tokens surface as they generate, callers render progress live and do
+ * NOT need a wall-clock timeout around the call. Cancelling collection stops the
+ * native query (via rac_rag_cancel_proto).
+ */
+fun RunAnywhere.ragQueryStream(
+    question: String,
+    options: RAGQueryOptions? = null,
+): Flow<RAGStreamEvent> =
+    callbackFlow {
+        if (!isInitialized) throw SDKException.notInitialized("SDK not initialized")
+        ensureServicesReady()
+        val queryOptions =
+            (options ?: RAGQueryOptions.defaults(question)).let {
+                if (it.question.isEmpty()) it.copy(question = question) else it
+            }
+        // Run the blocking native stream off the collector thread; forward each
+        // event, then close. trySend returning false means the collector is gone.
+        val worker =
+            launch(Dispatchers.IO) {
+                try {
+                    CppBridgeRAG.queryStream(queryOptions) { event -> trySend(event).isSuccess }
+                    close()
+                } catch (t: Throwable) {
+                    close(t)
+                }
+            }
+        awaitClose {
+            runCatching { CppBridgeRAG.cancelActiveQuery() }
+            worker.cancel()
+        }
+    }
+
+fun RunAnywhere.ragQueryStream(options: RAGQueryOptions): Flow<RAGStreamEvent> =
+    ragQueryStream(options.question, options)
 
 /** Immediately request cancellation of the active native RAG query. */
 suspend fun RunAnywhere.ragCancelQuery() {

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/RAG/RunAnywhereRAG.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/RAG/RunAnywhereRAG.kt
@@ -211,7 +211,8 @@ suspend fun RunAnywhere.ragQuery(options: RAGQueryOptions): RAGResult =
  *
  * Because tokens surface as they generate, callers render progress live and do
  * NOT need a wall-clock timeout around the call. Cancelling collection stops the
- * native query (via rac_rag_cancel_proto).
+ * native query request-scoped (via racRagCancelRequestProto), so concurrent
+ * collectors and unary queries serialize instead of cancelling each other.
  */
 fun RunAnywhere.ragQueryStream(
     question: String,
@@ -224,21 +225,29 @@ fun RunAnywhere.ragQueryStream(
             (options ?: RAGQueryOptions.defaults(question)).let {
                 if (it.question.isEmpty()) it.copy(question = question) else it
             }
-        // Run the blocking native stream off the collector thread; forward each
-        // event, then close. trySend returning false means the collector is gone.
+        val nativeRequest = CppBridgeRAG.prepareQuery(queryOptions)
+        // Run the blocking native stream through the RAG request coordinator so
+        // cancellation targets this exact request (via cancelQueryRequest) rather
+        // than any query on the session. trySend returning false stops the native
+        // producer through backpressure; collecting cancellation cancels the worker,
+        // which the coordinator turns into the request-scoped native cancel.
         val worker =
-            launch(Dispatchers.IO) {
+            launch {
                 try {
-                    CppBridgeRAG.queryStream(queryOptions) { event -> trySend(event).isSuccess }
+                    runCancellableNativeRagQuery(
+                        query = { requestId ->
+                            CppBridgeRAG.queryStreamRequest(requestId, nativeRequest) { event ->
+                                trySend(event).isSuccess
+                            }
+                        },
+                        cancel = CppBridgeRAG::cancelQueryRequest,
+                    )
                     close()
                 } catch (t: Throwable) {
                     close(t)
                 }
             }
-        awaitClose {
-            runCatching { CppBridgeRAG.cancelActiveQuery() }
-            worker.cancel()
-        }
+        awaitClose { worker.cancel() }
     }
 
 fun RunAnywhere.ragQueryStream(options: RAGQueryOptions): Flow<RAGStreamEvent> =


### PR DESCRIPTION
## What this does

Fills in telemetry fields that were coming through as null, adds a streaming RAG query path, and unblocks the Android example build in Android Studio.

### Telemetry (commons)
Fields that had real values available but were never being set now get populated: processing time on system and init events, LLM and VLM timing, voice per turn index and interruption, STT routing details, and the RAG reranker flag. VAD speech ended events now flush to the backend instead of getting stranded, so those rows stop being empty.

### RAG streaming
Adds rac_rag_query_stream_proto in commons with a JNI bridge and a Kotlin Flow on top (ragQueryStream). The example RAG screen now consumes the stream, which fixes the 30s timeout that hit on slower models when the query ran as a single blocking call.

### Android build unblock
Android Studio sync was failing on strict dependency locking and verification. Strict locking now applies only on CI or release, so local and IDE builds run relaxed. Verification trusts IDE only source and javadoc artifacts, runtime verification is unchanged.

## Notes
No proto version bump. Changes are additive. Remaining deliberately null fields (streaming LLM prompt eval, exact RAG token counts) are left for a follow up since they need either a broader ABI change or a real tokenizer at that layer.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes span telemetry extraction, a new blocking streaming RAG ABI, and VLM timing on the hot inference path—mostly additive, but regressions could affect dashboards or long-running RAG cancellation behavior.
> 
> **Overview**
> **Telemetry and observability** now carry values that were computed but dropped: LlamaCPP VLM batch `process()` fills vision token counts, decoded image size, context window, TTFT, encode time, and tokens/sec on `rac_vlm_result_t`, which commons forwards into VLM capability/telemetry. RAG query telemetry uses the **effective retrieval** `top_k`, stamps **reranker_used**, and sets envelope **error_code** on failed ops. Plain STT and hybrid router paths populate **routed_backend** / fallback / attempt count; voice-agent turns get **turn_index** and **interrupted**. **has_processing_time_ms** distinguishes measured durations (including 0 ms) from unset; VAD terminal events flush promptly; auth lifecycle completions mark success.
> 
> **Streaming RAG** adds `rac_rag_query_stream_proto` with shared `execute_rag_query` for unary vs token callbacks, JNI + `ragQueryStream` Flow, and the example **RagViewModel** streaming tokens live (replacing blocking `ragQuery` and the 30s timeout).
> 
> **Android example** uses **LENIENT** dependency locks off CI/write-locks and trusts IDE source/javadoc in verification metadata so Studio sync is less brittle; CI can still enforce strict locks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9c148027861e2032a1e23fe7da8e50a1181c6e38. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added request-scoped streaming RAG queries with token-by-token events, terminal completion/error events, and early termination/cancellation support.
  * Android RAG UI now renders answers incrementally, including citations and elapsed time.
  * Vision model results now include image dimensions and context length (and improved timing/telemetry exposure).
* **Bug Fixes**
  * Improved telemetry correctness for measured zero-duration operations.
  * Better attribution for routing/fallback/retriever/reranker and expanded voice turn/interruption metrics.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->