### PR TITLE
Bonsai fully-on-NPU decoder: SDK integration (1-bit/ternary/4B/8B)

### DIFF
--- a/engines/qhexrt/CMakeLists.txt
+++ b/engines/qhexrt/CMakeLists.txt
@@ -442,6 +442,33 @@ if(RAC_PLATFORM_ANDROID AND _qhexrt_prebuilt_valid)
         ${CMAKE_DL_LIBS})
     find_package(Threads REQUIRED)
     list(APPEND QHEXRT_LINK_LIBS Threads::Threads)
+
+    # A Bonsai-enabled core archive pulls in the FastRPC transport stub
+    # (run_main_on_hexagon_stub.c + bonsai_npu.cpp): rpcmem_* / remote_handle64_* /
+    # remote_session_control, provided by libcdsprpc.so — a /vendor system lib on
+    # device that the app already bundles in jniLibs. Detect the stub in the
+    # prebuilt core and link the matching cdsprpc stub so the static link resolves;
+    # the real vendor lib backs it at runtime. Override with -DQHEXRT_LIBCDSPRPC=.
+    file(STRINGS "${QHEXRT_CORE_LIB}" _qhexrt_core_fastrpc
+        REGEX "remote_handle64_open" LIMIT_COUNT 1)
+    if(_qhexrt_core_fastrpc)
+        if(NOT QHEXRT_LIBCDSPRPC)
+            find_file(QHEXRT_LIBCDSPRPC libcdsprpc.so
+                PATHS
+                    "$ENV{HEXAGON_SDK_ROOT}/ipc/fastrpc/remote/ship/android_aarch64"
+                    "${CMAKE_SOURCE_DIR}/../hexagon-sdk/root/Hexagon_SDK/6.6.0.0/ipc/fastrpc/remote/ship/android_aarch64"
+                    "${CMAKE_CURRENT_SOURCE_DIR}/../../sdk/runanywhere-kotlin/src/main/jniLibs/arm64-v8a"
+                NO_DEFAULT_PATH)
+        endif()
+        if(QHEXRT_LIBCDSPRPC AND EXISTS "${QHEXRT_LIBCDSPRPC}")
+            message(STATUS "  QHexRT: Bonsai FastRPC core -> linking libcdsprpc: ${QHEXRT_LIBCDSPRPC}")
+            list(APPEND QHEXRT_LINK_LIBS "${QHEXRT_LIBCDSPRPC}")
+        else()
+            message(FATAL_ERROR
+                "QHexRT prebuilt core needs FastRPC (libcdsprpc.so) but none was found; "
+                "set -DQHEXRT_LIBCDSPRPC=/path/to/libcdsprpc.so")
+        endif()
+    endif()
 else()
     set(RAC_QHEXRT_ENGINE_AVAILABLE 0)
     list(APPEND QHEXRT_COMPILE_DEFS RAC_QHEXRT_ENGINE_AVAILABLE=0)

