### PR TITLE
ci: OSS keyless telemetry gate

### DIFF
--- a/.github/workflows/oss-keyless-telemetry.yml
+++ b/.github/workflows/oss-keyless-telemetry.yml
@@ -9,13 +9,21 @@
 name: OSS keyless telemetry
 
 on:
+  pull_request:
+    paths:
+      - ".github/workflows/oss-keyless-telemetry.yml"
+      - "scripts/ci/oss_keyless_telemetry_blast.sh"
+      - "sdk/runanywhere-cli/**"
+      - "sdk/runanywhere-commons/src/infrastructure/network/**"
+      - "sdk/runanywhere-commons/src/lifecycle/**"
+      - "sdk/runanywhere-commons/src/core/sdk_state.cpp"
   schedule:
-    # Daily 08:00 UTC — not on PRs/pushes (avoids burning macos runners every merge).
+    # Daily 08:00 UTC — light cadence for Staging drift.
     - cron: "0 8 * * *"
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}-scheduled
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
 permissions:

--- a/.github/workflows/oss-keyless-telemetry.yml
+++ b/.github/workflows/oss-keyless-telemetry.yml
@@ -1,0 +1,50 @@
+# =============================================================================
+# OSS keyless telemetry gate — rcli development → public staging backend
+# =============================================================================
+# Primary CI for the open-source contract: build rcli in this public repo and
+# keyless-blast all 12 modalities at the staging backend (PUBLIC org). No API
+# key. Staging origin comes from repo secrets/vars — not hardcoded hosts.
+# =============================================================================
+
+name: OSS keyless telemetry
+
+on:
+  schedule:
+    # Daily 08:00 UTC — not on PRs/pushes (avoids burning macos runners every merge).
+    - cron: "0 8 * * *"
+  workflow_dispatch: {}
+
+concurrency:
+  group: ${{ github.workflow }}-scheduled
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  keyless-staging-blast:
+    name: rcli keyless → staging backend
+    runs-on: macos-14
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v7
+
+      - name: Install ninja + protobuf
+        run: brew install ninja protobuf
+
+      - name: Require staging backend origin
+        env:
+          STAGING_BASE_URL: ${{ secrets.STAGING_BASE_URL }}
+          RA_OSS_BASE_URL: ${{ vars.RA_OSS_BASE_URL }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${STAGING_BASE_URL:-}" && -z "${RA_OSS_BASE_URL:-}" ]]; then
+            echo "::error::Set repository secret STAGING_BASE_URL (or variable RA_OSS_BASE_URL) to the public staging backend origin."
+            exit 1
+          fi
+
+      - name: Build rcli + keyless blast (12 modalities)
+        env:
+          STAGING_BASE_URL: ${{ secrets.STAGING_BASE_URL }}
+          RA_OSS_BASE_URL: ${{ vars.RA_OSS_BASE_URL || secrets.STAGING_BASE_URL }}
+        run: bash scripts/ci/oss_keyless_telemetry_blast.sh

--- a/scripts/ci/oss_keyless_telemetry_blast.sh
+++ b/scripts/ci/oss_keyless_telemetry_blast.sh
@@ -1,0 +1,101 @@
+#!/usr/bin/env bash
+# OSS keyless gate: build (optional) rcli → development → public staging backend blast.
+# No API key. Asserts exit 0 and all 12 modalities stored ≥ 1.
+#
+# Requires a staging backend origin via env (never hardcode private infra hosts):
+#   STAGING_BASE_URL or RA_OSS_BASE_URL
+#
+#   STAGING_BASE_URL=https://staging.example.com ./scripts/ci/oss_keyless_telemetry_blast.sh
+#   RA_SKIP_BUILD=1 STAGING_BASE_URL=... ./scripts/ci/oss_keyless_telemetry_blast.sh
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+cd "$ROOT"
+
+OSS_URL="${RA_OSS_BASE_URL:-${STAGING_BASE_URL:-}}"
+if [[ -z "$OSS_URL" ]]; then
+  echo "Set STAGING_BASE_URL or RA_OSS_BASE_URL to the public staging backend origin." >&2
+  exit 1
+fi
+export STAGING_BASE_URL="${STAGING_BASE_URL:-$OSS_URL}"
+
+case "$(uname -s)" in
+  Darwin) PRESET="rcli-macos-release"; JOBS="$(sysctl -n hw.logicalcpu)" ;;
+  Linux)  PRESET="rcli-linux-release"; JOBS="$(nproc)" ;;
+  *)
+    echo "unsupported host OS '$(uname -s)'" >&2
+    exit 1
+    ;;
+esac
+
+RCLI="${RA_RCLI_BIN:-$ROOT/build/$PRESET/sdk/runanywhere-cli/rcli}"
+
+if [[ "${RA_SKIP_BUILD:-0}" != "1" ]]; then
+  if [[ ! -d "$ROOT/build/$PRESET" ]]; then
+    cmake --preset "$PRESET"
+  else
+    # Reconfigure so STAGING_BASE_URL is injected into generated development_config.cpp
+    cmake --preset "$PRESET"
+  fi
+  cmake --build "build/$PRESET" --target rcli -j "$JOBS"
+fi
+
+[[ -x "$RCLI" ]] || {
+  echo "rcli not executable: $RCLI" >&2
+  exit 1
+}
+
+SESSION="${RA_OSS_SESSION_ID:-oss-ci-$(date +%s)-$RANDOM}"
+TMP_HOME="$(mktemp -d "${TMPDIR:-/tmp}/oss-keyless.XXXXXX")"
+cleanup() { rm -rf "$TMP_HOME"; }
+trap cleanup EXIT
+
+# Ambient shell keys must not force JWT on the OSS path.
+unset RUNANYWHERE_API_KEY RUNANYWHERE_API_URL RUNANYWHERE_ENVIRONMENT RUNANYWHERE_BASE_URL || true
+
+export XDG_CONFIG_HOME="$TMP_HOME/config"
+export XDG_DATA_HOME="$TMP_HOME/data"
+export XDG_STATE_HOME="$TMP_HOME/state"
+export RUNANYWHERE_HOME="$TMP_HOME/home"
+
+echo "[oss-keyless] rcli=$RCLI"
+echo "[oss-keyless] base_url=$OSS_URL"
+echo "[oss-keyless] session_id=$SESSION"
+
+set +e
+OUT="$("$RCLI" --environment development \
+  --base-url "$OSS_URL" \
+  telemetry blast \
+  --processing-ms 42.5 \
+  --session-id "$SESSION" \
+  --input-tokens 128 \
+  --output-tokens 256 2>&1)"
+RC=$?
+set -e
+printf '%s\n' "$OUT"
+
+if [[ "$RC" -ne 0 ]]; then
+  echo "[oss-keyless] FAIL: rcli exited $RC" >&2
+  exit "$RC"
+fi
+
+MODALITIES=(llm stt tts vlm rag imagegen embeddings vad voice lora model system)
+missing=0
+for m in "${MODALITIES[@]}"; do
+  if ! printf '%s\n' "$OUT" | awk -v mod="$m" '
+    $1 == mod && $2 == "ok" {
+      for (i = 1; i <= NF; i++) if ($i ~ /^[0-9]+$/) nums[++n] = $i
+      if (n >= 3 && nums[n-1] + 0 >= 1) { found = 1; exit }
+    }
+    END { exit found ? 0 : 1 }
+  '; then
+    echo "[oss-keyless] FAIL: modality '$m' not ok / stored < 1" >&2
+    missing=1
+  fi
+done
+
+if [[ "$missing" -ne 0 ]]; then
+  exit 1
+fi
+
+echo "[oss-keyless] OK — 12/12 modalities stored (session_id=$SESSION)"


### PR DESCRIPTION
## Summary
- Add daily + manual GitHub Action that builds `rcli` and keyless-blasts all 12 telemetry modalities at the public staging backend (PUBLIC org).
- Staging origin is read from secret `STAGING_BASE_URL` / var `RA_OSS_BASE_URL` (already set) — no hardcoded hosts.

## Test plan
- [x] Local: `RA_SKIP_BUILD=1 STAGING_BASE_URL=... ./scripts/ci/oss_keyless_telemetry_blast.sh` → 12/12
- [x] Supabase MCP quality SQL on session `oss-ci-1784770421-30596` → required fields non-null, PUBLIC org, children present, LLM tokens 128/256
- [ ] After merge: `gh workflow run "OSS keyless telemetry"` goes green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added automated macOS validation for keyless telemetry reporting against the staging environment.
  * Added scheduled and manually triggered checks, with pull-request validation for related changes.
  * Added verification that all required telemetry metrics are successfully processed and stored.
  * Added isolated test execution to prevent local credentials or configuration from affecting results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->