### PR TITLE
fix(commons): exclude builtin:// pseudo-models from storage analyzer results

### DIFF
--- a/sdk/runanywhere-commons/src/infrastructure/storage/storage_analyzer.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/storage/storage_analyzer.cpp
@@ -64,6 +64,14 @@ int64_t clamp_non_negative(int64_t value) {
     return value < 0 ? 0 : value;
 }
 
+// Built-in platform pseudo-models (Apple Foundation Models, System TTS,
+// CoreML Diffusion) register with a "builtin://" local_path and have no
+// on-disk artifact, so they are not user-manageable storage entries.
+bool is_builtin_pseudo_model(const rac_model_info_t* model) {
+    return model != nullptr && model->local_path != nullptr &&
+           std::strncmp(model->local_path, "builtin://", 10) == 0;
+}
+
 float used_percent(int64_t total, int64_t used) {
     if (total <= 0 || used <= 0) {
         return 0.0f;
@@ -415,7 +423,7 @@ std::vector<DeleteCandidateRow> collect_model_delete_candidates(
         for (size_t i = 0; i < model_count; ++i) {
             const rac_model_info_t* current = models[i];
             if (!current || !current->id || !current->local_path ||
-                std::strlen(current->local_path) == 0) {
+                std::strlen(current->local_path) == 0 || is_builtin_pseudo_model(current)) {
                 continue;
             }
             add_model_candidate_from_info(handle, current, current->id, options.allow_loaded_models,
@@ -631,13 +639,18 @@ rac_result_t rac_storage_analyzer_analyze(rac_storage_analyzer_handle_t handle,
         }
     }
 
-    out_info->model_count = model_count;
     out_info->total_models_size = 0;
 
-    // Calculate metrics for each model
+    // Calculate metrics for each model. Built-in pseudo-models are skipped:
+    // they have no bytes on disk, so reporting them as 0-byte "downloaded
+    // models" only misleads storage UIs (issue #272's "Zero KB" rows).
+    size_t metrics_count = 0;
     for (size_t i = 0; i < model_count; i++) {
         const rac_model_info_t* model = models[i];
-        rac_model_storage_metrics_t* metrics = &out_info->models[i];
+        if (is_builtin_pseudo_model(model)) {
+            continue;
+        }
+        rac_model_storage_metrics_t* metrics = &out_info->models[metrics_count];
 
         // Copy model info
         metrics->model_id = model->id ? strdup(model->id) : nullptr;
@@ -678,7 +691,9 @@ rac_result_t rac_storage_analyzer_analyze(rac_storage_analyzer_handle_t handle,
         }
 
         out_info->total_models_size += metrics->size_on_disk;
+        metrics_count++;
     }
+    out_info->model_count = metrics_count;
 
     // Free the models array from registry
     rac_model_info_array_free(models, model_count);


### PR DESCRIPTION
## What

Partial fix for #272, the "Zero KB" half. The Models tab refresh half was already fixed on main in 9b77738bc, this handles the weird 0 KB rows that show up in storage and can never be deleted.

## Why

Built-in platform pseudo-models (Apple Foundation Models, System TTS, CoreML Diffusion) register with a `builtin://` local_path and have no files on disk:

- `rac_backend_platform_register.cpp:599,647,695` sets `local_path = strdup("builtin://...")`
- `rac_model_registry_get_downloaded()` (model_registry.cpp:646) returns any model with a non-empty local_path, so these come back as "downloaded"
- `rac_storage_analyzer_analyze()` then reports them as 0-byte downloaded models, and the delete-candidate path offers deletes that can never succeed

That is exactly the 0 KB undeletable rows from #272. I kept the fix inside the storage analyzer rather than filtering `get_downloaded()` itself, since the router intentionally accepts `builtin://` URIs elsewhere (rac_plugin_entry_platform.cpp:49) and other consumers rely on those entries existing.

## How

Single file, `storage_analyzer.cpp`:
- new `is_builtin_pseudo_model()` helper (prefix check on `builtin://`)
- metrics loop skips them and compacts the output array, so `model_count` reflects only real on-disk models
- delete-candidate collection skips them too

The metrics array is calloc'd, so the trailing unused slots are zeroed and the free path (which iterates `model_count`) stays correct.

## Testing

- `storage_analyzer_proto_tests` pass (macOS debug build)
- `test_core` passes
- touched line ranges are clang-format clean

---

Honesty note: I'm a college freshman doing these contributions to learn. I traced the root cause and wrote the logic myself and sanity-checked decisions with Claude Code along the way. If I misjudged the layer this belongs at or missed a consumer of those pseudo-model entries, I'd genuinely like to know. Happy to adjust :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Built-in models are now excluded from storage usage calculations.
  * Built-in models no longer appear as candidates for deletion.
  * Storage analysis results now report accurate model counts when built-in models are present.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->