### PR TITLE
fix(kotlin): stop public extensions from swallowing coroutine cancellation

### DIFF
--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/Models/RunAnywhereModelLifecycle.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/Models/RunAnywhereModelLifecycle.kt
@@ -24,6 +24,7 @@ import com.runanywhere.sdk.public.RunAnywhere
 import com.runanywhere.sdk.public.types.RAModelInfo
 import com.runanywhere.sdk.public.types.RAModelLoadRequest
 import com.runanywhere.sdk.public.types.RAModelLoadResult
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
 
@@ -48,7 +49,9 @@ suspend fun RunAnywhere.loadModel(request: RAModelLoadRequest): RAModelLoadResul
         }
         try {
             ensureServicesReady()
-        } catch (_: Throwable) {
+        } catch (e: CancellationException) {
+            throw e
+        } catch (_: Exception) {
         }
         val result =
             CppBridgeModelLifecycle.load(request)

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/STT/RunAnywhereSTT.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/STT/RunAnywhereSTT.kt
@@ -20,6 +20,7 @@ import com.runanywhere.sdk.infrastructure.logging.SDKLogger
 import com.runanywhere.sdk.public.RunAnywhere
 import com.runanywhere.sdk.public.types.RASTTOptions
 import com.runanywhere.sdk.public.types.RASTTOutput
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.channels.awaitClose
 import kotlinx.coroutines.flow.Flow
@@ -108,7 +109,9 @@ fun RunAnywhere.transcribeStream(
                         trySend(RASTTPartialResult(is_final = true))
                     }
                     close()
-                } catch (e: Throwable) {
+                } catch (e: CancellationException) {
+                    throw e
+                } catch (e: Exception) {
                     trySend(
                         RASTTPartialResult(
                             text = "STT stream failed: ${e.message ?: e::class.simpleName.orEmpty()}",

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/Storage/RunAnywhereDownload.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/Storage/RunAnywhereDownload.kt
@@ -146,7 +146,7 @@ suspend fun RunAnywhere.downloadModel(
                     downloadLogger.info(
                         "Download cancelled for ${resolvedModel.id} (task=${startResult.task_id})",
                     )
-                } catch (e: Throwable) {
+                } catch (e: Exception) {
                     downloadLogger.warn(
                         "Failed to cancel native download for ${resolvedModel.id} " +
                             "(task=${startResult.task_id}): ${e.message}",

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/TTS/RunAnywhereTTS.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/TTS/RunAnywhereTTS.kt
@@ -24,6 +24,7 @@ import com.runanywhere.sdk.native.bridge.RunAnywhereBridge
 import com.runanywhere.sdk.public.RunAnywhere
 import com.runanywhere.sdk.public.types.RATTSOptions
 import com.runanywhere.sdk.public.types.RATTSOutput
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.NonCancellable
@@ -127,7 +128,9 @@ fun RunAnywhere.synthesizeStream(
                             trySend(output).isSuccess
                         }
                     }
-                } catch (t: Throwable) {
+                } catch (t: CancellationException) {
+                    throw t
+                } catch (t: Exception) {
                     ttsLogger.warn("synthesizeStream errored: ${t.message}")
                 } finally {
                     close()


### PR DESCRIPTION
## What

Follow-up to the pattern from #563: four public extension sites catch `Throwable`, which also traps `kotlinx.coroutines.CancellationException` (and JVM `Error`s). This breaks Kotlin's cooperative cancellation contract, a cancelled coroutine should stop, not keep going.

## Sites

1. **loadModel** (`RunAnywhereModelLifecycle.kt:51`): the `ensureServicesReady()` guard ate the caller's cancellation, so `task.cancel()` during init still ran the heavy native load afterwards. Now rethrows cancellation and swallows only `Exception`, same as the reviewed `#563` registry fix.
2. **transcribeStream** (`RunAnywhereSTT.kt:112`): collector cancellation got converted into a synthetic `"STT stream failed"` final partial. Now cancellation propagates; real errors still produce the failure partial and close the flow.
3. **synthesizeStream** (`RunAnywhereTTS.kt:131`): normal cancellation logged a spurious `"synthesizeStream errored"` warning. Now rethrows; teardown is unchanged because `close()` lives in the `finally`.
4. **downloadModel cleanup** (`RunAnywhereDownload.kt:149`): being honest, this one is NOT a cancellation bug. The block runs under `NonCancellable` and the original `CancellationException` keeps propagating after the `finally` either way. I only narrowed `Throwable` to `Exception` so the best-effort native cancel doesn't log-and-ignore JVM `Error`s. Happy to drop this hunk if you'd rather keep the change minimal.

## Why the two-clause pattern

On the JVM `CancellationException` extends `Exception` (via `java.util.concurrent.CancellationException`), so just narrowing `Throwable` to `Exception` would still swallow it. The explicit `catch (e: CancellationException) { throw e }` clause first is required. Import used is `kotlinx.coroutines.CancellationException`, matching the existing usage in `NativeUnaryRequest.kt:8` and `ToolCallingOrchestrator.kt:31`.

## Testing

From a clean worktree of main: `:compileDebugKotlin` (no local natives), `:ktlintCheck`, `:testDebugUnitTest`, `:detekt` all pass.

---

Small note for transparency: I'm a freshman learning by contributing here. I found these by systematically comparing the Kotlin extensions against the Swift ones after you merged my earlier registry fix, and I bounced my reasoning off Claude Code before writing anything. If any of these catches were intentionally broad, tell me and I'll adjust or revert those hunks. Thanks for the quick reviews so far, it genuinely made my week :)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cancellation handling across model loading, speech-to-text streaming, speech synthesis, and model downloads.
  * Canceled operations now stop cleanly instead of being reported as generic failures.
  * Preserved existing error reporting for non-cancellation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->