### PR TITLE
fix(kotlin): keep archive type and structure when URL doesn't reveal an archive

### DIFF
--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/Storage/RunAnywhereStorage.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/Storage/RunAnywhereStorage.kt
@@ -14,6 +14,7 @@
 
 package com.runanywhere.sdk.public.extensions
 
+import ai.runanywhere.proto.v1.ArchiveArtifact
 import ai.runanywhere.proto.v1.ArchiveStructure
 import ai.runanywhere.proto.v1.ArchiveType
 import ai.runanywhere.proto.v1.InferenceFramework
@@ -140,8 +141,14 @@ suspend fun RunAnywhere.registerModel(
     // Preserve the structure on the archive artifact. The URL-form inferred
     // artifact only captures the archive type, not the nested/directory
     // layout, so patch it here and re-persist through the registry's proto
-    // save path (mirroring Swift's archive overload).
-    val archive = model.archiveArtifact ?: return model
+    // save path (mirroring Swift's archive overload). When the URL suffix
+    // doesn't reveal an archive (query strings, presigned CDN URLs), the
+    // URL-form registration produced a single_file artifact; Swift still
+    // persists an archive artifact carrying the caller's type and structure,
+    // so build one here instead of dropping the caller's intent.
+    val archive =
+        model.archiveArtifact
+            ?: ArchiveArtifact(type = archiveType ?: ArchiveType.ARCHIVE_TYPE_UNSPECIFIED)
     model =
         model
             .setArchiveArtifact(archive.copy(structure = structure))


### PR DESCRIPTION
## Description

The Kotlin archive `registerModel` overload bails with `?: return model` when the URL-form registration didn't infer an archive artifact from the URL suffix, which silently drops the caller's `ArchiveStructure` and `archiveType` for presigned or query-string archive URLs and persists a `single_file` artifact (downloads then skip extraction). Swift's archive overload always persists an archive artifact carrying the caller's type and structure, so this builds the same artifact via the existing `setArchiveArtifact` helper when inference comes up empty. One file, plus the `ArchiveArtifact` import.

Fixes #565

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Lint passes locally
- [ ] Added/updated tests for changes

Ran on the Kotlin SDK module against 0.34 (`258c27636`): `:compileDebugKotlin -Prunanywhere.useLocalNatives=false`, `:ktlintCheck`, `:testDebugUnitTest`, `:detekt`, all green. `setArchiveArtifact` already clears the `single_file` oneof and derives `artifact_type` from the archive type, so the fallback path produces the same shape Swift persists (type unspecified when the caller gave none, structure always set). No emulator on this machine so no on-device run.

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

small note: built with Claude Code helping me trace this across the Kotlin, Swift and commons layers, and I read through the final diff myself. still learning this codebase, happy to adjust if the artifact fallback belongs somewhere else :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model registration when archive details are missing.
  * Archive information is now created and saved using the provided archive type and structure, allowing registration to complete more reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->