### PR TITLE
fix(apple): Swift SDK + iOS/macOS example correctness fixes (Tier 1 + Tier 2)

### DIFF
--- a/engines/llamacpp/llamacpp_backend.cpp
+++ b/engines/llamacpp/llamacpp_backend.cpp
@@ -1021,9 +1021,45 @@ bool LlamaCppTextGeneration::generate_stream(const TextGenerationRequest& reques
     std::string prompt = build_prompt(request);
     RAC_LOG_INFO("LLM.LlamaCpp", "Generating with prompt length: %zu", prompt.length());
 
-    const auto tokens_list = common_tokenize(context_, prompt, true, true);
+    auto tokens_list = common_tokenize(context_, prompt, true, true);
 
     const int n_ctx = llama_n_ctx(context_);
+
+    // Context-window fit: a long multi-turn conversation renders {system,
+    // history, current} into a prompt that can exceed n_ctx. Left unchecked the
+    // prompt-decode below fails and surfaces as a generic RAC_ERROR_INFERENCE_FAILED
+    // ("inference failed") to the caller. Instead, drop the oldest history
+    // exchanges — never the system prompt or the current user turn — until the
+    // prompt leaves room to generate. Only engages when structured history is
+    // present (request.messages == [oldest history ..., current user turn]).
+    if (request.messages.size() > 1) {
+        const int gen_reserve = std::clamp(request.max_tokens, 128, std::max(128, n_ctx / 2));
+        const int prompt_budget = n_ctx - kReservedEosTokens - gen_reserve;
+        if (prompt_budget > 0 && static_cast<int>(tokens_list.size()) > prompt_budget) {
+            TextGenerationRequest fitted = request;
+            int dropped = 0;
+            while (static_cast<int>(tokens_list.size()) > prompt_budget &&
+                   fitted.messages.size() > 1) {
+                // Drop a whole [user, assistant] exchange from the front so the
+                // remaining history stays a valid user-first alternating
+                // sequence; never drop the final (current) user turn.
+                const size_t drop = std::min<size_t>(2, fitted.messages.size() - 1);
+                fitted.messages.erase(
+                    fitted.messages.begin(),
+                    fitted.messages.begin() + static_cast<std::ptrdiff_t>(drop));
+                dropped += static_cast<int>(drop);
+                prompt = build_prompt(fitted);
+                tokens_list = common_tokenize(context_, prompt, true, true);
+            }
+            if (dropped > 0) {
+                RAC_LOG_INFO("LLM.LlamaCpp",
+                             "Context fit: dropped %d oldest history message(s) to fit "
+                             "n_ctx=%d (prompt now %d tokens, gen_reserve=%d)",
+                             dropped, n_ctx, static_cast<int>(tokens_list.size()), gen_reserve);
+            }
+        }
+    }
+
     const int prompt_tokens = static_cast<int>(tokens_list.size());
 
     if (out_prompt_tokens) {

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI.xcodeproj/project.pbxproj
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI.xcodeproj/project.pbxproj
@@ -846,6 +846,10 @@
 				MACOSX_DEPLOYMENT_TARGET = 14.5;
 				MARKETING_VERSION = 0.19.13;
 				OTHER_LDFLAGS = "-all_load";
+				"OTHER_LDFLAGS[sdk=macosx*]" = (
+					"-force_load",
+					"$(SRCROOT)/../../../sdk/runanywhere-swift/Binaries/RACommons.xcframework/macos-arm64/librac_commons.a",
+				);
 				PRODUCT_BUNDLE_IDENTIFIER = com.runanywhere.RunAnywhere;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				REGISTER_APP_GROUPS = YES;

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI.xcodeproj/project.pbxproj
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI.xcodeproj/project.pbxproj
@@ -318,7 +318,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5480A2152E2F250400337F2F /* Build configuration list for PBXNativeTarget "RunAnywhereAITests" */;
 			buildPhases = (
-				9417651A8C4CCCB5473F1949 /* [CP] Check Pods Manifest.lock */,
 				5480A1FA2E2F250400337F2F /* Sources */,
 				5480A1FB2E2F250400337F2F /* Frameworks */,
 				5480A1FC2E2F250400337F2F /* Resources */,
@@ -340,7 +339,6 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 5480A2182E2F250400337F2F /* Build configuration list for PBXNativeTarget "RunAnywhereAIUITests" */;
 			buildPhases = (
-				94361D75FF8B6C07227D4520 /* [CP] Check Pods Manifest.lock */,
 				5480A2042E2F250400337F2F /* Sources */,
 				5480A2052E2F250400337F2F /* Frameworks */,
 				5480A2062E2F250400337F2F /* Resources */,

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Models/MarkdownDetector.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Models/MarkdownDetector.swift
@@ -34,6 +34,12 @@ class MarkdownDetector {
     }
 
     /// Analyze content for markdown patterns
+    // Compiled once. Recompiling per call was a hot-path cost: the streaming tail
+    // bubble re-runs detection on every token, so a per-render NSRegularExpression
+    // build ran once per token over the whole message.
+    private static let boldRegex = try? NSRegularExpression(pattern: "\\*\\*[^*]+\\*\\*")
+    private static let inlineCodeRegex = try? NSRegularExpression(pattern: "`[^`]+`")
+
     private func analyzeContent(_ content: String) -> ContentAnalysis {
         var analysis = ContentAnalysis()
 
@@ -54,17 +60,11 @@ class MarkdownDetector {
             }.count
         analysis.headingCount = headingCount
 
-        // Detect bold (**text**) - use regex to match proper pairs
-        let boldPattern = "\\*\\*[^*]+\\*\\*"
-        let boldRegex = try? NSRegularExpression(pattern: boldPattern)
-        let boldMatches = boldRegex?.matches(in: content, range: NSRange(content.startIndex..., in: content)) ?? []
-        analysis.boldCount = boldMatches.count
-
-        // Detect inline code (`code`) - use regex to match proper pairs
-        let codePattern = "`[^`]+`"
-        let codeRegex = try? NSRegularExpression(pattern: codePattern)
-        let codeMatches = codeRegex?.matches(in: content, range: NSRange(content.startIndex..., in: content)) ?? []
-        analysis.inlineCodeCount = codeMatches.count
+        // Detect bold (**text**) and inline code (`code`) with the pre-compiled
+        // regexes above.
+        let fullRange = NSRange(content.startIndex..., in: content)
+        analysis.boldCount = Self.boldRegex?.matches(in: content, range: fullRange).count ?? 0
+        analysis.inlineCodeCount = Self.inlineCodeRegex?.matches(in: content, range: fullRange).count ?? 0
 
         // Detect lists (only count lines that start with list markers after trimming leading spaces)
         let listCount = content.components(separatedBy: .newlines)

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Services/ConversationStore.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Services/ConversationStore.swift
@@ -67,6 +67,10 @@ class ConversationStore: ObservableObject {
         return conversation
     }
 
+    /// Ids of conversations the user deleted this session. A late write from an
+    /// in-flight generation (or a stale ViewModel) must not resurrect them.
+    private var deletedConversationIds: Set<String> = []
+
     func updateConversation(_ conversation: Conversation) {
         var updated = conversation
         updated.updatedAt = Date()
@@ -74,6 +78,11 @@ class ConversationStore: ObservableObject {
         if let index = conversations.firstIndex(where: { $0.id == conversation.id }) {
             // Update existing conversation
             conversations[index] = updated
+        } else if deletedConversationIds.contains(conversation.id) {
+            // Tombstoned: a write arriving after the user deleted this chat (e.g.
+            // an in-flight generation finalizing) must not re-create it on disk
+            // or in the list.
+            return
         } else {
             // First time adding this conversation (when first message is sent)
             conversations.insert(updated, at: 0)
@@ -87,6 +96,7 @@ class ConversationStore: ObservableObject {
     }
 
     func deleteConversation(_ conversation: Conversation) {
+        deletedConversationIds.insert(conversation.id)
         conversations.removeAll { $0.id == conversation.id }
 
         if currentConversation?.id == conversation.id {
@@ -97,6 +107,9 @@ class ConversationStore: ObservableObject {
         let fileURL = conversationFileURL(for: conversation.id)
         try? FileManager.default.removeItem(at: fileURL)
         try? FileManager.default.removeItem(at: attachmentDirectory(for: conversation.id))
+
+        // Let the chat ViewModel reset if it was viewing/generating this one.
+        NotificationCenter.default.post(name: .conversationDeleted, object: conversation.id)
     }
 
     func addMessage(_ message: Message, to conversation: Conversation) {

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Services/ConversationStore.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Services/ConversationStore.swift
@@ -289,7 +289,7 @@ class ConversationStore: ObservableObject {
 
         do {
             let data = try encoder.encode(conversation)
-            try data.write(to: fileURL)
+            try data.write(to: fileURL, options: [.atomic])
         } catch {
             print("Error saving conversation: \(error)")
         }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Services/ConversationStore.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Services/ConversationStore.swift
@@ -26,8 +26,10 @@ class ConversationStore: ObservableObject {
     }
     private let conversationsDirectory: URL
     private let attachmentsDirectory: URL
-    private let encoder = JSONEncoder()
     private let decoder = JSONDecoder()
+    /// Serial queue for all disk I/O (encode/write/read) so persistence never
+    /// blocks the main thread and writes to a file stay FIFO-ordered.
+    private let ioQueue = DispatchQueue(label: "com.runanywhere.conversationstore.io", qos: .utility)
 
     private init() {
         documentsDirectory = Self.getDocumentsDirectory()
@@ -38,12 +40,10 @@ class ConversationStore: ObservableObject {
         try? FileManager.default.createDirectory(at: conversationsDirectory, withIntermediateDirectories: true)
         try? FileManager.default.createDirectory(at: attachmentsDirectory, withIntermediateDirectories: true)
 
-        // Set up encoder/decoder
-        encoder.outputFormatting = .prettyPrinted
-        encoder.dateEncodingStrategy = .iso8601
         decoder.dateDecodingStrategy = .iso8601
 
-        // Load existing conversations
+        // Load existing conversations off the main thread so launch isn't blocked
+        // decoding every conversation file.
         loadConversations()
     }
 
@@ -273,38 +273,43 @@ class ConversationStore: ObservableObject {
     // MARK: - Private Methods
 
     private func loadConversations() {
-        do {
-            let files = try FileManager.default.contentsOfDirectory(
-                at: conversationsDirectory,
-                includingPropertiesForKeys: [.contentModificationDateKey]
-            )
-
-            var loadedConversations: [Conversation] = []
-
-            for file in files where file.pathExtension == "json" {
-                if let data = try? Data(contentsOf: file),
-                   let conversation = try? decoder.decode(Conversation.self, from: data) {
-                    loadedConversations.append(conversation)
+        let directory = conversationsDirectory
+        ioQueue.async { [weak self] in
+            let decoder = JSONDecoder()
+            decoder.dateDecodingStrategy = .iso8601
+            let files = (try? FileManager.default.contentsOfDirectory(
+                at: directory, includingPropertiesForKeys: nil)) ?? []
+            let loaded: [Conversation] = files
+                .filter { $0.pathExtension == "json" }
+                .compactMap { file in
+                    guard let data = try? Data(contentsOf: file) else { return nil }
+                    return try? decoder.decode(Conversation.self, from: data)
                 }
+            Task { @MainActor in
+                guard let self else { return }
+                // Merge (not replace): dedupe by id so a conversation created during
+                // the async-load window isn't clobbered. Sort newest-first.
+                let existing = Set(self.conversations.map { $0.id })
+                let merged = self.conversations + loaded.filter { !existing.contains($0.id) }
+                self.conversations = merged.sorted { $0.updatedAt > $1.updatedAt }
             }
-
-            // Sort by update date, newest first
-            conversations = loadedConversations.sorted { $0.updatedAt > $1.updatedAt }
-
-            // Don't automatically set current conversation - let ChatViewModel create a new one
-        } catch {
-            print("Error loading conversations: \(error)")
         }
     }
 
     private func saveConversation(_ conversation: Conversation) {
         let fileURL = conversationFileURL(for: conversation.id)
-
-        do {
-            let data = try encoder.encode(conversation)
-            try data.write(to: fileURL, options: [.atomic])
-        } catch {
-            print("Error saving conversation: \(error)")
+        // Encode + write off the main thread. The serial queue keeps writes to the
+        // same file FIFO-ordered (last write wins, as before), so moving off-main
+        // can't reorder a turn's successive saves.
+        ioQueue.async {
+            let encoder = JSONEncoder()
+            encoder.dateEncodingStrategy = .iso8601
+            do {
+                let data = try encoder.encode(conversation)
+                try data.write(to: fileURL, options: [.atomic])
+            } catch {
+                // Best-effort persistence; a failed write is retried on the next save.
+            }
         }
     }
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Services/ModelCatalogBootstrap.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Services/ModelCatalogBootstrap.swift
@@ -193,22 +193,14 @@ enum ModelCatalogBootstrap {
             memoryRequirement: 2_400_000_000,
             supportsThinking: true
         )
-        await registerLLM(
-            id: "mlx-gemma-4-e2b-it-4bit",
-            name: "MLX Gemma 4 E2B IT 4bit (Experimental)",
-            url: "https://huggingface.co/mlx-community/gemma-4-e2b-it-4bit",
-            framework: .mlx,
-            modality: .multimodal,
-            memoryRequirement: 2_200_000_000
-        )
-        await registerLLM(
-            id: "mlx-gemma-4-e4b-it-4bit",
-            name: "MLX Gemma 4 E4B IT 4bit (Experimental)",
-            url: "https://huggingface.co/mlx-community/gemma-4-e4b-it-4bit",
-            framework: .mlx,
-            modality: .multimodal,
-            memoryRequirement: 4_000_000_000
-        )
+        // NOTE: The MLX Gemma 4 (E2B/E4B) checkpoints are intentionally NOT
+        // registered. Their attention layers use an asymmetric QK-norm (some
+        // layers ship `self_attn.q_norm` without a matching `self_attn.k_norm`),
+        // but mlx-swift-lm 3.31.4's `Gemma4TextAttention` unconditionally loads
+        // `self_attn.k_norm.weight` and aborts with `keyNotFound` on the first
+        // such layer — so they download fully and then fail to load. Re-enable
+        // once mlx-swift-lm makes per-layer k_norm optional. The GGUF (llama.cpp)
+        // Gemma 4 variants below load fine and remain available.
         await registerLLM(
             id: "mlx-qwen2-vl-2b-instruct-4bit",
             name: "MLX Qwen2-VL 2B Instruct 4bit",

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Benchmarks/Services/LLMBenchmarkProvider.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Benchmarks/Services/LLMBenchmarkProvider.swift
@@ -79,7 +79,14 @@ struct LLMBenchmarkProvider: BenchmarkScenarioProvider {
             let benchRequest = benchOptions.toRALLMGenerateRequest(prompt: prompt)
             let benchEvents = try await RunAnywhere.generateStream(benchRequest)
 
-            let result = await RunAnywhere.aggregateStream(prompt: prompt, events: benchEvents)
+            let result = await withTaskCancellationHandler {
+                await RunAnywhere.aggregateStream(prompt: prompt, events: benchEvents)
+            } onCancel: {
+                // Benchmark cancelled mid-run: stop the in-flight generation so the
+                // model doesn't keep decoding for tens of seconds before the loop
+                // observes cancellation.
+                Task { await RunAnywhere.cancelGeneration() }
+            }
             let wallMs = Date().timeIntervalSince(benchStart) * 1000
             let generationMs = result.generationTimeMs > 0 ? result.generationTimeMs : wallMs
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/ChatNotificationNames.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/ChatNotificationNames.swift
@@ -9,4 +9,7 @@ import Foundation
 
 extension Notification.Name {
     static let conversationSelected = Notification.Name("ConversationSelected")
+    /// Posted (object: the deleted `Conversation.id` as `UUID`) when a conversation
+    /// is deleted, so the chat ViewModel can reset if it was viewing/generating it.
+    static let conversationDeleted = Notification.Name("ConversationDeleted")
 }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/Message.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Models/Message.swift
@@ -20,6 +20,13 @@ public struct Message: Identifiable, Codable, Sendable {
     public let modelInfo: MessageModelInfo?
     public let toolCallInfo: ToolCallInfo?
     public let attachment: MessageAttachment?
+    /// True when this assistant bubble holds error feedback (a "Generation
+    /// failed…" message or an `LLMError` description) rather than real model
+    /// output. A structured flag — not string matching — so `makeHistory` can
+    /// exclude it: an error bubble is UI-only and must never be fed back into
+    /// the conversation the model conditions on. Optional so conversations
+    /// persisted before this field existed decode as `nil`.
+    public let isError: Bool?
 
     public enum Role: String, Codable, Sendable {
         case system
@@ -36,7 +43,8 @@ public struct Message: Identifiable, Codable, Sendable {
         analytics: MessageAnalytics? = nil,
         modelInfo: MessageModelInfo? = nil,
         toolCallInfo: ToolCallInfo? = nil,
-        attachment: MessageAttachment? = nil
+        attachment: MessageAttachment? = nil,
+        isError: Bool? = nil
     ) {
         self.id = id
         self.role = role
@@ -47,6 +55,7 @@ public struct Message: Identifiable, Codable, Sendable {
         self.modelInfo = modelInfo
         self.toolCallInfo = toolCallInfo
         self.attachment = attachment
+        self.isError = isError
     }
 }
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Analytics.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Analytics.swift
@@ -97,6 +97,13 @@ extension LLMViewModel {
         )
 
         var updatedConversation = conversation
+        // Persist the live transcript, not `currentConversation`'s stale snapshot
+        // (which lags a full turn and is empty on a brand-new conversation). Without
+        // this, an analytics write during a turn whose assistant reply finalizes
+        // empty — where `finalizeGeneration` early-returns before its own repair —
+        // overwrites the on-disk conversation with a truncated message list and
+        // drops the user's just-sent message. Mirrors the tool-calling path.
+        updatedConversation.messages = messages
         updatedConversation.analytics = conversationAnalytics
         updatedConversation.performanceSummary = PerformanceSummary(from: messages)
         conversationStore.updateConversation(updatedConversation)

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Documents.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Documents.swift
@@ -26,6 +26,12 @@ extension LLMViewModel {
             setCurrentConversation(conversationStore.createConversation())
         }
 
+        // Pin this generation to its conversation + give it an identity so late
+        // tokens / finalization are dropped if the user switches away.
+        setGeneratingConversationId(currentConversation?.id)
+        let generationID = UUID()
+        setActiveGenerationID(generationID)
+
         let savedAttachment = persistDocumentAttachment(document)
         let userMessage = Message(role: .user, content: prompt, attachment: savedAttachment)
         let assistantMessage = Message(role: .assistant, content: "")
@@ -50,17 +56,21 @@ extension LLMViewModel {
                 answerModel.supportsThinking && !settings.thinkingModeEnabled
 
             let result = try await RunAnywhere.ragQuery(options)
-            updateDocumentMessage(
-                at: messageIndex,
-                answer: result.answer,
-                thinkingContent: result.hasThinkingContent ? result.thinkingContent : nil,
-                answerModel: answerModel
-            )
+            if isCurrentGeneration(generationID) {
+                updateDocumentMessage(
+                    at: messageIndex,
+                    answer: result.answer,
+                    thinkingContent: result.hasThinkingContent ? result.thinkingContent : nil,
+                    answerModel: answerModel
+                )
+            }
         } catch {
-            await handleGenerationError(error, at: messageIndex)
+            if isCurrentGeneration(generationID) {
+                await handleGenerationError(error, at: messageIndex)
+            }
         }
 
-        await finalizeGeneration(at: messageIndex)
+        await finalizeGeneration(at: messageIndex, generationID: generationID)
     }
 
     private func persistDocumentAttachment(_ document: ChatDocumentAttachment) -> MessageAttachment {

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Documents.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Documents.swift
@@ -43,34 +43,41 @@ extension LLMViewModel {
 
         let messageIndex = messagesValue.count - 1
 
-        do {
-            try await prepareDocumentRAGPipelineIfNeeded(
-                document: document,
-                embeddingModel: embeddingModel,
-                answerModel: answerModel
-            )
-
-            var options = RARAGQueryOptions.defaults(question: prompt)
-            let settings = SettingsViewModel.shared
-            options.disableThinking =
-                answerModel.supportsThinking && !settings.thinkingModeEnabled
-
-            let result = try await RunAnywhere.ragQuery(options)
-            if isCurrentGeneration(generationID) {
-                updateDocumentMessage(
-                    at: messageIndex,
-                    answer: result.answer,
-                    thinkingContent: result.hasThinkingContent ? result.thinkingContent : nil,
+        // Track the turn so Stop / conversation-switch cancels it and unlocks the
+        // composer (mirrors the text path). ragQuery is a single await with no SDK
+        // cancel entry point, so cancellation is observed once it returns.
+        let task = Task {
+            do {
+                try await prepareDocumentRAGPipelineIfNeeded(
+                    document: document,
+                    embeddingModel: embeddingModel,
                     answerModel: answerModel
                 )
-            }
-        } catch {
-            if isCurrentGeneration(generationID) {
-                await handleGenerationError(error, at: messageIndex)
-            }
-        }
 
-        await finalizeGeneration(at: messageIndex, generationID: generationID)
+                var options = RARAGQueryOptions.defaults(question: prompt)
+                let settings = SettingsViewModel.shared
+                options.disableThinking =
+                    answerModel.supportsThinking && !settings.thinkingModeEnabled
+
+                let result = try await RunAnywhere.ragQuery(options)
+                if isCurrentGeneration(generationID) {
+                    updateDocumentMessage(
+                        at: messageIndex,
+                        answer: result.answer,
+                        thinkingContent: result.hasThinkingContent ? result.thinkingContent : nil,
+                        answerModel: answerModel
+                    )
+                }
+            } catch {
+                if isCurrentGeneration(generationID) {
+                    await handleGenerationError(error, at: messageIndex)
+                }
+            }
+
+            await finalizeGeneration(at: messageIndex, generationID: generationID)
+        }
+        setGenerationTask(task)
+        await task.value
     }
 
     private func persistDocumentAttachment(_ document: ChatDocumentAttachment) -> MessageAttachment {

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Generation.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Generation.swift
@@ -108,19 +108,30 @@ extension LLMViewModel {
         // of bounds).
         let end = min(max(currentUserIndex, 0), messages.count)
         guard end > 0 else { return [] }
-        return messages[0..<end].compactMap { message in
+        var history: [RAChatMessage] = []
+        for message in messages[0..<end] {
             let role: RAMessageRole
             switch message.role {
             case .user: role = .user
             case .assistant: role = .assistant
-            case .system: return nil
+            case .system: continue
             }
-            guard !message.content.isEmpty else { return nil }
+            guard !message.content.isEmpty else { continue }
+            // Skip assistant error placeholders ("Generation failed…" / an
+            // LLMError description): these are UI-only feedback, never real
+            // model output, so they must not pollute the conversation history.
+            if role == .assistant, message.isError == true { continue }
+            // Collapse consecutive same-role turns (e.g. a dropped assistant turn
+            // leaves two user turns back-to-back). Many chat templates require a
+            // strictly alternating history and reject repeats; keep the most
+            // recent turn of any same-role run.
+            if history.last?.role == role { history.removeLast() }
             var chatMessage = RAChatMessage()
             chatMessage.role = role
             chatMessage.content = message.content
-            return chatMessage
+            history.append(chatMessage)
         }
+        return history
     }
 
     // MARK: - Message Updates
@@ -215,7 +226,8 @@ extension LLMViewModel {
                 analytics: currentMessage.analytics,
                 modelInfo: currentMessage.modelInfo,
                 toolCallInfo: currentMessage.toolCallInfo,
-                attachment: currentMessage.attachment
+                attachment: currentMessage.attachment,
+                isError: true
             )
             self.updateMessage(at: index, with: updatedMessage)
         }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Generation.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Generation.swift
@@ -14,7 +14,8 @@ extension LLMViewModel {
     func generateStreamingResponse(
         prompt: String,
         options: RALLMGenerationOptions,
-        messageIndex: Int
+        messageIndex: Int,
+        generationID: UUID?
     ) async throws {
         // The SDK's `aggregateStream(prompt:events:onToken:)` consumes the
         // RALLMStreamEvent sequence, populates the canonical
@@ -22,13 +23,16 @@ extension LLMViewModel {
         // currently-loaded LLM model), and invokes `onToken` for live UI
         // updates. Avoids the synthetic result construction the example used
         // to do alongside a hardcoded `framework = "llamacpp"` literal.
-        let request = Self.makeRequest(prompt: prompt, options: options)
+        let history = Self.makeHistory(from: self.messagesValue, currentUserIndex: messageIndex - 1)
+        let request = Self.makeRequest(prompt: prompt, options: options, history: history)
         let eventStream = try await RunAnywhere.generateStream(request)
         let result = await RunAnywhere.aggregateStream(
             prompt: prompt,
             events: eventStream
         ) { fullResponse in
             await MainActor.run {
+                // Drop tokens from a superseded generation (user navigated away).
+                guard self.isCurrentGeneration(generationID) else { return }
                 // `@Observable` publishes the message mutation; the chat view
                 // auto-scrolls via `.onChange(of: messages.last?.content)`.
                 self.updateMessageContent(at: messageIndex, content: fullResponse)
@@ -41,6 +45,7 @@ extension LLMViewModel {
             ])
         }
 
+        guard isCurrentGeneration(generationID) else { return }
         await updateMessageWithResult(
             at: messageIndex,
             result: result,
@@ -55,10 +60,13 @@ extension LLMViewModel {
     func generateNonStreamingResponse(
         prompt: String,
         options: RALLMGenerationOptions,
-        messageIndex: Int
+        messageIndex: Int,
+        generationID: UUID?
     ) async throws {
-        let request = Self.makeRequest(prompt: prompt, options: options)
+        let history = Self.makeHistory(from: self.messagesValue, currentUserIndex: messageIndex - 1)
+        let request = Self.makeRequest(prompt: prompt, options: options, history: history)
         let result = try await RunAnywhere.generate(request)
+        guard isCurrentGeneration(generationID) else { return }
         await updateMessageWithResult(
             at: messageIndex,
             result: result,
@@ -71,11 +79,48 @@ extension LLMViewModel {
     /// Compose a canonical `RALLMGenerateRequest` from a prompt and options.
     /// Example-local convenience for bridging the app's options-based API into
     /// the SDK's canonical request-based entry points.
-    static func makeRequest(prompt: String, options: RALLMGenerationOptions) -> RALLMGenerateRequest {
+    ///
+    /// `history` carries the prior conversation turns so commons renders
+    /// `{system_prompt, history, prompt}` via the model's chat template. Without
+    /// it every turn is sent context-free and the model cannot recall earlier
+    /// messages.
+    static func makeRequest(
+        prompt: String,
+        options: RALLMGenerationOptions,
+        history: [RAChatMessage] = []
+    ) -> RALLMGenerateRequest {
         var request = RALLMGenerateRequest()
         request.prompt = prompt
         request.options = options
+        request.history = history
         return request
+    }
+
+    /// Map the app's prior `Message`s into the SDK `history` field.
+    ///
+    /// Excludes the live user turn and the empty assistant slot being streamed
+    /// into (both live at/after `currentUserIndex`), and any `system` turns —
+    /// the system prompt travels separately via `options.systemPrompt`.
+    static func makeHistory(from messages: [Message], currentUserIndex: Int) -> [RAChatMessage] {
+        // Clamp the upper bound: `currentUserIndex` is captured before `await`s,
+        // so if the user switched/cleared the conversation mid-generation the
+        // buffer may now be shorter and an unclamped slice would crash (range out
+        // of bounds).
+        let end = min(max(currentUserIndex, 0), messages.count)
+        guard end > 0 else { return [] }
+        return messages[0..<end].compactMap { message in
+            let role: RAMessageRole
+            switch message.role {
+            case .user: role = .user
+            case .assistant: role = .assistant
+            case .system: return nil
+            }
+            guard !message.content.isEmpty else { return nil }
+            var chatMessage = RAChatMessage()
+            chatMessage.role = role
+            chatMessage.content = message.content
+            return chatMessage
+        }
     }
 
     // MARK: - Message Updates
@@ -107,6 +152,8 @@ extension LLMViewModel {
         // LLMViewModel is @MainActor (class-level); this extension inherits that
         // isolation so a MainActor.run wrapper here is a no-op that only adds an
         // artificial suspension point on the streaming hot path.
+        // Drop the final write + analytics persist if the user navigated away.
+        guard isActiveGenerationTarget else { return }
         guard index < self.messagesValue.count,
               let conversationId = self.currentConversation?.id else { return }
 
@@ -144,6 +191,10 @@ extension LLMViewModel {
     // MARK: - Error Handling
 
     func handleGenerationError(_ error: Error, at index: Int) async {
+        // Ignore errors from a generation the user has navigated away from, so a
+        // stale failure can't raise an error banner / write into the now-active
+        // conversation.
+        guard isActiveGenerationTarget else { return }
         self.setError(error)
 
         if index < self.messagesValue.count {
@@ -172,12 +223,38 @@ extension LLMViewModel {
 
     // MARK: - Finalization
 
-    func finalizeGeneration(at index: Int) async {
+    func finalizeGeneration(at index: Int, generationID: UUID?) async {
+        // Superseded? If a newer generation started, or the user navigated away
+        // (cancelActiveGeneration invalidated the id), this generation is no
+        // longer the owner: it must NOT touch isGenerating (the new owner manages
+        // it) nor persist. Silently drop.
+        guard activeGenerationID == generationID else { return }
+
+        // This generation still owns the chat, so it is the single owner of the
+        // isGenerating true->false transition (stopGeneration leaves it to us) —
+        // clear it exactly once for a normal completion or a Stop.
+        self.setActiveGenerationID(nil)
         self.setIsGenerating(false)
+
+        // Guard the JSON write against a conversation swap that somehow kept the
+        // id (should not normally happen once the id matches).
+        guard isActiveGenerationTarget else { return }
+        self.setGeneratingConversationId(nil)
 
         guard index < self.messagesValue.count else { return }
 
         let assistantMessage = self.messagesValue[index]
+
+        // A Stop that produced no assistant text leaves an empty bubble. Drop that
+        // empty slot from the visible chat and skip persistence so a cancelled turn
+        // with nothing to show doesn't leave an orphan assistant bubble. A partial
+        // response the user chose to keep has non-empty content and is preserved
+        // and persisted normally below. isGenerating was already cleared above, so
+        // the send control is restored either way.
+        guard !assistantMessage.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            self.removeTrailingEmptyAssistantMessage()
+            return
+        }
 
         // Use the CURRENT conversation from store (not the stale local copy).
         guard let conversationId = self.currentConversation?.id,

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+ModelManagement.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+ModelManagement.swift
@@ -77,6 +77,16 @@ extension LLMViewModel {
     // MARK: - Conversation Management
 
     func loadConversation(_ conversation: Conversation) {
+        // Re-selecting the already-open conversation is a no-op. Reloading its
+        // stored messages here would wipe an in-flight streaming assistant slot
+        // (persisted only at finalize), silently losing the response.
+        guard conversation.id != currentConversation?.id else { return }
+
+        // Switching to a DIFFERENT conversation: cancel + detach the in-flight
+        // generation so its streaming tokens and finalization can't corrupt the
+        // one being selected.
+        cancelActiveGeneration()
+
         setCurrentConversation(conversation)
 
         if conversation.messages.isEmpty {

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+ToolCalling.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+ToolCalling.swift
@@ -14,12 +14,16 @@ extension LLMViewModel {
     func generateWithToolCalling(
         prompt: String,
         options: RALLMGenerationOptions,
-        messageIndex: Int
+        messageIndex: Int,
+        generationID: UUID?
     ) async throws {
         // The SDK derives the tool-calling format from the loaded model and
         // orchestrates the tool call → execute → respond loop internally.
         let result = try await RunAnywhere.generateWithTools(prompt: prompt, options: options)
         let toolCallInfo = ToolCallInfo(from: result)
+
+        // Drop the write if this generation was superseded while awaiting.
+        guard isCurrentGeneration(generationID) else { return }
 
         // Update the message with the result
         await updateMessageWithToolResult(
@@ -39,6 +43,8 @@ extension LLMViewModel {
         toolCallInfo: ToolCallInfo?
     ) async {
         await MainActor.run {
+            // Drop the final write + persist if the user navigated away mid tool call.
+            guard self.isActiveGenerationTarget else { return }
             guard index < self.messagesValue.count else { return }
 
             let currentMessage = self.messagesValue[index]

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Vision.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Vision.swift
@@ -38,26 +38,33 @@ extension LLMViewModel {
 
         let messageIndex = messagesValue.count - 1
 
-        do {
-            try ensureVisionModelLoaded()
+        // Track the turn so Stop / conversation-switch can cancel it (mirrors the
+        // text path). The VLM stream isn't SDK-cancellable yet, so consumeVisionStream
+        // also breaks its loop cooperatively on Task.isCancelled.
+        let task = Task {
+            do {
+                try ensureVisionModelLoaded()
 
-            var options = RAVLMGenerationOptions.defaults(prompt: prompt)
-            options.maxTokens = 500
+                var options = RAVLMGenerationOptions.defaults(prompt: prompt)
+                options.maxTokens = 500
 
-            let stream = try await RunAnywhere.processImageStream(attachment.image, options: options)
-            let response = try await consumeVisionStream(
-                stream, messageIndex: messageIndex, generationID: generationID
-            )
-            if isCurrentGeneration(generationID) {
-                updateVisionMessage(at: messageIndex, response: response)
+                let stream = try await RunAnywhere.processImageStream(attachment.image, options: options)
+                let response = try await consumeVisionStream(
+                    stream, messageIndex: messageIndex, generationID: generationID
+                )
+                if isCurrentGeneration(generationID) {
+                    updateVisionMessage(at: messageIndex, response: response)
+                }
+            } catch {
+                if isCurrentGeneration(generationID) {
+                    await handleGenerationError(error, at: messageIndex)
+                }
             }
-        } catch {
-            if isCurrentGeneration(generationID) {
-                await handleGenerationError(error, at: messageIndex)
-            }
+
+            await finalizeGeneration(at: messageIndex, generationID: generationID)
         }
-
-        await finalizeGeneration(at: messageIndex, generationID: generationID)
+        setGenerationTask(task)
+        await task.value
     }
 
     private func persistImageAttachment(_ attachment: ChatImageAttachment) -> MessageAttachment {
@@ -95,6 +102,9 @@ extension LLMViewModel {
         var fullResponse = ""
 
         for await event in stream {
+            // Cooperative stop: the SDK VLM stream has no cancel entry point, so
+            // break here when the turn's task is cancelled (Stop / navigate-away).
+            if Task.isCancelled { break }
             switch event.kind {
             case .token:
                 guard !event.token.isEmpty else { continue }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Vision.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+Vision.swift
@@ -21,6 +21,12 @@ extension LLMViewModel {
             setCurrentConversation(conversationStore.createConversation())
         }
 
+        // Pin this generation to its conversation + give it an identity so late
+        // tokens / finalization are dropped if the user switches away.
+        setGeneratingConversationId(currentConversation?.id)
+        let generationID = UUID()
+        setActiveGenerationID(generationID)
+
         let savedAttachment = persistImageAttachment(attachment)
         let userMessage = Message(role: .user, content: prompt, attachment: savedAttachment)
         let assistantMessage = Message(role: .assistant, content: "")
@@ -39,13 +45,19 @@ extension LLMViewModel {
             options.maxTokens = 500
 
             let stream = try await RunAnywhere.processImageStream(attachment.image, options: options)
-            let response = try await consumeVisionStream(stream, messageIndex: messageIndex)
-            updateVisionMessage(at: messageIndex, response: response)
+            let response = try await consumeVisionStream(
+                stream, messageIndex: messageIndex, generationID: generationID
+            )
+            if isCurrentGeneration(generationID) {
+                updateVisionMessage(at: messageIndex, response: response)
+            }
         } catch {
-            await handleGenerationError(error, at: messageIndex)
+            if isCurrentGeneration(generationID) {
+                await handleGenerationError(error, at: messageIndex)
+            }
         }
 
-        await finalizeGeneration(at: messageIndex)
+        await finalizeGeneration(at: messageIndex, generationID: generationID)
     }
 
     private func persistImageAttachment(_ attachment: ChatImageAttachment) -> MessageAttachment {
@@ -77,7 +89,8 @@ extension LLMViewModel {
 
     private func consumeVisionStream(
         _ stream: AsyncStream<RAVLMStreamEvent>,
-        messageIndex: Int
+        messageIndex: Int,
+        generationID: UUID?
     ) async throws -> String {
         var fullResponse = ""
 
@@ -86,11 +99,17 @@ extension LLMViewModel {
             case .token:
                 guard !event.token.isEmpty else { continue }
                 fullResponse += event.token
-                updateMessageContent(at: messageIndex, content: fullResponse)
+                // Drop live tokens once superseded (the SDK VLM stream isn't
+                // cancelled on navigate-away, so keep draining but stop writing).
+                if isCurrentGeneration(generationID) {
+                    updateMessageContent(at: messageIndex, content: fullResponse)
+                }
             case .completed:
                 if fullResponse.isEmpty, !event.result.text.isEmpty {
                     fullResponse = event.result.text
-                    updateMessageContent(at: messageIndex, content: fullResponse)
+                    if isCurrentGeneration(generationID) {
+                        updateMessageContent(at: messageIndex, content: fullResponse)
+                    }
                 }
             case .error:
                 throw NSError(

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
@@ -61,6 +61,19 @@ final class LLMViewModel {
     // MARK: - Private State
 
     private var generationTask: Task<Void, Never>?
+    /// The conversation the in-flight generation is writing into. When the user
+    /// switches or clears conversations mid-generation this stops matching
+    /// `currentConversation`, so late streaming tokens, error writes, and
+    /// finalization are dropped instead of corrupting the newly-selected
+    /// conversation. `String?` to match `Conversation.id`.
+    private(set) var generatingConversationId: String?
+    /// Identity of the generation that currently owns the chat state. A
+    /// superseded generation (user navigated away / cleared / started a new one)
+    /// sees an id mismatch at finalize and no-ops — which lets
+    /// `cancelActiveGeneration()` clear `isGenerating` eagerly (restoring the send
+    /// control the instant the user leaves) without a stale finalize corrupting
+    /// the newly-selected conversation.
+    private(set) var activeGenerationID: UUID?
     var lifecycleCancellable: AnyCancellable?
     var generationCancellable: AnyCancellable?
     private var firstTokenLatencies: [String: Double] = [:]
@@ -120,11 +133,64 @@ final class LLMViewModel {
     }
 
     func updateMessage(at index: Int, with message: Message) {
+        // Drop writes from a generation the user has navigated away from. Every
+        // in-memory message mutation during generation — streaming tokens, final
+        // result, error text, vision, document, and tool-calling — funnels
+        // through here, so this single guard prevents a stale generation from
+        // corrupting the now-active conversation's messages.
+        guard isActiveGenerationTarget else { return }
+        guard index < messages.count else { return }
         messages[index] = message
     }
 
     func setIsGenerating(_ value: Bool) {
         isGenerating = value
+    }
+
+    /// True while the generation started for `generatingConversationId` still
+    /// owns the visible chat. Every message write/persist consults this so a
+    /// generation the user navigated away from cannot mutate or persist the
+    /// now-active conversation. Strict match (a nil target is never active), so a
+    /// cancelled generation's late tokens are also rejected.
+    var isActiveGenerationTarget: Bool {
+        generatingConversationId != nil && generatingConversationId == currentConversation?.id
+    }
+
+    /// True while `generationID` is still THE active generation. Write
+    /// initiations consult this (generation identity — not just conversation
+    /// identity) so a superseded, still-draining stream (e.g. a vision/RAG turn
+    /// the user navigated away from, whose SDK stream isn't cancelled) cannot
+    /// re-acquire the write path once a NEW generation re-pins the same visible
+    /// conversation.
+    func isCurrentGeneration(_ generationID: UUID?) -> Bool {
+        generationID != nil && activeGenerationID == generationID
+    }
+
+    func setGeneratingConversationId(_ id: String?) {
+        generatingConversationId = id
+    }
+
+    func setActiveGenerationID(_ id: UUID?) {
+        activeGenerationID = id
+    }
+
+    /// Cancel the in-flight generation and detach it from the active conversation
+    /// so its late token writes and finalization become no-ops. Shared by
+    /// `clearChat()` and `loadConversation(_:)`.
+    ///
+    /// Invalidating `activeGenerationID` supersedes the running generation: its
+    /// trailing `finalizeGeneration` sees an id mismatch and does nothing (no
+    /// persist, no state change). Because it can no longer clobber anything, we
+    /// clear `isGenerating` here immediately — restoring the send control the
+    /// instant the user leaves — instead of waiting for the abandoned generation
+    /// to unwind. `stopGeneration()` (same conversation, wants its partial
+    /// persisted) deliberately leaves both untouched.
+    func cancelActiveGeneration() {
+        generationTask?.cancel()
+        activeGenerationID = nil
+        generatingConversationId = nil
+        setIsGenerating(false)
+        Task { await RunAnywhere.cancelGeneration() }
     }
 
     func clearMessages() {
@@ -139,6 +205,16 @@ final class LLMViewModel {
         if !messages.isEmpty {
             messages.removeFirst()
         }
+    }
+
+    /// Drop a trailing empty assistant slot left behind by a Stop that produced
+    /// no text, so a cancelled turn with nothing to show doesn't leave an orphan
+    /// bubble. No-op unless the last message is a blank assistant message.
+    func removeTrailingEmptyAssistantMessage() {
+        guard let last = messages.last,
+              last.role == .assistant,
+              last.content.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        messages.removeLast()
     }
 
     func setLoadedModelName(_ name: String) {
@@ -224,8 +300,9 @@ final class LLMViewModel {
         }
 
         let (prompt, messageIndex) = prepareMessagesForSending()
+        let generationID = activeGenerationID
         generationTask = Task {
-            await executeGeneration(prompt: prompt, messageIndex: messageIndex)
+            await executeGeneration(prompt: prompt, messageIndex: messageIndex, generationID: generationID)
         }
     }
 
@@ -242,6 +319,11 @@ final class LLMViewModel {
             currentConversation = conversation
         }
 
+        // Pin this generation to its conversation (drops stale writes on switch)
+        // and give it an identity (lets a superseded finalize no-op).
+        generatingConversationId = currentConversation?.id
+        activeGenerationID = UUID()
+
         // Add user message
         let userMessage = Message(role: .user, content: prompt)
         messages.append(userMessage)
@@ -257,7 +339,7 @@ final class LLMViewModel {
         return (prompt, messages.count - 1)
     }
 
-    private func executeGeneration(prompt: String, messageIndex: Int) async {
+    private func executeGeneration(prompt: String, messageIndex: Int, generationID: UUID?) async {
         do {
             try await ensureModelIsLoaded()
 
@@ -267,18 +349,33 @@ final class LLMViewModel {
             // prompt is passed separately in options so the C++ layer can
             // place it correctly.
             let effectiveOptions = options
-            try await performGeneration(prompt: prompt, options: effectiveOptions, messageIndex: messageIndex)
+            try await performGeneration(
+                prompt: prompt,
+                options: effectiveOptions,
+                messageIndex: messageIndex,
+                generationID: generationID
+            )
         } catch {
-            await handleGenerationError(error, at: messageIndex)
+            // Drop the error write if this generation was superseded (user
+            // navigated away and possibly started a new one) or if the user
+            // pressed Stop: a cooperative cancellation is not a real failure, so it
+            // must not raise an error banner or leave a "Generation failed:
+            // cancelled" bubble (nor overwrite already-streamed partial text).
+            // finalizeGeneration then drops the now-empty assistant slot; a partial
+            // response keeps its text and is persisted.
+            if isCurrentGeneration(generationID), !Task.isCancelled {
+                await handleGenerationError(error, at: messageIndex)
+            }
         }
 
-        await finalizeGeneration(at: messageIndex)
+        await finalizeGeneration(at: messageIndex, generationID: generationID)
     }
 
     private func performGeneration(
         prompt: String,
         options: RALLMGenerationOptions,
-        messageIndex: Int
+        messageIndex: Int,
+        generationID: UUID?
     ) async throws {
         // Check if tool calling is enabled and we have registered tools
         let registeredTools = await RunAnywhere.getRegisteredTools()
@@ -286,21 +383,27 @@ final class LLMViewModel {
 
         if shouldUseToolCalling {
             logger.info("Using tool calling with \(registeredTools.count) registered tools")
-            try await generateWithToolCalling(prompt: prompt, options: options, messageIndex: messageIndex)
+            try await generateWithToolCalling(
+                prompt: prompt, options: options, messageIndex: messageIndex, generationID: generationID
+            )
             return
         }
 
         // All LLM backends now handle streaming via the canonical generateStream
         // entry point; the SDK no longer exposes a per-model capability flag.
         if useStreaming {
-            try await generateStreamingResponse(prompt: prompt, options: options, messageIndex: messageIndex)
+            try await generateStreamingResponse(
+                prompt: prompt, options: options, messageIndex: messageIndex, generationID: generationID
+            )
         } else {
-            try await generateNonStreamingResponse(prompt: prompt, options: options, messageIndex: messageIndex)
+            try await generateNonStreamingResponse(
+                prompt: prompt, options: options, messageIndex: messageIndex, generationID: generationID
+            )
         }
     }
 
     func clearChat() {
-        generationTask?.cancel()
+        cancelActiveGeneration()
 
         // Generate smart title for the old conversation before creating new one
         if let oldConversation = currentConversation,
@@ -313,7 +416,9 @@ final class LLMViewModel {
 
         messages.removeAll()
         currentInput = ""
-        isGenerating = false
+        // `isGenerating` is intentionally NOT reset here: if a generation is
+        // still unwinding, its own `finalizeGeneration` clears it (and drops its
+        // now-stale persist). If none is running it is already false.
         error = nil
 
         // Create new conversation
@@ -326,8 +431,13 @@ final class LLMViewModel {
     }
 
     func stopGeneration() {
+        // Cancel cooperatively and stop the SDK, but do NOT flip `isGenerating`
+        // here: cancellation is async, so the in-flight generation keeps
+        // unwinding. Its own `finalizeGeneration` owns the true->false
+        // transition, which keeps `canSend` false until the stream has actually
+        // stopped — otherwise a second `sendMessage()` could start and overlap
+        // the still-running generation on the single-callback LLM component.
         generationTask?.cancel()
-        isGenerating = false
 
         Task {
             await RunAnywhere.cancelGeneration()

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
@@ -282,6 +282,12 @@ final class LLMViewModel {
             name: .conversationSelected,
             object: nil
         )
+        NotificationCenter.default.addObserver(
+            self,
+            selector: #selector(conversationDeleted(_:)),
+            name: .conversationDeleted,
+            object: nil
+        )
 
         subscribeToModelLifecycle()
 
@@ -748,6 +754,25 @@ final class LLMViewModel {
     private func conversationSelected(_ notification: Notification) {
         if let conversation = notification.object as? Conversation {
             loadConversation(conversation)
+        }
+    }
+
+    @objc
+    private func conversationDeleted(_ notification: Notification) {
+        guard let deletedId = notification.object as? String,
+              currentConversation?.id == deletedId
+                || generatingConversationId == deletedId else { return }
+        // The chat the user is viewing/generating was deleted: stop any in-flight
+        // generation (so its finalize can't persist) and move off the tombstoned
+        // conversation so a later send starts a fresh chat instead of being
+        // silently dropped by the store's tombstone guard.
+        cancelActiveGeneration()
+        if let replacement = conversationStore.currentConversation, replacement.id != deletedId {
+            loadConversation(replacement)
+        } else {
+            messages.removeAll()
+            currentInput = ""
+            currentConversation = nil
         }
     }
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
@@ -174,6 +174,15 @@ final class LLMViewModel {
         activeGenerationID = id
     }
 
+    /// Store the task backing the current turn so `stopGeneration()` /
+    /// `cancelActiveGeneration()` can cancel image- and document-question turns,
+    /// which run outside `sendMessage` (the text path assigns `generationTask`
+    /// directly). Without this, Stop cancels a stale/nil task and the composer
+    /// stays locked until the turn finishes on its own.
+    func setGenerationTask(_ task: Task<Void, Never>?) {
+        generationTask = task
+    }
+
     /// Cancel the in-flight generation and detach it from the active conversation
     /// so its late token writes and finalization become no-ops. Shared by
     /// `clearChat()` and `loadConversation(_:)`.

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/Views/ChatInterfaceView.swift
@@ -679,20 +679,30 @@ extension ChatInterfaceView {
         switch result {
         case .success(let urls):
             guard let url = urls.first else { return }
-            do {
-                let text = try DocumentService.extractText(from: url)
-                pendingDocumentAttachment = ChatDocumentAttachment(
-                    filename: url.lastPathComponent,
-                    text: text
-                )
-                pendingImageAttachment = nil
-
-                if !areDocumentModelsReady {
-                    showNextDocumentModelPicker()
+            Task {
+                do {
+                    // Extract off the main actor — PDFKit/JSON parsing of a large
+                    // file blocks the UI (and risks the watchdog) if run inline.
+                    // extractText manages its own security-scoped access.
+                    let text = try await Task.detached(priority: .userInitiated) {
+                        try DocumentService.extractText(from: url)
+                    }.value
+                    await MainActor.run {
+                        pendingDocumentAttachment = ChatDocumentAttachment(
+                            filename: url.lastPathComponent,
+                            text: text
+                        )
+                        pendingImageAttachment = nil
+                        if !areDocumentModelsReady {
+                            showNextDocumentModelPicker()
+                        }
+                    }
+                } catch {
+                    await MainActor.run {
+                        debugMessage = error.localizedDescription
+                        showDebugAlert = true
+                    }
                 }
-            } catch {
-                debugMessage = error.localizedDescription
-                showDebugAlert = true
             }
         case .failure(let error):
             debugMessage = error.localizedDescription

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/ModelDownloadTracker.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/ModelDownloadTracker.swift
@@ -1,0 +1,71 @@
+//
+//  ModelDownloadTracker.swift
+//  RunAnywhereAI
+//
+//  Process-wide state for in-flight model downloads.
+//
+
+import Foundation
+import RunAnywhere
+
+/// Owns download state (progress + the cancellable `Task`) for each model being
+/// downloaded, outside any single row view.
+///
+/// Why this exists:
+/// - **Survives navigation** — the download continues (and stays visible) when the
+///   user leaves the row that started it, instead of the `Task` becoming an
+///   invisible orphan.
+/// - **Cancellable** — the stored `Task` can be cancelled; `RunAnywhere.downloadModel`
+///   is already Task-cancellation-aware and tears down the native worker.
+/// - **De-duplicated** — the same model shown in two places (e.g. Recommended and
+///   its family) can't start two concurrent downloads into the same partial file.
+@MainActor
+@Observable
+final class ModelDownloadTracker {
+    static let shared = ModelDownloadTracker()
+    private init() {}
+
+    private struct Active {
+        var progress: Double
+        let task: Task<Void, Never>
+    }
+
+    private var active: [String: Active] = [:]
+    private var errors: [String: String] = [:]
+
+    func isDownloading(_ modelID: String) -> Bool { active[modelID] != nil }
+    func progress(_ modelID: String) -> Double { active[modelID]?.progress ?? 0 }
+    func errorMessage(_ modelID: String) -> String? { errors[modelID] }
+    func clearError(_ modelID: String) { errors[modelID] = nil }
+
+    /// Start a download for `model` unless one is already in flight for it.
+    /// `onFinished` runs on the main actor after a successful download.
+    func start(_ model: RAModelInfo, onFinished: @escaping () -> Void) {
+        let modelID = model.id
+        guard active[modelID] == nil else { return }  // dedup: no second download
+        errors[modelID] = nil
+
+        let task = Task { [weak self] in
+            do {
+                _ = try await RunAnywhere.downloadModel(model) { progress in
+                    await MainActor.run { self?.active[modelID]?.progress = Double(progress.overallProgress) }
+                }
+                self?.active[modelID] = nil
+                onFinished()
+            } catch is CancellationError {
+                self?.active[modelID] = nil
+            } catch {
+                self?.active[modelID] = nil
+                // Surface the SDK's descriptive failure (disk-full / network / checksum).
+                self?.errors[modelID] = (error as? SDKException)?.message ?? error.localizedDescription
+            }
+        }
+        active[modelID] = Active(progress: 0, task: task)
+    }
+
+    /// Cancel an in-flight download; the SDK stops the native worker.
+    func cancel(_ modelID: String) {
+        active[modelID]?.task.cancel()
+        active[modelID] = nil
+    }
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/RecommendedModelViews.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/RecommendedModelViews.swift
@@ -43,6 +43,7 @@ struct ModelPrimaryActionButton: View {
 
     @State private var isDownloading = false
     @State private var downloadProgress: Double = 0.0
+    @State private var downloadErrorMessage: String?
 
     var body: some View {
         Group {
@@ -63,6 +64,12 @@ struct ModelPrimaryActionButton: View {
         .font(AppTypography.caption)
         .fontWeight(.semibold)
         .controlSize(.small)
+        .alert("Download Failed", isPresented: Binding(
+            get: { downloadErrorMessage != nil },
+            set: { if !$0 { downloadErrorMessage = nil } }
+        ), presenting: downloadErrorMessage) { _ in
+            Button("OK", role: .cancel) {}
+        } message: { Text($0) }
     }
 
     private var useButton: some View {
@@ -117,9 +124,12 @@ struct ModelPrimaryActionButton: View {
                 onChanged()
             }
         } catch {
+            // Surface the SDK's descriptive failure (disk-full / network / checksum)
+            // instead of silently reverting to "Get" with no feedback.
             await MainActor.run {
                 downloadProgress = 0.0
                 isDownloading = false
+                downloadErrorMessage = (error as? SDKException)?.message ?? error.localizedDescription
             }
         }
     }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/RecommendedModelViews.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Models/RecommendedModelViews.swift
@@ -41,9 +41,9 @@ struct ModelPrimaryActionButton: View {
     let onSelectModel: () -> Void
     let onChanged: () -> Void
 
-    @State private var isDownloading = false
-    @State private var downloadProgress: Double = 0.0
-    @State private var downloadErrorMessage: String?
+    // Download state lives in the shared tracker so it survives navigation, can be
+    // cancelled, and can't start twice for the same model.
+    private var downloads: ModelDownloadTracker { .shared }
 
     var body: some View {
         Group {
@@ -65,9 +65,9 @@ struct ModelPrimaryActionButton: View {
         .fontWeight(.semibold)
         .controlSize(.small)
         .alert("Download Failed", isPresented: Binding(
-            get: { downloadErrorMessage != nil },
-            set: { if !$0 { downloadErrorMessage = nil } }
-        ), presenting: downloadErrorMessage) { _ in
+            get: { downloads.errorMessage(model.id) != nil },
+            set: { if !$0 { downloads.clearError(model.id) } }
+        ), presenting: downloads.errorMessage(model.id)) { _ in
             Button("OK", role: .cancel) {}
         } message: { Text($0) }
     }
@@ -80,16 +80,24 @@ struct ModelPrimaryActionButton: View {
     }
 
     @ViewBuilder private var downloadControl: some View {
-        if isDownloading {
+        if downloads.isDownloading(model.id) {
             HStack(spacing: AppSpacing.xxSmall) {
                 ProgressView().scaleEffect(0.7)
-                Text("\(Int(downloadProgress * 100))%")
+                Text("\(Int(downloads.progress(model.id) * 100))%")
                     .font(AppTypography.caption2)
                     .foregroundColor(AppColors.textSecondary)
+                Button {
+                    downloads.cancel(model.id)
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(AppColors.textSecondary)
+                }
+                .buttonStyle(.plain)
+                .accessibilityLabel("Cancel download")
             }
         } else {
             Button {
-                Task { await download() }
+                downloads.start(model) { onChanged() }
             } label: {
                 HStack(spacing: AppSpacing.xxSmall) {
                     Image(systemName: "arrow.down.circle.fill")
@@ -110,29 +118,6 @@ struct ModelPrimaryActionButton: View {
         .foregroundColor(AppColors.statusGreen)
     }
 
-    private func download() async {
-        await MainActor.run {
-            isDownloading = true
-            downloadProgress = 0.0
-        }
-        do {
-            try await RunAnywhere.downloadModel(model) { progress in
-                await MainActor.run { downloadProgress = Double(progress.overallProgress) }
-            }
-            await MainActor.run {
-                isDownloading = false
-                onChanged()
-            }
-        } catch {
-            // Surface the SDK's descriptive failure (disk-full / network / checksum)
-            // instead of silently reverting to "Get" with no feedback.
-            await MainActor.run {
-                downloadProgress = 0.0
-                isDownloading = false
-                downloadErrorMessage = (error as? SDKException)?.message ?? error.localizedDescription
-            }
-        }
-    }
 }
 
 /// Rich, rounded card for a single recommended model in the hero section.

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Storage/StorageViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Storage/StorageViewModel.swift
@@ -91,5 +91,9 @@ class StorageViewModel: ObservableObject {
         }
 
         await refreshData()
+        // Keep the Models tab in sync (it's a separate singleton with cached
+        // rows) so a model deleted here doesn't still show as Installed/Active
+        // there and fail to load when tapped.
+        await ModelListViewModel.shared.loadModelsFromRegistry()
     }
 }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Vision/VLMCameraView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Vision/VLMCameraView.swift
@@ -65,6 +65,12 @@ struct VLMCameraView: View {
                 }
             }
         }
+        .onChange(of: viewModel.isModelLoaded) { _, loaded in
+            // Start the camera once a model is ready; stop it if the model is
+            // unloaded/deleted mid-session so the session doesn't keep running
+            // behind the "choose a vision model" prompt.
+            if loaded { setupCameraIfNeeded() } else { viewModel.stopCamera() }
+        }
     }
 
     // MARK: - Main Content
@@ -294,6 +300,11 @@ struct VLMCameraView: View {
     }
 
     private func setupCameraIfNeeded() {
+        // Don't run the camera until a vision model is loaded. Otherwise the
+        // capture session (and the iOS camera privacy indicator) runs with no
+        // visible preview and nothing to feed it, and the permission prompt
+        // fires before the user has chosen a model.
+        guard viewModel.isModelLoaded else { return }
         Task {
             await viewModel.checkCameraAuthorization()
             if viewModel.isCameraAuthorized {

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Vision/VLMViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Vision/VLMViewModel.swift
@@ -108,13 +108,29 @@ final class VLMViewModel: NSObject {
         }
     }
 
+    /// Resolve a capture device that exists on the current platform. iOS prefers
+    /// the rear wide-angle camera (falling back to any default video device);
+    /// macOS has no camera at `.back` position, so `AVCaptureDevice.default(for:)`
+    /// selects the built-in/Continuity/external camera (which reports
+    /// `.front`/`.unspecified`). Hard-coding `.back` returned nil on Mac, leaving
+    /// Live mode permanently stuck on "Camera Access Required" even after access
+    /// was granted.
+    private static func defaultCameraDevice() -> AVCaptureDevice? {
+        #if os(macOS)
+        return AVCaptureDevice.default(for: .video)
+        #else
+        return AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back)
+            ?? AVCaptureDevice.default(for: .video)
+        #endif
+    }
+
     func setupCamera() {
         guard isCameraAuthorized else { return }
 
         let session = AVCaptureSession()
         session.sessionPreset = .medium
 
-        guard let device = AVCaptureDevice.default(.builtInWideAngleCamera, for: .video, position: .back),
+        guard let device = Self.defaultCameraDevice(),
               let input = try? AVCaptureDeviceInput(device: device) else { return }
 
         if session.canAddInput(input) { session.addInput(input) }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/TTSViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/TTSViewModel.swift
@@ -64,6 +64,7 @@ class TTSViewModel: VoiceComponentViewModelBase {
         isSpeaking = true
         errorMessage = nil
         lastResult = nil
+        didRequestStop = false
 
         do {
             var options = RATTSOptions.defaults()
@@ -77,16 +78,25 @@ class TTSViewModel: VoiceComponentViewModelBase {
             let durationMs = Int(result.duration * 1000)
             logger.info("Speech generation complete: duration=\(durationMs)ms")
         } catch {
-            logger.error("Speech failed: \(error.localizedDescription)")
-            errorMessage = "Speech failed: \(error.localizedDescription)"
+            // A user- or teardown-initiated stop surfaces here as
+            // `.playbackInterrupted`; that is expected, not a failure to report.
+            if !didRequestStop {
+                logger.error("Speech failed: \(error.localizedDescription)")
+                errorMessage = "Speech failed: \(error.localizedDescription)"
+            }
         }
 
         isSpeaking = false
     }
 
+    /// Set when playback is stopped intentionally (Stop button or teardown) so the
+    /// `.playbackInterrupted` thrown back into `speak` isn't shown as an error.
+    private var didRequestStop = false
+
     /// Stop current speech
     func stopSpeaking() async {
         logger.info("Stopping speech")
+        didRequestStop = true
         await RunAnywhere.stopSpeaking()
         isSpeaking = false
     }
@@ -95,6 +105,10 @@ class TTSViewModel: VoiceComponentViewModelBase {
 
     /// Clean up resources - call from view's onDisappear
     func cleanup() {
+        // Stop any in-flight playback so speech doesn't keep playing after the
+        // screen is dismissed (mirrors STT/VAD cleanup stopping capture).
+        didRequestStop = true
+        Task { await RunAnywhere.stopSpeaking() }
         cleanupBase()
     }
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAgentViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAgentViewModel.swift
@@ -195,6 +195,9 @@ final class VoiceAgentViewModel: ObservableObject {
     // surface. The SDK wraps the raw C handle internally; this view model
     // consumes `RAVoiceEvent`s and switches on `event.payload`.
     private var eventTask: Task<Void, Never>?
+    /// True while `stopConversation` is tearing down the SDK voice agent. Blocks a
+    /// restart until cleanup completes so we never run two mic drivers at once.
+    private var isStopping = false
 
     // MARK: - Initialization State (for idempotency)
 
@@ -602,6 +605,23 @@ final class VoiceAgentViewModel: ObservableObject {
             return
         }
 
+        // Reentrancy guard: ignore a start while a session is already active/
+        // connecting, or while a stop is still tearing down. Otherwise a second
+        // streamVoiceAgent() spins up a second mic driver → permanent hot mic.
+        switch sessionState {
+        case .disconnected, .error:
+            break
+        default:
+            logger.warning("Ignoring startConversation: session already active")
+            return
+        }
+        guard !isStopping else {
+            logger.warning("Ignoring startConversation: stop still in progress")
+            return
+        }
+        eventTask?.cancel()
+        eventTask = nil
+
         sessionState = .connecting
         currentStatus = "Connecting..."
         errorMessage = nil
@@ -635,6 +655,8 @@ final class VoiceAgentViewModel: ObservableObject {
     /// reset UI state first, then release the SDK's voice-agent resources.
     /// `cleanupVoiceAgent()` never throws and is safe to call anytime.
     func stopConversation() async {
+        guard !isStopping else { return }
+        isStopping = true
         logger.info("Stopping voice session...")
         eventTask?.cancel()
         eventTask = nil
@@ -643,6 +665,7 @@ final class VoiceAgentViewModel: ObservableObject {
         audioLevel = 0.0
         isSpeechDetected = false
         await RunAnywhere.cleanupVoiceAgent()
+        isStopping = false
         logger.info("Voice session stopped")
     }
 

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAgentViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/VoiceAgentViewModel.swift
@@ -223,6 +223,17 @@ final class VoiceAgentViewModel: ObservableObject {
         // Ensure the catalog is loaded, then pre-select the best-for-device trio
         // so the user doesn't have to pick anything by hand.
         await ModelListViewModel.shared.loadModelsFromRegistry()
+
+        // If cleanup() ran while we were awaiting above (the user left the tab
+        // mid-initialization), it reset the init flags and removed our
+        // subscriptions. Bail instead of marking ourselves initialized with no
+        // live subscription — otherwise the next onAppear would take the refresh
+        // branch and the tab would be "deaf" again.
+        guard isViewModelInitialized else {
+            logger.debug("Voice agent initialization superseded by cleanup; aborting")
+            return
+        }
+
         preselectRecommendedPipeline()
 
         currentStatus = "Ready"
@@ -758,8 +769,24 @@ final class VoiceAgentViewModel: ObservableObject {
         eventTask?.cancel()
         eventTask = nil
         cancellables.removeAll()
+        // Reset ALL init/idempotency state together (matches
+        // VoiceComponentViewModelBase.cleanupBase()). The View's onAppear gates
+        // re-initialization on the @Published `isInitialized`; leaving it true
+        // across a leave+return made onAppear take the lightweight refresh branch
+        // instead of initialize(), so subscribeToSDKEvents() never re-ran and the
+        // Voice tab went "deaf" to model load/unload events.
+        isInitialized = false
         isViewModelInitialized = false
         hasSubscribedToSDKEvents = false
+        // Return the conversation-facing UI to a clean idle state (mirrors
+        // stopConversation) so leaving mid-session doesn't strand a stale
+        // "Listening…" / transcript / response when the tab is re-entered.
+        sessionState = .disconnected
+        currentStatus = "Ready"
+        audioLevel = 0.0
+        isSpeechDetected = false
+        currentTranscript = ""
+        assistantResponse = ""
         // VM teardown path (view's onDisappear) — Android's lifecycle
         // equivalent (`onCleared()` → `stop()`) also releases the agent here.
         Task {

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Shared/SharedDataBridge.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Shared/SharedDataBridge.swift
@@ -22,18 +22,24 @@ private let _darwinCallback: CFNotificationCallback = { _, _, name, _, _ in
 final class DarwinNotificationCenter: @unchecked Sendable {
     static let shared = DarwinNotificationCenter()
 
-    private var handlers: [String: [() -> Void]] = [:]
+    private var handlers: [String: () -> Void] = [:]
     // Serial queue replaces NSLock — Swift 6 compatible, avoids priority inversion
     private let queue = DispatchQueue(label: "com.runanywhere.darwin.notifications")
 
     private init() {}
 
     /// Register a callback for a Darwin notification name.
-    /// Safe to call multiple times for the same name.
+    /// Idempotent per name: re-registering the same name REPLACES the previous
+    /// callback rather than accumulating. Darwin notifications are process-global
+    /// 1:1 signals and each target process has exactly one logical owner per name
+    /// (KeyboardViewController in the extension, FlowSessionManager in the app), so
+    /// a single live handler is always correct. This prevents the handler list from
+    /// growing unbounded across keyboard presentations, where viewDidLoad re-runs
+    /// addObserver on every fresh KeyboardViewController with no symmetric removal.
     func addObserver(name: String, callback: @escaping () -> Void) {
         queue.sync {
             let isFirstObserver = handlers[name] == nil
-            handlers[name, default: []].append(callback)
+            handlers[name] = callback
 
             if isFirstObserver {
                 CFNotificationCenterAddObserver(
@@ -61,9 +67,9 @@ final class DarwinNotificationCenter: @unchecked Sendable {
 
     /// Called by the C callback — dispatches registered handlers on main queue.
     func fire(name: String) {
-        let cbs: [() -> Void] = queue.sync { handlers[name] ?? [] }
+        let callback: (() -> Void)? = queue.sync { handlers[name] }
         DispatchQueue.main.async {
-            cbs.forEach { $0() }
+            callback?()
         }
     }
 }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAIUITests/RunAnywhereAIStabilityUITests.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAIUITests/RunAnywhereAIStabilityUITests.swift
@@ -1,0 +1,221 @@
+//
+//  RunAnywhereAIStabilityUITests.swift
+//  RunAnywhereAIUITests
+//
+//  Real UI-flow tests that drive the actual iOS chat-first UI on the simulator.
+//  The app ships no accessibility identifiers, so test00 dumps the live element
+//  tree (printed to the test log) to derive robust queries; the rest exercise the
+//  real flows and assert the app stays alive (never crashes/hangs) at each step.
+//
+
+import XCTest
+
+final class RunAnywhereAIStabilityUITests: XCTestCase {
+
+    private var app: XCUIApplication!
+
+    override func setUpWithError() throws {
+        continueAfterFailure = true
+        app = XCUIApplication()
+        app.launch()
+    }
+
+    // MARK: - Helpers
+
+    private func shot(_ name: String) {
+        let a = XCTAttachment(screenshot: app.screenshot())
+        a.name = name
+        a.lifetime = .keepAlways
+        add(a)
+    }
+
+    private func dumpTree(_ label: String) {
+        // Attach the full accessibility hierarchy as a text file (extractable via
+        // xcresulttool) since print() from the runner is awkward to read.
+        let a = XCTAttachment(string: app.debugDescription)
+        a.name = "uitree-\(label)"
+        a.lifetime = .keepAlways
+        add(a)
+    }
+
+    private func assertAlive(_ ctx: String, file: StaticString = #filePath, line: UInt = #line) {
+        XCTAssertEqual(app.state, .runningForeground, "App not running after: \(ctx)", file: file, line: line)
+    }
+
+    /// Dismiss onboarding if the Welcome / Get Started screen is up.
+    private func dismissOnboardingIfPresent() {
+        let getStarted = app.buttons["Get Started"]
+        if getStarted.waitForExistence(timeout: 6) {
+            getStarted.tap()
+        }
+    }
+
+    // MARK: - Tests
+
+    /// Discovery: dump the element tree at launch and after entering the chat, so
+    /// the real labels/types are visible in the log.
+    func test00_discoverUITree() {
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 30), "app did not reach foreground")
+        _ = app.staticTexts.firstMatch.waitForExistence(timeout: 20)
+        shot("00a-launch")
+        dumpTree("launch")
+
+        dismissOnboardingIfPresent()
+        _ = app.staticTexts.firstMatch.waitForExistence(timeout: 10)
+        shot("00b-after-get-started")
+        dumpTree("after-get-started")
+
+        // Enumerate the primary interactive elements by label for reference.
+        print("BUTTONS: " + app.buttons.allElementsBoundByIndex.map { "[\($0.label)]" }.joined(separator: " "))
+        print("TEXTFIELDS: \(app.textFields.count)  TEXTVIEWS: \(app.textViews.count)")
+        print("STATICTEXTS(sample): " + app.staticTexts.allElementsBoundByIndex.prefix(15)
+            .map { "[\($0.label)]" }.joined(separator: " "))
+        assertAlive("discovery")
+    }
+
+    /// The app must reach an interactive first screen (not the "Couldn't Start"
+    /// error, not a stuck spinner).
+    func test01_launchesToInteractiveUI() {
+        assertAlive("launch")
+        XCTAssertFalse(app.staticTexts["RunAnywhere Couldn't Start"].waitForExistence(timeout: 3),
+                       "app shows the Couldn't Start error")
+        // Some interactive control appears within 30s.
+        XCTAssertTrue(app.buttons.firstMatch.waitForExistence(timeout: 30),
+                      "no interactive UI appeared (stuck init?)")
+        shot("01-interactive")
+    }
+
+    /// Onboarding → chat: tapping Get Started leaves onboarding and shows chat
+    /// chrome (the "Choose Model" control lives in the chat toolbar).
+    func test02_onboardingToChat() {
+        dismissOnboardingIfPresent()
+        // After onboarding, the chat toolbar's model control should exist.
+        let chooseModel = app.buttons["Choose Model"]
+        let landed = chooseModel.waitForExistence(timeout: 10)
+        shot("02-chat")
+        XCTAssertTrue(landed, "did not land on the chat screen (no 'Choose Model' control)")
+        assertAlive("onboarding→chat")
+    }
+
+    /// The model picker must open and be dismissable without crashing.
+    func test03_modelPickerOpensAndCloses() throws {
+        dismissOnboardingIfPresent()
+        let chooseModel = app.buttons["Choose Model"]
+        guard chooseModel.waitForExistence(timeout: 10) else {
+            shot("03-no-choose-model"); throw XCTSkip("No 'Choose Model' control")
+        }
+        chooseModel.tap()
+        // A sheet with a nav bar / list should appear.
+        let sheetUp = app.navigationBars.firstMatch.waitForExistence(timeout: 8)
+            || app.collectionViews.firstMatch.waitForExistence(timeout: 3)
+            || app.tables.firstMatch.waitForExistence(timeout: 3)
+        shot("03-model-picker")
+        assertAlive("model picker open")
+        XCTAssertTrue(sheetUp, "model picker sheet did not appear")
+        // Dismiss (Close/Cancel/Done button, or swipe down).
+        for label in ["Close", "Cancel", "Done"] where app.buttons[label].exists {
+            app.buttons[label].tap(); break
+        }
+        assertAlive("model picker closed")
+    }
+
+    /// Rapid open/close of sheets + backgrounding must not crash or hang.
+    func test04_stability() {
+        dismissOnboardingIfPresent()
+        let chooseModel = app.buttons["Choose Model"]
+        for i in 0..<6 where chooseModel.waitForExistence(timeout: 5) {
+            chooseModel.tap()
+            for label in ["Close", "Cancel", "Done"] where app.buttons[label].waitForExistence(timeout: 4) {
+                app.buttons[label].tap(); break
+            }
+            if i % 3 == 0 { assertAlive("sheet cycle \(i)") }
+        }
+        // Background + foreground.
+        XCUIDevice.shared.press(.home)
+        Thread.sleep(forTimeInterval: 2)
+        app.activate()
+        XCTAssertTrue(app.wait(for: .runningForeground, timeout: 15), "did not return to foreground")
+        shot("04-post-stability")
+        assertAlive("post-stability")
+    }
+
+    /// The chat composer must accept typed text.
+    func test05_chatInputAcceptsText() throws {
+        dismissOnboardingIfPresent()
+        let field = app.textViews.firstMatch.exists ? app.textViews.firstMatch : app.textFields.firstMatch
+        guard field.waitForExistence(timeout: 10) else {
+            shot("05-no-input"); throw XCTSkip("No chat input field found")
+        }
+        field.tap()
+        field.typeText("Hello from XCUITest")
+        shot("05-typed")
+        assertAlive("typed into composer")
+    }
+
+    /// Full chat E2E through the GUI: load a model, send a prompt, confirm a
+    /// response bubble appears. Heavily instrumented (screenshots + trees) because
+    /// it depends on a model download + on-device inference on the sim (slow).
+    func test06_chatEndToEnd() throws {
+        dismissOnboardingIfPresent()
+        guard app.buttons["Choose Model"].waitForExistence(timeout: 10) else {
+            throw XCTSkip("no chat screen")
+        }
+        app.buttons["Choose Model"].tap()
+        let use = app.buttons["Use"].firstMatch
+        guard use.waitForExistence(timeout: 10) else {
+            dumpTree("picker"); shot("06-no-use"); throw XCTSkip("no 'Use' in picker")
+        }
+        dumpTree("picker")
+        shot("06a-picker")
+        use.tap()
+
+        // Wait for the model to load (covers a sim download). Ready when the picker
+        // is gone and the composer TextField ('Type a message...') is back.
+        let composer = app.textFields.firstMatch
+        let deadline = Date().addingTimeInterval(600)
+        while Date() < deadline {
+            if !app.staticTexts["Choose Chat Model"].exists && composer.exists { break }
+            Thread.sleep(forTimeInterval: 5)
+        }
+        shot("06b-loaded")
+        dumpTree("chat-loaded")
+        guard composer.waitForExistence(timeout: 15) else {
+            XCTFail("composer missing after model load"); return
+        }
+
+        composer.tap()
+        // Dismiss the iOS multilingual-keyboard tutorial popup if it appears — it
+        // sits over the composer and intercepts the Send tap.
+        let continueBtn = app.buttons["Continue"]
+        if continueBtn.waitForExistence(timeout: 3) { continueBtn.tap() }
+        composer.typeText("Reply with exactly: OK")
+        if continueBtn.exists { continueBtn.tap() }
+        shot("06c-typed")
+        dumpTree("chat-typed")
+
+        // Send via the confirmed control (arrow.up.circle.fill; enables once there
+        // is text).
+        let send = app.buttons["Send message"]
+        XCTAssertTrue(send.waitForExistence(timeout: 5), "Send button not found")
+        let enableDeadline = Date().addingTimeInterval(10)
+        while !send.isEnabled && Date() < enableDeadline { Thread.sleep(forTimeInterval: 0.5) }
+        send.tap()
+        shot("06d-sent")
+
+        // Send succeeded when the composer clears. Then the on-device model streams
+        // its reply into a bubble (the 06e screenshot + chat-response tree are the
+        // ground-truth record).
+        var cleared = false
+        let clearDeadline = Date().addingTimeInterval(30)
+        while Date() < clearDeadline {
+            let val = (composer.value as? String) ?? ""
+            if val.isEmpty || val == "Type a message..." { cleared = true; break }
+            Thread.sleep(forTimeInterval: 1)
+        }
+        XCTAssertTrue(cleared, "composer did not clear — message did not send")
+        Thread.sleep(forTimeInterval: 90)  // let the reply stream on sim CPU
+        shot("06e-response")
+        dumpTree("chat-response")
+        assertAlive("after chat turn")
+    }
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereAIUnitTests/DarwinNotificationCenterTests.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAIUnitTests/DarwinNotificationCenterTests.swift
@@ -1,0 +1,35 @@
+//
+//  DarwinNotificationCenterTests.swift
+//  RunAnywhereAIUnitTests
+//
+//  DarwinNotificationCenter registration is idempotent per name (single
+//  replaceable slot) instead of accumulating handlers unbounded. Headless.
+//
+
+import XCTest
+@testable import RunAnywhereAI
+
+final class DarwinNotificationCenterTests: XCTestCase {
+
+    /// Re-registering the same name REPLACES the handler rather than appending,
+    /// so handlers don't accumulate unbounded across keyboard presentations.
+    func testAddObserverIsIdempotentPerName() {
+        let center = DarwinNotificationCenter.shared
+        let name = "com.runanywhere.test.idempotent.\(UUID().uuidString)"
+
+        var firstRan = false
+        var secondRan = false
+        center.addObserver(name: name) { firstRan = true }
+        center.addObserver(name: name) { secondRan = true }
+
+        let exp = expectation(description: "handlers dispatched")
+        center.fire(name: name)
+        // `fire` dispatches the handler on the main queue; this fulfil is queued
+        // after it (FIFO), so by the time it runs the handler has run.
+        DispatchQueue.main.async { exp.fulfill() }
+        wait(for: [exp], timeout: 1.0)
+
+        XCTAssertFalse(firstRan, "the replaced handler must not run")
+        XCTAssertTrue(secondRan, "only the latest handler runs")
+    }
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereAIUnitTests/FinalizeEmptyBubbleTests.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAIUnitTests/FinalizeEmptyBubbleTests.swift
@@ -1,0 +1,79 @@
+//
+//  FinalizeEmptyBubbleTests.swift
+//  RunAnywhereAIUnitTests
+//
+//  finalizeGeneration drops a trailing empty assistant bubble on Stop and
+//  preserves a real / partial reply. Headless state-assertion.
+//
+
+import XCTest
+@testable import RunAnywhereAI
+
+@MainActor
+final class FinalizeEmptyBubbleTests: XCTestCase {
+
+    private func makeConversation(id: String) -> Conversation {
+        Conversation(
+            id: id, title: "T", createdAt: Date(), updatedAt: Date(),
+            messages: [], modelName: nil, frameworkName: nil,
+            analytics: nil, performanceSummary: nil
+        )
+    }
+
+    /// A Stop with no produced text leaves an empty assistant slot; finalize must
+    /// drop it (no orphan bubble) and still clear isGenerating.
+    func testFinalizeDropsEmptyAssistantBubble() async {
+        let vm = LLMViewModel()
+        let gid = UUID()
+        vm.setCurrentConversation(makeConversation(id: "A"))
+        vm.setMessages([Message(role: .user, content: "hi"),
+                        Message(role: .assistant, content: "")])
+        vm.setGeneratingConversationId("A")
+        vm.setActiveGenerationID(gid)
+        vm.setIsGenerating(true)
+
+        await vm.finalizeGeneration(at: 1, generationID: gid)
+
+        XCTAssertFalse(vm.isGenerating)
+        XCTAssertEqual(vm.messagesValue.count, 1, "empty assistant bubble is dropped")
+        XCTAssertEqual(vm.messagesValue.last?.role, .user)
+    }
+
+    /// A real (or partial-but-kept) reply has non-empty content and must NOT be
+    /// dropped by the empty-bubble guard.
+    func testFinalizeKeepsNonEmptyAssistantMessage() async {
+        let vm = LLMViewModel()
+        let gid = UUID()
+        vm.setCurrentConversation(makeConversation(id: "A"))
+        vm.setMessages([Message(role: .user, content: "hi"),
+                        Message(role: .assistant, content: "a real answer")])
+        vm.setGeneratingConversationId("A")
+        vm.setActiveGenerationID(gid)
+        vm.setIsGenerating(true)
+
+        await vm.finalizeGeneration(at: 1, generationID: gid)
+
+        XCTAssertFalse(vm.isGenerating)
+        XCTAssertEqual(vm.messagesValue.count, 2, "non-empty assistant reply is preserved")
+        XCTAssertEqual(vm.messagesValue.last?.content, "a real answer")
+    }
+
+    /// The helper only removes a genuinely blank trailing assistant bubble.
+    func testRemoveTrailingEmptyAssistantMessageIsPrecise() {
+        let vm = LLMViewModel()
+
+        vm.setMessages([Message(role: .user, content: "q"),
+                        Message(role: .assistant, content: "   ")])
+        vm.removeTrailingEmptyAssistantMessage()
+        XCTAssertEqual(vm.messagesValue.count, 1, "blank assistant removed")
+
+        vm.setMessages([Message(role: .user, content: "q"),
+                        Message(role: .assistant, content: "answer")])
+        vm.removeTrailingEmptyAssistantMessage()
+        XCTAssertEqual(vm.messagesValue.count, 2, "non-blank assistant kept")
+
+        vm.setMessages([Message(role: .user, content: "q")])
+        vm.removeTrailingEmptyAssistantMessage()
+        XCTAssertEqual(vm.messagesValue.count, 1, "a user turn is never removed")
+    }
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereAIUnitTests/LLMViewModelGenerationGuardTests.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAIUnitTests/LLMViewModelGenerationGuardTests.swift
@@ -178,4 +178,43 @@ final class LLMViewModelGenerationGuardTests: XCTestCase {
         XCTAssertTrue(LLMViewModel.makeHistory(from: messages, currentUserIndex: 0).isEmpty)
         XCTAssertTrue(LLMViewModel.makeHistory(from: messages, currentUserIndex: -3).isEmpty)
     }
+
+    // MARK: - makeHistory turn hygiene (Tier-3 #4)
+
+    /// An assistant error placeholder (isError == true) is excluded from history,
+    /// and the resulting consecutive user turns collapse to the latest.
+    func testMakeHistorySkipsErrorAssistantBubble() {
+        let messages = [
+            Message(role: .user, content: "q1"),
+            Message(role: .assistant, content: "Generation failed: boom", isError: true),
+            Message(role: .user, content: "q2")
+        ]
+        let history = LLMViewModel.makeHistory(from: messages, currentUserIndex: 3)
+        XCTAssertEqual(history.count, 1)
+        XCTAssertEqual(history.first?.role, .user)
+        XCTAssertEqual(history.first?.content, "q2")
+    }
+
+    /// Consecutive same-role turns are collapsed (keep the most recent).
+    func testMakeHistoryCollapsesConsecutiveSameRole() {
+        let messages = [
+            Message(role: .user, content: "u1"),
+            Message(role: .user, content: "u2"),
+            Message(role: .assistant, content: "a1")
+        ]
+        let history = LLMViewModel.makeHistory(from: messages, currentUserIndex: 3)
+        XCTAssertEqual(history.map { $0.role }, [.user, .assistant])
+        XCTAssertEqual(history.map { $0.content }, ["u2", "a1"])
+    }
+
+    /// A normal alternating history passes through unchanged.
+    func testMakeHistoryKeepsAlternatingTurns() {
+        let messages = [
+            Message(role: .user, content: "u1"),
+            Message(role: .assistant, content: "a1"),
+            Message(role: .user, content: "u2")
+        ]
+        let history = LLMViewModel.makeHistory(from: messages, currentUserIndex: 3)
+        XCTAssertEqual(history.map { $0.content }, ["u1", "a1", "u2"])
+    }
 }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAIUnitTests/LLMViewModelGenerationGuardTests.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAIUnitTests/LLMViewModelGenerationGuardTests.swift
@@ -1,0 +1,181 @@
+//
+//  LLMViewModelGenerationGuardTests.swift
+//  RunAnywhereAIUnitTests
+//
+//  State-assertion tests for the generation-identity guards added for Tier-1
+//  bugs #1 (switching conversations mid-generation corrupts data) and #5
+//  (stopGeneration allows a second overlapping generation), plus the
+//  adversarial-review follow-ups (generation identity / supersession and the
+//  makeHistory stale-index crash clamp).
+//
+//  These drive the real ViewModel state API (@testable) and touch no SDK
+//  inference / network / hardware, so they run headlessly under `swift test`.
+//
+
+import RunAnywhere
+import XCTest
+@testable import RunAnywhereAI
+
+@MainActor
+final class LLMViewModelGenerationGuardTests: XCTestCase {
+
+    private func makeConversation(id: String, messages: [Message] = []) -> Conversation {
+        Conversation(
+            id: id,
+            title: "T",
+            createdAt: Date(),
+            updatedAt: Date(),
+            messages: messages,
+            modelName: nil,
+            frameworkName: nil,
+            analytics: nil,
+            performanceSummary: nil
+        )
+    }
+
+    /// A user turn plus the empty assistant slot that streamed tokens write into.
+    private func streamingMessages() -> [Message] {
+        [Message(role: .user, content: "hi"),
+         Message(role: .assistant, content: "")]
+    }
+
+    // MARK: - Bug #1: conversation-identity guard
+
+    /// While the generation still owns the visible conversation, streamed tokens
+    /// are written into the assistant slot as normal.
+    func testStreamingTokenWrittenWhileGenerationOwnsConversation() {
+        let vm = LLMViewModel()
+        vm.setCurrentConversation(makeConversation(id: "A"))
+        vm.setMessages(streamingMessages())
+        vm.setGeneratingConversationId("A")
+
+        XCTAssertTrue(vm.isActiveGenerationTarget)
+        vm.updateMessageContent(at: 1, content: "partial answer")
+        XCTAssertEqual(vm.messagesValue[1].content, "partial answer")
+    }
+
+    /// After the user switches to another conversation, a late streamed token
+    /// from the previous generation must NOT mutate the newly-selected
+    /// conversation. This is the exact corruption reported in bug #1.
+    func testStreamingTokenDroppedAfterSwitchingConversation() {
+        let vm = LLMViewModel()
+        vm.setCurrentConversation(makeConversation(id: "A"))
+        vm.setMessages(streamingMessages())
+        vm.setGeneratingConversationId("A")
+
+        // User navigates to conversation B; its messages replace the buffer.
+        vm.setCurrentConversation(makeConversation(id: "B"))
+        vm.setMessages([Message(role: .user, content: "different question"),
+                        Message(role: .assistant, content: "B's real answer")])
+
+        XCTAssertFalse(vm.isActiveGenerationTarget)
+        // A trailing token from generation A tries to write into index 1.
+        vm.updateMessageContent(at: 1, content: "LEAK FROM A")
+        // Conversation B's assistant message is untouched.
+        XCTAssertEqual(vm.messagesValue[1].content, "B's real answer")
+    }
+
+    /// A cancelled generation clears its target + identity and (unlike a Stop on
+    /// the same conversation) restores the send control immediately.
+    func testCancelActiveGenerationClearsStateAndRestoresInput() {
+        let vm = LLMViewModel()
+        vm.setCurrentConversation(makeConversation(id: "A"))
+        vm.setMessages(streamingMessages())
+        vm.setGeneratingConversationId("A")
+        vm.setActiveGenerationID(UUID())
+        vm.setIsGenerating(true)
+
+        vm.cancelActiveGeneration()
+
+        XCTAssertNil(vm.generatingConversationId)
+        XCTAssertNil(vm.activeGenerationID)
+        XCTAssertFalse(vm.isGenerating, "navigating away restores the send control eagerly")
+        XCTAssertFalse(vm.isActiveGenerationTarget)
+        // A trailing write from the abandoned generation is dropped.
+        vm.updateMessageContent(at: 1, content: "LEAK AFTER CANCEL")
+        XCTAssertEqual(vm.messagesValue[1].content, "")
+    }
+
+    /// `isActiveGenerationTarget` is a strict match: a nil target is never active.
+    func testNilTargetIsNeverActive() {
+        let vm = LLMViewModel()
+        vm.setCurrentConversation(makeConversation(id: "A"))
+        vm.setGeneratingConversationId(nil)
+        XCTAssertFalse(vm.isActiveGenerationTarget)
+    }
+
+    // MARK: - Bug #5 / generation identity: single owner of isGenerating
+
+    /// stopGeneration must NOT flip `isGenerating` synchronously. The in-flight
+    /// generation's own `finalizeGeneration` owns the true->false transition, so
+    /// `canSend` stays false and a second overlapping generation cannot start
+    /// before the first has actually unwound.
+    func testStopGenerationLeavesIsGeneratingTrue() {
+        let vm = LLMViewModel()
+        vm.setIsGenerating(true)
+
+        vm.stopGeneration()
+
+        XCTAssertTrue(
+            vm.isGenerating,
+            "stopGeneration must leave isGenerating true until the in-flight generation finalizes"
+        )
+    }
+
+    /// A superseded generation (its id no longer the active one) must not touch
+    /// isGenerating or persist — this is what makes the cross-conversation
+    /// restart race and the navigate-away input-lock safe.
+    func testSupersededFinalizeIsANoOp() async {
+        let vm = LLMViewModel()
+        vm.setIsGenerating(true)
+        vm.setActiveGenerationID(UUID())   // a newer generation now owns the state
+
+        await vm.finalizeGeneration(at: 0, generationID: UUID())  // stale id
+
+        XCTAssertTrue(vm.isGenerating, "a superseded generation must not clear the new owner's isGenerating")
+    }
+
+    /// The generation that still owns the id is the sole clearer of isGenerating.
+    func testOwnerFinalizeClearsIsGenerating() async {
+        let vm = LLMViewModel()
+        let gid = UUID()
+        vm.setActiveGenerationID(gid)
+        vm.setIsGenerating(true)
+
+        await vm.finalizeGeneration(at: 0, generationID: gid)
+
+        XCTAssertFalse(vm.isGenerating)
+        XCTAssertNil(vm.activeGenerationID)
+    }
+
+    /// Writes are gated by generation identity, not just conversation identity,
+    /// so a superseded stream cannot re-acquire the write path once a new
+    /// generation re-pins the same conversation.
+    func testIsCurrentGenerationIsGenerationIdentityNotConversation() {
+        let vm = LLMViewModel()
+        let gid = UUID()
+        vm.setActiveGenerationID(gid)
+        XCTAssertTrue(vm.isCurrentGeneration(gid))
+        XCTAssertFalse(vm.isCurrentGeneration(UUID()), "a different (superseded) generation is not current")
+        XCTAssertFalse(vm.isCurrentGeneration(nil))
+        vm.setActiveGenerationID(nil)
+        XCTAssertFalse(vm.isCurrentGeneration(gid), "no active generation → nothing is current")
+    }
+
+    // MARK: - makeHistory stale-index crash clamp
+
+    /// A stale `currentUserIndex` (captured before an await, then the buffer
+    /// shrank on a conversation switch) must not crash the slice.
+    func testMakeHistoryClampsStaleIndexInsteadOfCrashing() {
+        let messages = [Message(role: .user, content: "only one")]
+        // currentUserIndex far beyond messages.count — pre-clamp this crashed.
+        let history = LLMViewModel.makeHistory(from: messages, currentUserIndex: 99)
+        XCTAssertEqual(history.count, 1)
+    }
+
+    func testMakeHistoryHandlesZeroAndNegativeIndex() {
+        let messages = [Message(role: .user, content: "a"), Message(role: .assistant, content: "b")]
+        XCTAssertTrue(LLMViewModel.makeHistory(from: messages, currentUserIndex: 0).isEmpty)
+        XCTAssertTrue(LLMViewModel.makeHistory(from: messages, currentUserIndex: -3).isEmpty)
+    }
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereKeyboard/KeyboardView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereKeyboard/KeyboardView.swift
@@ -43,6 +43,10 @@ struct KeyboardView: View {
     // MARK: - State (polled from SharedDataBridge)
 
     @State private var sessionState: String = "idle"
+    /// When the local state first became "activating" with no app heartbeat, so a
+    /// failed activation (e.g. Full Access off → the app never launches) can revert
+    /// to idle instead of spinning forever.
+    @State private var activatingSince: Date?
     @State private var audioLevel: Float = 0
 
     // Waveform bar heights — 30 bars driven by audioLevel
@@ -545,6 +549,23 @@ struct KeyboardView: View {
             if heartbeat > 0 && (Date().timeIntervalSince1970 - heartbeat) > 3.0 {
                 newState = "idle"
             }
+        }
+
+        // Failed-activation recovery: heartbeat == 0 means the app never launched
+        // (e.g. Full Access is off), so no heartbeat will ever arrive and the
+        // heartbeat check above can't fire. Revert to idle after a grace period
+        // so the "Run" button reappears instead of a permanent spinner.
+        if newState == "activating" && SharedDataBridge.shared.lastHeartbeatTimestamp == 0 {
+            if let since = activatingSince {
+                if Date().timeIntervalSince(since) > 6.0 {
+                    newState = "idle"
+                    activatingSince = nil
+                }
+            } else {
+                activatingSince = Date()
+            }
+        } else if newState != "activating" {
+            activatingSince = nil
         }
 
         if newState != sessionState {

--- a/examples/ios/RunAnywhereAI/RunAnywhereKeyboard/KeyboardViewController.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereKeyboard/KeyboardViewController.swift
@@ -40,6 +40,15 @@ final class KeyboardViewController: UIInputViewController {
         setupKeyboardView()
     }
 
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewWillDisappear(animated)
+        // The keyboard is going away (switched away, text field closed, host app
+        // backgrounded). Tell the main app to end any active dictation session so
+        // the mic engine doesn't keep capturing in the background with no stop
+        // affordance. The main app already observes this channel and tears down.
+        DarwinNotificationCenter.shared.post(name: SharedConstants.DarwinNotifications.endSession)
+    }
+
     // MARK: - Setup
 
     private func setupKeyboardView() {

--- a/examples/ios/RunAnywhereAI/RunAnywhereKeyboard/KeyboardViewController.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereKeyboard/KeyboardViewController.swift
@@ -95,11 +95,18 @@ final class KeyboardViewController: UIInputViewController {
 
     // MARK: - Undo
 
+    /// Text THIS keyboard actually inserted, so Undo never blind-deletes the
+    /// user's own typing. The shared `lastInsertedText` is written by the app even
+    /// when the insertion notification was missed (extension jettisoned), which
+    /// would otherwise make Undo delete characters the user typed themselves.
+    private var lastInsertedByKeyboard: String?
+
     private func handleUndo() {
-        guard let text = SharedDataBridge.shared.lastInsertedText, !text.isEmpty else { return }
+        guard let text = lastInsertedByKeyboard, !text.isEmpty else { return }
         for _ in text {
             textDocumentProxy.deleteBackward()
         }
+        lastInsertedByKeyboard = nil
         SharedDataBridge.shared.lastInsertedText = nil
     }
 
@@ -108,6 +115,9 @@ final class KeyboardViewController: UIInputViewController {
     private func handleTranscriptionReady() {
         guard let text = SharedDataBridge.shared.transcribedText, !text.isEmpty else { return }
         textDocumentProxy.insertText(text)
+        // Record what we actually inserted so Undo only removes this, not the
+        // user's own text (see lastInsertedByKeyboard).
+        lastInsertedByKeyboard = text
         // Do NOT call clearSession() here — that would set state back to "idle".
         // FlowSessionManager handles the done→ready transition itself.
         SharedDataBridge.shared.transcribedText = nil

--- a/sdk/runanywhere-commons/src/core/model_lifecycle.cpp
+++ b/sdk/runanywhere-commons/src/core/model_lifecycle.cpp
@@ -703,9 +703,19 @@ rac_result_t rac_model_lifecycle_load_proto(rac_model_registry_handle_t registry
     rc = detail::create_backend_impl(vt, primitive, resolved_path, artifact_resolution.mmproj_path,
                                      &impl, &destroy);
     if (rc != RAC_SUCCESS) {
+        // Compose the generic per-code message with the backend's "caused by"
+        // detail (set via rac_error_set_details inside create/initialize, e.g.
+        // the real MLX weight-mismatch error) so the caller sees the actual
+        // reason instead of only "Failed to load the model".
+        const char* generic = rac_error_message(rc);
+        const char* detail_str = rac_error_get_details();
+        std::string load_error = generic ? generic : "";
+        if (detail_str != nullptr && detail_str[0] != '\0') {
+            load_error.append(": ").append(detail_str);
+        }
         ModelLoadResult result =
             detail::make_load_result(false, request.model_id(), category, framework, resolved_path,
-                                     artifact_resolution.artifacts, 0, rac_error_message(rc));
+                                     artifact_resolution.artifacts, 0, load_error);
         auto failed = std::make_shared<detail::LoadedModel>();
         failed->component = component;
         failed->state = runanywhere::v1::COMPONENT_LIFECYCLE_STATE_ERROR;

--- a/sdk/runanywhere-commons/src/core/rac_error_proto.cpp
+++ b/sdk/runanywhere-commons/src/core/rac_error_proto.cpp
@@ -47,6 +47,16 @@ rac_result_t rac_result_to_proto_error(rac_result_t code, rac_proto_buffer_t* ou
     const char* message = rac_error_message(code);
     error.set_message(message ? message : "");
 
+    // Surface the thread-local "caused by" detail (set via
+    // rac_error_set_details, e.g. the underlying backend/MLX load error) so
+    // callers see the real reason instead of only the generic per-code message.
+    // Runs on the same thread that produced the failure and set the detail, so
+    // the thread-local is still visible here.
+    const char* details = rac_error_get_details();
+    if (details != nullptr && details[0] != '\0') {
+        error.set_nested_message(details);
+    }
+
     if (signed_code != 0) {
         error.set_c_abi_code(signed_code);
     }

--- a/sdk/runanywhere-commons/tests/test_llm.cpp
+++ b/sdk/runanywhere-commons/tests/test_llm.cpp
@@ -9,9 +9,12 @@
 #include "test_common.h"
 #include "test_config.h"
 
+#include <algorithm>
 #include <atomic>
+#include <cctype>
 #include <cstring>
 #include <string>
+#include <vector>
 
 #include "rac/backends/rac_llm_llamacpp.h"
 #include "rac/core/rac_core.h"
@@ -425,6 +428,146 @@ static TestResult test_unload_reload() {
 }
 
 // =============================================================================
+// Test: multi-turn memory — history reaches the model
+//
+// rac_llm_options_t.history is alternating user/assistant turns; the engine
+// renders {system_prompt, history, prompt} via the chat template
+// (rac_llm_llamacpp.cpp). A fact planted in an earlier user turn must be
+// recalled when asked in the current prompt — proving history is threaded and
+// not silently dropped. This is the C-ABI regression guard for the Apple
+// "no memory" chat bug (which was really the Swift MLX runtime ignoring these
+// same fields; llama.cpp reads them here).
+// =============================================================================
+
+static std::string to_lower(const std::string& in) {
+    std::string out = in;
+    std::transform(out.begin(), out.end(), out.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    return out;
+}
+
+static TestResult test_generate_with_history() {
+    TestResult result;
+    result.test_name = "generate_with_history";
+
+    std::string model_path = test_config::get_llm_model_path();
+    if (!test_config::require_model(model_path, result.test_name, result)) {
+        return result;
+    }
+
+    if (!setup()) {
+        result.passed = false;
+        result.details = "setup() failed";
+        return result;
+    }
+
+    rac_handle_t handle = nullptr;
+    rac_result_t rc = rac_llm_llamacpp_create(model_path.c_str(), nullptr, &handle);
+    ASSERT_EQ(rc, RAC_SUCCESS, "rac_llm_llamacpp_create should succeed");
+
+    // Alternating user/assistant. history[0] plants the fact.
+    const char* history[] = {
+        "My name is Oliver. Please remember it.",
+        "Of course, I will remember that your name is Oliver.",
+    };
+    rac_llm_options_t opts = RAC_LLM_OPTIONS_DEFAULT;
+    opts.max_tokens = 48;
+    opts.temperature = 0.0f;  // greedy → deterministic recall
+    opts.history = history;
+    opts.n_history = 2;
+
+    rac_llm_result_t gen_result = {};
+    {
+        ScopedTimer timer("llm_generate_with_history");
+        rc = rac_llm_llamacpp_generate(handle, "What is my name? Reply with only my name.", &opts,
+                                       &gen_result);
+    }
+    ASSERT_EQ(rc, RAC_SUCCESS, "generate with history should succeed");
+    ASSERT_TRUE(gen_result.text != nullptr, "result text should not be NULL");
+
+    const std::string answer = gen_result.text ? gen_result.text : "";
+    std::cout << "  With-history answer: " << answer << "\n";
+    ASSERT_TRUE(to_lower(answer).find("oliver") != std::string::npos,
+                "model must recall the name planted in history");
+
+    rac_llm_result_free(&gen_result);
+    rac_llm_llamacpp_destroy(handle);
+    teardown();
+    return TEST_PASS();
+}
+
+// =============================================================================
+// Test: context overflow — long conversation must not fail
+//
+// A small context (512) plus a history far larger than it would, pre-fix,
+// tokenize past n_ctx and make llama.cpp's decode fail ("inference failed").
+// The sliding-window fit in llamacpp_backend.cpp drops the oldest history
+// turns until the prompt fits, so generation still succeeds. This is the
+// regression guard for the "long conversation beyond context length" bug.
+// =============================================================================
+
+static TestResult test_generate_history_overflow() {
+    TestResult result;
+    result.test_name = "generate_history_overflow";
+
+    std::string model_path = test_config::get_llm_model_path();
+    if (!test_config::require_model(model_path, result.test_name, result)) {
+        return result;
+    }
+
+    if (!setup()) {
+        result.passed = false;
+        result.details = "setup() failed";
+        return result;
+    }
+
+    // Small context so a modest history is guaranteed to overflow it.
+    rac_llm_llamacpp_config_t config = RAC_LLM_LLAMACPP_CONFIG_DEFAULT;
+    config.context_size = 512;
+
+    rac_handle_t handle = nullptr;
+    rac_result_t rc = rac_llm_llamacpp_create(model_path.c_str(), &config, &handle);
+    ASSERT_EQ(rc, RAC_SUCCESS, "rac_llm_llamacpp_create (ctx=512) should succeed");
+
+    // ~40 turns of filler → well over 512 tokens of history. Owned storage
+    // (the options array is const char* const*, pointing into these strings).
+    std::vector<std::string> turns;
+    for (int i = 0; i < 40; ++i) {
+        turns.push_back("This is filler conversation turn number " + std::to_string(i) +
+                        " intended purely to consume context window space so the total prompt "
+                        "exceeds the model's configured context length of five hundred tokens.");
+    }
+    std::vector<const char*> history;
+    history.reserve(turns.size());
+    for (const auto& turn : turns) {
+        history.push_back(turn.c_str());
+    }
+
+    rac_llm_options_t opts = RAC_LLM_OPTIONS_DEFAULT;
+    opts.max_tokens = 32;
+    opts.temperature = 0.0f;
+    opts.history = history.data();
+    opts.n_history = static_cast<int32_t>(history.size());
+
+    rac_llm_result_t gen_result = {};
+    {
+        ScopedTimer timer("llm_generate_history_overflow");
+        rc = rac_llm_llamacpp_generate(handle, "Please say hello.", &opts, &gen_result);
+    }
+    // The key assertion: the sliding-window fit keeps this from failing.
+    ASSERT_EQ(rc, RAC_SUCCESS, "overflowing history must be trimmed, not fail generation");
+    ASSERT_TRUE(gen_result.text != nullptr, "result text should not be NULL");
+    ASSERT_TRUE(gen_result.completion_tokens > 0, "should still generate after trimming");
+
+    std::cout << "  Overflow-trimmed answer: " << (gen_result.text ? gen_result.text : "") << "\n";
+
+    rac_llm_result_free(&gen_result);
+    rac_llm_llamacpp_destroy(handle);
+    teardown();
+    return TEST_PASS();
+}
+
+// =============================================================================
 // Main: register tests and dispatch via CLI args
 // =============================================================================
 
@@ -439,6 +582,8 @@ int main(int argc, char** argv) {
     suite.add("cancel_generation", test_cancel_generation);
     suite.add("get_model_info", test_get_model_info);
     suite.add("unload_reload", test_unload_reload);
+    suite.add("generate_with_history", test_generate_with_history);
+    suite.add("generate_history_overflow", test_generate_history_overflow);
 
     return suite.run(argc, argv);
 }

--- a/sdk/runanywhere-swift/Sources/MLXRuntime/MLX.swift
+++ b/sdk/runanywhere-swift/Sources/MLXRuntime/MLX.swift
@@ -293,6 +293,13 @@ private struct MLXLLMOptionsSnapshot: Sendable {
     let frequencyPenalty: Float
     let seed: Int64
     let disableThinking: Bool
+    /// System prompt (options.system_prompt); nil when NULL/empty. MLX used to
+    /// ignore this, so the model never saw the system instruction.
+    let systemPrompt: String?
+    /// Prior conversation turns (options.history/n_history), alternating
+    /// user,assistant in chronological order (commons-normalized). MLX used to
+    /// ignore these, so the model had no memory across turns.
+    let history: [String]
 
     init(_ options: UnsafePointer<rac_llm_options_t>?) {
         guard let options = options?.pointee else {
@@ -307,6 +314,8 @@ private struct MLXLLMOptionsSnapshot: Sendable {
             frequencyPenalty = 0
             seed = 0
             disableThinking = false
+            systemPrompt = nil
+            history = []
             return
         }
 
@@ -321,6 +330,16 @@ private struct MLXLLMOptionsSnapshot: Sendable {
         frequencyPenalty = options.frequency_penalty
         seed = options.seed
         disableThinking = options.disable_thinking == RAC_TRUE
+        if let sys = options.system_prompt.map({ String(cString: $0) }), !sys.isEmpty {
+            systemPrompt = sys
+        } else {
+            systemPrompt = nil
+        }
+        if let entries = options.history, options.n_history > 0 {
+            history = (0..<Int(options.n_history)).compactMap { entries[$0].map { String(cString: $0) } }
+        } else {
+            history = []
+        }
     }
 }
 
@@ -652,10 +671,7 @@ private final class MLXSession: @unchecked Sendable {
     func generate(prompt: String, options: MLXLLMOptionsSnapshot) async throws
         -> (String, MLXGenerationMetrics) {
         let params = generateParameters(from: options)
-        let input = UserInput(
-            prompt: prompt,
-            additionalContext: llmAdditionalContext(from: options)
-        )
+        let input = llmUserInput(prompt: prompt, options: options)
         return try await collect(input: input, parameters: params)
     }
 
@@ -666,10 +682,7 @@ private final class MLXSession: @unchecked Sendable {
         userData: MLXCallbackUserData
     ) async throws -> MLXGenerationMetrics {
         let params = generateParameters(from: options)
-        let input = UserInput(
-            prompt: prompt,
-            additionalContext: llmAdditionalContext(from: options)
-        )
+        let input = llmUserInput(prompt: prompt, options: options)
         return try await stream(input: input, parameters: params) { token in
             guard let callback else { return false }
             return token.withCString { callback($0, userData.rawValue) == RAC_TRUE }
@@ -1296,6 +1309,29 @@ private func llmAdditionalContext(from options: MLXLLMOptionsSnapshot) -> [Strin
         return nil
     }
     return ["enable_thinking": false]
+}
+
+/// Build the MLX `UserInput` for an LLM turn. Reconstructs the full conversation
+/// — `{system, history, current prompt}` — so the model's own chat template
+/// renders prior turns and the system instruction. Without this the MLX runtime
+/// only ever saw the current prompt (no memory, no system prompt); llama.cpp
+/// already renders this in commons, and MLX owns its template so it must do the
+/// same here. Falls back to the single-prompt path when there is no history and
+/// no system prompt.
+private func llmUserInput(prompt: String, options: MLXLLMOptionsSnapshot) -> UserInput {
+    let context = llmAdditionalContext(from: options)
+    guard options.systemPrompt != nil || !options.history.isEmpty else {
+        return UserInput(prompt: prompt, additionalContext: context)
+    }
+    var chat: [Chat.Message] = []
+    if let system = options.systemPrompt {
+        chat.append(.system(system))
+    }
+    for (index, turn) in options.history.enumerated() {
+        chat.append(index.isMultiple(of: 2) ? .user(turn) : .assistant(turn))
+    }
+    chat.append(.user(prompt))
+    return UserInput(chat: chat, additionalContext: context)
 }
 
 private func generateParameters(from options: MLXVLMOptionsSnapshot) -> GenerateParameters {

--- a/sdk/runanywhere-swift/Sources/MLXRuntime/MLX.swift
+++ b/sdk/runanywhere-swift/Sources/MLXRuntime/MLX.swift
@@ -799,8 +799,7 @@ private final class MLXSession: @unchecked Sendable {
 
         generationLoop: for try await event in events {
             if isCancelled {
-                shouldFlushHeldTokens = false
-                break
+                throw CancellationError()
             }
             switch event {
             case .chunk(let token):
@@ -863,7 +862,7 @@ private final class MLXSession: @unchecked Sendable {
 
         for await event in events {
             if isCancelled {
-                break
+                throw CancellationError()
             }
             switch event {
             case .chunk(let token):
@@ -1238,16 +1237,37 @@ private func describeMLXError(_ error: Error) -> String {
     return "\(described): \(localized)"
 }
 
+/// Maps a raw MLX error to a concise, user-facing explanation for known failure
+/// shapes. Returns nil when there is no friendlier form, in which case callers
+/// fall back to the raw description (which is always logged in full anyway).
+private func friendlyMLXLoadReason(_ error: Error) -> String? {
+    let described = String(describing: error)
+    // mlx-swift-lm raises `keyNotFound(...)` when a checkpoint's weights don't
+    // line up with the model implementation it selected — i.e. the on-device
+    // MLX runtime is too old for (or otherwise incompatible with) this model's
+    // architecture. Show that plainly instead of the raw tensor-key dump.
+    if described.contains("keyNotFound") || described.contains("not found in") {
+        return "This model isn't compatible with the current on-device MLX runtime "
+            + "— its architecture needs a newer MLX version. Try a different model."
+    }
+    return nil
+}
+
 private func recordMLXFailure(_ operation: String, error: Error, modelPath: String? = nil) {
     let reason = describeMLXError(error)
-    let detail: String
+    let rawDetail: String
     if let modelPath, !modelPath.isEmpty {
-        detail = "\(operation) failed for \(modelPath): \(reason)"
+        rawDetail = "\(operation) failed for \(modelPath): \(reason)"
     } else {
-        detail = "\(operation) failed: \(reason)"
+        rawDetail = "\(operation) failed: \(reason)"
     }
-    detail.withCString { rac_error_set_details($0) }
-    mlxRuntimeLogger.error("\(detail)")
+    // The full raw detail always goes to the logs so developers can debug the
+    // exact cause (e.g. the missing tensor key).
+    mlxRuntimeLogger.error("\(rawDetail)")
+    // The caller-facing detail (surfaced in the UI via rac_error_get_details)
+    // prefers a friendly summary for known failures; otherwise the raw detail.
+    let userDetail = friendlyMLXLoadReason(error) ?? rawDetail
+    userDetail.withCString { rac_error_set_details($0) }
 }
 
 private final class SyncResultBox<T>: @unchecked Sendable {
@@ -1536,6 +1556,9 @@ private let mlxLLMGenerate: rac_mlx_llm_generate_fn = { handle, promptPtr, optio
         outResult.pointee.tokens_per_second = output.1.tokensPerSecond
         return outResult.pointee.text == nil ? RAC_ERROR_OUT_OF_MEMORY : RAC_SUCCESS
     case .failure(let error):
+        if error is CancellationError {
+            return RAC_ERROR_CANCELLED
+        }
         recordMLXFailure("MLX text generation", error: error)
         return RAC_ERROR_GENERATION_FAILED
     }
@@ -1559,6 +1582,9 @@ private let mlxLLMGenerateStream: rac_mlx_llm_generate_stream_fn = { handle, pro
     case .success:
         return RAC_SUCCESS
     case .failure(let error):
+        if error is CancellationError {
+            return RAC_ERROR_CANCELLED
+        }
         recordMLXFailure("MLX streaming text generation", error: error)
         return RAC_ERROR_GENERATION_FAILED
     }
@@ -1587,6 +1613,9 @@ private let mlxVLMProcess: rac_mlx_vlm_process_fn = { handle, image, promptPtr, 
         outResult.pointee.tokens_per_second = output.1.tokensPerSecond
         return outResult.pointee.text == nil ? RAC_ERROR_OUT_OF_MEMORY : RAC_SUCCESS
     case .failure(let error):
+        if error is CancellationError {
+            return RAC_ERROR_CANCELLED
+        }
         recordMLXFailure("MLX vision generation", error: error)
         return RAC_ERROR_GENERATION_FAILED
     }
@@ -1618,6 +1647,9 @@ private let mlxVLMProcessStream: rac_mlx_vlm_process_stream_fn = { handle, image
     case .success:
         return RAC_SUCCESS
     case .failure(let error):
+        if error is CancellationError {
+            return RAC_ERROR_CANCELLED
+        }
         recordMLXFailure("MLX streaming vision generation", error: error)
         return RAC_ERROR_GENERATION_FAILED
     }

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Adapters/HandleStreamAdapter.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Adapters/HandleStreamAdapter.swift
@@ -228,6 +228,15 @@ public final class HandleStreamAdapter<Handle: Hashable, Event: Message>: @unche
                 $0.userPtr = userPtr
                 $0.installation = .installed
             }
+            // Re-assert registry membership. A concurrent tearDown may have
+            // evicted this entry AFTER `fanOut(for:)` handed it to our `attach`
+            // but BEFORE `attach` flipped `.notInstalled` -> `.installing` (the
+            // two are disjoint lock acquisitions). Re-inserting here — now that
+            // we hold a live C registration — guarantees this re-armed instance
+            // is discoverable, so the next `stream()` JOINS it instead of
+            // building a second fan-out and installing a SECOND C callback on
+            // the same native handle. Idempotent when the entry is still present.
+            HandleStreamAdapter.fanOuts.withLock { $0[storeKey] = self }
             return true
         }
 
@@ -328,12 +337,37 @@ public final class HandleStreamAdapter<Handle: Hashable, Event: Message>: @unche
                 quiesce()
                 Unmanaged<HandleFanOut>.fromOpaque(ptrToRelease.rawValue).release()
             }
-            HandleStreamAdapter.removeFanOut(for: storeKey)
+            removeFromRegistryIfTornDown()
 
             // Finish AFTER unregister/quiesce/release so a consumer that
             // reacts to `.finished` cannot race the C teardown.
             for continuation in teardown.continuations {
                 continuation.finish()
+            }
+        }
+
+        /// Evict this fan-out from the static registry, but ONLY if the
+        /// stored entry is still THIS instance AND it has not been
+        /// re-armed since teardown began. Between the `state`-lock
+        /// snapshot at the top of `tearDown()` (which flips
+        /// `installation` back to `.notInstalled`) and this call, a
+        /// concurrent `stream()` can look up this same instance — still
+        /// present in the registry — and take `attach()`'s installer
+        /// path, installing a FRESH C registration. Removing the entry
+        /// unconditionally would orphan that live registration and let
+        /// the next `stream()` build a second fan-out, double-registering
+        /// the C callback on the same native handle. Re-checking identity
+        /// and `installation` under BOTH the registry lock and the state
+        /// lock closes the add-then-remove window. Lock order is
+        /// registry -> state; no path holds `state` while acquiring the
+        /// registry lock, so this cannot deadlock.
+        private func removeFromRegistryIfTornDown() {
+            HandleStreamAdapter.fanOuts.withLock { dict in
+                guard let current = dict[storeKey] as? HandleFanOut,
+                      current === self else { return }
+                let stillTornDown = state.withLock { $0.installation == .notInstalled }
+                guard stillTornDown else { return }
+                dict.removeValue(forKey: storeKey)
             }
         }
     }
@@ -377,10 +411,6 @@ public final class HandleStreamAdapter<Handle: Hashable, Event: Message>: @unche
             dict[key] = candidate
             return candidate
         }
-    }
-
-    private static func removeFanOut(for key: HandleStreamStoreKey) {
-        fanOuts.withLock { _ = $0.removeValue(forKey: key) }
     }
 
     // MARK: - Stored properties

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Features/STT/Services/AudioCaptureManager.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Features/STT/Services/AudioCaptureManager.swift
@@ -158,34 +158,7 @@ public class AudioCaptureManager: ObservableObject, @unchecked Sendable {
 
         logger.info("Input format: \(inputFormat.sampleRate) Hz, \(inputFormat.channelCount) channels")
 
-        guard let outputFormat = AVAudioFormat(
-            commonFormat: .pcmFormatInt16,
-            sampleRate: targetSampleRate,
-            channels: 1,
-            interleaved: false
-        ) else {
-            throw AudioCaptureError.formatConversionFailed
-        }
-
-        guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
-            throw AudioCaptureError.formatConversionFailed
-        }
-
-        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
-            guard let self = self else { return }
-
-            self.updateAudioLevel(buffer: buffer)
-
-            guard let convertedBuffer = self.convert(buffer: buffer, using: converter, to: outputFormat) else {
-                return
-            }
-
-            if let audioData = self.bufferToData(buffer: convertedBuffer) {
-                DispatchQueue.main.async {
-                    onAudioData(audioData)
-                }
-            }
-        }
+        try installCaptureTap(on: inputNode, inputFormat: inputFormat, onAudioData: onAudioData)
 
         // Start the engine on a background thread to avoid blocking the main thread.
         // AVAudioEngine.start() performs synchronous IPC to mediaserverd.
@@ -311,6 +284,44 @@ public class AudioCaptureManager: ObservableObject, @unchecked Sendable {
     }
 
     // MARK: - Private Helpers
+
+    /// Build the Int16 output format + converter for `inputFormat` and install
+    /// the mic tap that converts each buffer and forwards the PCM data. Extracted
+    /// from `startRecording` to keep that function within the body-length limit.
+    private func installCaptureTap(
+        on inputNode: AVAudioInputNode,
+        inputFormat: AVAudioFormat,
+        onAudioData: @escaping @Sendable (Data) -> Void
+    ) throws {
+        guard let outputFormat = AVAudioFormat(
+            commonFormat: .pcmFormatInt16,
+            sampleRate: targetSampleRate,
+            channels: 1,
+            interleaved: false
+        ) else {
+            throw AudioCaptureError.formatConversionFailed
+        }
+
+        guard let converter = AVAudioConverter(from: inputFormat, to: outputFormat) else {
+            throw AudioCaptureError.formatConversionFailed
+        }
+
+        inputNode.installTap(onBus: 0, bufferSize: 4096, format: inputFormat) { [weak self] buffer, _ in
+            guard let self = self else { return }
+
+            self.updateAudioLevel(buffer: buffer)
+
+            guard let convertedBuffer = self.convert(buffer: buffer, using: converter, to: outputFormat) else {
+                return
+            }
+
+            if let audioData = self.bufferToData(buffer: convertedBuffer) {
+                DispatchQueue.main.async {
+                    onAudioData(audioData)
+                }
+            }
+        }
+    }
 
     /// Converts a PCM buffer to the target format. Internal for unit testing.
     internal func convert(

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Features/STT/Services/AudioCaptureManager.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Features/STT/Services/AudioCaptureManager.swift
@@ -48,6 +48,16 @@ public class AudioCaptureManager: ObservableObject, @unchecked Sendable {
     private var audioEngine: AVAudioEngine?
     private var inputNode: AVAudioInputNode?
 
+    /// Synchronous, atomically-updated source of truth for the start/stop guards.
+    /// `isRecording` below is an `@Published` UI mirror that is written a
+    /// main-queue turn later (`DispatchQueue.main.async`), so it cannot drive the
+    /// hardware-teardown decision without a TOCTOU race: stop-before-the-flip
+    /// leaves the engine running (hot mic), start-before-the-flip no-ops (no
+    /// capture), and two concurrent starts each build an engine (leak). This
+    /// claim flag is checked-and-set under the lock so start/stop are idempotent
+    /// and race-free.
+    private let recordingClaim = OSAllocatedUnfairLock(initialState: false)
+
     @Published public var isRecording = false
     @Published public var audioLevel: Float = 0.0
 
@@ -87,9 +97,26 @@ public class AudioCaptureManager: ObservableObject, @unchecked Sendable {
         configureSession: Bool = true,
         onAudioData: @escaping @Sendable (Data) -> Void
     ) async throws {
-        guard !isRecording else {
+        // Atomically claim the recording slot. If we're already recording (or a
+        // concurrent start already claimed it), bail before creating an engine so
+        // two starts can't leak a second AVAudioEngine.
+        let claimed = recordingClaim.withLock { claim -> Bool in
+            guard !claim else { return false }
+            claim = true
+            return true
+        }
+        guard claimed else {
             logger.warning("Already recording")
             return
+        }
+
+        // Any throwing failure during setup below must release the claim so a
+        // subsequent start can retry instead of wedging on "Already recording".
+        var startSucceeded = false
+        defer {
+            if !startSucceeded {
+                recordingClaim.withLock { $0 = false }
+            }
         }
 
         #if os(iOS) || os(tvOS)
@@ -176,8 +203,25 @@ public class AudioCaptureManager: ObservableObject, @unchecked Sendable {
             }
         }
 
+        // A stopRecording() may have interleaved during the awaits above — the
+        // main actor is free while we await session activation / engine start,
+        // and stopRecording ran while `audioEngine` was still nil, so it could
+        // not tear down THIS engine. If our claim was released out from under us,
+        // honor the stop: tear the just-started engine down instead of leaving a
+        // hot mic with the tap installed.
+        let stillClaimed = recordingClaim.withLock { $0 }
+        guard stillClaimed else {
+            DispatchQueue.global(qos: .userInitiated).async {
+                inputNode.removeTap(onBus: 0)
+                engine.stop()
+            }
+            logger.info("Recording start superseded by a concurrent stop; torn down")
+            return
+        }
+
         self.audioEngine = engine
         self.inputNode = inputNode
+        startSucceeded = true
 
         DispatchQueue.main.async {
             self.isRecording = true
@@ -222,7 +266,16 @@ public class AudioCaptureManager: ObservableObject, @unchecked Sendable {
     ///   deactivated. Pass `false` to keep the session alive for subsequent recordings
     ///   (e.g. between listening segments in a flow session).
     public func stopRecording(deactivateSession: Bool = true) {
-        guard isRecording else { return }
+        // Atomically release the claim. Only the first stop tears down hardware;
+        // re-entrant/concurrent stops — and a stop issued before the async
+        // `isRecording = true` flip — no-op instead of skipping teardown and
+        // leaving a hot mic.
+        let wasRecording = recordingClaim.withLock { claim -> Bool in
+            guard claim else { return false }
+            claim = false
+            return true
+        }
+        guard wasRecording else { return }
 
         // Capture references and nil out immediately so the logical state is "stopped"
         // and re-entrant calls hit the guard above.

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Features/TTS/Services/AudioPlaybackManager.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Features/TTS/Services/AudioPlaybackManager.swift
@@ -76,15 +76,22 @@ public class AudioPlaybackManager: NSObject, ObservableObject, AVAudioPlayerDele
             throw AudioPlaybackError.emptyAudioData
         }
 
-        try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
-            lock.withLock { $0.playbackContinuation = continuation }
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
+                lock.withLock { $0.playbackContinuation = continuation }
 
-            do {
-                try startPlayback(audioData)
-            } catch {
-                lock.withLock { $0.playbackContinuation = nil }
-                continuation.resume(throwing: error)
+                do {
+                    try startPlayback(audioData)
+                } catch {
+                    lock.withLock { $0.playbackContinuation = nil }
+                    continuation.resume(throwing: error)
+                }
             }
+        } onCancel: {
+            // Stop immediately when the awaiting task is cancelled (voice-agent
+            // teardown / user Stop) so a reply doesn't keep playing to the end;
+            // stop() resumes the continuation with .playbackInterrupted.
+            stop()
         }
     }
 

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Features/TTS/Services/AudioPlaybackManager.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Features/TTS/Services/AudioPlaybackManager.swift
@@ -45,7 +45,7 @@ public class AudioPlaybackManager: NSObject, ObservableObject, AVAudioPlayerDele
         var audioPlayer: AVAudioPlayer?
         var playbackCompletion: (@Sendable (Bool) -> Void)?
         var playbackContinuation: CheckedContinuation<Void, Error>?
-        var progressTimer: Timer?
+        var progressTimer: DispatchSourceTimer?
     }
 
     private let lock = OSAllocatedUnfairLock<State>(initialState: State())
@@ -186,24 +186,30 @@ public class AudioPlaybackManager: NSObject, ObservableObject, AVAudioPlayerDele
     }
 
     private func startProgressTimer() {
-        let timer = Timer.scheduledTimer(withTimeInterval: 0.1, repeats: true) { [weak self] _ in
+        // A run-loop `Timer` only fires on a thread with a live run loop, but
+        // `play(_:)` starts on a Swift-concurrency cooperative thread that has
+        // none, so a scheduled `Timer` never ticks and `currentTime` stays 0. A
+        // `DispatchSourceTimer` needs no run loop, fires on its target queue,
+        // and is safe to create/cancel from any thread.
+        let timer = DispatchSource.makeTimerSource(queue: .main)
+        timer.schedule(deadline: .now() + 0.1, repeating: 0.1)
+        timer.setEventHandler { [weak self] in
             guard let self,
                   let playbackTime = self.lock.withLockUnchecked({ $0.audioPlayer?.currentTime }) else {
                 return
             }
-            DispatchQueue.main.async {
-                self.currentTime = playbackTime
-            }
+            self.currentTime = playbackTime
         }
         lock.withLockUnchecked { state in
-            state.progressTimer?.invalidate()
+            state.progressTimer?.cancel()
             state.progressTimer = timer
         }
+        timer.resume()
     }
 
     private func stopProgressTimer() {
         lock.withLockUnchecked { state in
-            state.progressTimer?.invalidate()
+            state.progressTimer?.cancel()
             state.progressTimer = nil
         }
     }

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Features/TTS/System/SystemTTSService.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Features/TTS/System/SystemTTSService.swift
@@ -71,6 +71,9 @@ public final class SystemTTSService: NSObject {
                     // actually route audio to the speaker.
                     #if os(iOS) || os(tvOS)
                     let audioSession = AVAudioSession.sharedInstance()
+                    let previousCategory = audioSession.category
+                    let previousMode = audioSession.mode
+                    let previousOptions = audioSession.categoryOptions
                     try audioSession.setCategory(.playback, mode: .default, options: [.duckOthers])
                     try audioSession.setActive(true)
                     #endif
@@ -79,6 +82,12 @@ public final class SystemTTSService: NSObject {
 
                     // The delegate completes this continuation when speech ends.
                     speechCompletion = { result in
+                        #if os(iOS) || os(tvOS)
+                        // Restore the caller's prior audio-session configuration so a
+                        // single speak() call does not permanently leave the session
+                        // in .playback/.duckOthers.
+                        try? audioSession.setCategory(previousCategory, mode: previousMode, options: previousOptions)
+                        #endif
                         continuation.resume(with: result)
                     }
                     synthesizer.speak(utterance)
@@ -91,7 +100,11 @@ public final class SystemTTSService: NSObject {
 
     public func stop() {
         synthesizer.stopSpeaking(at: .immediate)
-        speechCompletion?(.success(()))
+        // Cancelling an in-flight speak() must surface as CancellationError to match
+        // speak()'s documented contract and the SDK-wide cancel-throws convention.
+        // Nil-ing the completion here also prevents the later didCancel delegate
+        // from double-resuming the continuation.
+        speechCompletion?(.failure(CancellationError()))
         speechCompletion = nil
     }
 

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Features/VoiceAgent/Services/VoiceAgentMicDriver.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Features/VoiceAgent/Services/VoiceAgentMicDriver.swift
@@ -49,17 +49,22 @@ final class VoiceAgentMicDriver: @unchecked Sendable {
         // capture engine mid-session.
         try await configureVoiceAudioSession()
         playback.managesAudioSession = false
-        try await capture.startRecording(configureSession: false) { [weak self] chunk in
-            self?.enqueueChunk(chunk)
-        }
-        logger.info("Voice-agent mic capture started")
 
+        // Register teardown BEFORE startRecording: configureVoiceAudioSession has
+        // already activated the shared .playAndRecord session, so if capture start
+        // throws (mic contended / engine fails) this defer still deactivates it —
+        // otherwise the activated session leaks and other apps stay ducked.
         defer {
             capture.stopRecording(deactivateSession: true)
             playback.stop()
             chunkLock.withLock { $0.removeAll() }
             logger.info("Voice-agent mic capture stopped")
         }
+
+        try await capture.startRecording(configureSession: false) { [weak self] chunk in
+            self?.enqueueChunk(chunk)
+        }
+        logger.info("Voice-agent mic capture started")
 
         try await feedLoop()
     }

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+Download.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+Download.swift
@@ -7,6 +7,7 @@
 
 import CRACommons
 import Foundation
+import os
 import SwiftProtobuf
 
 // MARK: - Download Bridge
@@ -41,11 +42,84 @@ private enum DownloadProtoABI {
     )
 }
 
-private final class DownloadProtoProgressBox {
-    let continuation: AsyncStream<RADownloadProgress>.Continuation
+/// Process-wide fan-out over the single native download progress callback slot.
+///
+/// `rac_download_set_progress_proto_callback` exposes exactly ONE callback
+/// slot. Registering it per subscriber lets a second subscriber overwrite the
+/// first's context, and the first stream's teardown (`setProgressCallback(nil,
+/// nil)`) then silences every other subscriber. Concurrent downloads therefore
+/// need one native registration multiplexed to many `AsyncStream`
+/// continuations, mirroring the LLMStreamAdapter fan-out. The trampoline reads
+/// this immortal singleton (no `user_data` pointer to release), so a native
+/// callback can never outlive its context.
+private final class DownloadProgressFanOut: @unchecked Sendable {
+    static let shared = DownloadProgressFanOut()
 
-    init(continuation: AsyncStream<RADownloadProgress>.Continuation) {
-        self.continuation = continuation
+    // Subscriber continuations. `dispatch` (invoked from the C trampoline while
+    // the commons progress-sink mutex is held) reads this, so it MUST NOT be the
+    // lock held across the native register/unregister calls.
+    private let subscribers = OSAllocatedUnfairLock(
+        initialState: [UUID: AsyncStream<RADownloadProgress>.Continuation]()
+    )
+
+    // Serializes the native register/unregister calls together with the
+    // first/last-subscriber decision, so two concurrent subscribe/unsubscribe
+    // can't reorder their native calls and leave the single slot inconsistent
+    // with `registered` (which would silence a fresh subscriber). Held ACROSS
+    // the native call. Never taken by `dispatch`, so it cannot invert with the
+    // commons progress-sink mutex: register/unregister acquire
+    // registration -> commons-mutex; dispatch acquires commons-mutex ->
+    // subscribers; the two lock sets are disjoint, so no cycle.
+    private let registration = OSAllocatedUnfairLock(initialState: false)
+
+    private init() {}
+
+    /// Add a subscriber; registers the native callback only for the first one.
+    /// Returns the subscription id, or nil if native registration failed. The
+    /// whole decision + native call is serialized under `registration`, so a
+    /// concurrent joiner cannot be stranded by a first-subscriber register
+    /// failure (it runs afterwards and re-tries the registration).
+    func subscribe(
+        _ continuation: AsyncStream<RADownloadProgress>.Continuation
+    ) -> UUID? {
+        let id = UUID()
+        return registration.withLock { registered -> UUID? in
+            subscribers.withLock { $0[id] = continuation }
+            guard !registered else { return id }
+            guard let setProgressCallback = DownloadProtoABI.setProgressCallback,
+                  setProgressCallback(downloadProtoProgressCallback, nil) == RAC_SUCCESS else {
+                subscribers.withLock { $0[id] = nil }
+                return nil
+            }
+            registered = true
+            return id
+        }
+    }
+
+    /// Remove a subscriber; unregisters the native callback once the last one
+    /// leaves. Serialized with `subscribe` under `registration` so it cannot
+    /// reorder against a concurrent register. commons-072:
+    /// `setProgressCallback(nil, nil)` serializes on the dispatcher mutex, so it
+    /// acts as a quiesce barrier — it cannot return while a callback is in flight.
+    func unsubscribe(_ id: UUID) {
+        registration.withLock { registered in
+            let isEmpty = subscribers.withLock { dict -> Bool in
+                dict[id] = nil
+                return dict.isEmpty
+            }
+            guard isEmpty, registered,
+                  let setProgressCallback = DownloadProtoABI.setProgressCallback else { return }
+            _ = setProgressCallback(nil, nil)
+            registered = false
+        }
+    }
+
+    /// Fan a single native progress update out to every active subscriber.
+    func dispatch(_ progress: RADownloadProgress) {
+        let continuations = subscribers.withLock { Array($0.values) }
+        for continuation in continuations {
+            continuation.yield(progress)
+        }
     }
 }
 
@@ -54,13 +128,11 @@ private func downloadProtoProgressCallback(
     protoSize: Int,
     userData: UnsafeMutableRawPointer?
 ) {
-    guard let userData, let protoBytes, protoSize > 0 else { return }
-    let box = Unmanaged<DownloadProtoProgressBox>.fromOpaque(userData).takeUnretainedValue()
-    if let progress = try? RADownloadProgress(
+    guard let protoBytes, protoSize > 0 else { return }
+    guard let progress = try? RADownloadProgress(
         serializedBytes: Data(bytes: protoBytes, count: protoSize)
-    ) {
-        box.continuation.yield(progress)
-    }
+    ) else { return }
+    DownloadProgressFanOut.shared.dispatch(progress)
 }
 
 extension CppBridge {
@@ -166,42 +238,19 @@ extension CppBridge {
 
         public nonisolated func progressEvents() -> AsyncStream<RADownloadProgress> {
             AsyncStream { continuation in
-                guard let setProgressCallback = DownloadProtoABI.setProgressCallback else {
-                    continuation.finish()
-                    return
-                }
-
-                let box = DownloadProtoProgressBox(continuation: continuation)
-                let retained = Unmanaged.passRetained(box)
-                let context = DownloadProtoContextPointer(rawValue: retained.toOpaque())
-                let status = setProgressCallback(downloadProtoProgressCallback, context.rawValue)
-
-                guard status == RAC_SUCCESS else {
-                    retained.release()
+                // One process-wide native callback slot is fanned out to every
+                // subscriber by DownloadProgressFanOut, so concurrent downloads
+                // (e.g. Voice one-tap STT + LLM + TTS) each get their own stream
+                // instead of clobbering a single shared registration.
+                guard let subscriptionID = DownloadProgressFanOut.shared.subscribe(continuation) else {
                     continuation.finish()
                     return
                 }
 
                 continuation.onTermination = { _ in
-                    // commons-072: `rac_download_set_progress_proto_callback`
-                    // and the dispatcher (`emit_progress` in
-                    // commons/src/infrastructure/download/download_orchestrator.cpp)
-                    // both serialize on `progress_sink().mutex`, and the
-                    // dispatcher holds that mutex across the user callback
-                    // invocation. Setting the slot to nil therefore acts as
-                    // a quiesce barrier: it cannot return until any in-flight
-                    // callback (which would dereference `userData`) has
-                    // returned. The subsequent `Unmanaged.release()` is safe.
-                    _ = setProgressCallback(nil, nil)
-                    Unmanaged<DownloadProtoProgressBox>.fromOpaque(context.rawValue).release()
+                    DownloadProgressFanOut.shared.unsubscribe(subscriptionID)
                 }
             }
         }
     }
-}
-
-/// Retained callback context released only after the native unregister call
-/// has synchronously quiesced the progress dispatcher.
-private struct DownloadProtoContextPointer: @unchecked Sendable {
-    let rawValue: UnsafeMutableRawPointer
 }

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+TTS.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+TTS.swift
@@ -109,7 +109,13 @@ private final class TTSStreamSessionContext: @unchecked Sendable {
     }
 
     func waitForTerminal() {
-        terminalSemaphore.wait()
+        // Bounded wait: if the native engine streams audio but never delivers a
+        // terminal event, don't park the consumer's stream forever. Time out and
+        // surface a failure terminal (yieldFailure also signals), matching the
+        // timed waits used elsewhere in the bridge.
+        if terminalSemaphore.wait(timeout: .now() + 120) == .timedOut {
+            yieldFailure("TTS synthesis timed out waiting for completion")
+        }
     }
 
     func yield(bytes: UnsafePointer<UInt8>?, size: Int) {

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+VoiceAgent.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+VoiceAgent.swift
@@ -88,6 +88,17 @@ extension CppBridge {
         /// Destroy the component
         public func destroy() {
             if let handle = handle {
+                // Voice-agent streams have NO terminal event, so a consumer can
+                // still hold the C callback registration at shutdown. Tear that
+                // registration down BEFORE freeing the handle:
+                // VoiceAgentStreamAdapter.tearDown() unregisters the callback,
+                // quiesces any in-flight C dispatch, releases the retained
+                // trampoline context, and finishes every consumer (safe no-op
+                // when no stream is active). Without this, rac_voice_agent_destroy
+                // frees the handle while a dispatch may still be inside the
+                // trampoline, and a later stream cancellation would call
+                // rac_voice_agent_set_proto_callback on the freed handle — a UAF.
+                VoiceAgentStreamAdapter(handle: handle).tearDown()
                 rac_voice_agent_cleanup(handle)
                 rac_voice_agent_destroy(handle)
                 self.handle = nil

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Errors/SDKException.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Foundation/Errors/SDKException.swift
@@ -78,7 +78,15 @@ public struct SDKException: Error, LocalizedError, Sendable, CustomStringConvert
 
     // MARK: LocalizedError
 
-    public var errorDescription: String? { proto.message }
+    public var errorDescription: String? {
+        // Include the underlying "caused by" detail (e.g. the real backend/MLX
+        // load error commons set via rac_error_set_details) when present, so
+        // callers see the actual reason instead of only the generic per-code
+        // message.
+        let nested = proto.nestedMessage
+        guard !nested.isEmpty, nested != proto.message else { return proto.message }
+        return proto.message.isEmpty ? nested : "\(proto.message): \(nested)"
+    }
 
     public var failureReason: String? {
         "[\(proto.category)] \(proto.code)"


### PR DESCRIPTION
## Apple-front correctness fixes (Swift SDK + iOS/macOS example)

Bug-fix pass across the **Apple layer** — the Swift SDK, MLX/LlamaCPP runtimes, C++ commons (where a fix benefits all SDKs), and the `RunAnywhereAI` iOS/macOS example app. Driven on native macOS; each fix is placed at the lowest layer that serves all consumers, verified against current source, and adversarially reviewed.

> **Draft** while a final adversarial review pass completes. Opening now for visibility.

### Tier 1 — high-impact / playable
1. **Switching conversations mid-generation corrupts data (HIGH)** — a generation-identity guard (`generatingConversationId` + `activeGenerationID`) drops stale streaming/finalize writes and persists so a mid-generation conversation switch can no longer corrupt the newly-selected chat; `makeHistory` index clamp fixes a crash on the same switch.
2. **Voice tab goes deaf after leave & return** — `cleanup()` now resets the `@Published isInitialized` (+ session UI state), and `initialize()` bails if torn down mid-init, so re-entry re-subscribes to SDK events.
3. **STT hot-mic / no-capture / engine leak (SDK)** — synchronous `OSAllocatedUnfairLock` claim replaces the async `isRecording` TOCTOU in `AudioCaptureManager` (benefits STT/VAD/keyboard/VoiceAgent), plus a re-check-after-start for the stop-during-start interleave.
4. **Vision "Live" dead on macOS** — platform-aware camera device selection (`AVCaptureDevice.default(for:.video)` on macOS vs hard-coded `.back`).
5. **`stopGeneration` overlapping generation** — `finalizeGeneration` is the sole owner of the `isGenerating` false-transition, so `canSend` stays gated until the in-flight generation truly ends.

### Tier 2 — SDK concurrency + app
6. **Fan-out teardown race → double C-callback registration (SDK)** — identity+state-aware fan-out eviction (`removeFromRegistryIfTornDown`) in `HandleStreamAdapter`.
7. **VoiceAgent handle destroyed while a stream holds its registration → UAF (SDK)** — tear the stream registration down before freeing the handle.
8. **Orphaned empty / "Generation failed" bubble persisted on Stop (app)** — a Stop no longer writes an error bubble or persists an empty assistant slot; partial replies are preserved.
9. **Download progress single global callback slot (SDK)** — process-wide fan-out over the one native slot (latent public-API hardening; the active download path uses race-free polling).
10. **Keyboard Darwin observers accumulate unbounded (app)** — idempotent per-name single-slot registration.
11. **MLX cancel returned partial text as `RAC_SUCCESS` (SDK)** — LLM/VLM cancel now throws `CancellationError` → `RAC_ERROR_CANCELLED`, consistent with TTS.

### Earlier fixes on this branch (already validated)
- Chat multi-turn memory (populate `request.history`).
- Long conversation → "Inference failed": llama.cpp sliding-window context truncation.
- Model-load errors surfaced (compose `rac_error_set_details` into `ModelLoadResult.error_message` / `SDKError.nested_message`); friendly MLX incompatibility message.
- Gate the two unloadable MLX Gemma 4 catalog entries.
- macOS build enablement for the example (link ONNX/LlamaCPP backends; macOS-scoped `-force_load`).

### Verification
- **C++/SDK:** SDK `swift test` — **51 passing** (incl. `HandleStreamAdapterTests`).
- **App:** new `RunAnywhereAIUnitTests` SPM target — **14 headless state-assertion tests** for the generation-identity guards, finalize/empty-bubble behavior, and Darwin idempotency (`swift test --filter RunAnywhereAIUnitTests`).
- **Build:** macOS `xcodebuild` (Swift-5 shipping config, local natives) — **BUILD SUCCEEDED**.
- **iOS build** could not be run in this environment (no iOS platform component installed); changes are iOS-neutral — to be confirmed by CI.

### ⚠️ Merge coordination
`sdk/runanywhere-commons/src/core/model_lifecycle.cpp` overlaps **PR #548** (`fix/npu-app-bugs`). The two edits are complementary (this branch enriches the load-failure error; #548 adds create-then-swap). Expect a small hand-resolved conflict that keeps both.

### Known residuals (documented, out of scope)
Vision/document chat turns aren't stored in `generationTask`, so Stop doesn't cancel their SDK compute (they finish; writes are dropped once superseded). `#3` has a narrow ABA edge (stop+start both during one start's `await`). A Mac with no camera still shows the permission screen. `#9`'s `progressEvents()` currently has no in-repo callers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Touches native C callbacks, voice-agent/stream teardown, audio capture, and shared commons error paths—race and UAF fixes are high impact but broad; `model_lifecycle.cpp` may conflict with PR #548.
> 
> **Overview**
> Cross-layer **correctness and concurrency** fixes for the Swift SDK, C++ commons/llama.cpp, MLX runtime, and the **RunAnywhereAI** example on iOS/macOS.
> 
> **Chat & inference:** The example now sends **prior turns** via `request.history` and llama.cpp **drops oldest history** when the rendered prompt exceeds `n_ctx`, avoiding generic inference failures on long threads. **Generation identity** (`generatingConversationId`, `activeGenerationID`) blocks stale streaming, errors, and persistence when switching conversations, clearing chat, or overlapping sends; **Stop** no longer clears `isGenerating` early or leaves empty/error bubbles.
> 
> **SDK safety:** **HandleStreamAdapter** avoids double C-callback registration after teardown races; **VoiceAgent** tears down streams before destroying the handle; **download progress** uses a process-wide fan-out over the single native callback slot; **AudioCaptureManager** uses a lock-backed recording claim to fix hot-mic/start-stop races; **MLX** maps cancel to `RAC_ERROR_CANCELLED`. **Model load** errors now surface `rac_error_set_details` (commons + `SDKError.nested_message`), with friendlier MLX incompatibility text; **MLX Gemma 4** catalog entries are removed until the runtime supports them.
> 
> **Example polish:** Voice tab re-inits after leave/return; macOS vision uses a real default camera; Darwin notifications are idempotent; SPM gains **RunAnywhereAIUnitTests** and macOS link tweaks. **14** headless unit tests cover generation guards and related app fixes.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 52f96dc98f3f823be95d237cc7387fa6bf167051. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Chat generation now uses conversation history and automatically trims long chats to fit the model context.
  * Model downloads provide shared progress tracking, cancellation, and clearer failure feedback.
  * Improved camera support on macOS and safer vision-model camera lifecycle.

* **Bug Fixes**
  * Prevented stale responses from affecting the wrong conversation after switching, stopping, or deleting chats.
  * Improved conversation persistence, deletion handling, and analytics accuracy.
  * Enhanced error details and audio/voice cancellation and cleanup behavior.
  * Unsupported experimental MLX Gemma models are no longer offered.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->