### PR TITLE
qhexrt: enable Bonsai-27B 1-bit custom op-package model in the app catalog

### DIFF
--- a/engines/qhexrt/qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/qhexrt_model_catalog.cpp
@@ -56,6 +56,7 @@ constexpr ModelPolicy kModelPolicies[] = {
     {"qwen3_0_6b", kV75V81, true},
     {"llama3_2_1b", kV79V81, false},
     {"ternary_bonsai_1_7b", kV75V81, false},
+    {"bonsai_27b_1bit", kV81, false},
     {"phi_tiny_moe", kV79V81, false},
     {"embeddinggemma_300m", kAllSupportedArches, false},
     // The V79 bundle requires QAIRT 2.48; Android production currently ships 2.47.

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -48,6 +48,7 @@ internal object ModelCatalog {
         SingleFileModel("qwen3_0_6b", "Qwen3 0.6B (HNPU)", "https://huggingface.co/runanywhere/qwen3_0_6b_HNPU/qwen3-0.6b-1024final.json", QHEXRT, LANGUAGE, 1_823_248_798L, contextLength = 1_024),
         SingleFileModel("llama3_2_1b", "Llama 3.2 1B (HNPU)", "https://huggingface.co/runanywhere/llama3_2_1b_HNPU/llama-3.2-1b.json", QHEXRT, LANGUAGE, 3_023_821_212L),
         SingleFileModel("ternary_bonsai_1_7b", "Ternary Bonsai 1.7B (HNPU)", "https://huggingface.co/runanywhere/ternary_bonsai_1_7b_HNPU/ternary-bonsai-1.7b-1024.json", QHEXRT, LANGUAGE, 2_367_579_370L, contextLength = 1_024),
+        SingleFileModel("bonsai_27b_1bit", "Bonsai-27B 1-bit (HNPU)", "https://huggingface.co/runanywhere/bonsai_27b_1bit_HNPU/bonsai-27b-1024.json", QHEXRT, LANGUAGE, 6_400_000_000L, contextLength = 1_024, supportsThinking = true),
         SingleFileModel("phi_tiny_moe", "Phi Tiny MoE (HNPU)", "https://huggingface.co/runanywhere/phi_tiny_moe_HNPU/phimoe.json", QHEXRT, LANGUAGE, 6_100_212_369L),
         SingleFileModel("embeddinggemma_300m", "EmbeddingGemma 300M (HNPU)", "https://huggingface.co/runanywhere/embeddinggemma_300m_HNPU", QHEXRT, EMBEDDING, 566_263_339L),
         SingleFileModel("gemma3n_e4b", "Gemma 3n E4B (HNPU)", "https://huggingface.co/runanywhere/gemma3n_e4b_HNPU/gemma-3n-E4B-it.json", QHEXRT, LANGUAGE, 10_929_816_419L),

--- a/sdk/runanywhere-kotlin/modules/runanywhere-core-qhexrt/src/main/kotlin/com/runanywhere/sdk/npu/qhexrt/QHexRTSkelInstaller.kt
+++ b/sdk/runanywhere-kotlin/modules/runanywhere-core-qhexrt/src/main/kotlin/com/runanywhere/sdk/npu/qhexrt/QHexRTSkelInstaller.kt
@@ -36,7 +36,7 @@ internal object QHexRTSkelInstaller {
             val skelNames =
                 context.assets
                     .list(assetDir)
-                    ?.filter { it.startsWith("libQnnHtpV") && it.endsWith("Skel.so") }
+                    ?.filter { (it.startsWith("libQnnHtpV") && it.endsWith("Skel.so")) || it == "libQnnBonsaiBitnet.so" }
                     .orEmpty()
                     .sorted()
             if (skelNames.isEmpty()) {


### PR DESCRIPTION
Enables the Bonsai-27B 1-bit (HNPU) model in the RunAnywhereAI app catalog — it now loads and generates on the Snapdragon v81 NPU end-to-end via the public SDK flow (registerModel → downloadModel → loadModel → generateStream).

- `qhexrt_model_catalog.cpp`: `bonsai_27b_1bit` is v81, `requires_hf_auth=false` (public HF repo).
- `ModelCatalog.kt`: add the Bonsai-27B 1-bit (HNPU) row.
- `QHexRTSkelInstaller.kt`: also install the custom op-package DSP skel (`libQnnBonsaiBitnet.so`) from assets onto `ADSP_LIBRARY_PATH`, alongside the HTP skels.

Custom-op-package models additionally need the host op-package + `libQnnHtpPrepare.so` in jniLibs and the DSP skel in assets. Those binaries are `.gitignore`d and are staged at build time by `QHexRT/forge/oppkg/BonsaiBitnetOpPkg/stage_into_sdk.sh` (see that repo). Verify the packaged APK (not just the AAR) contains the trio — a stale Gradle native-lib intermediate can silently drop one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `bonsai_27b_1bit` model on compatible V81 devices.
  * Added the model to the Android NPU catalog with its download information, context length, and thinking support.
  * Enabled recognition and installation of the model’s required runtime assets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->