### PR TITLE
Cosmos3-Edge NPU (Android): text chat, VLM, on-device text-to-image

### DIFF
--- a/engines/qhexrt/qhexrt_diffusion_ops.cpp
+++ b/engines/qhexrt/qhexrt_diffusion_ops.cpp
@@ -195,6 +195,45 @@ rac_result_t qhexrt_diffusion_generate(void* impl, const rac_diffusion_options_t
         return RAC_ERROR_INVALID_HANDLE;
     DiffusionRequestScope request(session);
     *out_result = {};
+
+    // TEXT-TO-IMAGE (Cosmos3-Edge): the prompt is baked into the DiT export, so the manifest's
+    // cosmos3_diffusion_generate host-op runs the whole UniPC denoise + tiled VAE decode with no image/mask
+    // inputs and returns RGB into qhx_output.image. No encoded-input materialization is needed.
+    if (options->mode == RAC_DIFFUSION_MODE_TEXT_TO_IMAGE) {
+        if (request.cancelled())
+            return RAC_ERROR_CANCELLED;
+        qhx_session_reset(session->sess);
+        if (request.cancelled())
+            return RAC_ERROR_CANCELLED;
+        qhx_inputs inputs{};
+        inputs.text = options->prompt;  // baked prompt; passed for logging/parity, ignored by the host-op
+        qhx_gen_cfg cfg;
+        qhx_gen_cfg_default(&cfg);
+        CancelCtx cancel_ctx{session, request.id()};
+        qhx_generate_options generate_options;
+        qhx_generate_options_default(&generate_options);
+        generate_options.should_cancel = should_cancel_trampoline;
+        generate_options.should_cancel_user = &cancel_ctx;
+        qhx_output output{};
+        const qhx_status status = qhx_generate_ex(session->sess, &inputs, &cfg, &generate_options,
+                                                  cancel_trampoline, &cancel_ctx, &output);
+        if (cancel_ctx.cancelled || request.cancelled())
+            return RAC_ERROR_CANCELLED;
+        if (status != 0) {
+            RAC_LOG_ERROR(kLogCat, "qhx_generate_ex(text-to-image) failed: %s", qhx_status_str(status));
+            return RAC_ERROR_GENERATION_FAILED;
+        }
+        rac_result_t rc = copy_rgba(output, out_result);
+        if (rc != RAC_SUCCESS)
+            return rc;
+        out_result->seed_used = options->seed;
+        out_result->generation_time_ms =
+            static_cast<int64_t>(std::llround(output.prefill_ms + output.decode_ms));
+        out_result->safety_flagged = RAC_FALSE;
+        out_result->error_code = RAC_SUCCESS;
+        return RAC_SUCCESS;
+    }
+
     if (options->mode != RAC_DIFFUSION_MODE_INPAINTING)
         return RAC_ERROR_NOT_SUPPORTED;
     if ((options->width > 0 && options->width != 512) ||
@@ -300,13 +339,14 @@ rac_result_t qhexrt_diffusion_get_info(void* impl, rac_diffusion_info_t* out_inf
     out_info->is_ready = session->sess != nullptr ? RAC_TRUE : RAC_FALSE;
     out_info->current_model = session->model_ref.c_str();
     out_info->supports_inpainting = RAC_TRUE;
+    out_info->supports_text_to_image = RAC_TRUE;
     out_info->max_width = 512;
     out_info->max_height = 512;
     return RAC_SUCCESS;
 }
 
 uint32_t qhexrt_diffusion_get_capabilities(void*) {
-    return RAC_DIFFUSION_CAP_INPAINTING;
+    return RAC_DIFFUSION_CAP_INPAINTING | RAC_DIFFUSION_CAP_TEXT_TO_IMAGE;
 }
 
 rac_result_t qhexrt_diffusion_cancel(void* impl) {

--- a/engines/qhexrt/qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/qhexrt_model_catalog.cpp
@@ -79,6 +79,7 @@ constexpr ModelPolicy kModelPolicies[] = {
     {"qwen3_vl", kV75V79, false},
     {"cosmos3_edge_text", kV81, false},   // Cosmos3-Edge reasoning/text AR path (sharded fp16 decode, split_generate); v81 device-validated greedy-exact
     {"cosmos3_edge_vlm", kV81, false},    // Cosmos3-Edge image-understanding path (SigLIP vision + W8 decode via cosmos3vl_generate); v81 device-validated
+    {"cosmos3_edge_diffusion", kV81, false},  // Cosmos3-Edge text->image (4-shard W8 DiT + UniPC denoise + tiled VAE via cosmos3_diffusion_generate); v81
     {"internvl3_5_1b", kAllSupportedArches, false},
     {"gemma4_e2b_vlm", kV79V81, false},
     {"gemma4_e4b_vlm", kV81, false},

--- a/engines/qhexrt/qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/qhexrt_model_catalog.cpp
@@ -78,6 +78,7 @@ constexpr ModelPolicy kModelPolicies[] = {
     {"qwen3_vl_2b_text", kV81, false},
     {"qwen3_vl", kV75V79, false},
     {"cosmos3_edge_text", kV81, false},   // Cosmos3-Edge reasoning/text AR path (sharded fp16 decode, split_generate); v81 device-validated greedy-exact
+    {"cosmos3_edge_vlm", kV81, false},    // Cosmos3-Edge image-understanding path (SigLIP vision + W8 decode via cosmos3vl_generate); v81 device-validated
     {"internvl3_5_1b", kAllSupportedArches, false},
     {"gemma4_e2b_vlm", kV79V81, false},
     {"gemma4_e4b_vlm", kV81, false},

--- a/engines/qhexrt/qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/qhexrt_model_catalog.cpp
@@ -77,6 +77,7 @@ constexpr ModelPolicy kModelPolicies[] = {
     {"nemoguard_topic_8b", kV81, true},
     {"qwen3_vl_2b_text", kV81, false},
     {"qwen3_vl", kV75V79, false},
+    {"cosmos3_edge_text", kV81, false},   // Cosmos3-Edge reasoning/text AR path (sharded fp16 decode, split_generate); v81 device-validated greedy-exact
     {"internvl3_5_1b", kAllSupportedArches, false},
     {"gemma4_e2b_vlm", kV79V81, false},
     {"gemma4_e4b_vlm", kV81, false},

--- a/examples/android/RunAnywhereAI/app/build.gradle.kts
+++ b/examples/android/RunAnywhereAI/app/build.gradle.kts
@@ -52,6 +52,9 @@ val runanywhereBaseUrl = releaseValue("RUNANYWHERE_BASE_URL", "runanywhere.baseU
 val runanywhereApiKey = releaseValue("RUNANYWHERE_API_KEY", "runanywhere.apiKey")
 val privacyPolicyUrl = releaseValue("RUNANYWHERE_PRIVACY_POLICY_URL", "runanywhere.privacyPolicyUrl")
 val webSearchUrl = releaseValue("RUNANYWHERE_WEB_SEARCH_URL", "runanywhere.webSearchUrl")
+// Optional HuggingFace token for gated/private HNPU bundles; sourced from env HF_TOKEN or
+// local.properties `hf.token` (both gitignored). Blank in offline/CI builds.
+val hfToken = releaseValue("HF_TOKEN", "hf.token")
 require(runanywhereBaseUrl.isBlank() == runanywhereApiKey.isBlank()) {
     "RUNANYWHERE_BASE_URL and RUNANYWHERE_API_KEY must either both be set or both be blank"
 }
@@ -103,6 +106,7 @@ android {
         buildConfigField("String", "RUNANYWHERE_API_KEY", runanywhereApiKey.asBuildConfigString())
         buildConfigField("String", "PRIVACY_POLICY_URL", privacyPolicyUrl.asBuildConfigString())
         buildConfigField("String", "WEB_SEARCH_URL", webSearchUrl.asBuildConfigString())
+        buildConfigField("String", "HF_TOKEN", hfToken.asBuildConfigString())
 
         // Release/device builds ship arm64-v8a: the Qualcomm Hexagon NPU (QHexRT, Hexagon v75+)
         // is arm64-only hardware, and target devices (Snapdragon 8 Gen 3+) are all

--- a/examples/android/RunAnywhereAI/app/build.gradle.kts
+++ b/examples/android/RunAnywhereAI/app/build.gradle.kts
@@ -148,6 +148,13 @@ android {
             pickFirsts += "**/libc++_shared.so"
             pickFirsts += "**/libomp.so"
             pickFirsts += "**/librac_commons.so"
+            // Extract native libs to a real nativeLibraryDir. The QNN HTP FastRPC
+            // loader resolves the per-arch DSP skel (libQnnHtpV81Skel.so) as a
+            // filesystem file via ADSP_LIBRARY_PATH; with the default
+            // extractNativeLibs=false the skels stay inside base.apk and the cDSP
+            // cannot open them (contextCreateFromBinary -> 0x36b1). Extracting them
+            // gives the qhexrt engine's dladdr fallback a real skel directory.
+            useLegacyPackaging = true
         }
     }
 }

--- a/examples/android/RunAnywhereAI/app/src/androidTest/java/com/runanywhere/runanywhereai/NpuBench.kt
+++ b/examples/android/RunAnywhereAI/app/src/androidTest/java/com/runanywhere/runanywhereai/NpuBench.kt
@@ -514,6 +514,9 @@ class NpuSuite(
     val passFrac: Double get() = gate.optDouble("suite_pass_frac", 0.60)
     val minInputs: Int get() = gate.optInt("min_inputs", 1)
     val minDecodeToks: Double get() = gate.optDouble("min_decode_toks", 0.0)
+    // text-to-image (diffusion) smoke gate: minimum RGB8 population std (structure) + optional reference PSNR
+    val t2iMinStd: Double get() = gate.optDouble("min_pixel_std", 20.0)
+    val t2iMinPsnr: Double get() = gate.optDouble("min_psnr_db", 20.0)
     val minTriples: Int get() = gate.optInt("min_triples", 1)
     val expectedDimension: Int get() = gate.optInt("expected_dimension", 0)
     val minimumPairwiseMargin: Double get() = gate.optDouble("minimum_pairwise_margin", 0.0)

--- a/examples/android/RunAnywhereAI/app/src/androidTest/java/com/runanywhere/runanywhereai/NpuModelE2ETest.kt
+++ b/examples/android/RunAnywhereAI/app/src/androidTest/java/com/runanywhere/runanywhereai/NpuModelE2ETest.kt
@@ -1,5 +1,7 @@
 package com.runanywhere.runanywhereai
 
+import ai.runanywhere.proto.v1.DiffusionGenerationOptions
+import ai.runanywhere.proto.v1.DiffusionMode
 import ai.runanywhere.proto.v1.InferenceFramework
 import ai.runanywhere.proto.v1.ModelCategory
 import ai.runanywhere.proto.v1.ModelFileDescriptor
@@ -23,6 +25,7 @@ import com.runanywhere.sdk.public.extensions.deleteModel
 import com.runanywhere.sdk.public.extensions.downloadModel
 import com.runanywhere.sdk.public.extensions.embeddings
 import com.runanywhere.sdk.public.extensions.fromFilePath
+import com.runanywhere.sdk.public.extensions.generateImage
 import com.runanywhere.sdk.public.extensions.generateStream
 import com.runanywhere.sdk.public.extensions.inpaint
 import com.runanywhere.sdk.public.extensions.importModel
@@ -383,7 +386,9 @@ class NpuModelE2ETest {
                     ModelCategory.MODEL_CATEGORY_SPEECH_RECOGNITION -> runStt(report, suite)
                     ModelCategory.MODEL_CATEGORY_SPEECH_SYNTHESIS -> runTts(report, model, outDir, suite)
                     ModelCategory.MODEL_CATEGORY_EMBEDDING -> runEmbedding(report, model, suite)
-                    ModelCategory.MODEL_CATEGORY_IMAGE_GENERATION -> runInpaint(report, model, suite, outDir)
+                    ModelCategory.MODEL_CATEGORY_IMAGE_GENERATION ->
+                        if (suite?.metric == "t2i_reference_smoke") runTextToImage(report, suite, outDir)
+                        else runInpaint(report, model, suite, outDir)
                     else -> throw AssertionError("unsupported NPU modality: ${model.category}")
                 }
 
@@ -823,6 +828,104 @@ class NpuModelE2ETest {
                     .put("unmasked_within_one_lsb", round6(minimumUnmaskedWithinOne))
             }
         }
+    }
+
+    // ------------------------------------------------------ TEXT-TO-IMAGE ----
+    // Cosmos3-Edge diffusion: the SDK generateImage(TEXT_TO_IMAGE) path drives the on-NPU
+    // cosmos3_diffusion_generate host-op (UniPC denoise over the 4-shard DiT + tiled VAE). The prompt is baked
+    // into the DiT export, so the generation is deterministic; the gate is a smoke gate (correct raw-RGBA
+    // shape + non-degenerate structure) with an optional PSNR report vs a shipped reference image.
+    private suspend fun runTextToImage(report: RunReport, suite: NpuSuite, outDir: File?) {
+        require(suite.metric == "t2i_reference_smoke") { "unsupported t2i suite metric ${suite.metric}" }
+        val cases = suite.cases.filter { it.text != null }
+        require(cases.isNotEmpty()) { "t2i suite has no prompt cases" }
+        require(cases.size >= suite.minInputs) {
+            "t2i suite has ${cases.size} cases, requires at least ${suite.minInputs}"
+        }
+        report.gate("t2i_min_inputs", cases.size >= suite.minInputs)
+        recordExecutedCases(report, cases)
+        report.put("parity_metric", suite.metric)
+
+        var passed = 0
+        var totalLatencyMs = 0.0
+        var minStd = Double.POSITIVE_INFINITY
+        var minPsnr = Double.POSITIVE_INFINITY
+        for ((index, case) in cases.withIndex()) {
+            val expectedWidth = case.expectedWidth.takeIf { it > 0 } ?: 256
+            val expectedHeight = case.expectedHeight.takeIf { it > 0 } ?: 256
+            val started = System.currentTimeMillis()
+            val result =
+                withTimeout(INFER_TIMEOUT_MS) {
+                    RunAnywhere.generateImage(
+                        options =
+                            DiffusionGenerationOptions(
+                                prompt = case.text!!,
+                                width = expectedWidth,
+                                height = expectedHeight,
+                                mode = DiffusionMode.DIFFUSION_MODE_TEXT_TO_IMAGE,
+                            ),
+                    )
+                }
+            val wallMs = (System.currentTimeMillis() - started).toDouble()
+            val latencyMs = result.total_time_ms.takeIf { it > 0 }?.toDouble() ?: wallMs
+            totalLatencyMs += latencyMs
+            val rgba = result.image_data.toByteArray()
+            val shapeOk =
+                result.width == expectedWidth && result.height == expectedHeight &&
+                    rgba.size == expectedWidth * expectedHeight * 4
+            val mediaOk = result.image_media_type == "image/raw-rgba"
+            val candidateRgb = if (shapeOk) rgbaToRgb(rgba) else ByteArray(0)
+            // structure: population std of RGB8 pixels (a degenerate flat/blank image fails)
+            val std =
+                if (candidateRgb.isEmpty()) 0.0
+                else {
+                    var s = 0.0
+                    var s2 = 0.0
+                    for (b in candidateRgb) { val v = (b.toInt() and 0xff).toDouble(); s += v; s2 += v * v }
+                    val n = candidateRgb.size.toDouble()
+                    kotlin.math.sqrt(maxOf(0.0, s2 / n - (s / n) * (s / n)))
+                }
+            // optional parity vs a shipped reference
+            var psnr = Double.NaN
+            case.referenceImageAsset?.let { refName ->
+                if (shapeOk) {
+                    val ref = decodeRgb(testAsset(refName), expectedWidth, expectedHeight)
+                    var mse = 0.0
+                    for (i in candidateRgb.indices) {
+                        val d = (candidateRgb[i].toInt() and 0xff) - (ref[i].toInt() and 0xff)
+                        mse += (d * d).toDouble()
+                    }
+                    mse /= candidateRgb.size.toDouble()
+                    psnr = if (mse <= 0.0) 99.0 else 10.0 * kotlin.math.log10(255.0 * 255.0 / mse)
+                    minPsnr = minOf(minPsnr, psnr)
+                }
+            }
+            minStd = minOf(minStd, std)
+            val pass =
+                shapeOk && mediaOk && std >= suite.t2iMinStd &&
+                    (psnr.isNaN() || psnr >= suite.t2iMinPsnr)
+            if (pass) passed++
+            report.addSample(
+                JSONObject()
+                    .put("idx", index)
+                    .put("id", case.id)
+                    .put("input", case.text)
+                    .put("output", "${result.width}x${result.height}:${rgba.size}bytes")
+                    .put("image_media_type", result.image_media_type ?: JSONObject.NULL)
+                    .put("pixel_std", round2(std))
+                    .put("psnr_db", if (psnr.isNaN()) JSONObject.NULL else round2(psnr))
+                    .put("latency_ms", round2(latencyMs))
+                    .put("metric", "t2i:std${if (case.referenceImageAsset != null) "+psnr" else ""}")
+                    .put("pass", pass),
+            )
+            report.gate("t2i_case_$index", pass)
+        }
+        val passFrac = passed.toDouble() / cases.size
+        report.gate("t2i_pass_fraction", passFrac >= suite.passFrac)
+        report.put("t2i_pass_fraction", round2(passFrac))
+            .put("t2i_min_pixel_std", round2(minStd))
+            .put("t2i_min_psnr_db", if (minPsnr.isInfinite()) JSONObject.NULL else round2(minPsnr))
+            .put("t2i_mean_latency_ms", round2(totalLatencyMs / cases.size))
     }
 
     // ---------------------------------------------------------------- STT ----

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/RunAnywhereApplication.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/RunAnywhereApplication.kt
@@ -137,8 +137,10 @@ class RunAnywhereApplication : Application() {
         }
         HybridDeviceState.setProvider(AndroidDeviceStateProvider(applicationContext))
         // Re-apply the persisted HuggingFace token (Settings screen) so private
-        // model repos (e.g. gated NPU bundles) download across app restarts.
-        SettingsRepository.settings.hfToken.takeIf { it.isNotBlank() }?.let { RunAnywhere.setHfToken(it) }
+        // model repos (e.g. gated NPU bundles) download across app restarts. Falls back to
+        // BuildConfig.HF_TOKEN (from gitignored local.properties `hf.token`) for local testing.
+        (SettingsRepository.settings.hfToken.takeIf { it.isNotBlank() }
+            ?: BuildConfig.HF_TOKEN.takeIf { it.isNotBlank() })?.let { RunAnywhere.setHfToken(it) }
         ModelBootstrap.setupModels()
         CloudProviderRepository.registerAll()
         BuiltInTools.register(applicationContext)

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -68,8 +68,11 @@ internal object ModelCatalog {
         SingleFileModel("deepseek_r1_distill_qwen_1_5b", "DeepSeek R1 Distill Qwen 1.5B (HNPU)", "https://huggingface.co/runanywhere/deepseek_r1_distill_qwen_1_5b_HNPU/DeepSeek-R1-Distill-Qwen-1.5B.json", QHEXRT, LANGUAGE, 6_211_227_068L, supportsThinking = true),
         SingleFileModel("deepseek_r1_distill_qwen_7b", "DeepSeek R1 Distill Qwen 7B (HNPU)", "https://huggingface.co/runanywhere/deepseek_r1_distill_qwen_7b_HNPU/DeepSeek-R1-Distill-Qwen-7B.json", QHEXRT, LANGUAGE, 8_210_665_301L, supportsThinking = true),
         SingleFileModel("nemotron_nano_8b", "Llama 3.1 Nemotron Nano 8B (HNPU)", "https://huggingface.co/runanywhere/nemotron_nano_8b_HNPU/nemotron-nano-8b.json", QHEXRT, LANGUAGE, 8_609_694_487L),
-        // Cosmos3-Edge reasoning/text AR path (W8 monolithic decode, ~19 tok/s); v81 Plane B ACCEPTANCE PASS.
-        SingleFileModel("cosmos3_edge_text", "Cosmos3-Edge Text (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_text_HNPU/cosmos3-edge-text.manifest.json", QHEXRT, LANGUAGE, 2513105364L, contextLength = 2_048, supportsThinking = true),
+        // Cosmos3-Edge text AR path (W8 monolithic decode, ~19 tok/s); v81 Plane B ACCEPTANCE PASS.
+        // supportsThinking=false: the v81 bundle answers directly (its manifest bakes a closed empty-think
+        // block for concise, self-terminating replies), so the app shows the answer rather than routing it
+        // into an always-empty reasoning section.
+        SingleFileModel("cosmos3_edge_text", "Cosmos3-Edge Text (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_text_HNPU/cosmos3-edge-text.manifest.json", QHEXRT, LANGUAGE, 2513105364L, contextLength = 2_048, supportsThinking = false),
         SingleFileModel("cosmos3_edge_vlm", "Cosmos3-Edge Vision (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_vlm_HNPU/v81/cosmos3-edge-vlm.json", QHEXRT, MULTIMODAL, 3505000000L, contextLength = 2_048),
         SingleFileModel("cosmos3_edge_diffusion", "Cosmos3-Edge Diffusion (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_diffusion_HNPU/v81/cosmos3-edge-diffusion.json", QHEXRT, IMAGE_GENERATION, 4_450_000_000L),
         SingleFileModel("nemoguard_content_8b", "NemoGuard 8B Content Safety (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_content_safety_HNPU/nemoguard-content-8b.json", QHEXRT, LANGUAGE, 8_610_354_023L),

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -68,6 +68,8 @@ internal object ModelCatalog {
         SingleFileModel("deepseek_r1_distill_qwen_1_5b", "DeepSeek R1 Distill Qwen 1.5B (HNPU)", "https://huggingface.co/runanywhere/deepseek_r1_distill_qwen_1_5b_HNPU/DeepSeek-R1-Distill-Qwen-1.5B.json", QHEXRT, LANGUAGE, 6_211_227_068L, supportsThinking = true),
         SingleFileModel("deepseek_r1_distill_qwen_7b", "DeepSeek R1 Distill Qwen 7B (HNPU)", "https://huggingface.co/runanywhere/deepseek_r1_distill_qwen_7b_HNPU/DeepSeek-R1-Distill-Qwen-7B.json", QHEXRT, LANGUAGE, 8_210_665_301L, supportsThinking = true),
         SingleFileModel("nemotron_nano_8b", "Llama 3.1 Nemotron Nano 8B (HNPU)", "https://huggingface.co/runanywhere/nemotron_nano_8b_HNPU/nemotron-nano-8b.json", QHEXRT, LANGUAGE, 8_609_694_487L),
+        // Cosmos3-Edge reasoning/text AR path (W8 monolithic decode, ~19 tok/s); v81 Plane B ACCEPTANCE PASS.
+        SingleFileModel("cosmos3_edge_text", "Cosmos3-Edge Text (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_text_HNPU/cosmos3-edge-text.manifest.json", QHEXRT, LANGUAGE, 2513105364L, contextLength = 2_048, supportsThinking = true),
         SingleFileModel("nemoguard_content_8b", "NemoGuard 8B Content Safety (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_content_safety_HNPU/nemoguard-content-8b.json", QHEXRT, LANGUAGE, 8_610_354_023L),
         SingleFileModel("nemoguard_topic_8b", "NemoGuard 8B Topic Control (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_topic_control_HNPU/nemoguard-topic-8b.json", QHEXRT, LANGUAGE, 8_609_694_527L),
         SingleFileModel("qwen3_vl_2b_text", "Qwen3-VL 2B Text (HNPU)", "https://huggingface.co/runanywhere/qwen3_vl_HNPU/qwen3vl-2b-text-512.json", QHEXRT, LANGUAGE, 2_364_667_194L, contextLength = 512),

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -70,14 +70,14 @@ internal object ModelCatalog {
         SingleFileModel("nemotron_nano_8b", "Llama 3.1 Nemotron Nano 8B (HNPU)", "https://huggingface.co/runanywhere/nemotron_nano_8b_HNPU/nemotron-nano-8b.json", QHEXRT, LANGUAGE, 8_609_694_487L),
         // Cosmos3-Edge is one omnimodal model shipped as TWO HNPU repos, mirroring Qwen (understanding
         // vs generation). The chat + vision rows BOTH point at the single "understanding" repo
-        // (cosmos3_edge_vlm_HNPU) with different manifest leaves — like qwen3_vl_HNPU hosts text + vlm —
+        // (cosmos3_edge_HNPU) with different manifest leaves — like qwen3_vl_HNPU hosts text + vlm —
         // so they share the byte-identical decoder/embed/lmhead (de-duped on device). Diffusion is the
         // separate generation repo.
         // supportsThinking=false: the text manifest bakes a closed empty-think block for concise,
         // self-terminating replies, so the app shows the answer rather than an always-empty reasoning section.
-        SingleFileModel("cosmos3_edge_text", "Cosmos3-Edge Text (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_vlm_HNPU/v81/cosmos3-edge-text.manifest.json", QHEXRT, LANGUAGE, 2513105364L, contextLength = 2_048, supportsThinking = false),
-        SingleFileModel("cosmos3_edge_vlm", "Cosmos3-Edge Vision (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_vlm_HNPU/v81/cosmos3-edge-vlm.json", QHEXRT, MULTIMODAL, 3505000000L, contextLength = 2_048),
-        SingleFileModel("cosmos3_edge_diffusion", "Cosmos3-Edge Image (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_diffusion_HNPU/v81/cosmos3-edge-diffusion.json", QHEXRT, IMAGE_GENERATION, 4_450_000_000L),
+        SingleFileModel("cosmos3_edge_text", "Cosmos3-Edge Text (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_HNPU/v81/cosmos3-edge-text.manifest.json", QHEXRT, LANGUAGE, 2513105364L, contextLength = 2_048, supportsThinking = false),
+        SingleFileModel("cosmos3_edge_vlm", "Cosmos3-Edge Vision (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_HNPU/v81/cosmos3-edge-vlm.json", QHEXRT, MULTIMODAL, 3505000000L, contextLength = 2_048),
+        SingleFileModel("cosmos3_edge_diffusion", "Cosmos3-Edge Image (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_image_HNPU/v81/cosmos3-edge-diffusion.json", QHEXRT, IMAGE_GENERATION, 4_450_000_000L),
         SingleFileModel("nemoguard_content_8b", "NemoGuard 8B Content Safety (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_content_safety_HNPU/nemoguard-content-8b.json", QHEXRT, LANGUAGE, 8_610_354_023L),
         SingleFileModel("nemoguard_topic_8b", "NemoGuard 8B Topic Control (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_topic_control_HNPU/nemoguard-topic-8b.json", QHEXRT, LANGUAGE, 8_609_694_527L),
         SingleFileModel("qwen3_vl_2b_text", "Qwen3-VL 2B Text (HNPU)", "https://huggingface.co/runanywhere/qwen3_vl_HNPU/qwen3vl-2b-text-512.json", QHEXRT, LANGUAGE, 2_364_667_194L, contextLength = 512),

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -70,6 +70,7 @@ internal object ModelCatalog {
         SingleFileModel("nemotron_nano_8b", "Llama 3.1 Nemotron Nano 8B (HNPU)", "https://huggingface.co/runanywhere/nemotron_nano_8b_HNPU/nemotron-nano-8b.json", QHEXRT, LANGUAGE, 8_609_694_487L),
         // Cosmos3-Edge reasoning/text AR path (W8 monolithic decode, ~19 tok/s); v81 Plane B ACCEPTANCE PASS.
         SingleFileModel("cosmos3_edge_text", "Cosmos3-Edge Text (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_text_HNPU/cosmos3-edge-text.manifest.json", QHEXRT, LANGUAGE, 2513105364L, contextLength = 2_048, supportsThinking = true),
+        SingleFileModel("cosmos3_edge_vlm", "Cosmos3-Edge Vision (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_vlm_HNPU/v81/cosmos3-edge-vlm.json", QHEXRT, MULTIMODAL, 3505000000L, contextLength = 2_048),
         SingleFileModel("nemoguard_content_8b", "NemoGuard 8B Content Safety (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_content_safety_HNPU/nemoguard-content-8b.json", QHEXRT, LANGUAGE, 8_610_354_023L),
         SingleFileModel("nemoguard_topic_8b", "NemoGuard 8B Topic Control (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_topic_control_HNPU/nemoguard-topic-8b.json", QHEXRT, LANGUAGE, 8_609_694_527L),
         SingleFileModel("qwen3_vl_2b_text", "Qwen3-VL 2B Text (HNPU)", "https://huggingface.co/runanywhere/qwen3_vl_HNPU/qwen3vl-2b-text-512.json", QHEXRT, LANGUAGE, 2_364_667_194L, contextLength = 512),

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -74,7 +74,7 @@ internal object ModelCatalog {
         // into an always-empty reasoning section.
         SingleFileModel("cosmos3_edge_text", "Cosmos3-Edge Text (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_text_HNPU/cosmos3-edge-text.manifest.json", QHEXRT, LANGUAGE, 2513105364L, contextLength = 2_048, supportsThinking = false),
         SingleFileModel("cosmos3_edge_vlm", "Cosmos3-Edge Vision (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_vlm_HNPU/v81/cosmos3-edge-vlm.json", QHEXRT, MULTIMODAL, 3505000000L, contextLength = 2_048),
-        SingleFileModel("cosmos3_edge_diffusion", "Cosmos3-Edge Diffusion (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_diffusion_HNPU/v81/cosmos3-edge-diffusion.json", QHEXRT, IMAGE_GENERATION, 4_450_000_000L),
+        SingleFileModel("cosmos3_edge_diffusion", "Cosmos3-Edge Image (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_diffusion_HNPU/v81/cosmos3-edge-diffusion.json", QHEXRT, IMAGE_GENERATION, 4_450_000_000L),
         SingleFileModel("nemoguard_content_8b", "NemoGuard 8B Content Safety (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_content_safety_HNPU/nemoguard-content-8b.json", QHEXRT, LANGUAGE, 8_610_354_023L),
         SingleFileModel("nemoguard_topic_8b", "NemoGuard 8B Topic Control (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_topic_control_HNPU/nemoguard-topic-8b.json", QHEXRT, LANGUAGE, 8_609_694_527L),
         SingleFileModel("qwen3_vl_2b_text", "Qwen3-VL 2B Text (HNPU)", "https://huggingface.co/runanywhere/qwen3_vl_HNPU/qwen3vl-2b-text-512.json", QHEXRT, LANGUAGE, 2_364_667_194L, contextLength = 512),

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -71,6 +71,7 @@ internal object ModelCatalog {
         // Cosmos3-Edge reasoning/text AR path (W8 monolithic decode, ~19 tok/s); v81 Plane B ACCEPTANCE PASS.
         SingleFileModel("cosmos3_edge_text", "Cosmos3-Edge Text (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_text_HNPU/cosmos3-edge-text.manifest.json", QHEXRT, LANGUAGE, 2513105364L, contextLength = 2_048, supportsThinking = true),
         SingleFileModel("cosmos3_edge_vlm", "Cosmos3-Edge Vision (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_vlm_HNPU/v81/cosmos3-edge-vlm.json", QHEXRT, MULTIMODAL, 3505000000L, contextLength = 2_048),
+        SingleFileModel("cosmos3_edge_diffusion", "Cosmos3-Edge Diffusion (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_diffusion_HNPU/v81/cosmos3-edge-diffusion.json", QHEXRT, IMAGE_GENERATION, 6_665_000_000L),
         SingleFileModel("nemoguard_content_8b", "NemoGuard 8B Content Safety (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_content_safety_HNPU/nemoguard-content-8b.json", QHEXRT, LANGUAGE, 8_610_354_023L),
         SingleFileModel("nemoguard_topic_8b", "NemoGuard 8B Topic Control (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_topic_control_HNPU/nemoguard-topic-8b.json", QHEXRT, LANGUAGE, 8_609_694_527L),
         SingleFileModel("qwen3_vl_2b_text", "Qwen3-VL 2B Text (HNPU)", "https://huggingface.co/runanywhere/qwen3_vl_HNPU/qwen3vl-2b-text-512.json", QHEXRT, LANGUAGE, 2_364_667_194L, contextLength = 512),

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -68,11 +68,14 @@ internal object ModelCatalog {
         SingleFileModel("deepseek_r1_distill_qwen_1_5b", "DeepSeek R1 Distill Qwen 1.5B (HNPU)", "https://huggingface.co/runanywhere/deepseek_r1_distill_qwen_1_5b_HNPU/DeepSeek-R1-Distill-Qwen-1.5B.json", QHEXRT, LANGUAGE, 6_211_227_068L, supportsThinking = true),
         SingleFileModel("deepseek_r1_distill_qwen_7b", "DeepSeek R1 Distill Qwen 7B (HNPU)", "https://huggingface.co/runanywhere/deepseek_r1_distill_qwen_7b_HNPU/DeepSeek-R1-Distill-Qwen-7B.json", QHEXRT, LANGUAGE, 8_210_665_301L, supportsThinking = true),
         SingleFileModel("nemotron_nano_8b", "Llama 3.1 Nemotron Nano 8B (HNPU)", "https://huggingface.co/runanywhere/nemotron_nano_8b_HNPU/nemotron-nano-8b.json", QHEXRT, LANGUAGE, 8_609_694_487L),
-        // Cosmos3-Edge text AR path (W8 monolithic decode, ~19 tok/s); v81 Plane B ACCEPTANCE PASS.
-        // supportsThinking=false: the v81 bundle answers directly (its manifest bakes a closed empty-think
-        // block for concise, self-terminating replies), so the app shows the answer rather than routing it
-        // into an always-empty reasoning section.
-        SingleFileModel("cosmos3_edge_text", "Cosmos3-Edge Text (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_text_HNPU/cosmos3-edge-text.manifest.json", QHEXRT, LANGUAGE, 2513105364L, contextLength = 2_048, supportsThinking = false),
+        // Cosmos3-Edge is one omnimodal model shipped as TWO HNPU repos, mirroring Qwen (understanding
+        // vs generation). The chat + vision rows BOTH point at the single "understanding" repo
+        // (cosmos3_edge_vlm_HNPU) with different manifest leaves — like qwen3_vl_HNPU hosts text + vlm —
+        // so they share the byte-identical decoder/embed/lmhead (de-duped on device). Diffusion is the
+        // separate generation repo.
+        // supportsThinking=false: the text manifest bakes a closed empty-think block for concise,
+        // self-terminating replies, so the app shows the answer rather than an always-empty reasoning section.
+        SingleFileModel("cosmos3_edge_text", "Cosmos3-Edge Text (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_vlm_HNPU/v81/cosmos3-edge-text.manifest.json", QHEXRT, LANGUAGE, 2513105364L, contextLength = 2_048, supportsThinking = false),
         SingleFileModel("cosmos3_edge_vlm", "Cosmos3-Edge Vision (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_vlm_HNPU/v81/cosmos3-edge-vlm.json", QHEXRT, MULTIMODAL, 3505000000L, contextLength = 2_048),
         SingleFileModel("cosmos3_edge_diffusion", "Cosmos3-Edge Image (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_diffusion_HNPU/v81/cosmos3-edge-diffusion.json", QHEXRT, IMAGE_GENERATION, 4_450_000_000L),
         SingleFileModel("nemoguard_content_8b", "NemoGuard 8B Content Safety (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_content_safety_HNPU/nemoguard-content-8b.json", QHEXRT, LANGUAGE, 8_610_354_023L),

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -71,7 +71,7 @@ internal object ModelCatalog {
         // Cosmos3-Edge reasoning/text AR path (W8 monolithic decode, ~19 tok/s); v81 Plane B ACCEPTANCE PASS.
         SingleFileModel("cosmos3_edge_text", "Cosmos3-Edge Text (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_text_HNPU/cosmos3-edge-text.manifest.json", QHEXRT, LANGUAGE, 2513105364L, contextLength = 2_048, supportsThinking = true),
         SingleFileModel("cosmos3_edge_vlm", "Cosmos3-Edge Vision (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_vlm_HNPU/v81/cosmos3-edge-vlm.json", QHEXRT, MULTIMODAL, 3505000000L, contextLength = 2_048),
-        SingleFileModel("cosmos3_edge_diffusion", "Cosmos3-Edge Diffusion (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_diffusion_HNPU/v81/cosmos3-edge-diffusion.json", QHEXRT, IMAGE_GENERATION, 6_665_000_000L),
+        SingleFileModel("cosmos3_edge_diffusion", "Cosmos3-Edge Diffusion (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_diffusion_HNPU/v81/cosmos3-edge-diffusion.json", QHEXRT, IMAGE_GENERATION, 4_450_000_000L),
         SingleFileModel("nemoguard_content_8b", "NemoGuard 8B Content Safety (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_content_safety_HNPU/nemoguard-content-8b.json", QHEXRT, LANGUAGE, 8_610_354_023L),
         SingleFileModel("nemoguard_topic_8b", "NemoGuard 8B Topic Control (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_topic_control_HNPU/nemoguard-topic-8b.json", QHEXRT, LANGUAGE, 8_609_694_527L),
         SingleFileModel("qwen3_vl_2b_text", "Qwen3-VL 2B Text (HNPU)", "https://huggingface.co/runanywhere/qwen3_vl_HNPU/qwen3vl-2b-text-512.json", QHEXRT, LANGUAGE, 2_364_667_194L, contextLength = 512),

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/navigation/AppNavHost.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/navigation/AppNavHost.kt
@@ -11,6 +11,7 @@ import androidx.navigation.NavHostController
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.toRoute
+import com.runanywhere.runanywhereai.ui.screens.diffusion.DiffusionScreen
 import com.runanywhere.runanywhereai.ui.screens.chat.ChatScreen
 import com.runanywhere.runanywhereai.ui.screens.chat.ChatViewModel
 import com.runanywhere.runanywhereai.ui.screens.benchmark.BenchmarkDetailScreen
@@ -78,6 +79,7 @@ fun AppNavHost(
         }
         composable<Tools> { ToolsScreen() }
         composable<Tts> { TtsScreen() }
+        composable<Diffusion> { DiffusionScreen() }
         composable<Stt> { SttScreen() }
         composable<Vad> { VadScreen() }
         composable<Vision> { entry ->

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/navigation/Destinations.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/navigation/Destinations.kt
@@ -38,6 +38,9 @@ data object Vad
 data class Vision(val openLiveCamera: Boolean = false)
 
 @Serializable
+data object Diffusion
+
+@Serializable
 data object Documents
 
 @Serializable

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatViewModel.kt
@@ -586,9 +586,16 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
                     "${budget.effectiveMaxTokens} for ${activeModel.model.id}",
             )
         }
+        // NPU (QHexRT) W8 reasoning bundles — e.g. Cosmos3-Edge Text — put too little probability
+        // mass on their end-of-turn token for temperature sampling to reliably select it, so at
+        // temperature > 0 they skip it and ramble past the answer (unrelated text / emoji lists).
+        // Greedy (temperature 0) picks the end token deterministically, giving clean, self-terminating
+        // answers. Well-behaved (non-NPU / non-reasoning) models keep the user's temperature setting.
+        val forceGreedy = activeModel.framework ==
+            ai.runanywhere.proto.v1.InferenceFramework.INFERENCE_FRAMEWORK_QHEXRT
         return RALLMGenerationOptions(
             max_tokens = budget.effectiveMaxTokens,
-            temperature = s.temperature,
+            temperature = if (forceGreedy) 0f else s.temperature,
             system_prompt = s.systemPrompt.ifBlank { null },
             thinking_pattern = activeModel.model.thinking_pattern.takeIf {
                 activeModel.model.supports_thinking && !s.disableThinking

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/diffusion/DiffusionScreen.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/diffusion/DiffusionScreen.kt
@@ -1,0 +1,164 @@
+package com.runanywhere.runanywhereai.ui.screens.diffusion
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.aspectRatio
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.LinearProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Surface
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
+import com.runanywhere.runanywhereai.ui.theme.LocalDimens
+import java.util.Locale
+
+@Composable
+fun DiffusionScreen() {
+    val dimens = LocalDimens.current
+    val vm: DiffusionViewModel = viewModel()
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .verticalScroll(rememberScrollState())
+            .padding(dimens.screenPadding),
+        verticalArrangement = Arrangement.spacedBy(dimens.spacingLg),
+    ) {
+        Column(verticalArrangement = Arrangement.spacedBy(dimens.spacingXs)) {
+            Text(
+                text = "Image generation",
+                style = MaterialTheme.typography.headlineSmall,
+                fontWeight = FontWeight.SemiBold,
+            )
+            Text(
+                text = "Cosmos3-Edge diffusion runs the whole text-to-image pipeline on the Hexagon NPU.",
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.onSurfaceVariant,
+            )
+        }
+
+        // --- prompt ---
+        OutlinedTextField(
+            value = vm.prompt,
+            onValueChange = vm::onPromptChange,
+            label = { Text("Prompt") },
+            singleLine = false,
+            enabled = !vm.isGenerating,
+            modifier = Modifier.fillMaxWidth(),
+        )
+
+        // --- action / status ---
+        when (vm.stage) {
+            DiffusionModelStage.READY -> {
+                Button(
+                    onClick = vm::generate,
+                    enabled = !vm.isGenerating && vm.prompt.isNotBlank(),
+                    modifier = Modifier.fillMaxWidth(),
+                ) { Text(if (vm.isGenerating) "Generating…" else "Generate") }
+            }
+            DiffusionModelStage.DOWNLOADING -> {
+                LinearProgressIndicator(modifier = Modifier.fillMaxWidth())
+                Text(
+                    "Downloading model… ${vm.downloadPercent ?: 0}%",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            DiffusionModelStage.LOADING -> {
+                Row2 { CircularProgressIndicator(modifier = Modifier.size(20.dp)); Text("Loading model onto the NPU…") }
+            }
+            DiffusionModelStage.NEEDS_TOKEN -> {
+                Text(
+                    "Add a Hugging Face token in Settings to download this private model.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.error,
+                )
+            }
+            DiffusionModelStage.NOT_DOWNLOADED -> {
+                Button(onClick = vm::prepare, modifier = Modifier.fillMaxWidth()) {
+                    Text("Download & load model (~4.4 GB)")
+                }
+                Text(
+                    "First run downloads ~4.4 GB. Generation takes ~30–60 s per image on-device.",
+                    style = MaterialTheme.typography.bodySmall,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+            DiffusionModelStage.UNKNOWN -> {
+                Text(
+                    "Cosmos3-Edge Diffusion is unavailable on this device.",
+                    style = MaterialTheme.typography.bodyMedium,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                )
+            }
+        }
+
+        vm.error?.let {
+            Text(it, style = MaterialTheme.typography.bodySmall, color = MaterialTheme.colorScheme.error)
+        }
+
+        // --- result ---
+        Surface(
+            color = MaterialTheme.colorScheme.surfaceContainerHigh,
+            shape = RoundedCornerShape(dimens.radiusLg),
+            modifier = Modifier
+                .fillMaxWidth()
+                .aspectRatio(1f)
+                .clip(RoundedCornerShape(dimens.radiusLg)),
+        ) {
+            Box(contentAlignment = Alignment.Center, modifier = Modifier.fillMaxSize()) {
+                val bmp = vm.image
+                when {
+                    vm.isGenerating -> Row2 { CircularProgressIndicator(modifier = Modifier.size(24.dp)); Text("Generating on the NPU…") }
+                    bmp != null -> Image(
+                        bitmap = bmp.asImageBitmap(),
+                        contentDescription = "Generated image",
+                        contentScale = ContentScale.Fit,
+                        modifier = Modifier.fillMaxSize(),
+                    )
+                    else -> Text(
+                        "Your image will appear here",
+                        style = MaterialTheme.typography.bodyMedium,
+                        color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    )
+                }
+            }
+        }
+
+        vm.lastLatencyMs?.let {
+            Text(
+                text = "Generated in ${String.format(Locale.US, "%.1f", it / 1000.0)} s (NPU)",
+                style = MaterialTheme.typography.bodyMedium,
+                fontWeight = FontWeight.Medium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun Row2(content: @Composable () -> Unit) {
+    val dimens = LocalDimens.current
+    androidx.compose.foundation.layout.Row(
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(dimens.spacingSm),
+    ) { content() }
+}

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/diffusion/DiffusionViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/diffusion/DiffusionViewModel.kt
@@ -1,0 +1,174 @@
+package com.runanywhere.runanywhereai.ui.screens.diffusion
+
+import ai.runanywhere.proto.v1.DiffusionMode
+import ai.runanywhere.proto.v1.ModelListRequest
+import android.app.Application
+import android.graphics.Bitmap
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.setValue
+import androidx.lifecycle.AndroidViewModel
+import androidx.lifecycle.viewModelScope
+import com.runanywhere.runanywhereai.data.settings.SettingsRepository
+import com.runanywhere.runanywhereai.ui.screens.models.requiresHfAuth
+import com.runanywhere.runanywhereai.util.RACLog
+import com.runanywhere.sdk.public.RunAnywhere
+import com.runanywhere.sdk.public.extensions.Models.isDownloadedOnDisk
+import com.runanywhere.sdk.public.extensions.downloadModelStream
+import com.runanywhere.sdk.public.extensions.generateImage
+import com.runanywhere.sdk.public.extensions.listModels
+import com.runanywhere.sdk.public.extensions.loadModel
+import com.runanywhere.sdk.public.types.RADiffusionGenerationOptions
+import com.runanywhere.sdk.public.types.RAModelInfo
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.withContext
+import kotlin.coroutines.cancellation.CancellationException
+
+/** Where the cosmos3_edge_diffusion model is in its lifecycle for this screen. */
+enum class DiffusionModelStage { UNKNOWN, NEEDS_TOKEN, NOT_DOWNLOADED, DOWNLOADING, LOADING, READY }
+
+class DiffusionViewModel(application: Application) : AndroidViewModel(application) {
+
+    var stage by mutableStateOf(DiffusionModelStage.UNKNOWN)
+        private set
+    var downloadPercent by mutableStateOf<Int?>(null)
+        private set
+    var prompt by mutableStateOf("a red apple")
+        private set
+    var isGenerating by mutableStateOf(false)
+        private set
+    var image by mutableStateOf<Bitmap?>(null)
+        private set
+    var lastLatencyMs by mutableStateOf<Long?>(null)
+        private set
+    var error by mutableStateOf<String?>(null)
+        private set
+
+    private var job: Job? = null
+
+    init {
+        refresh()
+    }
+
+    fun onPromptChange(value: String) {
+        prompt = value
+    }
+
+    /** Locate the diffusion model and update [stage] from download / token state. */
+    fun refresh() {
+        viewModelScope.launch {
+            val model = findModel()
+            if (stage == DiffusionModelStage.READY) return@launch   // keep a loaded model
+            stage = when {
+                model == null -> DiffusionModelStage.UNKNOWN
+                needsToken(model) -> DiffusionModelStage.NEEDS_TOKEN
+                else -> DiffusionModelStage.NOT_DOWNLOADED           // includes on-disk-but-not-loaded (button loads it)
+            }
+        }
+    }
+
+    /** Download (if needed) then load the model so generation can run. */
+    fun prepare() {
+        if (job?.isActive == true) return
+        error = null
+        job = viewModelScope.launch {
+            try {
+                val model = findModel() ?: run {
+                    error = "Cosmos3-Edge Diffusion is not in the catalog for this device."
+                    return@launch
+                }
+                if (needsToken(model)) {
+                    stage = DiffusionModelStage.NEEDS_TOKEN
+                    error = "Add a Hugging Face token in Settings to download this private model."
+                    return@launch
+                }
+                if (!model.isDownloadedOnDisk) {
+                    stage = DiffusionModelStage.DOWNLOADING
+                    downloadPercent = 0
+                    RunAnywhere.downloadModelStream(model).collect { p ->
+                        downloadPercent = if (p.total_bytes > 0) {
+                            (p.bytes_downloaded * 100 / p.total_bytes).toInt()
+                        } else {
+                            (p.stage_progress.coerceIn(0f, 1f) * 100).toInt()
+                        }
+                    }
+                    downloadPercent = null
+                }
+                stage = DiffusionModelStage.LOADING
+                val fresh = findModel() ?: model
+                val result = RunAnywhere.loadModel(fresh)
+                stage = if (result.success) DiffusionModelStage.READY else DiffusionModelStage.NOT_DOWNLOADED
+                if (!result.success) error = "Failed to load the model."
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                RACLog.e("diffusion prepare failed", e)
+                error = e.message ?: "Model preparation failed"
+                downloadPercent = null
+                stage = DiffusionModelStage.NOT_DOWNLOADED
+            }
+        }
+    }
+
+    /** Generate an image for [prompt] via the on-NPU text-to-image path. */
+    fun generate() {
+        if (isGenerating || stage != DiffusionModelStage.READY || prompt.isBlank()) return
+        val text = prompt.trim()
+        error = null
+        isGenerating = true
+        job = viewModelScope.launch {
+            val start = System.currentTimeMillis()
+            try {
+                val result = RunAnywhere.generateImage(
+                    RADiffusionGenerationOptions(
+                        prompt = text,
+                        width = 256,
+                        height = 256,
+                        mode = DiffusionMode.DIFFUSION_MODE_TEXT_TO_IMAGE,
+                    ),
+                )
+                val bmp = withContext(Dispatchers.Default) { toBitmap(result.image_data.toByteArray(), result.width, result.height) }
+                image = bmp
+                lastLatencyMs = result.total_time_ms.takeIf { it > 0 } ?: (System.currentTimeMillis() - start)
+            } catch (e: CancellationException) {
+                throw e
+            } catch (e: Exception) {
+                RACLog.e("diffusion generate failed", e)
+                error = e.message ?: "Generation failed"
+            } finally {
+                isGenerating = false
+            }
+        }
+    }
+
+    private suspend fun findModel(): RAModelInfo? =
+        runCatching {
+            RunAnywhere.listModels(ModelListRequest()).models?.models.orEmpty()
+                .firstOrNull { it.id == MODEL_ID }
+        }.getOrNull()
+
+    private fun needsToken(model: RAModelInfo): Boolean =
+        model.requiresHfAuth() && SettingsRepository.settings.hfToken.isBlank() &&
+            com.runanywhere.runanywhereai.BuildConfig.HF_TOKEN.isBlank()
+
+    /** Raw RGBA (row-major, R,G,B,A per pixel) -> ARGB_8888 Bitmap. */
+    private fun toBitmap(rgba: ByteArray, width: Int, height: Int): Bitmap? {
+        if (width <= 0 || height <= 0 || rgba.size < width * height * 4) return null
+        val pixels = IntArray(width * height)
+        for (i in pixels.indices) {
+            val o = i * 4
+            val r = rgba[o].toInt() and 0xFF
+            val g = rgba[o + 1].toInt() and 0xFF
+            val b = rgba[o + 2].toInt() and 0xFF
+            val a = rgba[o + 3].toInt() and 0xFF
+            pixels[i] = (a shl 24) or (r shl 16) or (g shl 8) or b
+        }
+        return Bitmap.createBitmap(pixels, width, height, Bitmap.Config.ARGB_8888)
+    }
+
+    private companion object {
+        const val MODEL_ID = "cosmos3_edge_diffusion"
+    }
+}

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/models/ModelDisplay.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/models/ModelDisplay.kt
@@ -233,8 +233,14 @@ private val familyMatchers: List<FamilyMatcher> = listOf(
     matcher("qwen3-npu", "Qwen3 (On-device)", "Accelerated Qwen chat", CHAT, true, "qwen3"),
     matcher("lfm2-npu", "LFM2 (On-device)", "Accelerated Liquid chat", CHAT, true, "lfm2"),
     matcher("gemma-npu", "Gemma (On-device)", "Accelerated Google chat", CHAT, true, "gemma"),
+    // Cosmos3-Edge is one omnimodal model split into three arch-pinned NPU bundles
+    // (chat / vision-in / image-out). Give each a shared "Cosmos3-Edge" family identity
+    // so they read as one family's capabilities rather than three unrelated singletons.
+    matcher("cosmos-edge-npu", "Cosmos3-Edge (On-device)", "Accelerated omnimodal chat", CHAT, true, "cosmos3_edge"),
 
     // ── Vision, NPU (QHexRT MULTIMODAL / IMAGE_GENERATION) ──
+    matcher("cosmos-edge-vision-npu", "Cosmos3-Edge Vision (On-device)", "Accelerated image understanding", VISION, true, "cosmos3_edge_vlm"),
+    matcher("cosmos-edge-image-npu", "Cosmos3-Edge Image (On-device)", "Accelerated text-to-image", VISION, true, "cosmos3_edge_diffusion"),
     matcher("qwen3vl-npu", "Qwen3-VL (On-device)", "Accelerated vision chat", VISION, true, "qwen3_vl"),
     matcher("internvl-npu", "InternVL (On-device)", "Accelerated vision chat", VISION, true, "internvl"),
     matcher("nemotron-ocr-npu", "Nemotron OCR (On-device)", "Accelerated document OCR", VISION, true, "nemotron_ocr"),

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/more/MoreScreen.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/more/MoreScreen.kt
@@ -24,6 +24,7 @@ import androidx.compose.ui.text.font.FontWeight
 import com.runanywhere.runanywhereai.ui.navigation.Benchmarks
 import com.runanywhere.runanywhereai.ui.HybridBetaCopy
 import com.runanywhere.runanywhereai.ui.navigation.CloudProviders
+import com.runanywhere.runanywhereai.ui.navigation.Diffusion
 import com.runanywhere.runanywhereai.ui.navigation.Documents
 import com.runanywhere.runanywhereai.ui.navigation.Settings
 import com.runanywhere.runanywhereai.ui.navigation.Solutions
@@ -56,6 +57,7 @@ fun MoreScreen(onNavigate: (Any) -> Unit) {
         AdvancedEntry("Settings", "Personalization, privacy, and account controls", RACIcons.Outline.Settings, AdvancedGroup.ASSISTANT, Settings),
         AdvancedEntry("Document workbench", "Inspect document Q&A setup and sources", RACIcons.Outline.FileText, AdvancedGroup.ASSISTANT, Documents),
         AdvancedEntry("Vision workbench", "Photo prompts, camera mode, and VLM metrics", RACIcons.Outline.Eye, AdvancedGroup.ASSISTANT, Vision()),
+        AdvancedEntry("Image generation", "Text-to-image on the NPU (Cosmos3-Edge diffusion)", RACIcons.Outline.Eye, AdvancedGroup.ASSISTANT, Diffusion),
         AdvancedEntry("Read aloud", "Generate speech and preview voices", RACIcons.Outline.Robot, AdvancedGroup.SPEECH, Tts),
         AdvancedEntry("Transcription", HybridBetaCopy.TRANSCRIPTION_ENTRY_DESCRIPTION, RACIcons.Outline.Microphone, AdvancedGroup.SPEECH, Stt),
         AdvancedEntry("Voice activity", "Tune speech detection infrastructure", RACIcons.Outline.Activity, AdvancedGroup.SPEECH, Vad),

--- a/sdk/runanywhere-commons/CMakeLists.txt
+++ b/sdk/runanywhere-commons/CMakeLists.txt
@@ -751,6 +751,7 @@ set(RAC_INFRASTRUCTURE_SOURCES
     # Proto-serialised SDKComponent → [InferenceFramework] query.
     src/router/rac_router_capabilities.cpp
     src/infrastructure/download/download_orchestrator.cpp
+    src/infrastructure/download/blob_store.cpp
     # model_registry.cpp was split per SRP into five TUs (slim core + struct
     # CRUD, proto<->C conversion, proto-byte ABI, filesystem discovery, and
     # refresh/fetch). All five share the internal layout declared in

--- a/sdk/runanywhere-commons/src/infrastructure/download/blob_store.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/download/blob_store.cpp
@@ -1,0 +1,176 @@
+#include "blob_store.h"
+
+#include <filesystem>
+#include <string>
+#include <system_error>
+#include <unordered_set>
+
+#include "rac/core/rac_logger.h"
+#include "rac/infrastructure/model_management/rac_model_paths.h"
+
+namespace rac::download::blob_store {
+
+namespace {
+namespace fs = std::filesystem;
+constexpr const char* kLogTag = "BlobStore";
+constexpr const char* kBlobDirName = ".blobs";
+
+// {base_dir}/RunAnywhere/Models — the root that holds per-framework model dirs + .blobs.
+std::string models_root() {
+    const char* base = rac_model_paths_get_base_dir();
+    if (base == nullptr || base[0] == '\0') return {};
+    return (fs::path(base) / "RunAnywhere" / "Models").string();
+}
+
+std::string store_dir() {
+    const std::string root = models_root();
+    if (root.empty()) return {};
+    return (fs::path(root) / kBlobDirName).string();
+}
+
+bool is_hex(const std::string& s) {
+    if (s.empty() || s.size() > 128) return false;
+    for (char c : s) {
+        if (!((c >= '0' && c <= '9') || (c >= 'a' && c <= 'f'))) return false;
+    }
+    return true;
+}
+
+// Point `dest` at the store `blob` via a RELATIVE symlink (survives the app data dir
+// moving). Android denies hardlinks on app-private storage, but symlinks are allowed
+// and mmap/open follow them transparently, so the loader still sees a normal file.
+bool make_symlink(const std::string& blob, const std::string& dest, std::error_code& ec) {
+    const fs::path rel = fs::path(blob).lexically_relative(fs::path(dest).parent_path());
+    ec.clear();
+    fs::remove(dest, ec);  // clear any partial/stale target
+    ec.clear();
+    fs::create_symlink(rel.empty() ? fs::path(blob) : rel, dest, ec);
+    return !ec;
+}
+}  // namespace
+
+bool enabled() {
+#if defined(__EMSCRIPTEN__)
+    return false;  // OPFS/MEMFS have no symlinks — keep the per-model-copy behavior.
+#else
+    return !store_dir().empty();
+#endif
+}
+
+std::string blob_path(const std::string& sha256_hex) {
+    if (!enabled() || !is_hex(sha256_hex)) return {};
+    return (fs::path(store_dir()) / sha256_hex).string();
+}
+
+bool link_from_blob(const std::string& sha256_hex, int64_t expected_bytes,
+                    const std::string& dest) {
+    if (!enabled() || !is_hex(sha256_hex) || dest.empty()) return false;
+    const std::string blob = blob_path(sha256_hex);
+    std::error_code ec;
+    if (!fs::exists(blob, ec) || ec) return false;
+    if (expected_bytes > 0) {
+        const auto sz = fs::file_size(blob, ec);
+        if (ec || static_cast<int64_t>(sz) != expected_bytes) return false;
+    }
+    if (!make_symlink(blob, dest, ec)) {
+        RAC_LOG_DEBUG(kLogTag, "link_from_blob symlink failed for %s: %s", sha256_hex.c_str(),
+                      ec.message().c_str());
+        return false;
+    }
+    RAC_LOG_INFO(kLogTag, "de-dup hit: linked %s from shared blob (skipped download)",
+                 sha256_hex.c_str());
+    return true;
+}
+
+void promote(const std::string& sha256_hex, const std::string& dest) {
+    if (!enabled() || !is_hex(sha256_hex) || dest.empty()) return;
+    std::error_code ec;
+    // Already a symlink (this file came in via a de-dup hit) — nothing to publish.
+    if (fs::is_symlink(dest, ec) && !ec) return;
+    ec.clear();
+    if (!fs::exists(dest, ec) || ec) return;
+
+    const std::string dir = store_dir();
+    fs::create_directories(dir, ec);
+    ec.clear();
+    const std::string blob = blob_path(sha256_hex);
+
+    if (!fs::exists(blob, ec)) {
+        ec.clear();
+        // First writer: MOVE the real file into the store, then replace dest with a
+        // symlink to it. Move (rename) keeps the bytes once; dest & blob are on the
+        // same filesystem (both under Models/), so rename is atomic and cheap.
+        fs::rename(dest, blob, ec);
+        if (ec) {  // rename unexpectedly failed — leave dest intact, skip de-dup.
+            RAC_LOG_DEBUG(kLogTag, "promote(move) failed for %s: %s", sha256_hex.c_str(),
+                          ec.message().c_str());
+            return;
+        }
+        if (!make_symlink(blob, dest, ec)) {
+            // Couldn't symlink — restore the file at dest so the model still loads.
+            std::error_code e2;
+            fs::rename(blob, dest, e2);
+            RAC_LOG_DEBUG(kLogTag, "promote(symlink) failed for %s: %s", sha256_hex.c_str(),
+                          ec.message().c_str());
+            return;
+        }
+        RAC_LOG_INFO(kLogTag, "promoted content %s to shared blob store", sha256_hex.c_str());
+        return;
+    }
+    ec.clear();
+    // Blob already exists (another model / concurrent download). Reclaim dest's bytes
+    // by replacing this duplicate with a symlink to the shared blob.
+    if (!make_symlink(blob, dest, ec)) {
+        // Restore a real file at dest from the blob so the model still loads.
+        std::error_code e2;
+        fs::copy_file(blob, dest, fs::copy_options::overwrite_existing, e2);
+    }
+}
+
+int64_t gc_orphans() {
+    if (!enabled()) return 0;
+    const std::string dir = store_dir();
+    const std::string root = models_root();
+    std::error_code ec;
+    if (!fs::exists(dir, ec) || ec) return 0;
+
+    // Mark: collect every blob (by sha filename) still referenced by a model symlink.
+    // Symlinks give no link-count refcount, so we scan the model tree once. Deletes
+    // are infrequent and each model is a handful of files, so this stays cheap.
+    std::unordered_set<std::string> referenced;
+    for (auto it = fs::recursive_directory_iterator(
+             root, fs::directory_options::skip_permission_denied, ec);
+         !ec && it != fs::recursive_directory_iterator(); it.increment(ec)) {
+        const fs::path& p = it->path();
+        if (p.filename() == kBlobDirName) {
+            it.disable_recursion_pending();  // never descend into the store itself
+            continue;
+        }
+        std::error_code e2;
+        if (!fs::is_symlink(p, e2) || e2) continue;
+        const fs::path tgt = fs::read_symlink(p, e2);
+        if (e2) continue;
+        referenced.insert(tgt.filename().string());  // the blob's sha filename
+    }
+
+    // Sweep: any blob nobody references is orphaned.
+    int64_t reclaimed = 0;
+    ec.clear();
+    for (const auto& entry : fs::directory_iterator(dir, ec)) {
+        if (ec) break;
+        std::error_code e2;
+        if (!entry.is_regular_file(e2) || e2) continue;
+        if (referenced.count(entry.path().filename().string()) > 0) continue;
+        const auto sz = fs::file_size(entry.path(), e2);
+        if (e2) continue;
+        fs::remove(entry.path(), e2);
+        if (!e2) reclaimed += static_cast<int64_t>(sz);
+    }
+    if (reclaimed > 0) {
+        RAC_LOG_INFO(kLogTag, "GC reclaimed %lld bytes of orphaned shared blobs",
+                     static_cast<long long>(reclaimed));
+    }
+    return reclaimed;
+}
+
+}  // namespace rac::download::blob_store

--- a/sdk/runanywhere-commons/src/infrastructure/download/blob_store.h
+++ b/sdk/runanywhere-commons/src/infrastructure/download/blob_store.h
@@ -1,0 +1,58 @@
+// Content-addressed blob store for de-duplicating downloaded model files.
+//
+// Multimodal / multi-bundle models (e.g. Cosmos3-Edge = text + VLM + diffusion)
+// share large weight files whose bytes are identical across bundles/repos (same
+// HuggingFace LFS oid == same sha256). Storage is keyed by model_id, so without
+// de-dup the shared decoder is downloaded and stored once per model.
+//
+// This store keeps ONE physical copy per unique content hash under
+//   {base}/RunAnywhere/Models/.blobs/<sha256>
+// and each per-model file becomes a relative SYMLINK into it. N models referencing
+// the same content cost the bytes once, and each model still sees a normal file at
+// its expected path (mmap/open follow the symlink, so the loader is unchanged — no
+// engine/manifest change).
+//
+// Why symlinks, not hardlinks: Android denies hardlinks on app-private storage
+// (f2fs + SELinux/protected_hardlinks), but permits symlinks. Symlinks carry no
+// filesystem refcount, so GC is a mark-sweep: scan the model tree for symlinks that
+// still target a blob, then delete any blob nobody references (see gc_orphans).
+//
+// Native-only: on Emscripten/OPFS symlinks don't exist, so the whole store is
+// disabled (every function is a no-op / returns false) and behavior is byte-
+// identical to the pre-dedup path (each model keeps its own copy).
+
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace rac::download::blob_store {
+
+// True when the store is usable on this build/platform (native FS with
+// hardlinks). Web/OPFS builds return false and all other calls are no-ops.
+bool enabled();
+
+// Absolute path of the blob for `sha256_hex` (does not create anything).
+std::string blob_path(const std::string& sha256_hex);
+
+// De-dup HIT: if a verified blob for `sha256_hex` already exists (and, when
+// `expected_bytes > 0`, its size matches), hardlink it into `dest` and return
+// true — the caller then SKIPS the network download entirely. Returns false when
+// the store is disabled, the hash is empty, no blob exists, or the link fails
+// (caller falls back to a normal download).
+bool link_from_blob(const std::string& sha256_hex, int64_t expected_bytes,
+                    const std::string& dest);
+
+// PROMOTE: after `dest` has been downloaded and sha-verified, publish it into the
+// store so future models de-dup against it. Best-effort: ensures `dest` ends up
+// sharing the store blob's inode. No-op on empty hash / disabled store / failure
+// (leaves `dest` as a valid standalone file). Safe under concurrent promotes.
+void promote(const std::string& sha256_hex, const std::string& dest);
+
+// Garbage-collect orphaned blobs: scan the model tree for symlinks still targeting
+// a blob, then delete any blob nobody references (every model that used it has been
+// deleted). Returns bytes reclaimed. O(total model files) mark-sweep; safe and
+// cheap to call after any model deletion.
+int64_t gc_orphans();
+
+}  // namespace rac::download::blob_store

--- a/sdk/runanywhere-commons/src/infrastructure/download/download_orchestrator.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/download/download_orchestrator.cpp
@@ -78,6 +78,7 @@
 #include "rac/infrastructure/http/rac_http_client.h"
 #include "rac/infrastructure/http/rac_http_transport.h"
 #include "rac/infrastructure/model_management/rac_model_paths.h"
+#include "blob_store.h"
 #include "rac/infrastructure/model_management/rac_model_registry.h"
 #include "rac/infrastructure/model_management/rac_model_types.h"
 
@@ -1403,7 +1404,17 @@ plan_file_step process_plan_file(const std::shared_ptr<proto_download_task>& tas
                      file.storage_key.c_str(), static_cast<long long>(file.expected_bytes));
     }
 
-    if (!already_complete) {
+    // Content-addressed de-dup: when another model already downloaded this exact
+    // content (identical sha256 from the HF LFS oid), hardlink the shared blob into
+    // place and skip the network entirely. Non-archive files only. A no-op on web /
+    // when the store is unusable, so it falls through to a normal download.
+    bool deduped = false;
+    if (!already_complete && !file.requires_extraction) {
+        deduped = rac::download::blob_store::link_from_blob(
+            file.checksum_sha256, file.expected_bytes, file.destination_path);
+    }
+
+    if (!already_complete && !deduped) {
         // Runtime free-space safety net. The planner gate runs once up front,
         // but free space can shrink between planning and this file's turn (other
         // downloads, the bytes already written by earlier files in this bundle),
@@ -1547,6 +1558,12 @@ plan_file_step process_plan_file(const std::shared_ptr<proto_download_task>& tas
         }
     } else {
         final_path = file.destination_path;
+        // Publish this verified file into the content-addressed store so future
+        // models with the same content de-dup against it (hardlink, no re-download).
+        // Skipped when it was itself a de-dup hit (already a link to the blob).
+        if (!deduped && !file.checksum_sha256.empty()) {
+            rac::download::blob_store::promote(file.checksum_sha256, file.destination_path);
+        }
     }
 
     if (total_expected > 0) {
@@ -1737,6 +1754,17 @@ bool run_parallel_direct_download_worker(const std::shared_ptr<proto_download_ta
                 continue;
             }
 
+            // Content-addressed de-dup (mirrors the sequential path): when the same
+            // content was already downloaded by another model, hardlink the shared
+            // blob in and skip the network for this part entirely.
+            if (!file.requires_extraction &&
+                rac::download::blob_store::link_from_blob(
+                    file.checksum_sha256, file.expected_bytes, file.destination_path)) {
+                update_parallel_progress(task, i, file.expected_bytes, file.expected_bytes,
+                                         total_expected, true);
+                continue;
+            }
+
             if (file.expected_bytes > 0) {
                 int64_t available = filesystem_available_bytes(file.destination_path);
                 const int64_t margin = 32LL * 1024 * 1024;  // 32 MiB headroom
@@ -1801,6 +1829,10 @@ bool run_parallel_direct_download_worker(const std::shared_ptr<proto_download_ta
             }
 
             const int64_t final_size = file_size_or_zero(file.destination_path);
+            // Publish the verified file into the shared store for future de-dup.
+            if (!file.requires_extraction && !file.checksum_sha256.empty()) {
+                rac::download::blob_store::promote(file.checksum_sha256, file.destination_path);
+            }
             update_parallel_progress(task, i, final_size,
                                      file.expected_bytes > 0 ? file.expected_bytes : final_size,
                                      total_expected, true);

--- a/sdk/runanywhere-commons/src/infrastructure/file_management/file_manager.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/file_management/file_manager.cpp
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <string>
 
+#include "infrastructure/download/blob_store.h"
 #include "rac/core/rac_logger.h"
 #include "rac/infrastructure/file_management/rac_file_manager.h"
 #include "rac/infrastructure/model_management/rac_model_paths.h"
@@ -307,6 +308,12 @@ rac_result_t rac_file_manager_delete_model(const rac_file_callbacks_t* cb, const
     }
 
     RAC_LOG_INFO(LOG_CATEGORY, "Deleted model folder");
+
+    // The deleted model's files were hardlinks into the content-addressed blob
+    // store; removing them may have orphaned shared blobs (now only referenced by
+    // the store itself). Reclaim those. No-op when the store is unused/disabled.
+    rac::download::blob_store::gc_orphans();
+
     return RAC_SUCCESS;
 }
 

--- a/sdk/runanywhere-commons/src/infrastructure/model_management/hf_resolver.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/model_management/hf_resolver.cpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <nlohmann/json.hpp>
 #include <regex>
+#include <unordered_set>
 
 #include "rac/core/rac_logger.h"
 #include "rac/infrastructure/http/rac_http_client.h"
@@ -579,6 +580,53 @@ bool is_downloadable_executable_code(const std::string& path) {
 
 }  // namespace
 
+// Recursively collect every string leaf value in `j`.
+void collect_json_strings(const nlohmann::json& j, std::vector<std::string>& out) {
+    if (j.is_string()) {
+        out.push_back(j.get<std::string>());
+    } else if (j.is_array() || j.is_object()) {
+        for (const auto& v : j) collect_json_strings(v, out);
+    }
+}
+
+// Fetch a pinned manifest and return the set of file BASENAMES it references (that also
+// exist in `bundle`). Generic — matches any JSON string value whose basename is a bundle
+// file, so it captures a manifest's artifacts (decode/embed/lmhead/vision/DiT/vae/tokenizer)
+// regardless of nesting, with zero per-framework schema in commons. Empty set => couldn't
+// prune (fetch/parse failed or nothing matched) => caller registers the whole folder.
+std::unordered_set<std::string> manifest_referenced_basenames(
+    const std::string& manifest_url, const std::vector<TreeFile>& bundle) {
+    std::unordered_set<std::string> refs;
+    rac_http_client_t* client = nullptr;
+    if (rac_http_client_create(&client) != RAC_SUCCESS || client == nullptr) return refs;
+    rac_http_request_t request = {};
+    request.method = "GET";
+    request.url = manifest_url.c_str();
+    request.timeout_ms = kTreeRequestTimeoutMs;
+    request.follow_redirects = RAC_TRUE;
+    rac_http_response_t response = {};
+    const rac_result_t rc = rac_http_request_send(client, &request, &response);
+    rac_http_client_destroy(client);
+    std::string body;
+    if (rc == RAC_SUCCESS && response.status == 200 && response.body_bytes != nullptr &&
+        response.body_len > 0) {
+        body.assign(reinterpret_cast<const char*>(response.body_bytes), response.body_len);
+    }
+    rac_http_response_free(&response);
+    if (body.empty()) return refs;
+    const nlohmann::json doc = nlohmann::json::parse(body, nullptr, /*allow_exceptions=*/false);
+    if (doc.is_discarded()) return refs;
+    std::unordered_set<std::string> bundle_basenames;
+    for (const auto& f : bundle) bundle_basenames.insert(basename_of(f.path));
+    std::vector<std::string> strings;
+    collect_json_strings(doc, strings);
+    for (const auto& s : strings) {
+        const std::string b = basename_of(s);
+        if (!b.empty() && bundle_basenames.count(b) > 0) refs.insert(b);
+    }
+    return refs;
+}
+
 rac_result_t resolve_folder_from_tree_json(const std::string& tree_json_body,
                                            const std::string& org, const std::string& repo,
                                            const std::string& subdir,
@@ -694,14 +742,34 @@ rac_result_t resolve_folder_from_tree_json(const std::string& tree_json_body,
         out->files.push_back(std::move(file));
         out->total_size_bytes += part.size_bytes;
     };
+    // Manifest-pruned download: when a specific manifest is pinned, register only the files it
+    // references (+ the manifest itself + small aux/config), so a chat manifest in a shared
+    // "understanding" repo does NOT pull the sibling vision/diffusion weights. Falls back to the
+    // whole folder when the manifest can't be fetched/parsed (referenced stays empty).
+    std::unordered_set<std::string> referenced;
+    if (!primary_rel.empty()) {
+        referenced = manifest_referenced_basenames(
+            url_base + prefix + bundle[primary_index].path, bundle);
+    }
+    constexpr int64_t kPruneMinBytes = 1 * 1024 * 1024;  // always keep tiny aux/config files
+    auto keep = [&](const TreeFile& part) {
+        if (referenced.empty()) return true;                // no prune info -> unchanged behavior
+        if (part.size_bytes < kPruneMinBytes) return true;  // small aux/config always kept
+        return referenced.count(basename_of(part.path)) > 0;
+    };
     append(bundle[primary_index], prefix + bundle[primary_index].path);
     for (size_t i = 0; i < bundle.size(); ++i) {
-        if (i != primary_index) {
+        if (i != primary_index && keep(bundle[i])) {
             append(bundle[i], prefix + bundle[i].path);
         }
     }
     if (root_config && !bundle_has_top_level_config) {
         append(*root_config, root_config->path);
+    }
+    if (!referenced.empty()) {
+        RAC_LOG_INFO(LOG_CAT, "Manifest-pruned '%s': %zu of %zu files kept (%lld bytes)",
+                     primary_rel.c_str(), out->files.size(), bundle.size(),
+                     static_cast<long long>(out->total_size_bytes));
     }
 
     out->model_id = sanitize_model_id(repo + (subdir.empty() ? "" : "-" + subdir));

--- a/sdk/runanywhere-commons/src/infrastructure/storage/storage_analyzer.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/storage/storage_analyzer.cpp
@@ -32,6 +32,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "infrastructure/download/blob_store.h"
 #include "rac/core/rac_logger.h"
 #include "rac/infrastructure/download/rac_download_orchestrator.h"
 #include "rac/infrastructure/events/rac_sdk_event_stream.h"
@@ -1314,6 +1315,13 @@ rac_result_t rac_storage_analyzer_delete_proto(rac_storage_analyzer_handle_t han
             remember_error(RAC_ERROR_INVALID_ARGUMENT);
         }
         rac_model_info_free(model);
+    }
+
+    // Deleting model folders removed their symlinks into the content-addressed blob
+    // store; reclaim any shared blob no surviving model still references. Run once
+    // after the whole batch (the GC mark-sweeps the model tree). No-op when disabled.
+    if (files_deleted && !request.dry_run()) {
+        rac::download::blob_store::gc_orphans();
     }
 
     if (request.dry_run()) {


### PR DESCRIPTION
## Cosmos3-Edge NPU on Android — text chat, VLM, and on-device text-to-image

Wires NVIDIA **Cosmos3-Edge** (Hexagon v81 / SM8850) into the Kotlin SDK + RunAnywhereAI example app across three modalities, all running on the NPU via the QHexRT backend.

### Changes
- **Catalog**: register Cosmos3-Edge **Text**, **VLM**, and **Diffusion** (arbitrary-prompt, ~4.4 GB) HNPU bundles.
- **Diffusion**: text-to-image through the public SDK route (`RunAnywhere.generateImage`) + a new **Diffusion (Image Gen)** screen in the example app.
- **Packaging**: extract native libs so the cDSP can load the HTP skel.
- **Chat (final commit)**: mark `cosmos3_edge_text` non-thinking so its direct answer renders as the reply (not an empty reasoning section), and force greedy decode for QHexRT LLMs so weak-EOS W8 bundles stop reliably instead of rambling under sampling.

### Behavior
Chat now answers once, concisely, and stops:
- *"What is the capital of France"* → **"The capital of France is Paris."** (~1.6 s, stops)
- *"and what about Japan"* → **"The capital of Japan is Tokyo."** (context-aware)

### Validation
Exercised end-to-end through the public SDK flow (`registerModel → downloadModel → loadModel → generate/generateImage → deleteModel`) on SM8850/v81; Plane B harness green (`framework=QHEXRT`, answer suite passes). Detailed device benchmarks live in the QHexRT repo per convention.

### Notes for review
- The greedy-decode policy applies to all QHexRT LLMs (reliable stopping on NPU W8 bundles); easy to narrow to a per-model flag if preferred.
- Engine-side fixes (EOS handling, system-prompt guard) are in the companion QHexRT PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added on-device text-to-image generation via Cosmos3-Edge diffusion, including QHexRT text-to-image support and updated runtime capability metadata.
  - Introduced Android “Image generation” (Diffusion) screen, navigation route, and added Cosmos3-Edge text/vision/diffusion models to the model catalogs.

- **Improvements**
  - Improved model download efficiency with shared content-addressed blob de-duplication and automatic orphan cleanup; integrated manifest-aware pruning for HF-resolved folders.
  - Improved Hugging Face token handling (settings plus local fallback) and refined framework-specific generation temperature behavior.

- **Tests**
  - Added diffusion text-to-image benchmark smoke-gates (min std, min PSNR) and expanded Android end-to-end diffusion coverage with optional reference PSNR checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->