### PR TITLE
fix(web): return null from model registry reads when no backend is installed

### DIFF
--- a/sdk/runanywhere-web/packages/core/src/Public/Extensions/RunAnywhere+ModelRegistry.ts
+++ b/sdk/runanywhere-web/packages/core/src/Public/Extensions/RunAnywhere+ModelRegistry.ts
@@ -68,20 +68,28 @@ export const ModelRegistry = {
     return requireAdapter().updateDownloadStatus(modelId, localPath);
   },
 
+  // Read APIs degrade gracefully when no backend adapter is installed yet
+  // (backends register asynchronously on Web), returning the declared `null`
+  // instead of throwing. This mirrors iOS (`RAModelGetResult(found: false)` /
+  // `RAModelListResult(success: false)`) and Kotlin, which return empty
+  // results rather than throwing on not-ready reads. Use `availability()` to
+  // distinguish "not installed" from "installed but empty". Mutating APIs above
+  // still throw via `requireAdapter()`, since a write with no registry is a
+  // caller error.
   getModel(modelId: string): ModelInfo | null {
-    return requireAdapter().get(modelId);
+    return ModelRegistryAdapter.tryDefault()?.get(modelId) ?? null;
   },
 
   listModels(): ModelInfoList | null {
-    return requireAdapter().list();
+    return ModelRegistryAdapter.tryDefault()?.list() ?? null;
   },
 
   queryModels(query: ModelQuery): ModelInfoList | null {
-    return requireAdapter().query(query);
+    return ModelRegistryAdapter.tryDefault()?.query(query) ?? null;
   },
 
   downloadedModels(): ModelInfoList | null {
-    return requireAdapter().listDownloaded();
+    return ModelRegistryAdapter.tryDefault()?.listDownloaded() ?? null;
   },
 
   removeModel(modelId: string): boolean {


### PR DESCRIPTION
## What

The Web SDK `ModelRegistry` read APIs — `getModel`, `listModels`, `queryModels`, `downloadedModels` — each declare a nullable return type (`ModelInfo | null` / `ModelInfoList | null`) but were routed through `requireAdapter()`, which **throws** `'RunAnywhere model registry proto adapter is not installed'` when no backend adapter is present. This makes them throw instead of returning their declared `null`.

This PR routes the four **read** methods through `ModelRegistryAdapter.tryDefault()` and coalesces to `null`, matching the graceful pattern `availability()` already uses in the same file. Mutating APIs (`register`, `update`, `remove`, `refresh`, `updateDownloadStatus`, `importModel`) keep throwing via `requireAdapter()`, since a write against a non-existent registry is a caller error.

## Why

- **Real runtime window.** Backends register asynchronously on Web (`LlamaCPP.register()` / `ONNX.register()` load their WASM lazily), so after `initialize()` there is a legitimate period where an app may list the catalog before a backend is installed. Today that throws; it should return the declared empty/null.
- **Cross-SDK parity (iOS is source of truth).** iOS returns `RAModelGetResult(found: false)` / `RAModelListResult(success: false)` and Kotlin returns equivalent empty results rather than throwing on a not-ready read (`RunAnywhere+ModelRegistry.swift`, `RunAnywhereModelRegistry.kt`). Web was the odd one out.
- **Callers already expect null**, confirming null (not an exception) is the intended "absent" signal:
  - `RunAnywhere+LoRA.ts:489` — `ModelRegistry.getModel(artifact.id)?.localPath ?? ''`
  - `RunAnywhere.ts:1478` (loadModel) — `ModelRegistryCapability.getModel(request.modelId) ?? undefined`
  - `RunAnywhere+ModelLifecycle.ts:350` — `safeGetModelSnapshot()` wraps `getModel` in try/catch purely to absorb this throw.
- `availability()` in the same file already returns `{ status: 'notInstalled' }` gracefully for the no-adapter case, so callers that need to distinguish "not installed" from "installed but empty" still can.

## Scope / non-goals

- Behavior for legit callers is unchanged: they use `?.` / `??` / try-catch and handle `null`. Only the failure mode changes (throw → null).
- `safeGetModelSnapshot`'s try/catch is now redundant but left in place as harmless defense-in-depth; happy to remove it if preferred.

## Testing (macOS, Node 26)

From `sdk/runanywhere-web`:
- `npm run typecheck -w packages/core` — PASS
- `npx eslint` on the changed file — PASS (0 problems)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Model registry read operations (fetching, listing, querying, and showing downloaded models) now fail gracefully when no model backend is available, returning an empty result instead of an error.
  * Model download and other modifying operations continue to surface errors when the backend is unavailable.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

---

## CI status note

The `kotlin-android` (and earlier `swift-spm`) check failures on this PR are **unrelated to this diff**, which changes a single TypeScript file in `@runanywhere/web` and touches no Kotlin, native, or Swift code.

- `swift-spm`: transient network flake fetching a C++ dependency (`Could not resolve host: github.com` cloning `nlohmann/json`). Cleared on re-trigger.
- `kotlin-android`: a flaky unit test unrelated to the web layer — `VoiceAgentStreamAdapterTest > last detach tears down the C registration` (`VoiceAgentStreamAdapterTest.kt:135`), 82/83 passing.

Both are green on `main` and on the other open PRs in the same CI window. Not re-pushing to chase infra/flaky failures; a maintainer re-run should clear the `kotlin-android` job.
