### PR TITLE
feat(rcli): Windows x86_64 CLI release support + macOS backend expansion

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -206,7 +206,7 @@ jobs:
       - name: Install static libcurl
         shell: pwsh
         run: |
-          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install curl:x64-windows-static
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install curl:x64-mingw-static --host-triplet=x64-mingw-static
           if ($LASTEXITCODE -ne 0) { throw "vcpkg curl install failed" }
       - name: Sherpa-ONNX prebuilts
         shell: cmd

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -222,7 +222,7 @@ jobs:
             Select-Object -First 1
           if (-not $Onnx) { throw "onnxruntime.dll not found" }
           $Onnx.DirectoryName | Out-File $env:GITHUB_PATH -Encoding utf8 -Append
-          "$env:GITHUB_WORKSPACE\sdk\runanywhere-commons\third_party\sherpa-onnx-windows\bin" |
+          "$env:GITHUB_WORKSPACE\sdk\runanywhere-commons\third_party\sherpa-onnx-windows\lib" |
             Out-File $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Unit tests
         shell: pwsh

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -195,6 +195,7 @@ jobs:
     # Windows is compiled and exercised on the native runner. MLX remains
     # Apple-only; the portable CLI ships llama.cpp + Sherpa/ONNX on Windows.
     runs-on: windows-2022
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -191,6 +191,50 @@ jobs:
       - name: Package smoke
         run: bash sdk/runanywhere-cli/scripts/package-rcli.sh build/rcli-linux-release linux-x86_64
 
+  rcli-windows:
+    # Windows is compiled and exercised on the native runner. MLX remains
+    # Apple-only; the portable CLI ships llama.cpp + Sherpa/ONNX on Windows.
+    runs-on: windows-2022
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          platform: windows
+      - name: Install static libcurl
+        shell: pwsh
+        run: |
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install curl:x64-windows-static
+          if ($LASTEXITCODE -ne 0) { throw "vcpkg curl install failed" }
+      - name: Sherpa-ONNX prebuilts
+        shell: cmd
+        run: sdk\runanywhere-commons\scripts\windows\download-sherpa-onnx.bat
+      - name: Configure
+        shell: pwsh
+        run: cmake --preset rcli-windows-release -DRAC_BUILD_TESTS=ON
+      - name: Build
+        shell: pwsh
+        run: cmake --build --preset rcli-windows-release
+      - name: Add native runtimes to PATH
+        shell: pwsh
+        run: |
+          $Onnx = Get-ChildItem build/rcli-windows-release -Filter onnxruntime.dll -File -Recurse |
+            Where-Object { $_.FullName -match 'onnxruntime-src[\\/]lib' } |
+            Select-Object -First 1
+          if (-not $Onnx) { throw "onnxruntime.dll not found" }
+          $Onnx.DirectoryName | Out-File $env:GITHUB_PATH -Encoding utf8 -Append
+          "$env:GITHUB_WORKSPACE\sdk\runanywhere-commons\third_party\sherpa-onnx-windows\bin" |
+            Out-File $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Unit tests
+        shell: pwsh
+        run: >-
+          ctest --test-dir build/rcli-windows-release
+          -R "rcli_unit_tests|desktop_adapter_tests" --output-on-failure
+      - name: Package and smoke
+        shell: pwsh
+        run: >-
+          ./sdk/runanywhere-cli/scripts/package-rcli-windows.ps1
+          -BuildDir build/rcli-windows-release
+
   wasm:
     runs-on: ubuntu-22.04
     steps:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -197,6 +197,8 @@ jobs:
     runs-on: windows-2022
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-toolchain
         with:
           platform: windows

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -195,7 +195,7 @@ jobs:
     # Windows is compiled and exercised on the native runner. MLX remains
     # Apple-only; the portable CLI ships llama.cpp + Sherpa/ONNX on Windows.
     runs-on: windows-2022
-    timeout-minutes: 45
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -261,7 +261,7 @@ jobs:
           [ -x "$BIN_DIR/RunAnywhereMLXCLI" ]
           [ -s "$BIN_DIR/mlx.metallib" ]
           echo "bin-dir=$BIN_DIR" >> "$GITHUB_OUTPUT"
-      - name: Smoke combined host (modelless — llama.cpp + MLX)
+      - name: Smoke combined host (modelless — llama.cpp + MLX + Apple secondary engines)
         env:
           RCLI_BIN_DIR: ${{ steps.mlx-host.outputs.bin-dir }}
         run: |
@@ -271,6 +271,8 @@ jobs:
           echo "$BACKENDS"
           echo "$BACKENDS" | grep -q '"name":"llamacpp"'
           echo "$BACKENDS" | grep -q '"name":"mlx"'
+          echo "$BACKENDS" | grep -q '"name":"sherpa"'
+          echo "$BACKENDS" | grep -q '"name":"coreml"'
           "$RCLI" list --all | grep -q 'bonsai-27b-q1_0'
           "$RCLI" list --all | grep -q 'mlx-bonsai-27b-1bit'
       - name: Configure ephemeral Developer ID credentials
@@ -448,6 +450,92 @@ jobs:
           path: |
             sdk/runanywhere-cli/dist/rcli-linux-x86_64-v*.tar.gz
             sdk/runanywhere-cli/dist/rcli-linux-x86_64-v*.tar.gz.sha256
+          retention-days: 7
+          if-no-files-found: error
+
+  native_rcli_windows:
+    needs: validate
+    runs-on: windows-2022
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          platform: windows
+      - name: Install static libcurl
+        shell: pwsh
+        run: |
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install curl:x64-windows-static
+          if ($LASTEXITCODE -ne 0) { throw "vcpkg curl install failed" }
+      - name: Sherpa-ONNX prebuilts
+        shell: cmd
+        run: sdk\runanywhere-commons\scripts\windows\download-sherpa-onnx.bat
+      - name: Build rcli (Windows x86_64)
+        shell: pwsh
+        run: |
+          cmake --preset rcli-windows-release -DRAC_BUILD_TESTS=ON
+          cmake --build --preset rcli-windows-release
+      - name: Add native runtimes to PATH
+        shell: pwsh
+        run: |
+          $Onnx = Get-ChildItem build/rcli-windows-release -Filter onnxruntime.dll -File -Recurse |
+            Where-Object { $_.FullName -match 'onnxruntime-src[\\/]lib' } |
+            Select-Object -First 1
+          if (-not $Onnx) { throw "onnxruntime.dll not found" }
+          $Onnx.DirectoryName | Out-File $env:GITHUB_PATH -Encoding utf8 -Append
+          "$env:GITHUB_WORKSPACE\sdk\runanywhere-commons\third_party\sherpa-onnx-windows\bin" |
+            Out-File $env:GITHUB_PATH -Encoding utf8 -Append
+      - name: Unit tests
+        shell: pwsh
+        run: >-
+          ctest --test-dir build/rcli-windows-release
+          -R "rcli_unit_tests|desktop_adapter_tests" --output-on-failure
+      - name: Authenticode sign rcli.exe
+        shell: pwsh
+        env:
+          WINDOWS_CERTIFICATE_BASE64: ${{ secrets.RCLI_WINDOWS_CODESIGN_PFX_BASE64 }}
+          WINDOWS_CERTIFICATE_PASSWORD: ${{ secrets.RCLI_WINDOWS_CODESIGN_PFX_PASSWORD }}
+        run: |
+          if ([string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_BASE64) -or
+              [string]::IsNullOrWhiteSpace($env:WINDOWS_CERTIFICATE_PASSWORD)) {
+            throw "Configure RCLI_WINDOWS_CODESIGN_PFX_BASE64 and RCLI_WINDOWS_CODESIGN_PFX_PASSWORD"
+          }
+          $Binary = Get-ChildItem build/rcli-windows-release -Filter rcli.exe -File -Recurse |
+            Where-Object { $_.FullName -match 'runanywhere-cli' } |
+            Select-Object -ExpandProperty FullName -First 1
+          if (-not $Binary) { throw "rcli.exe not found" }
+          $Pfx = Join-Path $env:RUNNER_TEMP "rcli-windows-codesign.pfx"
+          [IO.File]::WriteAllBytes($Pfx, [Convert]::FromBase64String($env:WINDOWS_CERTIFICATE_BASE64))
+          try {
+            $SignTool = Get-ChildItem "${env:ProgramFiles(x86)}\Windows Kits\10\bin" `
+              -Filter signtool.exe -File -Recurse |
+              Where-Object { $_.DirectoryName -match '\\x64$' } |
+              Sort-Object FullName -Descending |
+              Select-Object -ExpandProperty FullName -First 1
+            if (-not $SignTool) { throw "signtool.exe not found" }
+            & $SignTool sign /f $Pfx /p $env:WINDOWS_CERTIFICATE_PASSWORD `
+              /fd SHA256 /tr http://timestamp.digicert.com /td SHA256 $Binary
+            if ($LASTEXITCODE -ne 0) { throw "Authenticode signing failed" }
+            $Signature = Get-AuthenticodeSignature $Binary
+            if ($Signature.Status -ne 'Valid') {
+              throw "Authenticode verification failed: $($Signature.Status)"
+            }
+          } finally {
+            Remove-Item $Pfx -Force -ErrorAction SilentlyContinue
+          }
+      - name: Package rcli ZIP
+        shell: pwsh
+        run: >-
+          ./sdk/runanywhere-cli/scripts/package-rcli-windows.ps1
+          -BuildDir build/rcli-windows-release
+          -Version ${{ needs.validate.outputs.version }}
+      - name: Upload rcli Windows artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: rcli-windows
+          path: |
+            sdk/runanywhere-cli/dist/rcli-windows-x86_64-v*.zip
+            sdk/runanywhere-cli/dist/rcli-windows-x86_64-v*.zip.sha256
           retention-days: 7
           if-no-files-found: error
 
@@ -1541,6 +1629,7 @@ jobs:
       - native_linux
       - native_rcli_macos
       - native_rcli_linux
+      - native_rcli_windows
       - native_windows
       - native_web
       - sdk_kotlin
@@ -1571,6 +1660,7 @@ jobs:
       needs.native_linux.result == 'success' &&
       needs.native_rcli_macos.result == 'success' &&
       needs.native_rcli_linux.result == 'success' &&
+      needs.native_rcli_windows.result == 'success' &&
       needs.native_web.result == 'success' &&
       needs.sdk_kotlin.result == 'success' &&
       needs.sdk_web.result == 'success' &&
@@ -1670,6 +1760,7 @@ jobs:
           assert_pair "rcli macOS arm64"               "rcli-macos-arm64-v${VERSION}.tar.gz"
           assert_pair "rcli macOS notarized disk image" "rcli-macos-arm64-v${VERSION}.dmg"
           assert_pair "rcli Linux x86_64"              "rcli-linux-x86_64-v${VERSION}.tar.gz"
+          assert_pair "rcli Windows x86_64"            "rcli-windows-x86_64-v${VERSION}.zip"
           assert_pair "Kotlin Maven repository"        "runanywhere-kotlin-maven-v${VERSION}.zip"
           assert_pair "Web proto package"              "runanywhere-proto-ts-${VERSION}.tgz"
           assert_pair "Web core package"               "runanywhere-web-${VERSION}.tgz"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -467,7 +467,7 @@ jobs:
       - name: Install static libcurl
         shell: pwsh
         run: |
-          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install curl:x64-windows-static
+          & "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install curl:x64-mingw-static --host-triplet=x64-mingw-static
           if ($LASTEXITCODE -ne 0) { throw "vcpkg curl install failed" }
       - name: Sherpa-ONNX prebuilts
         shell: cmd

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -459,6 +459,8 @@ jobs:
     timeout-minutes: 90
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - uses: ./.github/actions/setup-toolchain
         with:
           platform: windows

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -483,7 +483,7 @@ jobs:
             Select-Object -First 1
           if (-not $Onnx) { throw "onnxruntime.dll not found" }
           $Onnx.DirectoryName | Out-File $env:GITHUB_PATH -Encoding utf8 -Append
-          "$env:GITHUB_WORKSPACE\sdk\runanywhere-commons\third_party\sherpa-onnx-windows\bin" |
+          "$env:GITHUB_WORKSPACE\sdk\runanywhere-commons\third_party\sherpa-onnx-windows\lib" |
             Out-File $env:GITHUB_PATH -Encoding utf8 -Append
       - name: Unit tests
         shell: pwsh

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -196,6 +196,16 @@ set(CMAKE_CXX_EXTENSIONS        OFF)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_EXPORT_COMPILE_COMMANDS ON)
 
+# M_PI and friends are POSIX/GNU math extensions, not standard C++. With
+# CMAKE_CXX_EXTENSIONS OFF (strict -std=c++20), MinGW/MSVC hide them unless
+# _USE_MATH_DEFINES is defined before <cmath>. llama.cpp's mtmd audio code uses
+# M_PI, so define it globally on Windows (harmless elsewhere; POSIX exposes it).
+# Set at the root so it reaches every subdirectory, including the llama.cpp
+# FetchContent tree under engines/.
+if(WIN32)
+    add_compile_definitions(_USE_MATH_DEFINES)
+endif()
+
 # =============================================================================
 # Subdirectories
 # =============================================================================

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,7 +77,7 @@ option(RAC_BUILD_PLATFORM     "Build the platform backend (Apple Foundation Mode
 option(RAC_BUILD_JNI          "Build the JNI bridge for Android / JVM hosts" OFF)
 option(RAC_BUILD_PLUGIN_SMOKE "Build tools/plugin-loader-smoke" OFF)
 option(RAC_BUILD_CLI          "Build the rcli desktop CLI (sdk/runanywhere-cli)" OFF)
-option(RAC_DESKTOP_ADAPTER    "Build the desktop (macOS/Linux) platform adapter + libcurl HTTP transport" OFF)
+option(RAC_DESKTOP_ADAPTER    "Build the desktop (macOS/Linux/Windows) platform adapter + libcurl HTTP transport" OFF)
 
 # Protobuf is a private implementation detail of the serialized-byte C ABI.
 # Keep its C++ namespace private too: static ML runtimes such as ONNX Runtime

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -163,7 +163,6 @@
                 "RAC_INCLUDE_LOCAL_DEV_CONFIG": "OFF",
                 "GGML_METAL": "OFF"
             },
-            "comment": "RAC_BUILD_SERVER is OFF on Windows: the optional `rcli serve` HTTP server pulls in cpp-httplib, which does not compile under MinGW-w64 (uses GetAddrInfoExCancel, absent from MinGW's headers). Core CLI (run/manage/inference: llama.cpp + Sherpa/ONNX) is unaffected; `rcli serve` is macOS/Linux-only for now.",
             "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
         },
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -156,13 +156,14 @@
                 "RAC_BACKEND_COREML": "OFF",
                 "RAC_RUNTIME_ONNXRT": "ON",
                 "RAC_BACKEND_RAG": "OFF",
-                "RAC_BUILD_SERVER": "ON",
+                "RAC_BUILD_SERVER": "OFF",
                 "RAC_STATIC_PLUGINS": "ON",
                 "RAC_BUILD_SHARED": "OFF",
                 "RAC_BUILD_PLATFORM": "OFF",
                 "RAC_INCLUDE_LOCAL_DEV_CONFIG": "OFF",
                 "GGML_METAL": "OFF"
             },
+            "comment": "RAC_BUILD_SERVER is OFF on Windows: the optional `rcli serve` HTTP server pulls in cpp-httplib, which does not compile under MinGW-w64 (uses GetAddrInfoExCancel, absent from MinGW's headers). Core CLI (run/manage/inference: llama.cpp + Sherpa/ONNX) is unaffected; `rcli serve` is macOS/Linux-only for now.",
             "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
         },
 

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -138,6 +138,33 @@
             },
             "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Linux" }
         },
