### PR TITLE
fix(flutter): native helper symbol leak crash + correct telemetry device/os

### DIFF
--- a/sdk/runanywhere-flutter/packages/runanywhere/android/src/main/cpp/CMakeLists.txt
+++ b/sdk/runanywhere-flutter/packages/runanywhere/android/src/main/cpp/CMakeLists.txt
@@ -26,6 +26,15 @@ if(ANDROID)
         PRIVATE
             -Wl,-z,max-page-size=16384
             -Wl,-z,common-page-size=16384
+            # Do not leak libc++ operator new/delete (or any static-runtime
+            # symbol) out of this helper. Exporting them lets the dynamic linker
+            # interpose this .so's allocator ahead of libc++_shared for other
+            # libraries (e.g. llama.cpp gguf std::strings), which frees a buffer
+            # on a different allocator view than it was allocated on and aborts
+            # with "pointer tag truncated" on Android 15+. The version script
+            # exports only the ra_flutter_* entry points + JNI_OnLoad.
+            -Wl,--exclude-libs,ALL
+            -Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/runanywhere_flutter_helpers.map
     )
 endif()
 

--- a/sdk/runanywhere-flutter/packages/runanywhere/android/src/main/cpp/runanywhere_flutter_helpers.map
+++ b/sdk/runanywhere-flutter/packages/runanywhere/android/src/main/cpp/runanywhere_flutter_helpers.map
@@ -1,0 +1,14 @@
+# Export only the Flutter helper's own C entry points. Everything else —
+# crucially the weak libc++ vague-linkage symbols (operator new/delete) pulled
+# in from the static C++ runtime — is localized so it cannot be exported and
+# interpose the process-wide allocator. Without this, `operator new`/`delete`
+# leaked from this .so bind ahead of libc++_shared for other libraries
+# (e.g. llama.cpp's gguf std::strings), so a buffer is new'd on one allocator
+# view and freed on another -> "pointer tag truncated" SIGABRT on Android 15+.
+{
+  global:
+    ra_flutter_*;
+    JNI_OnLoad;
+  local:
+    *;
+};

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_device.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_device.dart
@@ -406,6 +406,21 @@ class DartBridgeDevice {
   /// Device model from the canonical registration snapshot.
   static String get cachedDeviceModel => _cachedRegistrationInfo.deviceModel;
 
+  /// OS version from the canonical registration snapshot (Android
+  /// `Build.VERSION.RELEASE` / iOS `systemVersion`), not the kernel/build
+  /// string that `Platform.operatingSystemVersion` returns.
+  static String get cachedOsVersion => _cachedRegistrationInfo.osVersion;
+
+  /// Populate the device-info snapshot if it is still the placeholder default.
+  /// Lets callers that run before Phase 2 device registration (e.g. telemetry
+  /// device-info setup) get the real model/OS instead of `unknown` + the build
+  /// string. Idempotent: a no-op once a real snapshot has been collected.
+  static Future<void> ensureDeviceInfoSnapshot() async {
+    if (_cachedRegistrationInfo.deviceModel == 'unknown') {
+      await _refreshDeviceInfoSnapshot();
+    }
+  }
+
   /// Register accurate app/client metadata with commons before Phase 2 device
   /// registration builds its JSON payload.
   static Future<void> _configureClientInfo() async {

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_telemetry.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_telemetry.dart
@@ -205,10 +205,17 @@ class DartBridgeTelemetry {
         return;
       }
 
-      // Device info — the model lookup is async, so it only happens here in
-      // Phase 2 (the Phase-1 attach creates the manager without it).
+      // Device info — the model/OS lookup is async (device_info_plus), so it
+      // only happens here. Ensure the device snapshot is populated first; this
+      // runs before Phase 2 device registration refreshes it, so without this
+      // the manager would be stamped with the placeholder defaults (model
+      // "unknown" + the Platform.operatingSystemVersion build string).
+      await DartBridgeDevice.ensureDeviceInfoSnapshot();
       final deviceModel = await _getDeviceModel();
-      final osVersion = Platform.operatingSystemVersion;
+      final cachedOs = DartBridgeDevice.cachedOsVersion.trim();
+      final osVersion = cachedOs.isNotEmpty
+          ? cachedOs
+          : Platform.operatingSystemVersion;
       final setDeviceInfo = lib
           .lookupFunction<
             Void Function(Pointer<Void>, Pointer<Utf8>, Pointer<Utf8>),


### PR DESCRIPTION
Two Flutter Android fixes found while getting the example app running + telemetry verified on device (Nothing A059, Android 16).

## 1. Native helper leaked libc++ operator new/delete -> model-load crash

The Flutter app crashed with `SIGABRT: Pointer tag ... was truncated` inside `gguf_kv_to_str` -> `free` during LLM model load. The same `.so`s load fine in the Kotlin app.

`librunanywhere_flutter_helpers.so` (built from `NativePortHelpers.cpp`) exported libc++ `operator new` / `operator delete` as weak, default-visibility symbols. `-fvisibility=hidden` does not hide vague-linkage symbols from the static C++ runtime, so they leaked and interposed the allocator ahead of `libc++_shared`. A gguf `std::string` was then allocated on one allocator view and freed on another, which trips the Android 15+ tagged-pointer check. Kotlin has no helper `.so`, so it never hit this. (NDK version was not the cause; it reproduced with everything on NDK 27.)

Fix: a linker version script (`runanywhere_flutter_helpers.map`) exporting only `ra_flutter_*` and `JNI_OnLoad`, wired via `-Wl,--version-script=...` + `-Wl,--exclude-libs,ALL`. The helper now exports only its own 10 entry points, no `operator new/delete`. Verified on device: model load succeeds, no abort.

## 2. Telemetry device model + OS version were wrong

Flutter telemetry reported `device=unknown` and `os_version` as the kernel/build string (e.g. `B4.0-260225-1824`) instead of the phone model and Android release. `DartBridgeTelemetry.initialize()` stamped device info from an unpopulated snapshot (Phase 2 device registration refreshes it later) and used `Platform.operatingSystemVersion` for the OS.

Fix: telemetry now calls `DartBridgeDevice.ensureDeviceInfoSnapshot()` first and reads the OS from the `device_info_plus` snapshot (`version.release`). Device/OS now report correctly: `Nothing A059` / `16`. React Native was already correct (it reads `Build.MODEL` / `Build.VERSION.RELEASE` natively), so no RN change was needed.

## Verified on device (Android 16)

Model load succeeds, app runs, telemetry device/OS correct, no abort.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android native compatibility by limiting exported runtime symbols from the Flutter helper library to only the intended entry points.
  * Enhanced telemetry initialization by ensuring device-info snapshot data is available before reporting device model and OS version, using cached OS version when available.
* **Chores**
  * No additional user-facing changes beyond the above improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->