### PR TITLE
fix(kotlin): stop registry read APIs from throwing on service init failures

### DIFF
--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/Models/RunAnywhereModelRegistry.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/Models/RunAnywhereModelRegistry.kt
@@ -31,6 +31,7 @@ import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeModelRegistry
 import com.runanywhere.sdk.infrastructure.logging.SDKLogger
 import com.runanywhere.sdk.public.RunAnywhere
 import com.runanywhere.sdk.public.types.RAModelInfo
+import kotlinx.coroutines.CancellationException
 
 // MARK: - Registry Discovery (Swift parity)
 
@@ -56,7 +57,9 @@ suspend fun RunAnywhere.listModels(request: ModelListRequest = ModelListRequest(
     }
     try {
         ensureServicesReady()
-    } catch (_: Throwable) {
+    } catch (e: CancellationException) {
+        throw e
+    } catch (_: Exception) {
     }
     val infoList =
         if (request.query != null) {
@@ -76,7 +79,9 @@ suspend fun RunAnywhere.getModel(request: ModelGetRequest): ModelGetResult {
     }
     try {
         ensureServicesReady()
-    } catch (_: Throwable) {
+    } catch (e: CancellationException) {
+        throw e
+    } catch (_: Exception) {
     }
     if (request.model_id.isEmpty()) {
         return ModelGetResult(found = false, error_message = "model_id is required")
@@ -98,7 +103,9 @@ suspend fun RunAnywhere.refreshModelRegistry(
     if (!isInitialized) return
     try {
         ensureServicesReady()
-    } catch (_: Throwable) {
+    } catch (e: CancellationException) {
+        throw e
+    } catch (_: Exception) {
     }
 
     if (rescanLocal) {

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/Models/RunAnywhereModelRegistry.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/Models/RunAnywhereModelRegistry.kt
@@ -54,7 +54,10 @@ suspend fun RunAnywhere.listModels(request: ModelListRequest = ModelListRequest(
     if (!isInitialized) {
         return ModelListResult(success = false, error_message = "SDK not initialized")
     }
-    ensureServicesReady()
+    try {
+        ensureServicesReady()
+    } catch (_: Throwable) {
+    }
     val infoList =
         if (request.query != null) {
             CppBridgeModelRegistry.query(request.query)
@@ -71,7 +74,10 @@ suspend fun RunAnywhere.getModel(request: ModelGetRequest): ModelGetResult {
     if (!isInitialized) {
         return ModelGetResult(found = false, error_message = "SDK not initialized")
     }
-    ensureServicesReady()
+    try {
+        ensureServicesReady()
+    } catch (_: Throwable) {
+    }
     if (request.model_id.isEmpty()) {
         return ModelGetResult(found = false, error_message = "model_id is required")
     }
@@ -90,7 +96,10 @@ suspend fun RunAnywhere.refreshModelRegistry(
     pruneOrphans: Boolean = false,
 ) {
     if (!isInitialized) return
-    ensureServicesReady()
+    try {
+        ensureServicesReady()
+    } catch (_: Throwable) {
+    }
 
     if (rescanLocal) {
         CppBridgeModelRegistry.discoverDownloadedModels()


### PR DESCRIPTION
## Description

`listModels`, `getModel` and `refreshModelRegistry` in the Kotlin SDK call `ensureServicesReady()` bare, so a phase-2 services failure or an SDK lifetime race escapes from read-only discovery calls as `SDKException`. Swift deliberately swallows this at the same three sites (`try? await ensureServicesReady()` in `RunAnywhere+ModelRegistry.swift`) and still serves the local registry, and Kotlin's own `loadModel` already mirrors that pattern in `RunAnywhereModelLifecycle.kt`. This copies the same try/catch to the three registry read sites, nothing else.

Fixes #562

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Lint passes locally
- [ ] Added/updated tests for changes

Ran on the Kotlin SDK module: `:compileDebugKotlin -Prunanywhere.useLocalNatives=false`, `:ktlintCheck`, `:testDebugUnitTest`, `:detekt`, all green. No new tests per the repo convention for mechanical parity fixes. No emulator on this machine, so no on-device run; behavior change is limited to no longer rethrowing from the three read paths.

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

quick note: I built this with help from Claude Code and reviewed the final diff myself. freshman trying to learn my way around a big codebase, so if there's a reason these reads should propagate init errors on Android I'd genuinely like to understand it :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience for model listing, model retrieval, and registry refresh when service readiness checks hit non-cancellation errors.
  * Those failures are now handled so the overall workflow continues, while cancellation is still respected and propagated correctly.
  * Existing validation and model registry/query behavior remain unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->