+        {
+            "name": "rcli-windows-release",
+            "displayName": "rcli — Windows x86_64 Release",
+            "inherits": "base-release",
+            "cacheVariables": {
+                "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake",
+                "VCPKG_TARGET_TRIPLET": "x64-windows-static",
+                "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>",
+                "RAC_BUILD_CLI": "ON",
+                "RAC_DESKTOP_ADAPTER": "ON",
+                "RAC_BUILD_BACKENDS": "ON",
+                "RAC_BACKEND_LLAMACPP": "ON",
+                "RAC_BACKEND_SHERPA": "ON",
+                "RAC_BACKEND_ONNX": "ON",
+                "RAC_BACKEND_MLX": "OFF",
+                "RAC_BACKEND_COREML": "OFF",
+                "RAC_RUNTIME_ONNXRT": "ON",
+                "RAC_BACKEND_RAG": "OFF",
+                "RAC_BUILD_SERVER": "ON",
+                "RAC_STATIC_PLUGINS": "ON",
+                "RAC_BUILD_SHARED": "OFF",
+                "RAC_BUILD_PLATFORM": "OFF",
+                "RAC_INCLUDE_LOCAL_DEV_CONFIG": "OFF",
+                "GGML_METAL": "OFF"
+            },
+            "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
+        },
 
         {
             "name": "android-arm64",
@@ -243,6 +270,7 @@
         { "name": "linux-asan",       "configurePreset": "linux-asan" },
         { "name": "rcli-macos-release", "configurePreset": "rcli-macos-release" },
         { "name": "rcli-linux-release", "configurePreset": "rcli-linux-release" },
+        { "name": "rcli-windows-release", "configurePreset": "rcli-windows-release" },
         { "name": "android-arm64",    "configurePreset": "android-arm64" },
         { "name": "android-armv7",    "configurePreset": "android-armv7" },
         { "name": "android-x86_64",   "configurePreset": "android-x86_64" },
@@ -256,6 +284,7 @@
     "testPresets": [
         { "name": "macos-debug",   "configurePreset": "macos-debug",   "output": { "outputOnFailure": true } },
         { "name": "linux-debug",   "configurePreset": "linux-debug",   "output": { "outputOnFailure": true } },
-        { "name": "linux-asan",    "configurePreset": "linux-asan",    "output": { "outputOnFailure": true } }
+        { "name": "linux-asan",    "configurePreset": "linux-asan",    "output": { "outputOnFailure": true } },
+        { "name": "rcli-windows-release", "configurePreset": "rcli-windows-release", "output": { "outputOnFailure": true } }
     ]
 }

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -144,8 +144,8 @@
             "inherits": "base-release",
             "cacheVariables": {
                 "CMAKE_TOOLCHAIN_FILE": "$env{VCPKG_INSTALLATION_ROOT}/scripts/buildsystems/vcpkg.cmake",
-                "VCPKG_TARGET_TRIPLET": "x64-windows-static",
-                "CMAKE_MSVC_RUNTIME_LIBRARY": "MultiThreaded$<$<CONFIG:Debug>:Debug>",
+                "VCPKG_TARGET_TRIPLET": "x64-mingw-static",
+                "VCPKG_HOST_TRIPLET": "x64-mingw-static",
                 "RAC_BUILD_CLI": "ON",
                 "RAC_DESKTOP_ADAPTER": "ON",
                 "RAC_BUILD_BACKENDS": "ON",

--- a/Package.swift
+++ b/Package.swift
@@ -425,6 +425,7 @@ let package = Package(
                 "RADesktopHostAdapter",
                 "RABackendLlamaCPPBinary",
                 "RABackendMLXBinary",
+                "RABackendCoreMLBinary",
             ],
             path: "sdk/runanywhere-cli",
             exclude: [
@@ -474,6 +475,7 @@ let package = Package(
                 .define("CLI11_HAS_CODECVT", to: "0"),
                 .define("RCLI_HAS_LLAMACPP", to: "1"),
                 .define("RCLI_HAS_MLX", to: "1"),
+                .define("RCLI_HAS_COREML", to: "1"),
                 .define("RCLI_VERSION", to: "\"\(sdkVersion)\""),
                 .headerSearchPath("include"),
                 .headerSearchPath("src"),
@@ -506,6 +508,7 @@ let package = Package(
             name: "RunAnywhereMLXCLI",
             dependencies: [
                 "MLXRuntime",
+                "ONNXRuntime",
                 "RCLIHost",
             ],
             path: "sdk/runanywhere-swift/Sources/RunAnywhereMLXCLI"

--- a/engines/sherpa/CMakeLists.txt
+++ b/engines/sherpa/CMakeLists.txt
@@ -264,7 +264,9 @@ elseif(RAC_PLATFORM_WINDOWS)
     if(EXISTS "${SHERPA_ONNX_ROOT}/lib/sherpa-onnx-c-api.lib")
         set(SHERPA_ONNX_AVAILABLE ON)
         set(SHERPA_LIB_PATH "${SHERPA_ONNX_ROOT}/lib/sherpa-onnx-c-api.lib")
-        set(SHERPA_DLL_PATH "${SHERPA_ONNX_ROOT}/bin/sherpa-onnx-c-api.dll")
+        # The k2-fsa shared bundle ships the DLLs in lib/ (bin/ holds only the
+        # example executables and a copy of onnxruntime.dll).
+        set(SHERPA_DLL_PATH "${SHERPA_ONNX_ROOT}/lib/sherpa-onnx-c-api.dll")
         set(SHERPA_HEADER_PATH "${SHERPA_ONNX_ROOT}/include")
 
         add_library(sherpa_onnx SHARED IMPORTED GLOBAL)

--- a/engines/sherpa/sherpa_backend.cpp
+++ b/engines/sherpa/sherpa_backend.cpp
@@ -1311,8 +1311,15 @@ bool SherpaTTS::load_model(const std::string& model_path, TTSModelType model_typ
             while ((diag_entry = readdir(diag_dir)) != nullptr) {
                 if (diag_entry->d_name[0] == '.')
                     continue;
-                RAC_LOG_INFO("Sherpa.TTS", "  [%s] %s",
-                             diag_entry->d_type == DT_DIR ? "DIR" : "FILE", diag_entry->d_name);
+                // struct dirent::d_type / DT_DIR are POSIX extensions absent on
+                // MinGW; stat the entry instead (portable, matches the checks
+                // above).
+                struct stat entry_stat;
+                const std::string entry_path = model_path + "/" + diag_entry->d_name;
+                const bool is_dir =
+                    stat(entry_path.c_str(), &entry_stat) == 0 && S_ISDIR(entry_stat.st_mode);
+                RAC_LOG_INFO("Sherpa.TTS", "  [%s] %s", is_dir ? "DIR" : "FILE",
+                             diag_entry->d_name);
             }
             closedir(diag_dir);
             RAC_LOG_INFO("Sherpa.TTS", "=== End directory listing ===");

--- a/sdk/runanywhere-cli/CMakeLists.txt
+++ b/sdk/runanywhere-cli/CMakeLists.txt
@@ -50,9 +50,16 @@ set(RCLI_SOURCES
 )
 
 # Vendored single-file deps. linenoise is C; compiled into the core object lib.
-set(RCLI_THIRD_PARTY_SOURCES
-    third_party/linenoise/linenoise.c
-)
+if(WIN32)
+    # The vendored linenoise implementation is POSIX-only. Windows consoles
+    # provide native line editing; repl.cpp supplies the small getline/history
+    # fallback so the command surface remains identical.
+    set(RCLI_THIRD_PARTY_SOURCES "")
+else()
+    set(RCLI_THIRD_PARTY_SOURCES
+        third_party/linenoise/linenoise.c
+    )
+endif()
 
 add_library(rcli_core OBJECT ${RCLI_SOURCES} ${RCLI_THIRD_PARTY_SOURCES})
 
@@ -74,6 +81,9 @@ target_compile_definitions(rcli_core PUBLIC
     # <codecvt>, which the standard library deprecated in C++17. Use CLI11's
     # maintained locale-conversion path instead.
     CLI11_HAS_CODECVT=0)
+if(WIN32)
+    target_compile_definitions(rcli_core PUBLIC RCLI_NO_LINENOISE=1)
+endif()
 
 # Proto-byte ABI access (DownloadProgress, ModelInfo, Register* requests).
 # Same internal-consumer pattern as commons tests' rac_test_define_have_protobuf:

--- a/sdk/runanywhere-cli/CMakeLists.txt
+++ b/sdk/runanywhere-cli/CMakeLists.txt
@@ -17,6 +17,20 @@ if(NOT RAC_DESKTOP_ADAPTER)
     message(FATAL_ERROR "rcli requires -DRAC_DESKTOP_ADAPTER=ON (desktop platform adapter + curl transport)")
 endif()
 
+# winnt.h (via windows.h, pulled in by Abseil/protobuf) defines
+# ERROR_SEVERITY_WARNING/ERROR_SEVERITY_ERROR as macros that clobber the proto
+# enum runanywhere::v1::ErrorSeverity, breaking errors.pb.h in any TU that sees
+# windows.h before the proto header (e.g. cmd_run.cpp). Force-include a prefix
+# header that includes windows.h once and undefs those two collisions. Directory
+# scope so it covers rcli_core, the rcli binary, and the tests subdirectory.
+if(WIN32)
+    if(MSVC)
+        add_compile_options("/FI${CMAKE_CURRENT_SOURCE_DIR}/src/windows_proto_compat.h")
+    else()
+        add_compile_options(-include "${CMAKE_CURRENT_SOURCE_DIR}/src/windows_proto_compat.h")
+    endif()
+endif()
+
 set(RCLI_SOURCES
     src/app.cpp
     src/bootstrap.cpp

--- a/sdk/runanywhere-cli/README.md
+++ b/sdk/runanywhere-cli/README.md
@@ -40,7 +40,9 @@ irm https://raw.githubusercontent.com/RunanywhereAI/runanywhere-sdks/main/sdk/ru
 
 The Windows installer verifies the release checksum, installs `rcli.exe` and
 its pinned ONNX Runtime/Sherpa DLLs under `%LOCALAPPDATA%\Programs\rcli\bin`,
-and adds that `bin` directory to the current user's `PATH`.
+and adds that `bin` directory to the current user's `PATH`. The Windows build
+ships llama.cpp + Sherpa/ONNX; `rcli serve` (the OpenAI-compatible HTTP server)
+is macOS/Linux-only.
 
 The macOS GitHub Release also includes a Developer ID signed, notarized, and
 stapled disk image. Its `rcli-macos-arm64` directory has the same relocatable

--- a/sdk/runanywhere-cli/README.md
+++ b/sdk/runanywhere-cli/README.md
@@ -20,22 +20,43 @@ $ rcli serve qwen3        # OpenAI-compatible API on :8080
 
 ## Install
 
-**Homebrew** (after the first tagged release; tap publishing is in
-`scripts/update-tap.sh`):
+**Homebrew** (macOS Apple Silicon or Linux x86_64):
 
 ```bash
 brew install runanywhere-ai/tap/rcli
 ```
 
-**Install script** (macOS Apple Silicon, Linux x86_64):
+**Install script** (macOS Apple Silicon or Linux x86_64):
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/RunanywhereAI/runanywhere-sdks/main/sdk/runanywhere-cli/scripts/install.sh | sh
 ```
 
+**PowerShell installer** (Windows x86_64; no administrator shell required):
+
+```powershell
+irm https://raw.githubusercontent.com/RunanywhereAI/runanywhere-sdks/main/sdk/runanywhere-cli/scripts/install.ps1 | iex
+```
+
+The Windows installer verifies the release checksum, installs `rcli.exe` and
+its pinned ONNX Runtime/Sherpa DLLs under `%LOCALAPPDATA%\Programs\rcli`, and
+adds that directory to the current user's `PATH`.
+
 The macOS GitHub Release also includes a Developer ID signed, notarized, and
 stapled disk image. Its `rcli-macos-arm64` directory has the same relocatable
 layout as the Homebrew tarball.
+
+Published release assets are platform-specific:
+
+| Platform | Asset | Included engines |
+|---|---|---|
+| macOS Apple Silicon | `rcli-macos-arm64-vX.Y.Z.tar.gz` and signed/notarized DMG | llama.cpp + MLX + Sherpa-ONNX + ONNX Runtime + CoreML |
+| Linux x86_64 | `rcli-linux-x86_64-vX.Y.Z.tar.gz` | llama.cpp + Sherpa-ONNX + ONNX Runtime |
+| Windows x86_64 | `rcli-windows-x86_64-vX.Y.Z.zip` | llama.cpp + Sherpa-ONNX + ONNX Runtime |
+
+MLX is Apple Silicon/macOS-only. The command surface is shared across all
+three platforms; commands that require an unavailable platform engine return a
+clear unsupported-backend error.
 
 **From source** — see [Building](#building-from-source).
 
@@ -126,6 +147,13 @@ CONFIGURATION=release ./sdk/runanywhere-cli/scripts/build-mlx-cli.sh
 cmake --preset rcli-linux-release
 cmake --build build/rcli-linux-release -j 2
 
+# Windows x86_64 (PowerShell, with vcpkg available on VCPKG_INSTALLATION_ROOT):
+& "$env:VCPKG_INSTALLATION_ROOT\vcpkg.exe" install curl:x64-windows-static
+sdk\runanywhere-commons\scripts\windows\download-sherpa-onnx.bat
+cmake --preset rcli-windows-release
+cmake --build --preset rcli-windows-release
+./sdk/runanywhere-cli/scripts/package-rcli-windows.ps1
+
 # Lean dev loop (no backends — lifecycle/UX work only):
 cmake --preset macos-debug -DRAC_DESKTOP_ADAPTER=ON -DRAC_BUILD_CLI=ON
 cmake --build build/macos-debug -j 2 --target rcli test_rcli_unit
@@ -153,9 +181,10 @@ ctest --test-dir build/macos-debug -R "rcli_unit_tests|desktop_adapter_tests"
 bash sdk/runanywhere-commons/tests/scripts/run-cli-e2e-linux.sh
 ```
 
-CI: `pr-build.yml` builds both rcli presets and runs the modelless smoke +
-unit tests; `release.yml` packages `rcli-macos-arm64` / `rcli-linux-x86_64`
-tarballs (`scripts/package-rcli.sh`) and gates publishing on their presence.
+CI: `pr-build.yml` builds macOS, Linux, and Windows rcli targets and runs unit,
+backend-registration, relocatable-package, and modelless smoke checks. Windows
+is built natively on `windows-2022`. `release.yml` requires all three rcli
+packages before publishing the GitHub Release.
 
 ## macOS distribution signing
 
@@ -198,6 +227,18 @@ API-key path, key ID, and issuer ID variables documented at the top of that
 script. The normal credential-free packaging path remains ad-hoc signed for
 pull-request smoke.
 
+## Windows distribution signing
+
+The release workflow Authenticode-signs `rcli.exe`, validates the resulting
+signature, and only then creates the Windows ZIP. Configure these repository
+secrets before creating a release tag:
+
+- `RCLI_WINDOWS_CODESIGN_PFX_BASE64`
+- `RCLI_WINDOWS_CODESIGN_PFX_PASSWORD`
+
+Pull-request builds remain credential-free and validate the same unsigned
+binary/package layout before the protected release job performs signing.
+
 ## Architecture
 
 rcli is a 6th consumer of the `rac_*` C ABI — exactly like the mobile/web
@@ -206,11 +247,10 @@ lifecycle-owned model loading (`rac_model_lifecycle_load_proto` auto-pulls,
 resolves artifacts incl. VLM mmproj, loads the engine once), proto-byte
 streaming generation, the download orchestrator with the desktop libcurl
 transport, and the voice-agent pipeline. The reusable desktop platform layer
-(POSIX adapter + curl transport) lives in commons
+(native adapter + curl transport) lives in commons
 (`include/rac/desktop/rac_desktop.h`) and is shared with
 `runanywhere-server`, the tests and the Playground apps.
-See `AGENTS.md` (layering rules) and
-`thoughts/shared/plans/rcli_desktop_cli.md` (design + implementation log).
+See `AGENTS.md` for the package layering rules.
 
 ## Known limitations
 
@@ -219,4 +259,4 @@ See `AGENTS.md` (layering rules) and
 - `rcli voice` with thinking models (qwen3) speaks the `<think>` text — pick a
   non-thinking LLM (`--llm lfm2`) until voice-agent thinking control lands.
 - Raw-URL pulls get inferred metadata (size/modality may show as `-`/generic).
-- macOS x86_64 and Windows binaries are not published yet.
+- macOS x86_64, Linux ARM64, and Windows ARM64 binaries are not published yet.

--- a/sdk/runanywhere-cli/README.md
+++ b/sdk/runanywhere-cli/README.md
@@ -39,8 +39,8 @@ irm https://raw.githubusercontent.com/RunanywhereAI/runanywhere-sdks/main/sdk/ru
 ```
 
 The Windows installer verifies the release checksum, installs `rcli.exe` and
-its pinned ONNX Runtime/Sherpa DLLs under `%LOCALAPPDATA%\Programs\rcli`, and
-adds that directory to the current user's `PATH`.
+its pinned ONNX Runtime/Sherpa DLLs under `%LOCALAPPDATA%\Programs\rcli\bin`,
+and adds that `bin` directory to the current user's `PATH`.
 
 The macOS GitHub Release also includes a Developer ID signed, notarized, and
 stapled disk image. Its `rcli-macos-arm64` directory has the same relocatable

--- a/sdk/runanywhere-cli/scripts/install.ps1
+++ b/sdk/runanywhere-cli/scripts/install.ps1
@@ -1,0 +1,64 @@
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$Version = "",
+
+    [Parameter(Mandatory = $false)]
+    [string]$InstallDir = "$env:LOCALAPPDATA\Programs\rcli"
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$Repo = "RunanywhereAI/runanywhere-sdks"
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Latest = Invoke-RestMethod "https://api.github.com/repos/$Repo/releases/latest"
+    $Version = ([string]$Latest.tag_name).TrimStart("v")
+}
+$Version = $Version.TrimStart("v")
+
+$Asset = "rcli-windows-x86_64-v$Version.zip"
+$BaseUrl = "https://github.com/$Repo/releases/download/v$Version"
+$TempDir = Join-Path ([IO.Path]::GetTempPath()) "rcli-install-$([Guid]::NewGuid())"
+New-Item $TempDir -ItemType Directory -Force | Out-Null
+
+try {
+    $Zip = Join-Path $TempDir $Asset
+    $Checksum = "$Zip.sha256"
+    Invoke-WebRequest "$BaseUrl/$Asset" -OutFile $Zip
+    Invoke-WebRequest "$BaseUrl/$Asset.sha256" -OutFile $Checksum
+
+    $Expected = ((Get-Content $Checksum -Raw).Trim() -split '\s+')[0].ToLowerInvariant()
+    $Actual = (Get-FileHash $Zip -Algorithm SHA256).Hash.ToLowerInvariant()
+    if ($Actual -ne $Expected) {
+        throw "SHA-256 verification failed for $Asset"
+    }
+
+    $Expanded = Join-Path $TempDir "expanded"
+    Expand-Archive $Zip -DestinationPath $Expanded
+    $Payload = Join-Path $Expanded "rcli-windows-x86_64"
+    if (-not (Test-Path (Join-Path $Payload "bin\rcli.exe"))) {
+        throw "release archive does not contain rcli-windows-x86_64/bin/rcli.exe"
+    }
+
+    $BinDir = Join-Path $InstallDir "bin"
+    Remove-Item $BinDir -Recurse -Force -ErrorAction SilentlyContinue
+    New-Item $BinDir -ItemType Directory -Force | Out-Null
+    Copy-Item (Join-Path $Payload "bin\*") $BinDir -Recurse
+    Copy-Item (Join-Path $Payload "README.md") (Join-Path $InstallDir "README.md") -Force
+
+    $UserPath = [Environment]::GetEnvironmentVariable("Path", "User")
+    $Entries = @($UserPath -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+    if ($Entries -notcontains $BinDir) {
+        $NewPath = (@($Entries) + $BinDir) -join ';'
+        [Environment]::SetEnvironmentVariable("Path", $NewPath, "User")
+        Write-Host "Added $BinDir to your user PATH. Open a new terminal to use it."
+    }
+    $env:PATH = "$BinDir;$env:PATH"
+
+    & (Join-Path $BinDir "rcli.exe") version
+    if ($LASTEXITCODE -ne 0) { throw "installed rcli smoke test failed" }
+    Write-Host "Installed rcli $Version to $BinDir"
+    Write-Host "Try: rcli list --all; rcli run qwen3"
+} finally {
+    Remove-Item $TempDir -Recurse -Force -ErrorAction SilentlyContinue
+}

--- a/sdk/runanywhere-cli/scripts/package-rcli-windows.ps1
+++ b/sdk/runanywhere-cli/scripts/package-rcli-windows.ps1
@@ -70,8 +70,10 @@ if (-not $OnnxDll) {
 }
 Copy-Item $OnnxDll (Join-Path $BinDir "onnxruntime.dll")
 
-$SherpaBin = Join-Path $RepoRoot "sdk\runanywhere-commons\third_party\sherpa-onnx-windows\bin"
-Copy-RuntimeDlls $SherpaBin @("onnxruntime.dll")
+# Sherpa ships sherpa-onnx-c-api.dll and its siblings in lib/ (bin/ holds only
+# the example executables and a duplicate onnxruntime.dll).
+$SherpaLib = Join-Path $RepoRoot "sdk\runanywhere-commons\third_party\sherpa-onnx-windows\lib"
+Copy-RuntimeDlls $SherpaLib @("onnxruntime.dll")
 if (-not (Test-Path (Join-Path $BinDir "sherpa-onnx-c-api.dll"))) {
     throw "sherpa-onnx-c-api.dll was not staged"
 }

--- a/sdk/runanywhere-cli/scripts/package-rcli-windows.ps1
+++ b/sdk/runanywhere-cli/scripts/package-rcli-windows.ps1
@@ -1,0 +1,112 @@
+param(
+    [Parameter(Mandatory = $false)]
+    [string]$BuildDir = "build/rcli-windows-release",
+
+    [Parameter(Mandatory = $false)]
+    [string]$Version = ""
+)
+
+$ErrorActionPreference = "Stop"
+Set-StrictMode -Version Latest
+
+$CliRoot = (Resolve-Path (Join-Path $PSScriptRoot "..")).Path
+$RepoRoot = (Resolve-Path (Join-Path $CliRoot "..\..")).Path
+if (-not [IO.Path]::IsPathRooted($BuildDir)) {
+    $BuildDir = Join-Path $RepoRoot $BuildDir
+}
+$BuildDir = (Resolve-Path $BuildDir).Path
+
+if ([string]::IsNullOrWhiteSpace($Version)) {
+    $Version = (Get-Content (Join-Path $RepoRoot "sdk\runanywhere-commons\VERSION") -Raw).Trim()
+}
+$Version = $Version.TrimStart("v")
+
+$BinaryCandidates = @(
+    (Join-Path $BuildDir "sdk\runanywhere-cli\rcli.exe"),
+    (Join-Path $BuildDir "sdk\runanywhere-cli\Release\rcli.exe")
+)
+$Binary = $BinaryCandidates | Where-Object { Test-Path $_ } | Select-Object -First 1
+if (-not $Binary) {
+    $Binary = Get-ChildItem -Path $BuildDir -Filter "rcli.exe" -File -Recurse |
+        Where-Object { $_.FullName -match "runanywhere-cli" } |
+        Select-Object -ExpandProperty FullName -First 1
+}
+if (-not $Binary) {
+    throw "rcli.exe was not found under $BuildDir"
+}
+
+$Platform = "windows-x86_64"
+$DistDir = Join-Path $CliRoot "dist"
+$StageRoot = Join-Path $DistDir "stage"
+$Stage = Join-Path $StageRoot "rcli-$Platform"
+$BinDir = Join-Path $Stage "bin"
+$Zip = Join-Path $DistDir "rcli-$Platform-v$Version.zip"
+
+Remove-Item $Stage -Recurse -Force -ErrorAction SilentlyContinue
+New-Item $BinDir -ItemType Directory -Force | Out-Null
+Copy-Item $Binary (Join-Path $BinDir "rcli.exe")
+Copy-Item (Join-Path $CliRoot "README.md") (Join-Path $Stage "README.md")
+
+function Copy-RuntimeDlls([string]$Source, [string[]]$Exclude = @()) {
+    if (-not (Test-Path $Source)) { return }
+    Get-ChildItem -Path $Source -Filter "*.dll" -File | ForEach-Object {
+        if (-not ($Exclude -contains $_.Name)) {
+            $Destination = Join-Path $BinDir $_.Name
+            if (-not (Test-Path $Destination)) {
+                Copy-Item $_.FullName $Destination
+            }
+        }
+    }
+}
+
+# The CLI links the pinned standalone ONNX Runtime. Sherpa's upstream bundle
+# may carry an older onnxruntime.dll, so stage the repository pin first and
+# deliberately exclude that duplicate while collecting Sherpa's other DLLs.
+$OnnxDll = Get-ChildItem -Path $BuildDir -Filter "onnxruntime.dll" -File -Recurse |
+    Where-Object { $_.FullName -match "onnxruntime-src[\\/]lib" } |
+    Select-Object -ExpandProperty FullName -First 1
+if (-not $OnnxDll) {
+    throw "the pinned ONNX Runtime DLL was not found under $BuildDir"
+}
+Copy-Item $OnnxDll (Join-Path $BinDir "onnxruntime.dll")
+
+$SherpaBin = Join-Path $RepoRoot "sdk\runanywhere-commons\third_party\sherpa-onnx-windows\bin"
+Copy-RuntimeDlls $SherpaBin @("onnxruntime.dll")
+if (-not (Test-Path (Join-Path $BinDir "sherpa-onnx-c-api.dll"))) {
+    throw "sherpa-onnx-c-api.dll was not staged"
+}
+
+# Validate from the exact relocatable directory that users receive.
+$OldPath = $env:PATH
+try {
+    $env:PATH = "$BinDir;$OldPath"
+    & (Join-Path $BinDir "rcli.exe") version
+    if ($LASTEXITCODE -ne 0) { throw "packaged rcli version smoke failed" }
+    $Backends = (& (Join-Path $BinDir "rcli.exe") backends --json) -join "`n"
+    Write-Host $Backends
+    if ($LASTEXITCODE -ne 0) { throw "packaged rcli backends smoke failed" }
+    if ($Backends -notmatch '"name":"llamacpp"') { throw "llama.cpp backend is missing" }
+    if ($Backends -notmatch '"name":"sherpa"') { throw "Sherpa backend is missing" }
+} finally {
+    $env:PATH = $OldPath
+}
+
+Get-ChildItem -Path $BinDir -File | ForEach-Object {
+    $Bytes = [IO.File]::ReadAllBytes($_.FullName)
+    $Text = [Text.Encoding]::ASCII.GetString($Bytes)
+    if ($Text.Contains($RepoRoot) -or $Text -match '[A-Za-z]:\\Users\\[^\\]+\\') {
+        throw "packaged artifact embeds a developer checkout path: $($_.Name)"
+    }
+}
+
+New-Item $DistDir -ItemType Directory -Force | Out-Null
+Remove-Item $Zip, "$Zip.sha256" -Force -ErrorAction SilentlyContinue
+Compress-Archive -Path $Stage -DestinationPath $Zip -CompressionLevel Optimal
+$Hash = (Get-FileHash $Zip -Algorithm SHA256).Hash.ToLowerInvariant()
+"$Hash  $([IO.Path]::GetFileName($Zip))" |
+    Set-Content -Path "$Zip.sha256" -Encoding ascii -NoNewline
+
+Write-Host "Packaged: $Zip"
+Get-ChildItem -Path $Stage -Recurse -File | ForEach-Object {
+    Write-Host $_.FullName.Substring($StageRoot.Length + 1)
+}

--- a/sdk/runanywhere-cli/src/config/cli_paths.cpp
+++ b/sdk/runanywhere-cli/src/config/cli_paths.cpp
@@ -1,10 +1,48 @@
 #include "config/cli_paths.h"
 
 #include <cstdlib>
+#include <string>
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <cstring>
+
+#include <windows.h>
+#endif
 
 #include "rac/desktop/rac_desktop.h"
 
 namespace rcli::paths {
+
+namespace {
+
+// Read an environment variable as UTF-8. On Windows std::getenv decodes the
+// value through the process ANSI code page, corrupting Unicode paths (e.g. an
+// international LOCALAPPDATA/USERPROFILE/RUNANYWHERE_HOME); read the wide value
+// and convert with CP_UTF8 instead. Returns empty when unset or empty.
+std::string getenv_utf8(const char* name) {
+#if defined(_WIN32)
+    const std::wstring wname(name, name + std::strlen(name));  // name is ASCII
+    const wchar_t* wvalue = _wgetenv(wname.c_str());
+    if (!wvalue || wvalue[0] == L'\0') {
+        return {};
+    }
+    const int len = WideCharToMultiByte(CP_UTF8, 0, wvalue, -1, nullptr, 0, nullptr, nullptr);
+    if (len <= 1) {
+        return {};
+    }
+    std::string out(static_cast<size_t>(len - 1), '\0');  // len counts the NUL
+    WideCharToMultiByte(CP_UTF8, 0, wvalue, -1, out.data(), len, nullptr, nullptr);
+    return out;
+#else
+    const char* value = std::getenv(name);
+    return (value && value[0] != '\0') ? std::string(value) : std::string();
+#endif
+}
+
+}  // namespace
 
 std::string normalize_dir(std::string dir) {
     while (dir.size() > 1 && (dir.back() == '/' || dir.back() == '\\')) {
@@ -17,8 +55,8 @@ std::string resolve_home(const std::string& override_dir) {
     if (!override_dir.empty()) {
         return normalize_dir(override_dir);
     }
-    if (const char* env = std::getenv("RUNANYWHERE_HOME"); env && env[0] != '\0') {
-        return normalize_dir(env);
+    if (std::string env = getenv_utf8("RUNANYWHERE_HOME"); !env.empty()) {
+        return normalize_dir(std::move(env));
     }
     char buffer[1024] = {};
     if (rac_desktop_default_base_dir(buffer, sizeof(buffer)) == RAC_SUCCESS) {
@@ -28,18 +66,18 @@ std::string resolve_home(const std::string& override_dir) {
 }
 
 std::string state_dir() {
-    if (const char* env = std::getenv("XDG_STATE_HOME"); env && env[0] != '\0') {
-        return normalize_dir(env) + "/runanywhere";
+    if (std::string env = getenv_utf8("XDG_STATE_HOME"); !env.empty()) {
+        return normalize_dir(std::move(env)) + "/runanywhere";
     }
-    if (const char* home = std::getenv("HOME"); home && home[0] != '\0') {
-        return normalize_dir(home) + "/.local/state/runanywhere";
+    if (std::string home = getenv_utf8("HOME"); !home.empty()) {
+        return normalize_dir(std::move(home)) + "/.local/state/runanywhere";
     }
 #if defined(_WIN32)
-    if (const char* local = std::getenv("LOCALAPPDATA"); local && local[0] != '\0') {
-        return normalize_dir(local) + "/RunAnywhere/state";
+    if (std::string local = getenv_utf8("LOCALAPPDATA"); !local.empty()) {
+        return normalize_dir(std::move(local)) + "/RunAnywhere/state";
     }
-    if (const char* profile = std::getenv("USERPROFILE"); profile && profile[0] != '\0') {
-        return normalize_dir(profile) + "/AppData/Local/RunAnywhere/state";
+    if (std::string profile = getenv_utf8("USERPROFILE"); !profile.empty()) {
+        return normalize_dir(std::move(profile)) + "/AppData/Local/RunAnywhere/state";
     }
 #endif
     return {};

--- a/sdk/runanywhere-cli/src/config/cli_paths.cpp
+++ b/sdk/runanywhere-cli/src/config/cli_paths.cpp
@@ -7,7 +7,7 @@
 namespace rcli::paths {
 
 std::string normalize_dir(std::string dir) {
-    while (dir.size() > 1 && dir.back() == '/') {
+    while (dir.size() > 1 && (dir.back() == '/' || dir.back() == '\\')) {
         dir.pop_back();
     }
     return dir;
@@ -34,6 +34,14 @@ std::string state_dir() {
     if (const char* home = std::getenv("HOME"); home && home[0] != '\0') {
         return normalize_dir(home) + "/.local/state/runanywhere";
     }
+#if defined(_WIN32)
+    if (const char* local = std::getenv("LOCALAPPDATA"); local && local[0] != '\0') {
+        return normalize_dir(local) + "/RunAnywhere/state";
+    }
+    if (const char* profile = std::getenv("USERPROFILE"); profile && profile[0] != '\0') {
+        return normalize_dir(profile) + "/AppData/Local/RunAnywhere/state";
+    }
+#endif
     return {};
 }
 

--- a/sdk/runanywhere-cli/src/repl/repl.cpp
+++ b/sdk/runanywhere-cli/src/repl/repl.cpp
@@ -13,11 +13,19 @@ extern "C" {
 
 namespace rcli::repl {
 
+namespace {
+// MSVC's <filesystem>/<fstream> decode a narrow std::string through the ANSI
+// code page; build the path from UTF-8 so non-ASCII history paths (e.g. an
+// international Windows username) resolve correctly. POSIX is unaffected.
+std::filesystem::path utf8_path(const std::string& s) {
+    return std::filesystem::path(reinterpret_cast<const char8_t*>(s.c_str()));
+}
+}  // namespace
+
 LineEditor::LineEditor(std::string history_path) : history_path_(std::move(history_path)) {
     if (!history_path_.empty()) {
         std::error_code ec;
-        std::filesystem::create_directories(
-            std::filesystem::path(history_path_).parent_path(), ec);
+        std::filesystem::create_directories(utf8_path(history_path_).parent_path(), ec);
 #if !defined(RCLI_NO_LINENOISE)
         linenoiseHistoryLoad(history_path_.c_str());
         linenoiseHistorySetMaxLen(512);
@@ -53,7 +61,7 @@ void LineEditor::add_history(const std::string& line) {
     if (!line.empty()) {
 #if defined(RCLI_NO_LINENOISE)
         if (!history_path_.empty()) {
-            std::ofstream history(history_path_, std::ios::app);
+            std::ofstream history(utf8_path(history_path_), std::ios::app);
             history << line << '\n';
         }
 #else

--- a/sdk/runanywhere-cli/src/repl/repl.cpp
+++ b/sdk/runanywhere-cli/src/repl/repl.cpp
@@ -1,11 +1,15 @@
 #include "repl/repl.h"
 
 #include <filesystem>
+#include <fstream>
+#include <iostream>
 #include <system_error>
 
+#if !defined(RCLI_NO_LINENOISE)
 extern "C" {
 #include <linenoise.h>
 }
+#endif
 
 namespace rcli::repl {
 
@@ -14,18 +18,27 @@ LineEditor::LineEditor(std::string history_path) : history_path_(std::move(histo
         std::error_code ec;
         std::filesystem::create_directories(
             std::filesystem::path(history_path_).parent_path(), ec);
+#if !defined(RCLI_NO_LINENOISE)
         linenoiseHistoryLoad(history_path_.c_str());
         linenoiseHistorySetMaxLen(512);
+#endif
     }
 }
 
 LineEditor::~LineEditor() {
+#if !defined(RCLI_NO_LINENOISE)
     if (!history_path_.empty()) {
         linenoiseHistorySave(history_path_.c_str());
     }
+#endif
 }
 
 bool LineEditor::read_line(const std::string& prompt, std::string* out_line) {
+#if defined(RCLI_NO_LINENOISE)
+    std::cerr << prompt;
+    std::cerr.flush();
+    return static_cast<bool>(std::getline(std::cin, *out_line));
+#else
     char* raw = linenoise(prompt.c_str());
     if (raw == nullptr) {
         return false;  // EOF / Ctrl-D (Ctrl-C inside linenoise returns NULL too)
@@ -33,11 +46,19 @@ bool LineEditor::read_line(const std::string& prompt, std::string* out_line) {
     *out_line = raw;
     linenoiseFree(raw);
     return true;
+#endif
 }
 
 void LineEditor::add_history(const std::string& line) {
     if (!line.empty()) {
+#if defined(RCLI_NO_LINENOISE)
+        if (!history_path_.empty()) {
+            std::ofstream history(history_path_, std::ios::app);
+            history << line << '\n';
+        }
+#else
         linenoiseHistoryAdd(line.c_str());
+#endif
     }
 }
 

--- a/sdk/runanywhere-cli/src/util/term.cpp
+++ b/sdk/runanywhere-cli/src/util/term.cpp
@@ -1,5 +1,6 @@
 #include "util/term.h"
 
+#include <cstdio>   // stdout/stderr/stdin, _fileno (Windows TTY checks below)
 #include <cstdlib>
 
 #if defined(_WIN32)

--- a/sdk/runanywhere-cli/src/util/term.cpp
+++ b/sdk/runanywhere-cli/src/util/term.cpp
@@ -1,29 +1,56 @@
 #include "util/term.h"
 
+#include <cstdlib>
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <io.h>
+#include <windows.h>
+#else
 #include <sys/ioctl.h>
 #include <unistd.h>
-
-#include <cstdlib>
+#endif
 
 namespace rcli::term {
 
 bool stdout_is_tty() {
+#if defined(_WIN32)
+    return _isatty(_fileno(stdout)) != 0;
+#else
     return isatty(STDOUT_FILENO) == 1;
+#endif
 }
 
 bool stderr_is_tty() {
+#if defined(_WIN32)
+    return _isatty(_fileno(stderr)) != 0;
+#else
     return isatty(STDERR_FILENO) == 1;
+#endif
 }
 
 bool stdin_is_tty() {
+#if defined(_WIN32)
+    return _isatty(_fileno(stdin)) != 0;
+#else
     return isatty(STDIN_FILENO) == 1;
+#endif
 }
 
 int terminal_width() {
+#if defined(_WIN32)
+    CONSOLE_SCREEN_BUFFER_INFO info{};
+    if (GetConsoleScreenBufferInfo(GetStdHandle(STD_ERROR_HANDLE), &info)) {
+        return static_cast<int>(info.srWindow.Right - info.srWindow.Left + 1);
+    }
+#else
     winsize ws{};
     if (ioctl(STDERR_FILENO, TIOCGWINSZ, &ws) == 0 && ws.ws_col > 0) {
         return ws.ws_col;
     }
+#endif
     return 80;
 }
 

--- a/sdk/runanywhere-cli/src/windows_proto_compat.h
+++ b/sdk/runanywhere-cli/src/windows_proto_compat.h
@@ -1,0 +1,28 @@
+#ifndef RCLI_WINDOWS_PROTO_COMPAT_H
+#define RCLI_WINDOWS_PROTO_COMPAT_H
+
+// Force-included ahead of every rcli translation unit on Windows (see the CLI
+// CMakeLists). <winnt.h> — pulled in via <windows.h> by Abseil/protobuf headers
+// the CLI transitively includes — defines ERROR_SEVERITY_WARNING and
+// ERROR_SEVERITY_ERROR as preprocessor macros. Those clobber the identically
+// named values of the generated proto enum runanywhere::v1::ErrorSeverity,
+// breaking errors.pb.h with "expected '}' before numeric constant" wherever a
+// TU includes windows.h before the proto header (e.g. cmd_run.cpp).
+//
+// Include windows.h once up front and undef only the two colliding macros, so
+// later proto headers parse cleanly. Subsequent <windows.h> includes are no-ops
+// (its own include guard), so the undefs stick.
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#ifndef WIN32_LEAN_AND_MEAN
+#define WIN32_LEAN_AND_MEAN
+#endif
+#include <windows.h>
+#undef ERROR_SEVERITY_WARNING
+#undef ERROR_SEVERITY_ERROR
+#endif  // _WIN32
+
+#endif  // RCLI_WINDOWS_PROTO_COMPAT_H

--- a/sdk/runanywhere-cli/tests/test_rcli_unit.cpp
+++ b/sdk/runanywhere-cli/tests/test_rcli_unit.cpp
@@ -36,16 +36,32 @@ public:
       prev_ = prev;
     }
     if (value) {
+#if defined(_WIN32)
+      _putenv_s(name, value);
+#else
       setenv(name, value, 1);
+#endif
     } else {
+#if defined(_WIN32)
+      _putenv_s(name, "");
+#else
       unsetenv(name);
+#endif
     }
   }
   ~EnvVar() {
     if (had_prev_) {
+#if defined(_WIN32)
+      _putenv_s(name_.c_str(), prev_.c_str());
+#else
       setenv(name_.c_str(), prev_.c_str(), 1);
+#endif
     } else {
+#if defined(_WIN32)
+      _putenv_s(name_.c_str(), "");
+#else
       unsetenv(name_.c_str());
+#endif
     }
   }
 
@@ -171,12 +187,21 @@ TestResult test_resolve_home_precedence() {
   {
     // Default: XDG data dir under runanywhere.
     EnvVar env("RUNANYWHERE_HOME", nullptr);
+#if defined(_WIN32)
+    EnvVar local("LOCALAPPDATA", "C:/rcli-local");
+    const std::string home = rcli::paths::resolve_home("");
+    if (home != "C:/rcli-local/RunAnywhere") {
+      result.details = "expected C:/rcli-local/RunAnywhere, got " + home;
+      return result;
+    }
+#else
     EnvVar xdg("XDG_DATA_HOME", "/xdg-data");
     const std::string home = rcli::paths::resolve_home("");
     if (home != "/xdg-data/runanywhere") {
       result.details = "expected /xdg-data/runanywhere, got " + home;
       return result;
     }
+#endif
   }
   result.passed = true;
   return result;

--- a/sdk/runanywhere-commons/CMakeLists.txt
+++ b/sdk/runanywhere-commons/CMakeLists.txt
@@ -400,6 +400,13 @@ set(ENABLE_LIBXML2 OFF CACHE BOOL "" FORCE)
 set(ENABLE_EXPAT OFF CACHE BOOL "" FORCE)
 set(ENABLE_PCREPOSIX OFF CACHE BOOL "" FORCE)
 set(ENABLE_PCRE2POSIX OFF CACHE BOOL "" FORCE)
+# MSVC has no libc regcomp, so libarchive's POSIX_REGEX_LIB=AUTO falls through to
+# a PCRE/libgcc branch that hard-errors ("libgcc not found") at configure time.
+# We only use libarchive for extraction (no archive_match/regex), so disable the
+# POSIX regex search entirely on Windows.
+if(WIN32)
+    set(POSIX_REGEX_LIB "NONE" CACHE STRING "" FORCE)
+endif()
 # libarchive's ENABLE_LIBGCC gates a `find_library(GCC_LIBRARY gcc)` / `-lgcc`
 # link. Needed on MSVC for the bundled runtime; a no-op on Apple/Clang (no
 # libgcc); on Linux+GCC keep it OFF so we don't add an explicit -lgcc to the

--- a/sdk/runanywhere-commons/CMakeLists.txt
+++ b/sdk/runanywhere-commons/CMakeLists.txt
@@ -79,11 +79,11 @@ if(EMSCRIPTEN AND NOT RAC_BACKEND_ONNX AND NOT RAC_WASM_RAG_STANDALONE)
 endif()
 option(RAC_BUILD_SERVER "Build OpenAI-compatible HTTP server (runanywhere-server)" OFF)
 
-# Desktop (macOS/Linux) platform adapter: POSIX file I/O + 0600-file secure
-# storage + libcurl HTTP transport. Consumed by desktop binaries that link
+# Desktop (macOS/Linux/Windows) platform adapter: native file I/O, protected
+# secure storage + libcurl HTTP transport. Consumed by desktop binaries that link
 # rac_commons directly (rcli, runanywhere-server, real-inference tests,
 # Playground apps). See include/rac/desktop/rac_desktop.h.
-option(RAC_DESKTOP_ADAPTER "Build desktop (macOS/Linux) platform adapter + libcurl HTTP transport" OFF)
+option(RAC_DESKTOP_ADAPTER "Build desktop (macOS/Linux/Windows) platform adapter + libcurl HTTP transport" OFF)
 
 # Opt-in proto regeneration.
 #
@@ -966,10 +966,10 @@ set(RAC_FEATURES_SOURCES
     $<$<NOT:$<CXX_COMPILER_ID:MSVC>>:src/features/result_free.cpp>
 )
 
-# Desktop platform adapter (POSIX + libcurl) — macOS/Linux binaries only
+# Desktop platform adapter (native filesystem + libcurl) — desktop hosts only
 if(RAC_DESKTOP_ADAPTER)
-    if(ANDROID OR EMSCRIPTEN OR WIN32 OR (APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
-        message(FATAL_ERROR "RAC_DESKTOP_ADAPTER is only supported on desktop macOS/Linux builds "
+    if(ANDROID OR EMSCRIPTEN OR (APPLE AND NOT CMAKE_SYSTEM_NAME STREQUAL "Darwin"))
+        message(FATAL_ERROR "RAC_DESKTOP_ADAPTER is only supported on desktop macOS/Linux/Windows builds "
                             "(got CMAKE_SYSTEM_NAME=${CMAKE_SYSTEM_NAME})")
     endif()
     set(RAC_DESKTOP_SOURCES
@@ -977,7 +977,7 @@ if(RAC_DESKTOP_ADAPTER)
         src/desktop/desktop_secure_store.cpp
         src/desktop/http_transport_curl.cpp
     )
-    message(STATUS "Building desktop platform adapter (POSIX file I/O + libcurl HTTP transport)")
+    message(STATUS "Building desktop platform adapter (native file I/O + libcurl HTTP transport)")
 else()
     set(RAC_DESKTOP_SOURCES "")
 endif()
@@ -1246,6 +1246,10 @@ endif()
 if(RAC_DESKTOP_ADAPTER)
     find_package(CURL REQUIRED)
     target_link_libraries(rac_commons PUBLIC CURL::libcurl)
+    if(WIN32)
+        # CryptProtectData/CryptUnprotectData protect the per-user secure store.
+        target_link_libraries(rac_commons PUBLIC crypt32)
+    endif()
 endif()
 
 # =============================================================================

--- a/sdk/runanywhere-commons/include/rac/desktop/rac_desktop.h
+++ b/sdk/runanywhere-commons/include/rac/desktop/rac_desktop.h
@@ -1,6 +1,6 @@
 /**
  * @file rac_desktop.h
- * @brief RunAnywhere Commons - Desktop (macOS/Linux) platform adapter + HTTP transport.
+ * @brief RunAnywhere Commons - Desktop platform adapter + HTTP transport.
  *
  * Desktop equivalent of the per-SDK platform bridges (Swift URLSession adapter,
  * Kotlin OkHttp adapter, ...). Built only when RAC_DESKTOP_ADAPTER=ON; consumed
@@ -9,7 +9,7 @@
  *
  * Provides:
  *   - rac_desktop_adapter_init():  fills a rac_platform_adapter_t with real
- *     POSIX implementations (file I/O, directory enumeration, 0600-file secure
+ *     native implementations (file I/O, directory enumeration, protected secure
  *     storage, stderr logging, monotonic-epoch clock, memory info). The
  *     http_download / extract_archive slots stay NULL on purpose — downloads
  *     route through the HTTP transport below and archive extraction uses the
@@ -19,8 +19,8 @@
  *     so the download orchestrator, model assignment fetch, and telemetry all
  *     work without a mobile SDK bridge.
  *   - rac_desktop_default_base_dir():  canonical desktop storage root
- *     (${XDG_DATA_HOME:-~/.local/share}/runanywhere) shared by every desktop
- *     consumer so models land in one place.
+ *     (${XDG_DATA_HOME:-~/.local/share}/runanywhere on POSIX or
+ *     %LOCALAPPDATA%/RunAnywhere on Windows) shared by every desktop consumer.
  *
  * Typical bootstrap (mirrors tests/test_voice_agent.cpp but with real I/O):
  *
@@ -37,9 +37,8 @@
  * mutex; the curl transport uses one easy handle per request.
  *
  * Security note: secure_get/set/delete persist to per-key files created with
- * mode 0600 under the config dir. This is deliberate, documented MVP behavior
- * for desktop (no Keychain/libsecret dependency) — do not store anything more
- * sensitive than API keys / device ids through it.
+ * mode 0600 under the POSIX config dir. Windows encrypts each value with the
+ * current user's DPAPI key before writing it under AppData.
  */
 
 #ifndef RAC_DESKTOP_RAC_DESKTOP_H
@@ -57,14 +56,14 @@ extern "C" {
  */
 typedef struct rac_desktop_adapter_config {
     /**
-     * Directory for the secure-store files (created 0700 if missing).
-     * NULL → ${XDG_CONFIG_HOME:-~/.config}/runanywhere
+     * Directory for the secure-store files (created 0700 on POSIX if missing).
+     * NULL → the platform default config directory.
      */
     const char* secure_store_dir;
 } rac_desktop_adapter_config_t;
 
 /**
- * @brief Populate a platform adapter with the desktop POSIX implementation.
+ * @brief Populate a platform adapter with the desktop native implementation.
  *
  * The adapter struct itself is caller-owned (keep it alive until
  * rac_shutdown(), exactly like the SDK bridges do). Internal state (secure
@@ -94,8 +93,8 @@ RAC_API rac_result_t rac_desktop_http_transport_register(void);
 /**
  * @brief Canonical desktop storage root shared by all desktop consumers.
  *
- * Resolves ${XDG_DATA_HOME:-$HOME/.local/share}/runanywhere (no trailing
- * slash). Pass this to rac_model_paths_set_base_dir() so model downloads land
+ * Resolves the platform data directory (no trailing slash). Pass this to
+ * rac_model_paths_set_base_dir() so model downloads land
  * in <root>/Models/{framework}/{modelId} — the same layout used by the Linux
  * test rig and Playground tooling. The directory is NOT created by this call.
  *

--- a/sdk/runanywhere-commons/scripts/windows/download-sherpa-onnx.bat
+++ b/sdk/runanywhere-commons/scripts/windows/download-sherpa-onnx.bat
@@ -98,7 +98,7 @@ echo [EXTRACT] Decompressing (7-Zip)...
 mkdir "%DEST_DIR%" 2>nul
 7z x -y "%TEMP_DL%\sherpa-onnx.tar.bz2" -o"%TEMP_DL%"
 if errorlevel 1 (
-    echo [ERROR] bzip2 decompression (7-Zip) failed.
+    echo [ERROR] 7-Zip bzip2 decompression failed.
     rmdir /s /q "%TEMP_DL%" 2>nul
     exit /b 1
 )

--- a/sdk/runanywhere-commons/scripts/windows/download-sherpa-onnx.bat
+++ b/sdk/runanywhere-commons/scripts/windows/download-sherpa-onnx.bat
@@ -68,8 +68,12 @@ mkdir "%TEMP_DL%" 2>nul
 :: Download
 echo [DOWNLOAD] Downloading Sherpa-ONNX v%VERSION%...
 :: --fail turns an HTTP 404 into a non-zero exit instead of silently writing the
-:: error body (which then fails opaquely at the tar step).
-curl -L --fail --show-error --retry 3 -o "%TEMP_DL%\sherpa-onnx.tar.bz2" "%URL%"
+:: error body (which then fails opaquely at the tar step). --connect-timeout /
+:: --max-time bound a stalled transfer (curl has no default timeout and would
+:: otherwise hang the CI job indefinitely); --retry-all-errors retries the
+:: timeout too.
+curl -L --fail --show-error --connect-timeout 30 --max-time 900 --retry 3 ^
+    --retry-delay 5 --retry-all-errors -o "%TEMP_DL%\sherpa-onnx.tar.bz2" "%URL%"
 if errorlevel 1 (
     echo [ERROR] Download failed for %URL%
     rmdir /s /q "%TEMP_DL%" 2>nul
@@ -85,19 +89,16 @@ if %DL_SIZE% LSS 1000000 (
     exit /b 1
 )
 
-:: Extract
+:: Extract straight into DEST_DIR, dropping the archive's top-level directory.
+:: --strip-components=1 avoids a second copy pass (the old xcopy step could hang
+:: on cmd's "File or Directory?" prompt with no stdin on CI).
 echo [EXTRACT] Extracting archive...
 mkdir "%DEST_DIR%" 2>nul
-tar -xjf "%TEMP_DL%\sherpa-onnx.tar.bz2" -C "%TEMP_DL%"
+tar -xjf "%TEMP_DL%\sherpa-onnx.tar.bz2" --strip-components=1 -C "%DEST_DIR%"
 if errorlevel 1 (
     echo [ERROR] Extraction failed.
     rmdir /s /q "%TEMP_DL%" 2>nul
     exit /b 1
-)
-
-:: Move contents (strip top-level directory)
-for /d %%d in ("%TEMP_DL%\sherpa-onnx-*") do (
-    xcopy /s /y /q "%%d\*" "%DEST_DIR%\" >nul
 )
 
 :: Download C API headers if missing

--- a/sdk/runanywhere-commons/scripts/windows/download-sherpa-onnx.bat
+++ b/sdk/runanywhere-commons/scripts/windows/download-sherpa-onnx.bat
@@ -89,12 +89,21 @@ if %DL_SIZE% LSS 1000000 (
     exit /b 1
 )
 
-:: Extract straight into DEST_DIR, dropping the archive's top-level directory.
-:: --strip-components=1 avoids a second copy pass (the old xcopy step could hang
-:: on cmd's "File or Directory?" prompt with no stdin on CI).
-echo [EXTRACT] Extracting archive...
+:: Extract. Windows' bundled bsdtar hangs indefinitely decompressing .tar.bz2
+:: on CI (its bzip2 filter stalls with no console), so use 7-Zip — preinstalled
+:: on GitHub windows runners — to turn .tar.bz2 into a plain .tar, then plain
+:: tar (no bzip2) to lay it down, dropping the archive's top-level directory.
+:: -y answers any 7-Zip prompt so it can never block on stdin.
+echo [EXTRACT] Decompressing (7-Zip)...
 mkdir "%DEST_DIR%" 2>nul
-tar -xjf "%TEMP_DL%\sherpa-onnx.tar.bz2" --strip-components=1 -C "%DEST_DIR%"
+7z x -y "%TEMP_DL%\sherpa-onnx.tar.bz2" -o"%TEMP_DL%"
+if errorlevel 1 (
+    echo [ERROR] bzip2 decompression (7-Zip) failed.
+    rmdir /s /q "%TEMP_DL%" 2>nul
+    exit /b 1
+)
+echo [EXTRACT] Unpacking tar...
+tar -xf "%TEMP_DL%\sherpa-onnx.tar" --strip-components=1 -C "%DEST_DIR%"
 if errorlevel 1 (
     echo [ERROR] Extraction failed.
     rmdir /s /q "%TEMP_DL%" 2>nul

--- a/sdk/runanywhere-commons/scripts/windows/download-sherpa-onnx.bat
+++ b/sdk/runanywhere-commons/scripts/windows/download-sherpa-onnx.bat
@@ -38,8 +38,12 @@ if exist "%DEST_DIR%\lib" if "%FORCE%"=="0" (
 )
 
 :: Determine URL
-set "URL=https://github.com/k2-fsa/sherpa-onnx/releases/download/v%VERSION%/sherpa-onnx-v%VERSION%-win-x64-shared.tar.bz2"
-set "ARCHIVE_NAME=sherpa-onnx-v%VERSION%-win-x64-shared"
+:: k2-fsa publishes the Windows x64 build as MSVC-runtime + config variants;
+:: there is no plain "-win-x64-shared" asset (that URL 404s). Use the static-CRT
+:: Release variant (-MT-Release) so the bundled DLLs carry no VC++ redist
+:: dependency, matching the /MT rcli build (CMAKE_MSVC_RUNTIME_LIBRARY).
+set "URL=https://github.com/k2-fsa/sherpa-onnx/releases/download/v%VERSION%/sherpa-onnx-v%VERSION%-win-x64-shared-MT-Release.tar.bz2"
+set "ARCHIVE_NAME=sherpa-onnx-v%VERSION%-win-x64-shared-MT-Release"
 
 echo.
 echo ========================================
@@ -63,9 +67,20 @@ mkdir "%TEMP_DL%" 2>nul
 
 :: Download
 echo [DOWNLOAD] Downloading Sherpa-ONNX v%VERSION%...
-curl -L -o "%TEMP_DL%\sherpa-onnx.tar.bz2" "%URL%"
+:: --fail turns an HTTP 404 into a non-zero exit instead of silently writing the
+:: error body (which then fails opaquely at the tar step).
+curl -L --fail --show-error --retry 3 -o "%TEMP_DL%\sherpa-onnx.tar.bz2" "%URL%"
 if errorlevel 1 (
-    echo [ERROR] Download failed.
+    echo [ERROR] Download failed for %URL%
+    rmdir /s /q "%TEMP_DL%" 2>nul
+    exit /b 1
+)
+
+:: Guard against a truncated or HTML/error body slipping past curl.
+set "DL_SIZE=0"
+for %%A in ("%TEMP_DL%\sherpa-onnx.tar.bz2") do set "DL_SIZE=%%~zA"
+if %DL_SIZE% LSS 1000000 (
+    echo [ERROR] Downloaded archive is only %DL_SIZE% bytes; expected a multi-MB tarball.
     rmdir /s /q "%TEMP_DL%" 2>nul
     exit /b 1
 )

--- a/sdk/runanywhere-commons/src/desktop/desktop_adapter.cpp
+++ b/sdk/runanywhere-commons/src/desktop/desktop_adapter.cpp
@@ -1,11 +1,11 @@
 /**
  * @file desktop_adapter.cpp
- * @brief Desktop (macOS/Linux) rac_platform_adapter_t implementation.
+ * @brief Desktop (macOS/Linux/Windows) rac_platform_adapter_t implementation.
  *
- * Real POSIX counterparts of the stub adapter used by the commons tests
- * (tests/test_voice_agent.cpp): file I/O via <fcntl.h>/std::filesystem,
- * directory enumeration via opendir/readdir, memory info via host_statistics64
- * (macOS) / /proc/meminfo (Linux), logging to stderr. Secure storage lives in
+ * Native counterparts of the stub adapter used by the commons tests
+ * (tests/test_voice_agent.cpp): file I/O and enumeration via std::filesystem,
+ * memory info via host_statistics64 (macOS), /proc/meminfo (Linux), or
+ * GlobalMemoryStatusEx (Windows), logging to stderr. Secure storage lives in
  * desktop_secure_store.cpp; HTTP in http_transport_curl.cpp.
  *
  * Slots intentionally left NULL:
@@ -17,11 +17,6 @@
  *     UUID through secure storage instead.
  */
 
-#include <dirent.h>
-#include <fcntl.h>
-#include <pwd.h>
-#include <unistd.h>
-
 #include <cerrno>
 #include <chrono>
 #include <cstdio>
@@ -29,8 +24,17 @@
 #include <cstring>
 #include <filesystem>
 #include <string>
-#include <sys/stat.h>
 #include <system_error>
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#else
+#include <pwd.h>
+#include <unistd.h>
+#endif
 
 #if defined(__APPLE__)
 #include <mach/mach.h>
@@ -48,6 +52,15 @@ namespace fs = std::filesystem;
 namespace rac::desktop {
 
 std::string home_dir() {
+#if defined(_WIN32)
+    for (const char* key : {"USERPROFILE", "LOCALAPPDATA"}) {
+        const char* value = std::getenv(key);
+        if (value && value[0] != '\0') {
+            return value;
+        }
+    }
+    return {};
+#else
     const char* home = std::getenv("HOME");
     if (home && home[0] != '\0') {
         return home;
@@ -58,8 +71,10 @@ std::string home_dir() {
         }
     }
     return {};
+#endif
 }
 
+#if !defined(_WIN32)
 static std::string xdg_dir(const char* env_name, const char* home_suffix) {
     const char* env = std::getenv(env_name);
     std::string base;
@@ -77,13 +92,39 @@ static std::string xdg_dir(const char* env_name, const char* home_suffix) {
     }
     return base + "/runanywhere";
 }
+#else
+static std::string windows_app_dir(const char* preferred_env) {
+    const char* env = std::getenv(preferred_env);
+    std::string base;
+    if (env && env[0] != '\0') {
+        base = env;
+    } else {
+        base = home_dir();
+    }
+    if (base.empty()) {
+        return {};
+    }
+    while (!base.empty() && (base.back() == '/' || base.back() == '\\')) {
+        base.pop_back();
+    }
+    return base + "/RunAnywhere";
+}
+#endif
 
 std::string default_config_dir() {
+#if defined(_WIN32)
+    return windows_app_dir("APPDATA");
+#else
     return xdg_dir("XDG_CONFIG_HOME", "/.config");
+#endif
 }
 
 std::string default_data_dir() {
+#if defined(_WIN32)
+    return windows_app_dir("LOCALAPPDATA");
+#else
     return xdg_dir("XDG_DATA_HOME", "/.local/share");
+#endif
 }
 
 }  // namespace rac::desktop
@@ -104,6 +145,19 @@ rac_result_t errno_to_rac(int err, rac_result_t fallback) {
     }
 }
 
+rac_result_t filesystem_error_to_rac(const std::error_code& ec, rac_result_t fallback) {
+    if (ec == std::errc::no_such_file_or_directory) {
+        return RAC_ERROR_FILE_NOT_FOUND;
+    }
+    if (ec == std::errc::permission_denied) {
+        return RAC_ERROR_PERMISSION_DENIED;
+    }
+    if (ec == std::errc::no_space_on_device) {
+        return RAC_ERROR_STORAGE_FULL;
+    }
+    return fallback;
+}
+
 // -----------------------------------------------------------------------------
 // File system
 // -----------------------------------------------------------------------------
@@ -113,8 +167,8 @@ rac_bool_t desktop_file_exists(const char* path, void* /*user_data*/) {
         return RAC_FALSE;
     }
     // Mirrors FileManager.fileExists(atPath:) — true for files AND directories.
-    struct stat st{};
-    return stat(path, &st) == 0 ? RAC_TRUE : RAC_FALSE;
+    std::error_code ec;
+    return fs::exists(fs::path(path), ec) && !ec ? RAC_TRUE : RAC_FALSE;
 }
 
 rac_result_t desktop_file_read(const char* path, void** out_data, size_t* out_size,
@@ -197,8 +251,8 @@ rac_result_t desktop_file_delete(const char* path, void* /*user_data*/) {
 // Directory enumeration
 // -----------------------------------------------------------------------------
 
-bool entry_is_hidden(const char* name) {
-    return name[0] == '.';
+bool entry_is_hidden(const std::string& name) {
+    return !name.empty() && name[0] == '.';
 }
 
 rac_result_t desktop_file_list_directory(const char* dir_path, rac_directory_entry_t* out_entries,
@@ -207,18 +261,24 @@ rac_result_t desktop_file_list_directory(const char* dir_path, rac_directory_ent
         return RAC_ERROR_INVALID_ARGUMENT;
     }
 
-    DIR* dir = opendir(dir_path);
-    if (!dir) {
-        return errno_to_rac(errno, RAC_ERROR_STORAGE_ERROR);
-    }
-
     const size_t capacity = out_entries ? *in_out_count : 0;
     size_t count = 0;
-    while (dirent* entry = readdir(dir)) {
-        if (entry_is_hidden(entry->d_name)) {
+    std::error_code ec;
+    fs::directory_iterator iterator(fs::path(dir_path), ec);
+    if (ec) {
+        return filesystem_error_to_rac(ec, RAC_ERROR_STORAGE_ERROR);
+    }
+    const fs::directory_iterator end;
+    for (; iterator != end; iterator.increment(ec)) {
+        if (ec) {
+            return filesystem_error_to_rac(ec, RAC_ERROR_STORAGE_ERROR);
+        }
+        const fs::directory_entry& entry = *iterator;
+        const std::string name = entry.path().filename().string();
+        if (entry_is_hidden(name)) {
             continue;
         }
-        const size_t name_len = std::strlen(entry->d_name);
+        const size_t name_len = name.size();
         if (name_len + 1 > RAC_DIRECTORY_ENTRY_NAME_MAX) {
             // Truncation contract: skip oversized names, never half-copy them.
             std::fprintf(stderr, "[WARN] [PlatformAdapter] skipping oversized entry in %s\n",
@@ -231,21 +291,19 @@ rac_result_t desktop_file_list_directory(const char* dir_path, rac_directory_ent
                 break;
             }
             rac_directory_entry_t& dst = out_entries[count];
-            std::memcpy(dst.name, entry->d_name, name_len + 1);
+            std::memcpy(dst.name, name.c_str(), name_len + 1);
 
-            std::string full = std::string(dir_path) + "/" + entry->d_name;
-            struct stat st{};
-            if (stat(full.c_str(), &st) == 0) {
-                dst.is_dir = S_ISDIR(st.st_mode) ? RAC_TRUE : RAC_FALSE;
-                dst.size_bytes = S_ISDIR(st.st_mode) ? 0 : static_cast<int64_t>(st.st_size);
-            } else {
-                dst.is_dir = (entry->d_type == DT_DIR) ? RAC_TRUE : RAC_FALSE;
+            std::error_code type_ec;
+            const bool is_dir = entry.is_directory(type_ec);
+            dst.is_dir = !type_ec && is_dir ? RAC_TRUE : RAC_FALSE;
+            std::error_code size_ec;
+            dst.size_bytes = is_dir ? 0 : static_cast<int64_t>(entry.file_size(size_ec));
+            if (size_ec) {
                 dst.size_bytes = 0;
             }
         }
         ++count;
     }
-    closedir(dir);
 
     *in_out_count = count;
     return RAC_SUCCESS;
@@ -255,20 +313,9 @@ rac_bool_t desktop_is_non_empty_directory(const char* path, void* /*user_data*/)
     if (!path) {
         return RAC_FALSE;
     }
-    DIR* dir = opendir(path);
-    if (!dir) {
-        return RAC_FALSE;
-    }
-    rac_bool_t non_empty = RAC_FALSE;
-    while (dirent* entry = readdir(dir)) {
-        if (std::strcmp(entry->d_name, ".") == 0 || std::strcmp(entry->d_name, "..") == 0) {
-            continue;
-        }
-        non_empty = RAC_TRUE;
-        break;
-    }
-    closedir(dir);
-    return non_empty;
+    std::error_code ec;
+    fs::directory_iterator iterator(fs::path(path), ec);
+    return !ec && iterator != fs::directory_iterator{} ? RAC_TRUE : RAC_FALSE;
 }
 
 // -----------------------------------------------------------------------------
@@ -366,6 +413,16 @@ rac_result_t desktop_get_memory_info(rac_memory_info_t* out_info, void* /*user_d
     out_info->used_bytes = (out_info->total_bytes > out_info->available_bytes)
                                ? (out_info->total_bytes - out_info->available_bytes)
                                : 0;
+    return RAC_SUCCESS;
+#elif defined(_WIN32)
+    MEMORYSTATUSEX status{};
+    status.dwLength = sizeof(status);
+    if (!GlobalMemoryStatusEx(&status)) {
+        return RAC_ERROR_NOT_SUPPORTED;
+    }
+    out_info->total_bytes = status.ullTotalPhys;
+    out_info->available_bytes = status.ullAvailPhys;
+    out_info->used_bytes = status.ullTotalPhys - status.ullAvailPhys;
     return RAC_SUCCESS;
 #else
     return RAC_ERROR_NOT_SUPPORTED;

--- a/sdk/runanywhere-commons/src/desktop/desktop_adapter.cpp
+++ b/sdk/runanywhere-commons/src/desktop/desktop_adapter.cpp
@@ -44,6 +44,9 @@
 #include <sys/sysinfo.h>
 #endif
 
+#if defined(_WIN32)
+#include "core/internal/platform_compat.h"  // rac_to_wstring for UTF-8 path handling
+#endif
 #include "desktop/desktop_internal.h"
 #include "rac/desktop/rac_desktop.h"
 
@@ -159,6 +162,51 @@ rac_result_t filesystem_error_to_rac(const std::error_code& ec, rac_result_t fal
 }
 
 // -----------------------------------------------------------------------------
+// UTF-8 path helpers
+//
+// The platform-adapter contract documents every path/name as UTF-8. On Windows
+// the narrow std::fopen / std::remove / fs::path(const char*) overloads decode
+// bytes with the process ANSI code page, not UTF-8, so a non-ASCII path would
+// reach the wrong file (or spuriously report ENOENT). Convert to wide with the
+// shared rac_to_wstring helper (the same one ONNX Runtime session paths use) and
+// call the wide CRT/filesystem APIs. On POSIX the narrow byte string is already
+// UTF-8, so each helper reduces to the original call with no behavior change.
+// -----------------------------------------------------------------------------
+
+fs::path utf8_to_path(const char* utf8) {
+#if defined(_WIN32)
+    return fs::path(rac_to_wstring(utf8));
+#else
+    return fs::path(utf8);
+#endif
+}
+
+FILE* utf8_fopen(const char* utf8, const char* mode) {
+#if defined(_WIN32)
+    // mode is ASCII ("rb"/"wb"), so widening it byte-for-byte is safe.
+    return _wfopen(rac_to_wstring(utf8).c_str(), rac_to_wstring(mode).c_str());
+#else
+    return std::fopen(utf8, mode);
+#endif
+}
+
+int utf8_remove(const char* utf8) {
+#if defined(_WIN32)
+    return _wremove(rac_to_wstring(utf8).c_str());
+#else
+    return std::remove(utf8);
+#endif
+}
+
+// UTF-8 filename, never the ANSI code page: fs::path::string() throws on
+// Windows for code points the active code page cannot represent, and that
+// exception would escape this C-ABI callback. u8string() is always UTF-8.
+std::string filename_utf8(const fs::path& p) {
+    const auto name = p.filename().u8string();  // std::u8string, always UTF-8
+    return std::string(reinterpret_cast<const char*>(name.data()), name.size());
+}
+
+// -----------------------------------------------------------------------------
 // File system
 // -----------------------------------------------------------------------------
 
@@ -168,7 +216,7 @@ rac_bool_t desktop_file_exists(const char* path, void* /*user_data*/) {
     }
     // Mirrors FileManager.fileExists(atPath:) — true for files AND directories.
     std::error_code ec;
-    return fs::exists(fs::path(path), ec) && !ec ? RAC_TRUE : RAC_FALSE;
+    return fs::exists(utf8_to_path(path), ec) && !ec ? RAC_TRUE : RAC_FALSE;
 }
 
 rac_result_t desktop_file_read(const char* path, void** out_data, size_t* out_size,
@@ -179,7 +227,7 @@ rac_result_t desktop_file_read(const char* path, void** out_data, size_t* out_si
     *out_data = nullptr;
     *out_size = 0;
 
-    FILE* f = std::fopen(path, "rb");
+    FILE* f = utf8_fopen(path, "rb");
     if (!f) {
         return errno_to_rac(errno, RAC_ERROR_FILE_READ_FAILED);
     }
@@ -220,12 +268,12 @@ rac_result_t desktop_file_write(const char* path, const void* data, size_t size,
     }
 
     std::error_code ec;
-    fs::path parent = fs::path(path).parent_path();
+    fs::path parent = utf8_to_path(path).parent_path();
     if (!parent.empty()) {
         fs::create_directories(parent, ec);  // ec ignored: fopen below surfaces failure
     }
 
-    FILE* f = std::fopen(path, "wb");
+    FILE* f = utf8_fopen(path, "wb");
     if (!f) {
         return errno_to_rac(errno, RAC_ERROR_FILE_WRITE_FAILED);
     }
@@ -241,7 +289,7 @@ rac_result_t desktop_file_delete(const char* path, void* /*user_data*/) {
     if (!path) {
         return RAC_ERROR_INVALID_ARGUMENT;
     }
-    if (std::remove(path) != 0) {
+    if (utf8_remove(path) != 0) {
         return errno_to_rac(errno, RAC_ERROR_FILE_DELETE_FAILED);
     }
     return RAC_SUCCESS;
@@ -264,7 +312,7 @@ rac_result_t desktop_file_list_directory(const char* dir_path, rac_directory_ent
     const size_t capacity = out_entries ? *in_out_count : 0;
     size_t count = 0;
     std::error_code ec;
-    fs::directory_iterator iterator(fs::path(dir_path), ec);
+    fs::directory_iterator iterator(utf8_to_path(dir_path), ec);
     if (ec) {
         return filesystem_error_to_rac(ec, RAC_ERROR_STORAGE_ERROR);
     }
@@ -274,7 +322,7 @@ rac_result_t desktop_file_list_directory(const char* dir_path, rac_directory_ent
             return filesystem_error_to_rac(ec, RAC_ERROR_STORAGE_ERROR);
         }
         const fs::directory_entry& entry = *iterator;
-        const std::string name = entry.path().filename().string();
+        const std::string name = filename_utf8(entry.path());
         if (entry_is_hidden(name)) {
             continue;
         }
@@ -314,7 +362,7 @@ rac_bool_t desktop_is_non_empty_directory(const char* path, void* /*user_data*/)
         return RAC_FALSE;
     }
     std::error_code ec;
-    fs::directory_iterator iterator(fs::path(path), ec);
+    fs::directory_iterator iterator(utf8_to_path(path), ec);
     return !ec && iterator != fs::directory_iterator{} ? RAC_TRUE : RAC_FALSE;
 }
 

--- a/sdk/runanywhere-commons/src/desktop/desktop_adapter.cpp
+++ b/sdk/runanywhere-commons/src/desktop/desktop_adapter.cpp
@@ -44,10 +44,8 @@
 #include <sys/sysinfo.h>
 #endif
 
-#if defined(_WIN32)
-#include "core/internal/platform_compat.h"  // rac_to_wstring for UTF-8 path handling
-#endif
 #include "desktop/desktop_internal.h"
+#include "desktop/desktop_path_utf8.h"  // utf8_to_path / utf8_fopen / utf8_remove / filename_utf8
 #include "rac/desktop/rac_desktop.h"
 
 namespace fs = std::filesystem;
@@ -134,6 +132,11 @@ std::string default_data_dir() {
 
 namespace {
 
+using rac::desktop::filename_utf8;
+using rac::desktop::utf8_fopen;
+using rac::desktop::utf8_remove;
+using rac::desktop::utf8_to_path;
+
 rac_result_t errno_to_rac(int err, rac_result_t fallback) {
     switch (err) {
         case ENOENT:
@@ -159,51 +162,6 @@ rac_result_t filesystem_error_to_rac(const std::error_code& ec, rac_result_t fal
         return RAC_ERROR_STORAGE_FULL;
     }
     return fallback;
-}
-
-// -----------------------------------------------------------------------------
-// UTF-8 path helpers
-//
-// The platform-adapter contract documents every path/name as UTF-8. On Windows
-// the narrow std::fopen / std::remove / fs::path(const char*) overloads decode
-// bytes with the process ANSI code page, not UTF-8, so a non-ASCII path would
-// reach the wrong file (or spuriously report ENOENT). Convert to wide with the
-// shared rac_to_wstring helper (the same one ONNX Runtime session paths use) and
-// call the wide CRT/filesystem APIs. On POSIX the narrow byte string is already
-// UTF-8, so each helper reduces to the original call with no behavior change.
-// -----------------------------------------------------------------------------
-
-fs::path utf8_to_path(const char* utf8) {
-#if defined(_WIN32)
-    return fs::path(rac_to_wstring(utf8));
-#else
-    return fs::path(utf8);
-#endif
-}
-
-FILE* utf8_fopen(const char* utf8, const char* mode) {
-#if defined(_WIN32)
-    // mode is ASCII ("rb"/"wb"), so widening it byte-for-byte is safe.
-    return _wfopen(rac_to_wstring(utf8).c_str(), rac_to_wstring(mode).c_str());
-#else
-    return std::fopen(utf8, mode);
-#endif
-}
-
-int utf8_remove(const char* utf8) {
-#if defined(_WIN32)
-    return _wremove(rac_to_wstring(utf8).c_str());
-#else
-    return std::remove(utf8);
-#endif
-}
-
-// UTF-8 filename, never the ANSI code page: fs::path::string() throws on
-// Windows for code points the active code page cannot represent, and that
-// exception would escape this C-ABI callback. u8string() is always UTF-8.
-std::string filename_utf8(const fs::path& p) {
-    const auto name = p.filename().u8string();  // std::u8string, always UTF-8
-    return std::string(reinterpret_cast<const char*>(name.data()), name.size());
 }
 
 // -----------------------------------------------------------------------------
@@ -318,6 +276,9 @@ rac_result_t desktop_file_list_directory(const char* dir_path, rac_directory_ent
     }
     const fs::directory_iterator end;
     for (; iterator != end; iterator.increment(ec)) {
+        // A failed increment can advance the iterator to `end`, ending the loop
+        // before this guard runs on the next pass — so the final increment is
+        // re-checked after the loop below.
         if (ec) {
             return filesystem_error_to_rac(ec, RAC_ERROR_STORAGE_ERROR);
         }
@@ -351,6 +312,12 @@ rac_result_t desktop_file_list_directory(const char* dir_path, rac_directory_ent
             }
         }
         ++count;
+    }
+    // Catch a failure from the increment that advanced the iterator to `end`
+    // (the in-loop guard above never sees it). A capacity `break` leaves `ec`
+    // holding the previous, already-checked success, so it is not a false error.
+    if (ec) {
+        return filesystem_error_to_rac(ec, RAC_ERROR_STORAGE_ERROR);
     }
 
     *in_out_count = count;

--- a/sdk/runanywhere-commons/src/desktop/desktop_internal.h
+++ b/sdk/runanywhere-commons/src/desktop/desktop_internal.h
@@ -24,13 +24,13 @@ rac_result_t secure_delete(const char* key, void* user_data);
 
 // --- shared path helpers (desktop_adapter.cpp) -------------------------------
 
-/** $HOME with fallback to getpwuid; empty string when unresolvable. */
+/** User home/profile directory; empty string when unresolvable. */
 std::string home_dir();
 
-/** ${XDG_CONFIG_HOME:-$HOME/.config}/runanywhere (no trailing slash). */
+/** XDG config directory on POSIX, AppData on Windows (no trailing slash). */
 std::string default_config_dir();
 
-/** ${XDG_DATA_HOME:-$HOME/.local/share}/runanywhere (no trailing slash). */
+/** XDG data directory on POSIX, LocalAppData on Windows (no trailing slash). */
 std::string default_data_dir();
 
 }  // namespace rac::desktop

--- a/sdk/runanywhere-commons/src/desktop/desktop_path_utf8.h
+++ b/sdk/runanywhere-commons/src/desktop/desktop_path_utf8.h
@@ -1,0 +1,68 @@
+#ifndef RAC_DESKTOP_PATH_UTF8_H
+#define RAC_DESKTOP_PATH_UTF8_H
+
+/**
+ * @file desktop_path_utf8.h
+ * @brief UTF-8-correct filesystem helpers shared by the desktop platform
+ *        adapter and the desktop secure store.
+ *
+ * The rac_platform_adapter_t contract documents every path/name as UTF-8. On
+ * Windows the narrow std::fopen / std::remove / fs::path(const char*) overloads
+ * decode bytes with the process ANSI code page, not UTF-8, so a non-ASCII path
+ * (CJK / accented AppData or custom dir) would reach the wrong file or
+ * spuriously report ENOENT. These wrappers convert to wide with the shared
+ * rac_to_wstring helper (the same one ONNX Runtime session paths use) and call
+ * the wide CRT/filesystem APIs. On POSIX the narrow byte string is already
+ * UTF-8, so each helper reduces to the original call with no behavior change.
+ */
+
+#include <cstdio>
+#include <filesystem>
+#include <string>
+
+#if defined(_WIN32)
+#include "core/internal/platform_compat.h"  // rac_to_wstring
+#endif
+
+namespace rac::desktop {
+
+inline std::filesystem::path utf8_to_path(const char* utf8) {
+#if defined(_WIN32)
+    return std::filesystem::path(rac_to_wstring(utf8));
+#else
+    return std::filesystem::path(utf8);
+#endif
+}
+
+inline std::filesystem::path utf8_to_path(const std::string& utf8) {
+    return utf8_to_path(utf8.c_str());
+}
+
+inline FILE* utf8_fopen(const char* utf8, const char* mode) {
+#if defined(_WIN32)
+    // mode is ASCII ("rb"/"wb"), so widening it byte-for-byte is safe.
+    return _wfopen(rac_to_wstring(utf8).c_str(), rac_to_wstring(mode).c_str());
+#else
+    return std::fopen(utf8, mode);
+#endif
+}
+
+inline int utf8_remove(const char* utf8) {
+#if defined(_WIN32)
+    return _wremove(rac_to_wstring(utf8).c_str());
+#else
+    return std::remove(utf8);
+#endif
+}
+
+// UTF-8 filename, never the ANSI code page: fs::path::string() throws on Windows
+// for code points the active code page cannot represent, and that exception
+// would escape a C-ABI callback. u8string() is always UTF-8.
+inline std::string filename_utf8(const std::filesystem::path& p) {
+    const auto name = p.filename().u8string();  // std::u8string, always UTF-8
+    return std::string(reinterpret_cast<const char*>(name.data()), name.size());
+}
+
+}  // namespace rac::desktop
+
+#endif  // RAC_DESKTOP_PATH_UTF8_H

--- a/sdk/runanywhere-commons/src/desktop/desktop_secure_store.cpp
+++ b/sdk/runanywhere-commons/src/desktop/desktop_secure_store.cpp
@@ -24,15 +24,17 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <windows.h>
 #include <wincrypt.h>
+#include <windows.h>
 #else
 #include <fcntl.h>
-#include <sys/stat.h>
 #include <unistd.h>
+
+#include <sys/stat.h>
 #endif
 
 #include "desktop/desktop_internal.h"
+#include "desktop/desktop_path_utf8.h"  // utf8_to_path / utf8_fopen / utf8_remove
 #include "rac/core/rac_error.h"
 
 namespace rac::desktop {
@@ -72,14 +74,13 @@ std::string key_path_locked(const char* key) {
     }
     const std::string secure_dir = g_store_dir + "/secure";
     std::error_code ec;
-    fs::create_directories(secure_dir, ec);
+    fs::create_directories(utf8_to_path(secure_dir), ec);
     if (ec) {
         return {};
     }
 #if !defined(_WIN32)
     // Existing directories may have wider permissions than the current umask.
-    if (chmod(g_store_dir.c_str(), S_IRWXU) != 0 ||
-        chmod(secure_dir.c_str(), S_IRWXU) != 0) {
+    if (chmod(g_store_dir.c_str(), S_IRWXU) != 0 || chmod(secure_dir.c_str(), S_IRWXU) != 0) {
         return {};
     }
 #endif
@@ -91,8 +92,7 @@ std::string key_path_locked(const char* key) {
 void secure_store_set_dir(const std::string& dir) {
     std::lock_guard<std::mutex> lock(g_store_mutex);
     g_store_dir = dir;
-    while (!g_store_dir.empty() &&
-           (g_store_dir.back() == '/' || g_store_dir.back() == '\\')) {
+    while (!g_store_dir.empty() && (g_store_dir.back() == '/' || g_store_dir.back() == '\\')) {
         g_store_dir.pop_back();
     }
 }
@@ -108,7 +108,7 @@ rac_result_t secure_get(const char* key, char** out_value, void* /*user_data*/) 
         return RAC_ERROR_SECURE_STORAGE_FAILED;
     }
 
-    FILE* f = std::fopen(path.c_str(), "rb");
+    FILE* f = utf8_fopen(path.c_str(), "rb");
     if (!f) {
         return (errno == ENOENT) ? RAC_ERROR_FILE_NOT_FOUND : RAC_ERROR_SECURE_STORAGE_FAILED;
     }
@@ -173,11 +173,10 @@ rac_result_t secure_set(const char* key, const char* value, void* /*user_data*/)
                           CRYPTPROTECT_UI_FORBIDDEN, &protected_blob)) {
         return RAC_ERROR_SECURE_STORAGE_FAILED;
     }
-    FILE* file = std::fopen(path.c_str(), "wb");
+    FILE* file = utf8_fopen(path.c_str(), "wb");
     bool ok = false;
     if (file) {
-        const size_t written =
-            std::fwrite(protected_blob.pbData, 1, protected_blob.cbData, file);
+        const size_t written = std::fwrite(protected_blob.pbData, 1, protected_blob.cbData, file);
         const int close_rc = std::fclose(file);
         ok = written == protected_blob.cbData && close_rc == 0;
     }
@@ -222,7 +221,7 @@ rac_result_t secure_delete(const char* key, void* /*user_data*/) {
         return RAC_ERROR_SECURE_STORAGE_FAILED;
     }
 
-    if (std::remove(path.c_str()) != 0 && errno != ENOENT) {
+    if (utf8_remove(path.c_str()) != 0 && errno != ENOENT) {
         return RAC_ERROR_SECURE_STORAGE_FAILED;
     }
     return RAC_SUCCESS;  // deleting an absent key is a no-op, like Keychain

--- a/sdk/runanywhere-commons/src/desktop/desktop_secure_store.cpp
+++ b/sdk/runanywhere-commons/src/desktop/desktop_secure_store.cpp
@@ -1,11 +1,10 @@
 /**
  * @file desktop_secure_store.cpp
- * @brief Desktop secure-storage slots backed by per-key files (mode 0600).
+ * @brief Desktop secure-storage slots backed by protected per-key files.
  *
- * Documented MVP trade-off (see rac_desktop.h): no Keychain/libsecret
- * dependency. Each key is stored as its own file under <store_dir>/secure/
- * (directory mode 0700), so there is no parser, writes are per-key atomic at
- * the filesystem level, and the not-found contract maps 1:1 onto ENOENT.
+ * POSIX stores each value in a 0600 file under a 0700 directory. Windows
+ * encrypts each value with the current user's DPAPI key before writing it
+ * under AppData. There is no shared parser and each key maps to one file.
  *
  * Contract (rac_platform_adapter.h secure_get docs):
  *   - clean miss            → RAC_ERROR_FILE_NOT_FOUND, *out_value untouched
@@ -13,16 +12,25 @@
  *   - success               → *out_value heap-allocated, freed via rac_free()
  */
 
-#include <fcntl.h>
-#include <unistd.h>
-
 #include <cerrno>
 #include <cstdio>
 #include <cstdlib>
 #include <cstring>
+#include <filesystem>
 #include <mutex>
 #include <string>
+
+#if defined(_WIN32)
+#ifndef NOMINMAX
+#define NOMINMAX
+#endif
+#include <windows.h>
+#include <wincrypt.h>
+#else
+#include <fcntl.h>
 #include <sys/stat.h>
+#include <unistd.h>
+#endif
 
 #include "desktop/desktop_internal.h"
 #include "rac/core/rac_error.h"
@@ -30,6 +38,8 @@
 namespace rac::desktop {
 
 namespace {
+
+namespace fs = std::filesystem;
 
 std::mutex g_store_mutex;
 std::string g_store_dir;  // <config dir>; files live in <config dir>/secure/
@@ -61,12 +71,18 @@ std::string key_path_locked(const char* key) {
         return {};
     }
     const std::string secure_dir = g_store_dir + "/secure";
-    // mkdir -p with owner-only permissions; EEXIST is fine.
-    for (const std::string& dir : {g_store_dir, secure_dir}) {
-        if (mkdir(dir.c_str(), S_IRWXU) != 0 && errno != EEXIST) {
-            return {};
-        }
+    std::error_code ec;
+    fs::create_directories(secure_dir, ec);
+    if (ec) {
+        return {};
     }
+#if !defined(_WIN32)
+    // Existing directories may have wider permissions than the current umask.
+    if (chmod(g_store_dir.c_str(), S_IRWXU) != 0 ||
+        chmod(secure_dir.c_str(), S_IRWXU) != 0) {
+        return {};
+    }
+#endif
     return secure_dir + "/" + encode_key(key);
 }
 
@@ -75,7 +91,8 @@ std::string key_path_locked(const char* key) {
 void secure_store_set_dir(const std::string& dir) {
     std::lock_guard<std::mutex> lock(g_store_mutex);
     g_store_dir = dir;
-    while (!g_store_dir.empty() && g_store_dir.back() == '/') {
+    while (!g_store_dir.empty() &&
+           (g_store_dir.back() == '/' || g_store_dir.back() == '\\')) {
         g_store_dir.pop_back();
     }
 }
@@ -108,11 +125,30 @@ rac_result_t secure_get(const char* key, char** out_value, void* /*user_data*/) 
         return RAC_ERROR_SECURE_STORAGE_FAILED;
     }
 
+#if defined(_WIN32)
+    DATA_BLOB protected_blob{};
+    protected_blob.cbData = static_cast<DWORD>(value.size());
+    protected_blob.pbData = reinterpret_cast<BYTE*>(value.data());
+    DATA_BLOB clear_blob{};
+    if (!CryptUnprotectData(&protected_blob, nullptr, nullptr, nullptr, nullptr,
+                            CRYPTPROTECT_UI_FORBIDDEN, &clear_blob)) {
+        return RAC_ERROR_SECURE_STORAGE_FAILED;
+    }
+    char* copy = static_cast<char*>(std::malloc(clear_blob.cbData + 1));
+    if (!copy) {
+        LocalFree(clear_blob.pbData);
+        return RAC_ERROR_SECURE_STORAGE_FAILED;
+    }
+    std::memcpy(copy, clear_blob.pbData, clear_blob.cbData);
+    copy[clear_blob.cbData] = '\0';
+    LocalFree(clear_blob.pbData);
+#else
     char* copy = static_cast<char*>(std::malloc(value.size() + 1));
     if (!copy) {
         return RAC_ERROR_SECURE_STORAGE_FAILED;
     }
     std::memcpy(copy, value.c_str(), value.size() + 1);
+#endif
     *out_value = copy;
     return RAC_SUCCESS;
 }
@@ -128,6 +164,26 @@ rac_result_t secure_set(const char* key, const char* value, void* /*user_data*/)
         return RAC_ERROR_SECURE_STORAGE_FAILED;
     }
 
+#if defined(_WIN32)
+    DATA_BLOB clear_blob{};
+    clear_blob.cbData = static_cast<DWORD>(std::strlen(value));
+    clear_blob.pbData = reinterpret_cast<BYTE*>(const_cast<char*>(value));
+    DATA_BLOB protected_blob{};
+    if (!CryptProtectData(&clear_blob, L"RunAnywhere rcli", nullptr, nullptr, nullptr,
+                          CRYPTPROTECT_UI_FORBIDDEN, &protected_blob)) {
+        return RAC_ERROR_SECURE_STORAGE_FAILED;
+    }
+    FILE* file = std::fopen(path.c_str(), "wb");
+    bool ok = false;
+    if (file) {
+        const size_t written =
+            std::fwrite(protected_blob.pbData, 1, protected_blob.cbData, file);
+        const int close_rc = std::fclose(file);
+        ok = written == protected_blob.cbData && close_rc == 0;
+    }
+    LocalFree(protected_blob.pbData);
+    return ok ? RAC_SUCCESS : RAC_ERROR_SECURE_STORAGE_FAILED;
+#else
     // O_CREAT with 0600 so the value is never world-readable, even briefly.
     const int fd = open(path.c_str(), O_WRONLY | O_CREAT | O_TRUNC, S_IRUSR | S_IWUSR);
     if (fd < 0) {
@@ -152,6 +208,7 @@ rac_result_t secure_set(const char* key, const char* value, void* /*user_data*/)
     ok = (fchmod(fd, S_IRUSR | S_IWUSR) == 0) && ok;
     ok = (close(fd) == 0) && ok;
     return ok ? RAC_SUCCESS : RAC_ERROR_SECURE_STORAGE_FAILED;
+#endif
 }
 
 rac_result_t secure_delete(const char* key, void* /*user_data*/) {
@@ -165,7 +222,7 @@ rac_result_t secure_delete(const char* key, void* /*user_data*/) {
         return RAC_ERROR_SECURE_STORAGE_FAILED;
     }
 
-    if (unlink(path.c_str()) != 0 && errno != ENOENT) {
+    if (std::remove(path.c_str()) != 0 && errno != ENOENT) {
         return RAC_ERROR_SECURE_STORAGE_FAILED;
     }
     return RAC_SUCCESS;  // deleting an absent key is a no-op, like Keychain

--- a/sdk/runanywhere-commons/src/desktop/desktop_secure_store.cpp
+++ b/sdk/runanywhere-commons/src/desktop/desktop_secure_store.cpp
@@ -24,8 +24,12 @@
 #ifndef NOMINMAX
 #define NOMINMAX
 #endif
-#include <wincrypt.h>
+// clang-format off
+// windows.h must precede wincrypt.h — wincrypt.h relies on its base types
+// (LONG/DWORD/BYTE/...). Alphabetical include sorting would break the build.
 #include <windows.h>
+#include <wincrypt.h>
+// clang-format on
 #else
 #include <fcntl.h>
 #include <unistd.h>

--- a/sdk/runanywhere-commons/tests/test_desktop_adapter.cpp
+++ b/sdk/runanywhere-commons/tests/test_desktop_adapter.cpp
@@ -2,7 +2,7 @@
  * @file test_desktop_adapter.cpp
  * @brief Unit tests for the desktop platform adapter (RAC_DESKTOP_ADAPTER).
  *
- * Exercises the POSIX adapter slots directly (no rac_init needed), the 0600
+ * Exercises the desktop adapter slots directly (no rac_init needed), secure
  * secure-store contract, the libcurl transport registration, and the
  * model-paths base-dir dedup rule the desktop layout depends on. Network
  * behavior is covered by the Docker CLI e2e (hermetic local-HTTP pull), not
@@ -11,15 +11,19 @@
 
 #include "test_common.h"
 
-#include <sys/stat.h>
-#include <unistd.h>
-
+#include <chrono>
 #include <cstdlib>
 #include <cstring>
 #include <filesystem>
+#include <fstream>
+#include <iterator>
 #include <set>
 #include <string>
 #include <vector>
+
+#if !defined(_WIN32)
+#include <sys/stat.h>
+#endif
 
 #include "rac/core/rac_platform_adapter.h"
 #include "rac/desktop/rac_desktop.h"
@@ -35,11 +39,14 @@ struct TempDir {
     std::string path;
 
     TempDir() {
-        std::string tmpl = (fs::temp_directory_path() / "rac_desktop_test_XXXXXX").string();
-        std::vector<char> buf(tmpl.begin(), tmpl.end());
-        buf.push_back('\0');
-        if (mkdtemp(buf.data()) != nullptr) {
-            path = buf.data();
+        const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
+        path = (fs::temp_directory_path() /
+                ("rac_desktop_test_" + std::to_string(unique)))
+                   .string();
+        std::error_code ec;
+        fs::create_directories(path, ec);
+        if (ec) {
+            path.clear();
         }
     }
 
@@ -222,8 +229,17 @@ TestResult test_secure_store() {
         return result;
     }
 
-    // Permission contract: file mode is exactly 0600, store dir 0700.
+    // Permission contract: POSIX uses 0600/0700. Windows stores a DPAPI blob.
     const std::string key_file = tmp.path + "/cfg/secure/rac.device.id";
+#if defined(_WIN32)
+    std::ifstream encrypted(key_file, std::ios::binary);
+    const std::string stored((std::istreambuf_iterator<char>(encrypted)),
+                             std::istreambuf_iterator<char>());
+    if (stored.empty() || stored.find("device-1234") != std::string::npos) {
+        result.details = "Windows secure-store value was not DPAPI protected";
+        return result;
+    }
+#else
     struct stat st {};
     if (stat(key_file.c_str(), &st) != 0) {
         result.details = "expected key file at " + key_file;
@@ -239,6 +255,7 @@ TestResult test_secure_store() {
         result.details = "secure dir mode is not 0700";
         return result;
     }
+#endif
 
     // Keys with separators must be encoded, not treated as paths.
     if (adapter.secure_set("a/b:c", "x", nullptr) != RAC_SUCCESS) {

--- a/sdk/runanywhere-commons/tests/test_desktop_adapter.cpp
+++ b/sdk/runanywhere-commons/tests/test_desktop_adapter.cpp
@@ -234,11 +234,15 @@ TestResult test_secure_store() {
     const std::string key_file = tmp.path + "/cfg/secure/rac.device.id";
 #if defined(_WIN32)
     // Construct the path from UTF-8 so MSVC's <fstream> does not reinterpret it
-    // through the ANSI code page.
-    std::ifstream encrypted(fs::path(reinterpret_cast<const char8_t*>(key_file.c_str())),
-                            std::ios::binary);
-    const std::string stored((std::istreambuf_iterator<char>(encrypted)),
-                             std::istreambuf_iterator<char>());
+    // through the ANSI code page. Scope the stream so the handle is released
+    // before secure_delete below — Windows cannot unlink a file that is open.
+    std::string stored;
+    {
+        std::ifstream encrypted(fs::path(reinterpret_cast<const char8_t*>(key_file.c_str())),
+                                std::ios::binary);
+        stored.assign((std::istreambuf_iterator<char>(encrypted)),
+                      std::istreambuf_iterator<char>());
+    }
     if (stored.empty() || stored.find("device-1234") != std::string::npos) {
         result.details = "Windows secure-store value was not DPAPI protected";
         return result;
@@ -393,10 +397,19 @@ TestResult test_default_base_dir() {
         return result;
     }
     const std::string dir(buffer);
+#if defined(_WIN32)
+    // Windows: <LOCALAPPDATA>\RunAnywhere — drive-letter rooted, "RunAnywhere".
+    const bool rooted = dir.size() >= 2 && dir[1] == ':';
+    if (dir.empty() || dir.find("RunAnywhere") == std::string::npos || !rooted) {
+        result.details = "unexpected default base dir: " + dir;
+        return result;
+    }
+#else
     if (dir.empty() || dir.find("runanywhere") == std::string::npos || dir.front() != '/') {
         result.details = "unexpected default base dir: " + dir;
         return result;
     }
+#endif
 
     char tiny[4] = {};
     if (rac_desktop_default_base_dir(tiny, sizeof(tiny)) != RAC_ERROR_BUFFER_TOO_SMALL) {

--- a/sdk/runanywhere-commons/tests/test_desktop_adapter.cpp
+++ b/sdk/runanywhere-commons/tests/test_desktop_adapter.cpp
@@ -40,9 +40,11 @@ struct TempDir {
 
     TempDir() {
         const auto unique = std::chrono::steady_clock::now().time_since_epoch().count();
-        path = (fs::temp_directory_path() /
-                ("rac_desktop_test_" + std::to_string(unique)))
-                   .string();
+        // u8string() (not string(), which uses the Windows ANSI code page) so the
+        // path handed to the UTF-8 adapter API round-trips on non-ASCII temp roots.
+        const auto u8 =
+            (fs::temp_directory_path() / ("rac_desktop_test_" + std::to_string(unique))).u8string();
+        path = std::string(reinterpret_cast<const char*>(u8.data()), u8.size());
         std::error_code ec;
         fs::create_directories(path, ec);
         if (ec) {
@@ -99,8 +101,7 @@ TestResult test_file_roundtrip() {
         result.details = "file_read failed";
         return result;
     }
-    const bool content_ok =
-        size == payload.size() && std::memcmp(data, payload.data(), size) == 0;
+    const bool content_ok = size == payload.size() && std::memcmp(data, payload.data(), size) == 0;
     free(data);
     if (!content_ok) {
         result.details = "file_read returned different bytes";
@@ -232,7 +233,10 @@ TestResult test_secure_store() {
     // Permission contract: POSIX uses 0600/0700. Windows stores a DPAPI blob.
     const std::string key_file = tmp.path + "/cfg/secure/rac.device.id";
 #if defined(_WIN32)
-    std::ifstream encrypted(key_file, std::ios::binary);
+    // Construct the path from UTF-8 so MSVC's <fstream> does not reinterpret it
+    // through the ANSI code page.
+    std::ifstream encrypted(fs::path(reinterpret_cast<const char8_t*>(key_file.c_str())),
+                            std::ios::binary);
     const std::string stored((std::istreambuf_iterator<char>(encrypted)),
                              std::istreambuf_iterator<char>());
     if (stored.empty() || stored.find("device-1234") != std::string::npos) {
@@ -240,7 +244,7 @@ TestResult test_secure_store() {
         return result;
     }
 #else
-    struct stat st {};
+    struct stat st{};
     if (stat(key_file.c_str(), &st) != 0) {
         result.details = "expected key file at " + key_file;
         return result;
@@ -249,9 +253,8 @@ TestResult test_secure_store() {
         result.details = "key file mode is not 0600";
         return result;
     }
-    struct stat dir_st {};
-    if (stat((tmp.path + "/cfg/secure").c_str(), &dir_st) != 0 ||
-        (dir_st.st_mode & 0777) != 0700) {
+    struct stat dir_st{};
+    if (stat((tmp.path + "/cfg/secure").c_str(), &dir_st) != 0 || (dir_st.st_mode & 0777) != 0700) {
         result.details = "secure dir mode is not 0700";
         return result;
     }

--- a/sdk/runanywhere-swift/Sources/RunAnywhereMLXCLI/main.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhereMLXCLI/main.swift
@@ -11,7 +11,7 @@ import RCLIHost
 struct RunAnywhereMLXCLI {
     static func main() {
         guard registerAppleBackends() else {
-            stderrWrite("error: failed to register RunAnywhere MLX runtime callbacks\n")
+            stderrWrite("error: failed to register RunAnywhere Apple backend callbacks (MLX + ONNX)\n")
             Darwin.exit(1)
         }
 

--- a/sdk/runanywhere-swift/Sources/RunAnywhereMLXCLI/main.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhereMLXCLI/main.swift
@@ -1,6 +1,7 @@
 import Darwin
 import Foundation
 import MLXRuntime
+import ONNXRuntime
 import RCLIHost
 
 /// macOS CLI entry: registers MLX Swift callbacks, then hands off to the
@@ -9,7 +10,7 @@ import RCLIHost
 @main
 struct RunAnywhereMLXCLI {
     static func main() {
-        guard registerMLXRuntime() else {
+        guard registerAppleBackends() else {
             stderrWrite("error: failed to register RunAnywhere MLX runtime callbacks\n")
             Darwin.exit(1)
         }
@@ -27,17 +28,19 @@ struct RunAnywhereMLXCLI {
         Darwin.exit(exitCode)
     }
 
-    private static func registerMLXRuntime() -> Bool {
+    private static func registerAppleBackends() -> Bool {
         if Thread.isMainThread {
             return MainActor.assumeIsolated {
-                MLX.register()
+                ONNX.register()
+                return MLX.register()
             }
         }
 
         var registered = false
         DispatchQueue.main.sync {
             registered = MainActor.assumeIsolated {
-                MLX.register()
+                ONNX.register()
+                return MLX.register()
             }
         }
         return registered


### PR DESCRIPTION
## Summary

Adds **Windows x86_64** as a first-class `rcli` (RunAnywhere CLI) release platform and hardens the desktop portability layer, building on the `0.34 release` (#559) already merged to `main`. No version change — this is purely additive CLI/packaging/CI work on top of `v0.20.11`.

Backend coverage after this PR:
- **macOS arm64**: llama.cpp, MLX, Sherpa/ONNX, CoreML
- **Linux x86_64**: llama.cpp, Sherpa/ONNX
- **Windows x86_64**: llama.cpp, Sherpa/ONNX
- MLX and CoreML remain macOS-only (Apple frameworks).

## What's included

**Native portability (C++ commons + CLI)**
- Windows desktop platform adapter (`desktop_adapter.cpp`): file I/O, paths, memory info under `_WIN32`.
- Windows DPAPI-backed secure storage (`desktop_secure_store.cpp`): each value encrypted with `CryptProtectData`/`CryptUnprotectData` (per-user, `CRYPTPROTECT_UI_FORBIDDEN`) and written under AppData; POSIX keeps 0600 files under a 0700 dir.
- Terminal / path / REPL / env portability (`term.cpp`, `cli_paths.cpp`, `repl.cpp`).
- macOS CLI now registers Apple secondary engines (Sherpa/ONNX via `ONNX.register()` + CoreML via `RABackendCoreMLBinary`) alongside MLX.

**Build & packaging**
- `rcli-windows-release` CMake preset (vcpkg static triplet, llama.cpp + Sherpa/ONNX, MLX/CoreML off).
- PowerShell installer (`install.ps1`) — downloads by version, verifies SHA-256, installs to `%LOCALAPPDATA%\Programs\rcli`, updates user PATH, smoke-tests.
- Windows ZIP packaging (`package-rcli-windows.ps1`) — stages `rcli-windows-x86_64/`, bundles the pinned ONNX Runtime + Sherpa DLLs, guards against embedded dev paths, emits `.zip` + `.sha256`.

**CI (`pr-build.yml` + `release.yml`)**
- PR: new `rcli-windows` job — build + `rcli_unit_tests`/`desktop_adapter_tests` + package/backend smoke (unsigned).
- Release: new `native_rcli_windows` job — build, test, Authenticode sign, package, upload; wired into the assembly gate.
- Hard release-asset check now requires `rcli-windows-x86_64-v${VERSION}.zip`.
- macOS combined-host smoke now also asserts `sherpa` + `coreml` backends.
- CLI unit + desktop-adapter tests added.

**Docs**
- CLI `README.md`: install instructions for macOS, Linux, Windows; explicit note that MLX is macOS-only.

## Signing prerequisites (repo secrets — not in this PR)

The release workflow **fails closed** rather than publishing unsigned binaries. Before running the production release, these repo secrets must be configured by an admin:
- `RCLI_DEVELOPER_ID_CERT_P12_BASE64`, `RCLI_DEVELOPER_ID_CERT_PASSWORD` (macOS Developer ID)
- `RCLI_WINDOWS_CODESIGN_PFX_BASE64`, `RCLI_WINDOWS_CODESIGN_PFX_PASSWORD` (Windows Authenticode)

(Apple notarization secrets `RCLI_NOTARY_APPLE_ID` / `RCLI_NOTARY_APP_SPECIFIC_PASSWORD` / `RCLI_NOTARY_TEAM_ID` are already configured.)

## Release note (do not add a `release:*` label)

VERSION is unchanged (`0.20.11`), so auto-tag's semver-bump verification would fail on a release label. Merge this PR **without** a release label; the `v0.20.11` tag will be re-pointed to the merge commit manually and `release.yml` dispatched manually afterward.

## Follow-up fix in this branch

- `fix(desktop): decode UTF-8 paths correctly on Windows` — the desktop adapter's file I/O used narrow `std::fopen`/`std::remove`/`fs::path(const char*)`, which decode with the Windows ANSI code page instead of UTF-8 (the contract mandates UTF-8). Non-ASCII paths would hit the wrong file/ENOENT, and `fs::path::string()` in the directory enumerator could throw across the `extern "C"` callback → process abort on `rcli list`. Routed through the existing `rac_to_wstring` helper + wide CRT/filesystem APIs on `_WIN32`; POSIX unchanged. (Caught in review — CI wouldn't surface it since CI uses ASCII paths.)

## Local validation (macOS)
- clang-format clean on all changed C/C++ files; `release.yml`/`pr-build.yml` valid YAML; `CMakePresets.json` valid JSON.
- Full `rcli-macos-release` combined native host built; `rcli backends` registers **coreml + llamacpp + sherpa** (MLX is Swift-callback-only by design).
- Combined **Swift/MLX host** (`RunAnywhereMLXCLI`) built and smoke-tested: registers **llamacpp + mlx + sherpa + coreml** (+ onnx) — the full macOS backend set.
- `rcli_unit_tests` + `desktop_adapter_tests` pass.

Windows is validated through GitHub Actions (local host is macOS).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added signed Windows x86_64 native-CLI releases (versioned ZIPs) with automated packaging, smoke testing, and a PowerShell installer.
  * Extended native desktop support to Windows, including DPAPI-backed per-key secure storage.
  * Updated the Apple Swift CLI to register both ONNX and MLX backends.

* **Documentation**
  * Expanded Windows installation/build-from-source and release/signing guidance, plus clearer CI coverage and unreleased-binary notes.

* **Bug Fixes / CI**
  * Improved Windows terminal/TTY detection and UTF-8-aware path handling.
  * Tightened Windows build, backend validation, and release asset/signature checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->