--- a/engines/qhexrt/qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/qhexrt_model_catalog.cpp
@@ -56,6 +56,7 @@ constexpr ModelPolicy kModelPolicies[] = {
     {"qwen3_0_6b", kV75V81, true},
     {"llama3_2_1b", kV79V81, false},
     {"ternary_bonsai_1_7b", kV75V81, false},
+    {"bonsai_1_7b_1bit", kV81, false},
     {"bonsai_4b_1bit", kV75V81, false},
     {"bonsai_8b_1bit", kV75V81, false},
     {"bonsai_27b_1bit", kV81, false},

--- a/engines/qhexrt/qhexrt_session.cpp
+++ b/engines/qhexrt/qhexrt_session.cpp
@@ -331,7 +331,19 @@ std::string resolve_manifest(const char* path, const char* arch) {
     std::error_code ec;
     fs::path p(path);
     if (fs::is_regular_file(p, ec)) {
-        return p.generic_string();  // a manifest file was passed directly
+        // A real manifest .json was passed directly — use it.
+        std::string name = p.filename().generic_string();
+        if (ends_with_ci(name, ".json") && !is_aux_json(name) && looks_like_manifest(p)) {
+            return p.generic_string();
+        }
+        // Otherwise commons handed us a non-manifest bundle file. This happens for
+        // a directory-based framework whose model carries multi_file descriptors:
+        // rac_model_paths_resolve_artifact scans the folder and returns the first
+        // QNN_CONTEXT `.bin` (e.g. the fp16 embedding blob) as the primary path,
+        // which synthesize_artifact_resolution_from_descriptors then cannot
+        // override. Recover by resolving the manifest from the file's own bundle
+        // directory (the layout below handles the arch-subdir and flat cases).
+        p = p.parent_path();
     }
     if (!fs::is_directory(p, ec)) {
         return {};

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -52,6 +52,7 @@ internal object ModelCatalog {
         // ring, degenerates into garbage, and the decode fails with rc=-130.
         SingleFileModel("llama3_2_1b", "Llama 3.2 1B (HNPU)", "https://huggingface.co/runanywhere/llama3_2_1b_HNPU/llama-3.2-1b.json", QHEXRT, LANGUAGE, 3_023_821_212L, contextLength = 512),
         SingleFileModel("ternary_bonsai_1_7b", "Ternary Bonsai 1.7B (HNPU)", "https://huggingface.co/runanywhere/ternary_bonsai_1_7b_HNPU/ternary-bonsai-1.7b-1024.json", QHEXRT, LANGUAGE, 2_367_579_370L, contextLength = 1_024),
+        SingleFileModel("bonsai_1_7b_1bit", "Bonsai-1.7B 1-bit (HNPU, fully-on-NPU)", "https://huggingface.co/runanywhere/bonsai_1_7b_1bit_HNPU/bonsai-1.7b-1bit-1024.json", QHEXRT, LANGUAGE, 902_000_000L, contextLength = 1_024),
         SingleFileModel("bonsai_4b_1bit", "Bonsai-4B 1-bit (HNPU)", "https://huggingface.co/runanywhere/bonsai_4b_1bit_HNPU/bonsai-4b-1024.json", QHEXRT, LANGUAGE, 1_358_352_318L, contextLength = 1_024, supportsThinking = true),
         SingleFileModel("bonsai_8b_1bit", "Bonsai-8B 1-bit (HNPU)", "https://huggingface.co/runanywhere/bonsai_8b_1bit_HNPU/bonsai-8b-1024.json", QHEXRT, LANGUAGE, 2_323_975_102L, contextLength = 1_024, supportsThinking = true),
         SingleFileModel("bonsai_27b_1bit", "Bonsai-27B 1-bit (HNPU)", "https://huggingface.co/runanywhere/bonsai_27b_1bit_HNPU/bonsai-27b-1024.json", QHEXRT, LANGUAGE, 6_400_000_000L, contextLength = 1_024, supportsThinking = true),

--- a/sdk/runanywhere-kotlin/modules/runanywhere-core-qhexrt/src/main/kotlin/com/runanywhere/sdk/npu/qhexrt/QHexRTSkelInstaller.kt
+++ b/sdk/runanywhere-kotlin/modules/runanywhere-core-qhexrt/src/main/kotlin/com/runanywhere/sdk/npu/qhexrt/QHexRTSkelInstaller.kt
@@ -36,7 +36,14 @@ internal object QHexRTSkelInstaller {
             val skelNames =
                 context.assets
                     .list(assetDir)
-                    ?.filter { (it.startsWith("libQnnHtpV") && it.endsWith("Skel.so")) || it == "libQnnBonsaiBitnet.so" }
+                    ?.filter {
+                        (it.startsWith("libQnnHtpV") && it.endsWith("Skel.so")) ||
+                            it == "libQnnBonsaiBitnet.so" ||
+                            // Bonsai fully-on-NPU 1-bit decoder FastRPC skel: the cDSP
+                            // resolves it by name via ADSP_LIBRARY_PATH, so it must be
+                            // installed into the skel dir alongside the QNN skels.
+                            it == "librun_main_on_hexagon_skel.so"
+                    }
                     .orEmpty()
                     .sorted()
             if (skelNames.isEmpty()) {


### PR DESCRIPTION
Wires the fully-on-NPU Bonsai FastRPC decoder into the QHexRT engine + example app so the fast (non-QNN) 1-bit/ternary bundles run through the standard `registerModel → downloadModel → loadModel → generateStream → deleteModel` SDK flow.

## Changes (5 files, +50/-2)
- `engines/qhexrt/CMakeLists.txt` — link `libcdsprpc.so` when the core carries the FastRPC stub.
- `engines/qhexrt/qhexrt_session.cpp` — recover the manifest from the bundle dir when handed a non-manifest bundle file.
- `engines/qhexrt/qhexrt_model_catalog.cpp` + example `ModelCatalog.kt` — register the Bonsai-1.7B 1-bit NPU model.
- `QHexRTSkelInstaller.kt` — install the `librun_main_on_hexagon_skel.so` fully-on-NPU decoder skel into the app skel dir.

## Validation
Plane B app E2E (SMOKE_PASS, framework=QHEXRT) for Bonsai-1.7B (1-bit + ternary), 4B, and 8B on v81 (SM8850) via this integration; 4B/8B download the fully-on-NPU bundles from the public HNPU repos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the Bonsai-1.7B 1-bit model to the curated Android model catalog.
  * Added support for installing the runtime components required by Bonsai models on supported devices.
  * Improved Android compatibility for models using the QHexRT runtime.

* **Bug Fixes**
  * Improved manifest detection when users provide a model file directly.
  * Added clearer configuration errors when required Android runtime libraries are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->