### PR TITLE
Hybrid streaming voice agent (NPU LLM + CPU STT/TTS)

### DIFF
--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/models/ModelRecommendation.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/models/ModelRecommendation.kt
@@ -144,9 +144,19 @@ object ModelRecommendation {
         val byId = models.associateBy { it.id }
         val preferNpu = hasNpu && tier == HardwareTier.HIGH_END
         return VoicePipeline(
-            stt = pickAsr(preferNpu, hasNpu, budget, byId, models),
+            // The voice PIPELINE keeps STT on CPU (sherpa) even on NPU devices: an
+            // NPU STT would fight the NPU LLM for the single Hexagon slot, forcing a
+            // slow per-turn Whisper<->LLM swap. CPU STT leaves the slot for the LLM
+            // (which stays warm) and routes the turn through the streaming hybrid path
+            // (useNpuSwap=false). NPU Whisper is still preferred for standalone
+            // dictation via recommendedFor(STT); this falls back to NPU only if no
+            // CPU ASR is available.
+            stt = pickAsr(preferNpu = false, hasNpu, budget, byId, models),
             llm = pickLLMs(tier, preferNpu, budget, byId, models).firstOrNull(),
-            tts = pickTts(preferNpu, hasNpu, budget, byId, models),
+            // TTS also stays on CPU (sherpa piper) for the same reason as STT: an NPU
+            // TTS would contend with the NPU LLM for the single Hexagon slot. Only the
+            // LLM runs on the NPU in the hybrid pipeline.
+            tts = pickTts(preferNpu = false, hasNpu, budget, byId, models),
             // VAD is tiny + backend-neutral (ONNX Silero); include it so the pipeline is
             // fully pre-staged. The voice agent also auto-ensures it, so it's a nicety.
             vad = pickCategory(

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/voice/VoiceScreen.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/voice/VoiceScreen.kt
@@ -146,11 +146,15 @@ fun VoiceScreen() {
         scope.launch {
             isPreparing = true
             try {
-                // Sequential so per-component progress reads cleanly and memory stays bounded.
+                // Sequential so per-component progress reads cleanly and memory stays
+                // bounded. Best-effort: download (and load) EVERY component. A load
+                // failure on one model — e.g. a 2nd NPU model that can't co-reside with
+                // the first in the single Hexagon slot — must NOT abort downloading the
+                // remaining required models (this used to `break` here, so it stopped
+                // after the first and left the rest un-downloaded).
                 for (component in components) {
                     val model = component.model ?: continue
-                    val ok = component.viewModel.prepare(model)
-                    if (!ok && !component.optional) break
+                    component.viewModel.prepare(model)
                 }
             } finally {
                 isPreparing = false

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/voice/VoiceViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/voice/VoiceViewModel.kt
@@ -53,6 +53,13 @@ class VoiceViewModel : ViewModel() {
     private var cleanupJob: Job? = null
     private var assistantTurnIndex: Int? = null
 
+    // True while the in-flight turn's transcript is an STT non-speech hallucination
+    // (e.g. "[BLANK_AUDIO]", "[wind blowing]" on silence). Such a turn's user/
+    // assistant text is kept out of the UI so an always-on session does not fill
+    // the transcript with — and appear to loop over — its own ambient noise. The
+    // SDK separately mutes the phantom reply's audio.
+    private var phantomTurn = false
+
     // NPU per-turn-swap path: a single-slot Hexagon NPU cannot hold the STT and the chat LLM at once, so
     // the shared voice-agent (which requires all components co-resident) can't run there. When both the
     // recognizer and the chat model are QHexRT we drive the turn manually — record -> transcribe (loads
@@ -156,7 +163,10 @@ class VoiceViewModel : ViewModel() {
                 state = VoiceState.TRANSCRIBING
                 withContext(Dispatchers.IO) { RunAnywhere.loadModel(RAModelLoadRequest(model_id = stt.id)) }
                 val transcript = RunAnywhere.transcribe(audio).text.trim()
-                if (transcript.isBlank()) { state = VoiceState.IDLE; return@launch }
+                // Drop blank + non-speech hallucinations ("[BLANK_AUDIO]", "[wind
+                // blowing]") so this push-to-talk NPU-swap path ignores them the
+                // same way the streaming handleEvent path does.
+                if (isNonSpeechTranscript(transcript)) { state = VoiceState.IDLE; return@launch }
                 turns += VoiceTurn(transcript, isUser = true)
                 assistantTurnIndex = null
                 // 2. Load the chat LLM (evicts Whisper) and produce the reply.
@@ -294,22 +304,29 @@ class VoiceViewModel : ViewModel() {
         }
         event.user_said?.let { userSaid ->
             val text = userSaid.text.trim()
-            if (userSaid.is_final && text.isNotBlank()) {
-                turns += VoiceTurn(text, isUser = true)
-                assistantTurnIndex = null
+            if (userSaid.is_final) {
+                // Drop phantom (non-speech hallucination) turns from the UI; the
+                // SDK mutes their audio, so the whole turn is silently ignored.
+                phantomTurn = isNonSpeechTranscript(text)
+                if (!phantomTurn && text.isNotBlank()) {
+                    turns += VoiceTurn(text, isUser = true)
+                    assistantTurnIndex = null
+                }
             }
         }
         event.agent_response_started?.let {
-            state = VoiceState.THINKING
-            ensureAssistantTurn()
+            if (!phantomTurn) {
+                state = VoiceState.THINKING
+                ensureAssistantTurn()
+            }
         }
         event.assistant_token?.let { token ->
-            if (token.text.isNotEmpty() && token.kind.isDisplayableVoiceAnswer()) {
+            if (!phantomTurn && token.text.isNotEmpty() && token.kind.isDisplayableVoiceAnswer()) {
                 state = VoiceState.THINKING
                 appendAssistantToken(token.text)
             }
         }
-        if (event.audio != null || event.agent_response_completed != null) {
+        if (!phantomTurn && (event.audio != null || event.agent_response_completed != null)) {
             state = VoiceState.SPEAKING
         }
         event.session_stopped?.let { state = VoiceState.IDLE }
@@ -361,3 +378,21 @@ class VoiceViewModel : ViewModel() {
 
 internal fun TokenKind.isDisplayableVoiceAnswer(): Boolean =
     this == TokenKind.TOKEN_KIND_ANSWER || this == TokenKind.TOKEN_KIND_UNSPECIFIED
+
+// True when the transcript carries no real speech — empty, or nothing but
+// bracketed/parenthesized non-speech tags ("[BLANK_AUDIO]", "[wind blowing]",
+// "(music)"), punctuation, or symbols. Mirrors the SDK-side guard; kept local
+// because the SDK's copy is module-internal. Real speech always leaves an
+// alphanumeric char outside any tag, so genuine utterances are never dropped.
+internal fun isNonSpeechTranscript(text: String?): Boolean {
+    if (text.isNullOrEmpty()) return true
+    var depth = 0
+    for (c in text) {
+        when (c) {
+            '[', '(', '{', '<' -> depth++
+            ']', ')', '}', '>' -> if (depth > 0) depth--
+            else -> if (depth == 0 && c.isLetterOrDigit()) return false
+        }
+    }
+    return true
+}

--- a/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_d7_abi.cpp
+++ b/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_d7_abi.cpp
@@ -18,6 +18,7 @@
  */
 
 #include <algorithm>
+#include <cctype>
 #include <chrono>
 #include <cstdint>
 #include <cstdlib>
@@ -59,6 +60,7 @@
 #include "rac_voice_event_abi_internal.h"
 #include "voice_agent_internal.h"
 #include "voice_agent_internal_helpers.h"
+#include "voice_agent_tts_chunking.h"
 
 #if defined(RAC_HAVE_PROTOBUF)
 
@@ -199,7 +201,8 @@ void d7_emit_assistant_token(rac_voice_agent_handle_t handle, const char* text, 
 void d7_emit_audio(rac_voice_agent_handle_t handle, const void* data, size_t size,
                    int32_t sample_rate, bool is_final, const std::string& session_id,
                    const std::string& turn_id, const std::string& request_id,
-                   rac_voice_agent_turn_event_callback_fn cb, void* user_data) {
+                   rac_voice_agent_turn_event_callback_fn cb, void* user_data,
+                   int32_t chunk_index = 0) {
     runanywhere::v1::VoiceEvent event;
     event.set_category(runanywhere::v1::EVENT_CATEGORY_TTS);
     event.set_severity(runanywhere::v1::ERROR_SEVERITY_INFO);
@@ -211,6 +214,7 @@ void d7_emit_audio(rac_voice_agent_handle_t handle, const void* data, size_t siz
     a->set_channels(1);
     a->set_encoding(runanywhere::v1::AUDIO_ENCODING_PCM_F32_LE);
     a->set_is_final(is_final);
+    a->set_chunk_index(chunk_index);
     d7_emit_voice_event(handle, &event, session_id, turn_id, request_id, cb, user_data);
 }
 
@@ -400,6 +404,231 @@ void d7_emit_cancelled(rac_voice_agent_handle_t handle,
                   event_callback, user_data);
     rac::voice_agent::detail::emit_turn_lifecycle(
         handle, runanywhere::v1::TURN_LIFECYCLE_EVENT_KIND_CANCELLED);
+}
+
+// ---------------------------------------------------------------------------
+// Streaming LLM -> TTS bridge (hybrid voice: NPU LLM + CPU TTS).
+//
+// Instead of blocking for the whole answer and then synthesizing it in one shot,
+// we consume the LLM token stream, cut it into speakable sentences with the shared
+// chunk policy, synthesize each sentence, and emit it as its own AudioFrameEvent
+// (is_final=false). Audio therefore starts after the FIRST sentence, and the app
+// plays sentence N while commons generates+synthesizes N+1. When the LLM is on the
+// NPU and TTS is on CPU (sherpa) the two never contend for the single Hexagon slot.
+// ---------------------------------------------------------------------------
+
+using rac::voice_agent::detail::cap_for_tts;
+using rac::voice_agent::detail::drain_sentences;
+
+struct D7StreamOutcome {
+    rac_result_t status = RAC_SUCCESS;  // SUCCESS, CANCELLED, or a generation/synthesis error
+    std::string full_text;              // raw LLM text (with <think>) for split_voice_response
+    int32_t tokens = 0;
+    std::vector<uint8_t> pcm;    // all synthesized float32-LE audio, concatenated (out_result WAV)
+    int32_t sample_rate = 0;     // sample rate of the first synthesized chunk
+    int32_t chunk_index = 0;     // running AudioFrameEvent index; == emitted count when done
+    bool any_audio = false;
+    bool playing_state_emitted = false;  // did we already move GENERATING_RESPONSE -> PLAYING_TTS
+    double tts_ms = 0.0;                 // accumulated synthesis wall time
+};
+
+struct D7StreamState {
+    rac_voice_agent_handle_t handle;
+    bool have_lifecycle_tts;
+    rac::lifecycle::LifecycleTtsRef* tts_ref;
+    const std::string* session_id;
+    const std::string* turn_id;
+    const std::string* request_id;
+    rac_voice_agent_turn_event_callback_fn cb;
+    void* user_data;
+    D7TurnCancellationScope* cancellation;
+    std::string buf;  // token accumulation handed to drain_sentences
+    D7StreamOutcome* out;
+};
+
+// Synthesize one already-sanitized sentence (hard-capped for the TTS phoneme
+// limit) and emit each capped piece as an AudioFrameEvent. Returns non-SUCCESS to
+// abort the turn (cancellation or a synthesis error).
+rac_result_t d7_synth_and_emit(D7StreamState& st, const std::string& sentence) {
+    for (const std::string& piece : cap_for_tts(sentence)) {
+        if (piece.empty())
+            continue;
+        if (st.cancellation->cancelled())
+            return RAC_ERROR_CANCELLED;
+
+        rac_tts_result_t tts = {};
+        rac_result_t rc;
+        const auto t0 = std::chrono::steady_clock::now();
+        if (st.have_lifecycle_tts) {
+            rac_tts_service_t tts_service{st.tts_ref->ops, st.tts_ref->impl, st.tts_ref->model_id};
+            rc = rac_tts_synthesize(&tts_service, piece.c_str(), nullptr, &tts);
+        } else {
+            rc = rac_tts_component_synthesize(st.handle->tts_handle, piece.c_str(), nullptr, &tts);
+        }
+        st.out->tts_ms +=
+            std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t0).count();
+        if (rc != RAC_SUCCESS) {
+            rac_tts_result_free(&tts);
+            return rc;
+        }
+
+        // First audio chunk moves the documented pipeline into PLAYING_TTS.
+        if (!st.out->playing_state_emitted) {
+            st.out->playing_state_emitted = true;
+            d7_emit_state(st.handle, runanywhere::v1::PIPELINE_STATE_GENERATING_RESPONSE,
+                          runanywhere::v1::PIPELINE_STATE_PLAYING_TTS, *st.session_id, *st.turn_id,
+                          *st.request_id, st.cb, st.user_data);
+        }
+        const int32_t sr = tts.sample_rate > 0 ? tts.sample_rate : RAC_TTS_DEFAULT_SAMPLE_RATE;
+        if (st.out->sample_rate == 0)
+            st.out->sample_rate = sr;
+        const bool has_pcm = tts.audio_data && tts.audio_size > 0;
+        d7_emit_audio(st.handle, has_pcm ? tts.audio_data : nullptr, has_pcm ? tts.audio_size : 0,
+                      sr, /*is_final=*/false, *st.session_id, *st.turn_id, *st.request_id, st.cb,
+                      st.user_data, st.out->chunk_index++);
+        if (has_pcm) {
+            const uint8_t* b = static_cast<const uint8_t*>(tts.audio_data);
+            st.out->pcm.insert(st.out->pcm.end(), b, b + tts.audio_size);
+            st.out->any_audio = true;
+        }
+        rac_tts_result_free(&tts);
+    }
+    return RAC_SUCCESS;
+}
+
+// rac_llm_stream_callback_fn: fired per token on the calling thread. Accumulates
+// text, drains any completed sentences, and synthesizes+emits them inline. Return
+// RAC_FALSE to stop generation (cancellation or a fatal synthesis error).
+rac_bool_t d7_on_llm_token(const char* token, void* user_data) {
+    D7StreamState& st = *static_cast<D7StreamState*>(user_data);
+    if (st.cancellation->cancelled()) {
+        st.out->status = RAC_ERROR_CANCELLED;
+        return RAC_FALSE;
+    }
+    if (token && token[0] != '\0') {
+        st.out->full_text += token;
+        st.buf += token;
+        st.out->tokens += 1;
+    }
+    for (const std::string& sentence : drain_sentences(st.buf, /*flush=*/false)) {
+        const rac_result_t rc = d7_synth_and_emit(st, sentence);
+        if (rc != RAC_SUCCESS) {
+            st.out->status = rc;
+            return RAC_FALSE;
+        }
+    }
+    return RAC_TRUE;
+}
+
+// Drive the whole LLM->TTS response. Lifecycle LLMs stream (NPU decode overlaps CPU
+// synthesis); the legacy per-handle component path (no single-callback stream API)
+// generates fully, then streams the TTS from the finished answer.
+D7StreamOutcome d7_stream_response(rac_voice_agent_handle_t handle, bool have_lifecycle_llm,
+                                   rac::llm::LifecycleLlmRef* llm_ref, bool have_lifecycle_tts,
+                                   rac::lifecycle::LifecycleTtsRef* tts_ref, const char* prompt,
+                                   const rac_llm_options_t* llm_opts, const std::string& session_id,
+                                   const std::string& turn_id, const std::string& request_id,
+                                   rac_voice_agent_turn_event_callback_fn cb, void* user_data,
+                                   D7TurnCancellationScope& cancellation) {
+    D7StreamOutcome out;
+    D7StreamState st{handle,   have_lifecycle_tts, tts_ref, &session_id,   &turn_id,     &request_id,
+                     cb,       user_data,          &cancellation,          std::string(), &out};
+
+    if (have_lifecycle_llm && llm_ref->ops != nullptr && llm_ref->ops->generate_stream != nullptr) {
+        rac_llm_service_t llm_service{llm_ref->ops, llm_ref->impl, llm_ref->model_id};
+        const rac_result_t gen_rc =
+            rac_llm_generate_stream(&llm_service, prompt, llm_opts, d7_on_llm_token, &st);
+        if (out.status == RAC_SUCCESS && gen_rc != RAC_SUCCESS)
+            out.status = gen_rc;
+    } else if (have_lifecycle_llm && llm_ref->ops != nullptr && llm_ref->ops->generate != nullptr) {
+        // Lifecycle LLM without a streaming op: generate the whole answer, then
+        // chunk the finished text through TTS (same shape as the component path
+        // below). Keeps non-streaming backends — and the unit-test mock — working
+        // instead of failing the turn on a missing generate_stream.
+        rac_llm_service_t llm_service{llm_ref->ops, llm_ref->impl, llm_ref->model_id};
+        rac_llm_result_t llm = {};
+        const rac_result_t gen_rc = rac_llm_generate(&llm_service, prompt, llm_opts, &llm);
+        if (gen_rc != RAC_SUCCESS) {
+            rac_llm_result_free(&llm);
+            out.status = gen_rc;
+            return out;
+        }
+        if (llm.text) {
+            out.full_text = llm.text;
+            st.buf = llm.text;
+        }
+        out.tokens = llm.completion_tokens;
+        rac_llm_result_free(&llm);
+    } else {
+        rac_llm_result_t llm = {};
+        const rac_result_t gen_rc =
+            rac_llm_component_generate(handle->llm_handle, prompt, llm_opts, &llm);
+        if (gen_rc != RAC_SUCCESS) {
+            rac_llm_result_free(&llm);
+            out.status = gen_rc;
+            return out;
+        }
+        if (llm.text) {
+            out.full_text = llm.text;
+            st.buf = llm.text;
+        }
+        out.tokens = llm.completion_tokens;
+        rac_llm_result_free(&llm);
+    }
+    if (out.status != RAC_SUCCESS)
+        return out;
+
+    // Flush the trailing partial (and, for the component path, the whole buffered
+    // answer) through the chunker to TTS.
+    for (const std::string& sentence : drain_sentences(st.buf, /*flush=*/true)) {
+        const rac_result_t rc = d7_synth_and_emit(st, sentence);
+        if (rc != RAC_SUCCESS) {
+            out.status = rc;
+            return out;
+        }
+    }
+    return out;
+}
+
+// Whisper (and other STT engines) emit bracketed / parenthesized non-speech
+// tags when handed silence or ambient noise — "[BLANK_AUDIO]", "[wind blowing]",
+// "(music)", "[ Silence ]", "<no speech>", "♪♪♪", "...", etc. In an always-on
+// listening session the mic keeps capping ~15 s buffers of near-silence between
+// the user's real utterances; if such a phantom transcript is treated as user
+// speech, the agent answers its own ambient noise and loops forever. Treat a
+// transcript that reduces to nothing but bracketed tags, punctuation, or symbols
+// as empty so the turn is skipped. Real speech always leaves alphanumeric
+// characters OUTSIDE brackets, so this never drops a genuine utterance.
+bool transcript_is_non_speech(const char* text) {
+    if (text == nullptr) {
+        return true;
+    }
+    int depth = 0;
+    for (const char* p = text; *p != '\0'; ++p) {
+        const unsigned char c = static_cast<unsigned char>(*p);
+        if (c == '[' || c == '(' || c == '{' || c == '<') {
+            ++depth;
+            continue;
+        }
+        if (c == ']' || c == ')' || c == '}' || c == '>') {
+            if (depth > 0) {
+                --depth;
+            }
+            continue;
+        }
+        if (depth > 0) {
+            continue;  // inside a non-speech tag
+        }
+        // Content = ASCII alphanumeric OR any non-ASCII byte (>= 0x80). The latter
+        // covers every UTF-8 multibyte codepoint, so non-Latin scripts (Chinese,
+        // Arabic, Japanese, …) count as real speech rather than being byte-wise
+        // misclassified as non-speech and dropped. Matches Kotlin's Unicode-aware
+        // Char.isLetterOrDigit() closely enough for this gate's purpose.
+        if (std::isalnum(c) != 0 || c >= 0x80) {
+            return false;  // real content outside any tag → genuine speech
+        }
+    }
+    return true;
 }
 
 }  // namespace
@@ -632,6 +861,25 @@ rac_result_t d7_process_utterance(rac_voice_agent_handle_t handle, const std::st
                                "STT transcription was empty");
         return RAC_ERROR_INVALID_STATE;
     }
+    if (transcript_is_non_speech(stt.text)) {
+        // STT hallucinated a non-speech tag (e.g. "[BLANK_AUDIO]", "[wind
+        // blowing]") on a silence/noise buffer. Skip the turn QUIETLY — no LLM,
+        // no TTS, and NO error event — and drop back to listening, so an
+        // always-on session does not answer its own ambient noise in a loop.
+        rac_stt_result_free(&stt);
+        if (have_lifecycle_stt) {
+            rac::lifecycle::release_lifecycle_stt(&stt_ref);
+        }
+        if (turn_has_speech) {
+            d7_emit_vad(handle, runanywhere::v1::VAD_STREAM_EVENT_KIND_SPEECH_ACTIVITY,
+                        /*is_speech=*/false, session_id, turn_id, request_id, event_callback,
+                        user_data);
+        }
+        d7_emit_state(handle, runanywhere::v1::PIPELINE_STATE_PROCESSING_SPEECH,
+                      runanywhere::v1::PIPELINE_STATE_IDLE, session_id, turn_id, request_id,
+                      event_callback, user_data);
+        return RAC_SUCCESS;
+    }
     // Only emit the matching "speech ended" event if we
     // previously emitted "speech started" for this turn. Emitting
     // SPEECH_ENDED unconditionally would still desynchronize frontends
@@ -676,81 +924,94 @@ rac_result_t d7_process_utterance(rac_voice_agent_handle_t handle, const std::st
         llm_opts.n_history = static_cast<int32_t>(history_ptrs.size());
     }
 
-    rac_llm_result_t llm = {};
-    const auto t_llm = std::chrono::steady_clock::now();
     if (have_lifecycle_llm) {
         // Every turn owns a fresh cancellation scope. Clear only the
         // lifecycle bookkeeping bit here; each backend resets its own
         // request-scoped cancel state when generation begins.
         rac::llm::clear_lifecycle_llm_cancel(&llm_ref);
     }
+
+    // Acquire the TTS voice BEFORE generation: the streaming path synthesizes and
+    // emits audio from INSIDE the LLM token stream, so the voice must be resident
+    // when the first sentence lands. In the hybrid deployment the LLM is QHexRT
+    // (NPU) and STT/TTS are sherpa (CPU), so they never contend for the single
+    // Hexagon slot and CPU synthesis overlaps NPU decode.
+    rac::lifecycle::LifecycleTtsRef tts_ref{};
+    const bool have_lifecycle_tts = rac::lifecycle::acquire_lifecycle_tts(&tts_ref) == RAC_SUCCESS;
+
+    auto release_pipeline = [&]() {
+        if (have_lifecycle_tts) {
+            rac::lifecycle::release_lifecycle_tts(&tts_ref);
+        }
+        if (have_lifecycle_llm) {
+            rac::llm::release_lifecycle_llm(&llm_ref);
+        }
+        if (have_lifecycle_stt) {
+            rac::lifecycle::release_lifecycle_stt(&stt_ref);
+        }
+    };
+
+    // LLM generation and streaming TTS run under one cancellation stage: barge-in
+    // cancels the LLM (halting generation), and the token callback then stops
+    // enqueuing further speech.
     if (!cancellation.begin_stage(rac_voice_agent_turn_stage::llm) ||
         !cancellation.begin_backend()) {
         rac_stt_result_free(&stt);
-        if (have_lifecycle_llm) {
-            rac::llm::release_lifecycle_llm(&llm_ref);
-        }
-        if (have_lifecycle_stt) {
-            rac::lifecycle::release_lifecycle_stt(&stt_ref);
-        }
+        release_pipeline();
         turn_metrics.error_code = RAC_ERROR_CANCELLED;
         turn_metrics.error_message = "Voice turn cancelled";
         d7_emit_cancelled(handle, runanywhere::v1::PIPELINE_STATE_GENERATING_RESPONSE, session_id,
                           turn_id, request_id, event_callback, user_data);
         return RAC_ERROR_CANCELLED;
     }
-    if (have_lifecycle_llm) {
-        rac_llm_service_t llm_service{llm_ref.ops, llm_ref.impl, llm_ref.model_id};
-        rc = rac_llm_generate(&llm_service, stt.text, &llm_opts, &llm);
-    } else {
-        rc = rac_llm_component_generate(handle->llm_handle, stt.text, &llm_opts, &llm);
-    }
+
+    const auto t_response = std::chrono::steady_clock::now();
+    D7StreamOutcome stream =
+        d7_stream_response(handle, have_lifecycle_llm, &llm_ref, have_lifecycle_tts, &tts_ref,
+                           stt.text, &llm_opts, session_id, turn_id, request_id, event_callback,
+                           user_data, cancellation);
     cancellation.end_stage();
-    turn_metrics.llm_ms =
-        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_llm).count();
-    turn_metrics.tokens = llm.completion_tokens;
-    if (cancellation.cancelled()) {
+    const double response_ms =
+        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_response)
+            .count();
+    turn_metrics.tts_ms = stream.tts_ms;
+    // Streaming interleaves decode and synthesis; attribute the non-synthesis wall
+    // time to the LLM as an approximation.
+    turn_metrics.llm_ms = response_ms > stream.tts_ms ? response_ms - stream.tts_ms : 0.0;
+    turn_metrics.tokens = stream.tokens;
+
+    if (cancellation.cancelled() || stream.status == RAC_ERROR_CANCELLED) {
         rac_stt_result_free(&stt);
-        rac_llm_result_free(&llm);
-        if (have_lifecycle_llm) {
-            rac::llm::release_lifecycle_llm(&llm_ref);
-        }
-        if (have_lifecycle_stt) {
-            rac::lifecycle::release_lifecycle_stt(&stt_ref);
-        }
+        release_pipeline();
         turn_metrics.error_code = RAC_ERROR_CANCELLED;
         turn_metrics.error_message = "Voice turn cancelled";
-        d7_emit_cancelled(handle, runanywhere::v1::PIPELINE_STATE_GENERATING_RESPONSE, session_id,
-                          turn_id, request_id, event_callback, user_data);
+        d7_emit_cancelled(handle,
+                          stream.playing_state_emitted
+                              ? runanywhere::v1::PIPELINE_STATE_PLAYING_TTS
+                              : runanywhere::v1::PIPELINE_STATE_GENERATING_RESPONSE,
+                          session_id, turn_id, request_id, event_callback, user_data);
         return RAC_ERROR_CANCELLED;
     }
-    if (rc != RAC_SUCCESS) {
-        if (have_lifecycle_llm) {
-            rac::llm::release_lifecycle_llm(&llm_ref);
-        }
+    if (stream.status != RAC_SUCCESS) {
+        // A synthesis error surfaces once audio has begun (tts); anything earlier
+        // is a generation failure (llm).
+        const char* failed = stream.any_audio ? "tts" : "llm";
         rac_stt_result_free(&stt);
-        if (have_lifecycle_stt) {
-            rac::lifecycle::release_lifecycle_stt(&stt_ref);
-        }
-        turn_metrics.error_code = rc;
-        turn_metrics.error_message = "LLM generation failed";
-        d7_emit_error(handle, rc, "llm", "LLM generation failed", session_id, turn_id, request_id,
-                      event_callback, user_data);
-        emit_component_failure(handle, "llm", rc, "LLM generation failed");
-        return rc;
+        release_pipeline();
+        turn_metrics.error_code = stream.status;
+        turn_metrics.error_message = "Voice response streaming failed";
+        d7_emit_error(handle, stream.status, failed, "Voice response streaming failed", session_id,
+                      turn_id, request_id, event_callback, user_data);
+        emit_component_failure(handle, failed, stream.status, "Voice response streaming failed");
+        return stream.status;
     }
-    const VoiceResponseParts response = split_voice_response(llm.text);
+
+    const VoiceResponseParts response = split_voice_response(stream.full_text.c_str());
     turn_metrics.response_chars = static_cast<int32_t>(response.answer.size());
     const rac_result_t response_status = validate_voice_response(response);
     if (response_status != RAC_SUCCESS) {
         rac_stt_result_free(&stt);
-        rac_llm_result_free(&llm);
-        if (have_lifecycle_llm) {
-            rac::llm::release_lifecycle_llm(&llm_ref);
-        }
-        if (have_lifecycle_stt) {
-            rac::lifecycle::release_lifecycle_stt(&stt_ref);
-        }
+        release_pipeline();
         turn_metrics.error_code = response_status;
         turn_metrics.error_message = kVoiceAgentEmptyResponseMessage;
         d7_emit_error(handle, response_status, "llm", kVoiceAgentEmptyResponseMessage, session_id,
@@ -775,6 +1036,8 @@ rac_result_t d7_process_utterance(rac_voice_agent_handle_t handle, const std::st
         }
     }
 
+    // Emit the full assistant text (thinking + answer) for text-facing subscribers;
+    // the spoken audio has already streamed out sentence-by-sentence above.
     if (!response.thinking.empty()) {
         d7_emit_assistant_token(handle, response.thinking.c_str(), false,
                                 runanywhere::v1::TOKEN_KIND_THOUGHT, session_id, turn_id,
@@ -784,91 +1047,22 @@ rac_result_t d7_process_utterance(rac_voice_agent_handle_t handle, const std::st
                             runanywhere::v1::TOKEN_KIND_ANSWER, session_id, turn_id, request_id,
                             event_callback, user_data);
 
-    d7_emit_state(handle, runanywhere::v1::PIPELINE_STATE_GENERATING_RESPONSE,
-                  runanywhere::v1::PIPELINE_STATE_PLAYING_TTS, session_id, turn_id, request_id,
-                  event_callback, user_data);
-
-    rac::lifecycle::LifecycleTtsRef tts_ref{};
-    const bool have_lifecycle_tts = rac::lifecycle::acquire_lifecycle_tts(&tts_ref) == RAC_SUCCESS;
-    rac_tts_result_t tts = {};
-    const auto t_tts = std::chrono::steady_clock::now();
-    if (!cancellation.begin_stage(rac_voice_agent_turn_stage::tts) ||
-        !cancellation.begin_backend()) {
-        if (have_lifecycle_tts) {
-            rac::lifecycle::release_lifecycle_tts(&tts_ref);
-        }
-        rac_stt_result_free(&stt);
-        rac_llm_result_free(&llm);
-        if (have_lifecycle_llm) {
-            rac::llm::release_lifecycle_llm(&llm_ref);
-        }
-        if (have_lifecycle_stt) {
-            rac::lifecycle::release_lifecycle_stt(&stt_ref);
-        }
-        turn_metrics.error_code = RAC_ERROR_CANCELLED;
-        turn_metrics.error_message = "Voice turn cancelled";
-        d7_emit_cancelled(handle, runanywhere::v1::PIPELINE_STATE_PLAYING_TTS, session_id, turn_id,
-                          request_id, event_callback, user_data);
-        return RAC_ERROR_CANCELLED;
-    }
-    if (have_lifecycle_tts) {
-        rac_tts_service_t tts_service{tts_ref.ops, tts_ref.impl, tts_ref.model_id};
-        rc = rac_tts_synthesize(&tts_service, response.answer.c_str(), nullptr, &tts);
-    } else {
-        rc = rac_tts_component_synthesize(handle->tts_handle, response.answer.c_str(), nullptr,
-                                          &tts);
-    }
-    cancellation.end_stage();
-    turn_metrics.tts_ms =
-        std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_tts).count();
-    if (cancellation.cancelled()) {
-        rac_tts_result_free(&tts);
-        if (have_lifecycle_tts) {
-            rac::lifecycle::release_lifecycle_tts(&tts_ref);
-        }
-        rac_stt_result_free(&stt);
-        rac_llm_result_free(&llm);
-        if (have_lifecycle_llm) {
-            rac::llm::release_lifecycle_llm(&llm_ref);
-        }
-        if (have_lifecycle_stt) {
-            rac::lifecycle::release_lifecycle_stt(&stt_ref);
-        }
-        turn_metrics.error_code = RAC_ERROR_CANCELLED;
-        turn_metrics.error_message = "Voice turn cancelled";
-        d7_emit_cancelled(handle, runanywhere::v1::PIPELINE_STATE_PLAYING_TTS, session_id, turn_id,
-                          request_id, event_callback, user_data);
-        return RAC_ERROR_CANCELLED;
-    }
-    if (rc != RAC_SUCCESS) {
-        if (have_lifecycle_tts) {
-            rac::lifecycle::release_lifecycle_tts(&tts_ref);
-        }
-        rac_stt_result_free(&stt);
-        rac_llm_result_free(&llm);
-        if (have_lifecycle_llm) {
-            rac::llm::release_lifecycle_llm(&llm_ref);
-        }
-        if (have_lifecycle_stt) {
-            rac::lifecycle::release_lifecycle_stt(&stt_ref);
-        }
-        turn_metrics.error_code = rc;
-        turn_metrics.error_message = "TTS synthesis failed";
-        d7_emit_error(handle, rc, "tts", "TTS synthesis failed", session_id, turn_id, request_id,
+    // If no speakable audio streamed (an empty/degenerate answer), still move
+    // through PLAYING_TTS so the documented state machine stays valid.
+    if (!stream.playing_state_emitted) {
+        d7_emit_state(handle, runanywhere::v1::PIPELINE_STATE_GENERATING_RESPONSE,
+                      runanywhere::v1::PIPELINE_STATE_PLAYING_TTS, session_id, turn_id, request_id,
                       event_callback, user_data);
-        emit_component_failure(handle, "tts", rc, "TTS synthesis failed");
-        return rc;
     }
+    // Terminal audio frame: is_final=true marks end-of-stream for consumers (the
+    // spoken chunks above were all emitted with is_final=false).
+    d7_emit_audio(handle, nullptr, 0,
+                  stream.sample_rate > 0 ? stream.sample_rate : RAC_TTS_DEFAULT_SAMPLE_RATE, true,
+                  session_id, turn_id, request_id, event_callback, user_data, stream.chunk_index);
 
-    d7_emit_audio(handle, tts.audio_data && tts.audio_size > 0 ? tts.audio_data : nullptr,
-                  tts.audio_data && tts.audio_size > 0 ? tts.audio_size : 0,
-                  tts.sample_rate > 0 ? tts.sample_rate : RAC_TTS_DEFAULT_SAMPLE_RATE, true,
-                  session_id, turn_id, request_id, event_callback, user_data);
-
-    // When the caller wants the synthesized reply inline (the streaming
-    // feed-audio ingress path), package transcript + response + TTS audio as
-    // a VoiceAgentResult. The audio is converted to a self-describing WAV so
-    // the SDK plays it directly without tracking raw float32 rate/encoding.
+    // When the caller wants the synthesized reply inline (the feed-audio ingress
+    // path), package transcript + response + the full reply as a self-describing
+    // WAV (every streamed chunk concatenated) so the SDK plays it directly.
     if (out_result) {
         out_result->set_speech_detected(turn_has_speech);
         out_result->set_transcription(stt.text);
@@ -878,12 +1072,12 @@ rac_result_t d7_process_utterance(rac_voice_agent_handle_t handle, const std::st
         if (!response.thinking.empty()) {
             out_result->set_thinking_content(response.thinking);
         }
-        if (tts.audio_data && tts.audio_size > 0) {
+        if (!stream.pcm.empty()) {
             void* wav_data = nullptr;
             size_t wav_size = 0;
-            if (rac_audio_float32_to_wav(tts.audio_data, tts.audio_size,
-                                         tts.sample_rate > 0 ? tts.sample_rate
-                                                             : RAC_TTS_DEFAULT_SAMPLE_RATE,
+            if (rac_audio_float32_to_wav(stream.pcm.data(), stream.pcm.size(),
+                                         stream.sample_rate > 0 ? stream.sample_rate
+                                                                : RAC_TTS_DEFAULT_SAMPLE_RATE,
                                          &wav_data, &wav_size) == RAC_SUCCESS &&
                 wav_data && wav_size > 0) {
                 out_result->set_synthesized_audio(wav_data, wav_size);
@@ -908,17 +1102,7 @@ rac_result_t d7_process_utterance(rac_voice_agent_handle_t handle, const std::st
                         response.answer.c_str());
 
     rac_stt_result_free(&stt);
-    rac_llm_result_free(&llm);
-    rac_tts_result_free(&tts);
-    if (have_lifecycle_tts) {
-        rac::lifecycle::release_lifecycle_tts(&tts_ref);
-    }
-    if (have_lifecycle_llm) {
-        rac::llm::release_lifecycle_llm(&llm_ref);
-    }
-    if (have_lifecycle_stt) {
-        rac::lifecycle::release_lifecycle_stt(&stt_ref);
-    }
+    release_pipeline();
     return RAC_SUCCESS;
 }
 

--- a/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_tts_chunking.h
+++ b/sdk/runanywhere-commons/src/features/voice_agent/voice_agent_tts_chunking.h
@@ -1,0 +1,218 @@
+/**
+ * @file voice_agent_tts_chunking.h
+ * @brief Pure text -> speakable-chunk policy for the streaming voice agent (header-only).
+ *
+ * Turns a growing stream of LLM tokens into short, clean, speakable chunks so the
+ * voice agent can synthesize and emit audio sentence-by-sentence AS the LLM
+ * decodes (instead of waiting for the whole answer, then one-shot TTS). It:
+ *   - splits on sentence boundaries (. ! ? followed by whitespace),
+ *   - drops <think>...</think> reasoning so it is never spoken,
+ *   - strips markdown and collapses whitespace, and
+ *   - hard-caps each chunk so an over-long phoneme run never fails an NPU TTS
+ *     (MeloTTS on v79 rejects a sequence past its 512-phoneme cap with rc=-130).
+ *
+ * C++ port of the Kotlin `VoiceTtsChunkPolicy` used by the demo app's per-turn
+ * NPU-swap path; promoting it to commons lets EVERY SDK stream spoken replies
+ * without re-porting the logic. Header-only (inline): consumed by a single TU
+ * (voice_agent_d7_abi.cpp), so no separate .cpp / CMake source entry is needed.
+ * std::regex is deliberately NOT used: its ECMAScript grammar has no lookbehind
+ * or DOTALL, so the scanning is hand-written.
+ */
+
+#ifndef RAC_FEATURES_VOICE_AGENT_VOICE_AGENT_TTS_CHUNKING_H
+#define RAC_FEATURES_VOICE_AGENT_VOICE_AGENT_TTS_CHUNKING_H
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+namespace rac::voice_agent::detail {
+
+/// ~a couple hundred chars maps under MeloTTS's 512-phoneme cap; keep each spoken
+/// chunk well under so g2p never overruns.
+constexpr int kVoiceTtsMaxChars = 160;
+
+/// Small on-device chat models (e.g. Qwen3-0.6B) tend to comma-JOIN a spoken
+/// reply into a single long sentence ("Paris is the capital of France, and Tokyo
+/// is the capital of Japan."), so splitting only on . ! ? would stream nothing.
+/// We therefore ALSO break at a clause boundary ( , ; : ) — but only once the
+/// pending fragment is at least this long, so a SHORT sentence stays whole (no
+/// choppy sub-clause TTS) and only a LONG run-on gets streamed clause-by-clause.
+constexpr int kVoiceTtsMinClauseChars = 50;
+
+namespace chunk_internal {
+
+inline bool is_ws(char c) {
+    // Match Kotlin's \s: space, tab, newline, carriage return, form feed, vtab.
+    return c == ' ' || c == '\t' || c == '\n' || c == '\r' || c == '\f' || c == '\v';
+}
+
+// Remove every COMPLETE <think>...</think> block (non-greedy, spanning newlines).
+// An unclosed trailing <think> is left in place for the caller to hold.
+inline void strip_complete_think(std::string& s) {
+    constexpr char kOpen[] = "<think>";
+    constexpr char kClose[] = "</think>";
+    constexpr size_t kCloseLen = sizeof(kClose) - 1;
+    size_t open = 0;
+    while ((open = s.find(kOpen, open)) != std::string::npos) {
+        const size_t close = s.find(kClose, open);
+        if (close == std::string::npos) {
+            break;  // unclosed reasoning block — leave it for the caller
+        }
+        s.erase(open, (close + kCloseLen) - open);
+    }
+}
+
+// Split into speakable segments. A `.`/`!`/`?` followed by whitespace ALWAYS
+// breaks (true sentence boundary; "3.14"/"U.S." never split mid-token since no
+// whitespace follows). A clause mark `,`/`;`/`:` followed by whitespace breaks
+// ONLY once the pending segment is >= @p min_clause chars, so short sentences
+// stay whole and only long run-ons stream clause-by-clause. The whitespace run is
+// consumed. Includes a trailing (possibly empty) part when the text ends on a
+// boundary, matching the sentence-split contract drain_sentences relies on.
+inline std::vector<std::string> split_speakable(const std::string& s, int min_clause) {
+    std::vector<std::string> parts;
+    size_t start = 0;
+    size_t i = 0;
+    while (i < s.size()) {
+        const char c = s[i];
+        const bool sentence_end = (c == '.' || c == '!' || c == '?');
+        const bool clause_end = (c == ',' || c == ';' || c == ':');
+        if ((sentence_end || clause_end) && i + 1 < s.size() && is_ws(s[i + 1])) {
+            const size_t seg_len = (i + 1) - start;
+            if (sentence_end || static_cast<int>(seg_len) >= min_clause) {
+                parts.push_back(s.substr(start, (i + 1) - start));
+                size_t j = i + 1;
+                while (j < s.size() && is_ws(s[j])) {
+                    ++j;
+                }
+                start = j;
+                i = j;
+                continue;
+            }
+        }
+        ++i;
+    }
+    parts.push_back(s.substr(start));  // trailing part (may be empty)
+    return parts;
+}
+
+}  // namespace chunk_internal
+
+/// Strip markdown formatting and collapse whitespace so the TTS g2p front-end
+/// sees clean prose.
+inline std::string sanitize_for_tts(const std::string& text) {
+    std::string collapsed;
+    collapsed.reserve(text.size());
+    bool pending_space = false;
+    bool seen_non_space = false;
+    for (char c : text) {
+        const bool markdown = (c == '*' || c == '_' || c == '`' || c == '#' || c == '>' ||
+                               c == '~' || c == '|');
+        if (markdown || chunk_internal::is_ws(c)) {
+            pending_space = seen_non_space;  // no leading spaces
+            continue;
+        }
+        if (pending_space) {
+            collapsed.push_back(' ');
+            pending_space = false;
+        }
+        collapsed.push_back(c);
+        seen_non_space = true;
+    }
+    return collapsed;  // trailing pending_space intentionally dropped (trim)
+}
+
+/**
+ * Pull complete, speakable sentences out of @p buf (mutating it), dropping
+ * <think> reasoning so it is never read aloud. With @p flush the trailing partial
+ * is returned too and the buffer is drained; otherwise the trailing partial (plus
+ * any still-open <think>) is kept in @p buf for the next call. Each returned
+ * sentence is already sanitized and non-empty.
+ */
+inline std::vector<std::string> drain_sentences(std::string& buf, bool flush) {
+    std::string stripped = buf;
+    chunk_internal::strip_complete_think(stripped);
+
+    const size_t open = stripped.find("<think>");  // an unclosed reasoning block, if any
+    const std::string held = (open != std::string::npos) ? stripped.substr(open) : std::string();
+    const std::string speakable =
+        (open != std::string::npos) ? stripped.substr(0, open) : stripped;
+
+    std::vector<std::string> parts =
+        chunk_internal::split_speakable(speakable, kVoiceTtsMinClauseChars);
+    const size_t complete = flush ? parts.size() : (parts.empty() ? 0 : parts.size() - 1);
+
+    std::vector<std::string> out;
+    out.reserve(complete);
+    for (size_t i = 0; i < complete; ++i) {
+        std::string clean = sanitize_for_tts(parts[i]);
+        if (!clean.empty()) {
+            out.push_back(std::move(clean));
+        }
+    }
+
+    buf.clear();
+    if (!flush) {
+        buf = (parts.empty() ? std::string() : parts.back()) + held;
+    }
+    return out;
+}
+
+/**
+ * Hard-cap @p text into <= @p max_chars chunks, splitting on word boundaries. A
+ * single word longer than the cap (a URL / run-on token) is force-split so NO
+ * chunk ever exceeds the cap.
+ */
+inline std::vector<std::string> cap_for_tts(const std::string& text,
+                                            int max_chars = kVoiceTtsMaxChars) {
+    std::vector<std::string> out;
+    if (max_chars <= 0 || static_cast<int>(text.size()) <= max_chars) {
+        out.push_back(text);
+        return out;
+    }
+    const size_t cap = static_cast<size_t>(max_chars);
+    std::string cur;
+    auto flush_cur = [&]() {
+        if (!cur.empty()) {
+            out.push_back(cur);
+            cur.clear();
+        }
+    };
+
+    size_t i = 0;
+    while (true) {
+        const size_t sp = text.find(' ', i);
+        const std::string word = (sp == std::string::npos) ? text.substr(i) : text.substr(i, sp - i);
+
+        if (word.size() > cap) {
+            // a single over-long token: force-split so NO chunk exceeds the cap
+            flush_cur();
+            size_t k = 0;
+            while (k < word.size()) {
+                const size_t end = std::min(k + cap, word.size());
+                out.push_back(word.substr(k, end - k));
+                k = end;
+            }
+        } else {
+            if (!cur.empty() && cur.size() + 1 + word.size() > cap) {
+                flush_cur();
+            }
+            if (!cur.empty()) {
+                cur.push_back(' ');
+            }
+            cur += word;
+        }
+
+        if (sp == std::string::npos) {
+            break;
+        }
+        i = sp + 1;
+    }
+    flush_cur();
+    return out;
+}
+
+}  // namespace rac::voice_agent::detail
+
+#endif  // RAC_FEATURES_VOICE_AGENT_VOICE_AGENT_TTS_CHUNKING_H

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/features/TTS/Services/StreamingAudioPlayer.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/features/TTS/Services/StreamingAudioPlayer.kt
@@ -1,0 +1,223 @@
+/*
+ * Copyright 2026 RunAnywhere SDK
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * StreamingAudioPlayer.kt
+ *
+ * Incremental PCM playback for the streaming voice agent. Unlike
+ * AudioPlaybackManager (MODE_STATIC, one-shot WAV blob), this plays a sequence
+ * of float32 PCM chunks as they arrive — so a spoken reply starts playing after
+ * its FIRST sentence/clause while the rest is still being generated + synthesized
+ * on the NPU/CPU. Fed by AudioFrameEvent payloads off `RunAnywhere.streamVoiceAgent()`
+ * (the voice-agent AudioFrameEvent is float32 little-endian, mono).
+ *
+ * Threading: enqueue() runs on the flow collector and only appends to an
+ * unbounded queue (never blocks the collector); a dedicated writer thread drains
+ * the queue and does blocking AudioTrack writes, which pace playback naturally.
+ */
+
+package com.runanywhere.sdk.features.TTS.Services
+
+import android.media.AudioAttributes
+import android.media.AudioFormat
+import android.media.AudioTrack
+import com.runanywhere.sdk.features.VoiceAgent.Services.VoiceTtsPlaybackGate
+import com.runanywhere.sdk.infrastructure.logging.SDKLogger
+import java.nio.ByteBuffer
+import java.nio.ByteOrder
+import java.util.concurrent.LinkedBlockingQueue
+
+internal class StreamingAudioPlayer {
+    private val logger = SDKLogger("StreamingAudio")
+
+    // Unbounded so the flow collector never blocks handing off a chunk; the writer
+    // thread paces real playback via blocking AudioTrack writes.
+    private val queue = LinkedBlockingQueue<FloatArray>()
+    private var track: AudioTrack? = null
+    private var writer: Thread? = null
+    private var sampleRate = 0
+
+    // Total mono frames handed to (and accepted by) AudioTrack.write across the
+    // whole reply. WRITE_BLOCKING only blocks until samples are COPIED into the
+    // track buffer, not until they are rendered, so at end-of-stream up to a
+    // buffer's worth is still unplayed; the drain below waits for the hardware
+    // playback head to reach this count before releasing (else the tail clips).
+    @Volatile private var framesWritten = 0L
+
+    @Volatile private var stopped = false
+
+    /** Sentinel: the reply's audio is complete — drain then release the track. */
+    private val endOfStream = FloatArray(0)
+
+    /**
+     * Append one non-final AudioFrameEvent PCM chunk. [pcmLeFloat32] is float32
+     * little-endian mono samples; [sampleRateHz] is the chunk's rate (all chunks
+     * of a reply share it — piper is 22050). Lazily starts the track on the first
+     * chunk. No-op after [markFinal]/[stop].
+     */
+    fun enqueue(pcmLeFloat32: ByteArray, sampleRateHz: Int) {
+        if (stopped || pcmLeFloat32.isEmpty()) return
+        ensureStarted(if (sampleRateHz > 0) sampleRateHz else DEFAULT_RATE)
+        queue.put(toFloats(pcmLeFloat32))
+    }
+
+    /** The terminal AudioFrameEvent (is_final): let queued audio finish, then release. */
+    fun markFinal() {
+        if (stopped) return
+        // Only meaningful if playback ever started; otherwise nothing to drain.
+        if (track != null) queue.put(endOfStream)
+    }
+
+    /** Hard stop (session teardown / barge-in): abort playback immediately. */
+    fun stop() {
+        if (stopped) return
+        stopped = true
+        writer?.interrupt()
+        releaseTrack()
+    }
+
+    @Synchronized
+    private fun ensureStarted(rate: Int) {
+        if (track != null || stopped) return
+        sampleRate = rate
+        val minBuf =
+            AudioTrack.getMinBufferSize(
+                rate,
+                AudioFormat.CHANNEL_OUT_MONO,
+                AudioFormat.ENCODING_PCM_FLOAT,
+            )
+        if (minBuf <= 0) {
+            logger.error("Invalid AudioTrack min buffer ($minBuf) for rate=$rate; audio disabled")
+            stopped = true
+            return
+        }
+        // ~0.5 s of headroom so short inter-chunk synthesis gaps don't underrun.
+        val bufBytes = maxOf(minBuf, rate * BYTES_PER_SAMPLE / 2)
+        val t =
+            AudioTrack
+                .Builder()
+                .setAudioAttributes(
+                    AudioAttributes
+                        .Builder()
+                        .setUsage(AudioAttributes.USAGE_MEDIA)
+                        .setContentType(AudioAttributes.CONTENT_TYPE_SPEECH)
+                        .build(),
+                ).setAudioFormat(
+                    AudioFormat
+                        .Builder()
+                        .setEncoding(AudioFormat.ENCODING_PCM_FLOAT)
+                        .setSampleRate(rate)
+                        .setChannelMask(AudioFormat.CHANNEL_OUT_MONO)
+                        .build(),
+                ).setBufferSizeInBytes(bufBytes)
+                .setTransferMode(AudioTrack.MODE_STREAM)
+                .build()
+        t.play()
+        track = t
+        // Half-duplex: tell the mic driver to stop feeding the core while this
+        // reply plays, so the device does not transcribe its own TTS (echo loop).
+        VoiceTtsPlaybackGate.onPlaybackStart()
+        writer = Thread({ writeLoop() }, "StreamingAudioPlayer").also { it.start() }
+        logger.info("Streaming audio started (rate=$rate, buf=$bufBytes)")
+    }
+
+    private fun writeLoop() {
+        val t = track ?: return
+        try {
+            while (!stopped) {
+                val buf = queue.take()
+                if (buf === endOfStream) {
+                    // Blocking writes above copied all queued audio into the track
+                    // buffer, but a buffer's worth is still unplayed. Wait for the
+                    // hardware to render it out before releasing, or the last
+                    // ~0.5 s of the reply is clipped.
+                    drainAndRelease()
+                    return
+                }
+                var off = 0
+                while (off < buf.size && !stopped) {
+                    val n = t.write(buf, off, buf.size - off, AudioTrack.WRITE_BLOCKING)
+                    if (n < 0) {
+                        logger.warning("AudioTrack.write returned $n; stopping stream")
+                        return
+                    }
+                    off += n
+                    framesWritten += n // mono float32: 1 float == 1 frame
+                }
+            }
+        } catch (_: InterruptedException) {
+            // stop() interrupted us — normal teardown.
+        } catch (e: Exception) {
+            logger.warning("Streaming audio writer failed: ${e.message}")
+        }
+    }
+
+    /**
+     * Natural end-of-stream: let the hardware play out everything already
+     * written before releasing, so the reply's tail is not clipped. Polls the
+     * playback head toward [framesWritten] with a stall + hard-cap guard so a
+     * misbehaving track can never hang the writer thread. A concurrent hard
+     * [stop] flips `stopped` and breaks the wait immediately (barge-in wins).
+     */
+    private fun drainAndRelease() {
+        val t = track
+        if (t != null) {
+            try {
+                t.stop() // MODE_STREAM: renders the last written buffer, then halts
+                val target = framesWritten
+                var lastHead = -1L
+                var stalls = 0
+                var waited = 0
+                while (!stopped && waited < MAX_DRAIN_MS) {
+                    val head = t.playbackHeadPosition.toLong() and 0xFFFFFFFFL
+                    if (head >= target) break
+                    if (head == lastHead) {
+                        if (++stalls >= DRAIN_STALL_TICKS) break
+                    } else {
+                        stalls = 0
+                        lastHead = head
+                    }
+                    Thread.sleep(DRAIN_TICK_MS.toLong())
+                    waited += DRAIN_TICK_MS
+                }
+            } catch (_: InterruptedException) {
+                // stop() interrupted us — teardown; fall through to release.
+            } catch (_: Exception) {
+            }
+        }
+        releaseTrack()
+    }
+
+    @Synchronized
+    private fun releaseTrack() {
+        val t = track ?: return
+        track = null
+        try {
+            t.stop()
+        } catch (_: Exception) {
+        }
+        t.release()
+        // Reply finished playing (or was hard-stopped): re-open the mic after the
+        // hardware buffer drain + acoustic-decay tail (handled inside the gate).
+        VoiceTtsPlaybackGate.onPlaybackStop()
+    }
+
+    private fun toFloats(bytes: ByteArray): FloatArray {
+        val fb = ByteBuffer.wrap(bytes).order(ByteOrder.LITTLE_ENDIAN).asFloatBuffer()
+        val out = FloatArray(fb.remaining())
+        fb.get(out)
+        return out
+    }
+
+    private companion object {
+        const val DEFAULT_RATE = 22_050
+        const val BYTES_PER_SAMPLE = 4 // float32 mono
+
+        // End-of-stream drain: poll the playback head every DRAIN_TICK_MS until it
+        // reaches the written frame count. DRAIN_STALL_TICKS of no progress (head
+        // frozen) or MAX_DRAIN_MS total both end the wait defensively.
+        const val DRAIN_TICK_MS = 20
+        const val DRAIN_STALL_TICKS = 15 // ~300 ms of a frozen head → give up
+        const val MAX_DRAIN_MS = 4_000 // hard cap so the writer never hangs
+    }
+}

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/features/VoiceAgent/Services/VoiceAgentMicDriver.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/features/VoiceAgent/Services/VoiceAgentMicDriver.kt
@@ -20,7 +20,6 @@ package com.runanywhere.sdk.features.VoiceAgent.Services
 import ai.runanywhere.proto.v1.AudioEncoding
 import ai.runanywhere.proto.v1.VoiceAgentResult
 import com.runanywhere.sdk.features.STT.Services.AudioCaptureManager
-import com.runanywhere.sdk.features.TTS.Services.AudioPlaybackManager
 import com.runanywhere.sdk.infrastructure.logging.SDKLogger
 import com.runanywhere.sdk.native.bridge.RunAnywhereBridge
 import kotlinx.coroutines.channels.BufferOverflow
@@ -44,7 +43,6 @@ internal class VoiceAgentMicDriver(
 ) {
     private val logger = SDKLogger("VoiceAgentMic")
     private val capture = AudioCaptureManager()
-    private val playback = AudioPlaybackManager()
 
     suspend fun run() {
         val chunks =
@@ -58,7 +56,6 @@ internal class VoiceAgentMicDriver(
             feedLoop(chunks)
         } finally {
             capture.stopRecording()
-            playback.stop()
             chunks.close()
             logger.info("Voice-agent mic capture stopped")
         }
@@ -67,6 +64,14 @@ internal class VoiceAgentMicDriver(
     private suspend fun feedLoop(chunks: Channel<ByteArray>) {
         while (currentCoroutineContext().isActive) {
             val chunk = chunks.receive()
+
+            // Half-duplex: while a streaming reply is playing out the speaker
+            // (plus a short acoustic-decay tail), drop captured frames instead
+            // of feeding them to the core. Playback is now async + app-side
+            // (StreamingAudioPlayer), so without this the mic re-records the
+            // device's own TTS and the agent transcribes + answers itself in an
+            // endless loop. No barge-in by design, so dropping here is correct.
+            if (VoiceTtsPlaybackGate.micSuppressed()) continue
 
             val resultBytes =
                 try {
@@ -99,29 +104,47 @@ internal class VoiceAgentMicDriver(
                 } ?: continue
 
             // A non-empty reply means the core closed an utterance and ran a full
-            // turn this call. synthesized_audio is self-describing WAV.
+            // turn this call. Audio is played INCREMENTALLY by StreamingAudioPlayer
+            // as AudioFrameEvents arrive on the streamVoiceAgent flow. The whole
+            // reply WAV is already synthesized by the time this blocking call
+            // returns, so we know exactly how long it will play — mute the mic for
+            // that duration + a tail RIGHT NOW, before receiving another frame.
+            // This is the deterministic echo guard: without it the device speaker's
+            // own reply is re-captured, transcribed, and answered in an endless
+            // loop (worse on the phone speaker than a distant one). Also drain any
+            // frames captured while the turn ran.
             val reply = result.synthesized_audio
             if (reply != null && reply.size > 0) {
-                logger.info("Playing agent reply (${reply.size} WAV bytes)")
-                playReply(reply.toByteArray())
-                // Drop frames captured while the turn ran / the device spoke so
-                // stale audio is not folded into the next turn.
                 while (chunks.tryReceive().isSuccess) Unit
+                val playbackMs = wavPlaybackMs(reply.toByteArray())
+                if (playbackMs > 0) {
+                    VoiceTtsPlaybackGate.suppressForMs(playbackMs + REPLY_TAIL_MS)
+                    logger.info("turn reply ~${playbackMs}ms; muting mic through playback")
+                }
             }
         }
     }
 
-    private suspend fun playReply(wav: ByteArray) {
-        if (wav.isEmpty()) return
-        try {
-            playback.play(wav)
-        } catch (e: CancellationException) {
-            playback.stop()
-            throw e
-        } catch (e: Exception) {
-            logger.warning("Agent reply playback failed: ${e.message}")
-        }
+    /**
+     * Duration in ms of a canonical little-endian WAV (as written by the core's
+     * float32→WAV helper): byteRate is a uint32 at byte offset 28, the data-chunk
+     * size a uint32 at offset 40. Falls back to (total − 44-byte header) if the
+     * stored data size looks wrong. Returns 0 for anything too short to be a WAV.
+     */
+    private fun wavPlaybackMs(wav: ByteArray): Long {
+        if (wav.size < WAV_HEADER_BYTES) return 0
+        val byteRate = le32(wav, 28)
+        if (byteRate <= 0) return 0
+        val stored = le32(wav, 40)
+        val dataSize = if (stored in 1..(wav.size - WAV_HEADER_BYTES).toLong()) stored else (wav.size - WAV_HEADER_BYTES).toLong()
+        return dataSize * 1000 / byteRate
     }
+
+    private fun le32(b: ByteArray, off: Int): Long =
+        (b[off].toLong() and 0xFF) or
+            ((b[off + 1].toLong() and 0xFF) shl 8) or
+            ((b[off + 2].toLong() and 0xFF) shl 16) or
+            ((b[off + 3].toLong() and 0xFF) shl 24)
 
     private companion object {
         const val SAMPLE_RATE_HZ = 16_000
@@ -133,5 +156,15 @@ internal class VoiceAgentMicDriver(
          * frames captured mid-turn are discarded anyway (no barge-in).
          */
         const val MIC_CHANNEL_CAPACITY = 128
+
+        /** Canonical PCM/float WAV header size (RIFF + fmt + data headers). */
+        const val WAV_HEADER_BYTES = 44
+
+        /**
+         * Extra mute past the reply's raw duration: absorbs AudioTrack start-up
+         * latency, inter-chunk pacing, and the speaker→mic acoustic decay so the
+         * reply's final syllable is never re-transcribed.
+         */
+        const val REPLY_TAIL_MS = 1_200L
     }
 }

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/features/VoiceAgent/Services/VoiceTtsPlaybackGate.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/features/VoiceAgent/Services/VoiceTtsPlaybackGate.kt
@@ -1,0 +1,80 @@
+/*
+ * Copyright 2026 RunAnywhere SDK
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * VoiceTtsPlaybackGate.kt
+ *
+ * Half-duplex gate between the streaming TTS player and the voice-agent mic
+ * driver. The voice agent is strictly turn-taking (no barge-in): while a reply
+ * is playing out the device speaker, the mic must NOT feed captured audio to
+ * the core — otherwise the device transcribes its OWN TTS output and the agent
+ * talks to itself in an endless loop (observed: reply "…the capital is parent…"
+ * re-transcribed and re-answered every ~15 s).
+ *
+ * Playback moved app-side to StreamingAudioPlayer (incremental AudioTrack), so
+ * it happens asynchronously AFTER the core's blocking feed/turn returns; the
+ * mic-driver's one-shot post-turn frame-drop no longer covers the out-loud
+ * playback window. This gate closes that window: StreamingAudioPlayer marks
+ * playback active for the whole reply, and VoiceAgentMicDriver drops mic frames
+ * while active plus a short acoustic-decay tail after the last frame drains.
+ */
+
+package com.runanywhere.sdk.features.VoiceAgent.Services
+
+import com.runanywhere.sdk.infrastructure.logging.SDKLogger
+import java.util.concurrent.atomic.AtomicInteger
+
+internal object VoiceTtsPlaybackGate {
+    private val logger = SDKLogger("VoiceTtsGate")
+
+    // >0 while any streaming reply is actively writing to an AudioTrack.
+    private val active = AtomicInteger(0)
+
+    // Wall-clock cutoff covering the hardware buffer drain + room reverb after
+    // the last chunk is handed to AudioTrack.stop() (deep-buffer output keeps
+    // playing for a beat after the writer finishes), AND the deterministic,
+    // reply-duration-based window the mic driver sets the instant a turn returns
+    // (see [suppressForMs]). Whichever reaches furthest into the future wins.
+    @Volatile private var suppressUntilMs = 0L
+
+    /** A streaming reply started playing. Balanced by [onPlaybackStop]. */
+    fun onPlaybackStart() {
+        active.incrementAndGet()
+    }
+
+    /** The reply's AudioTrack was released (drained or hard-stopped). */
+    fun onPlaybackStop(tailMs: Long = TAIL_MS) {
+        if (active.get() > 0) active.decrementAndGet()
+        extendUntil(System.currentTimeMillis() + tailMs)
+    }
+
+    /**
+     * Deterministically mute the mic for [ms] from now. Called by the mic driver
+     * the moment a turn returns with a reply, using the reply audio's own known
+     * duration — so the whole out-loud playback is covered regardless of when the
+     * async AudioTrack actually starts/stops. This is the primary echo guard; the
+     * [onPlaybackStart]/[onPlaybackStop] pair is a secondary safety net.
+     */
+    fun suppressForMs(ms: Long) {
+        extendUntil(System.currentTimeMillis() + ms)
+    }
+
+    /**
+     * True while a reply is playing or within the suppression window. The mic
+     * driver drops (does not feed) captured frames while this holds, so the
+     * device never transcribes its own TTS.
+     */
+    fun micSuppressed(): Boolean =
+        active.get() > 0 || System.currentTimeMillis() < suppressUntilMs
+
+    private fun extendUntil(untilMs: Long) {
+        if (untilMs > suppressUntilMs) {
+            suppressUntilMs = untilMs
+            logger.debug("mic suppressed for ${untilMs - System.currentTimeMillis()}ms")
+        }
+    }
+
+    // Covers AudioTrack deep-buffer drain (~0.5 s buffer) plus a margin for the
+    // speaker→mic acoustic tail so the last syllable is not re-transcribed.
+    private const val TAIL_MS = 800L
+}

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/VoiceAgent/RunAnywhereVoiceAgent.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/VoiceAgent/RunAnywhereVoiceAgent.kt
@@ -20,6 +20,7 @@ import ai.runanywhere.proto.v1.SDKComponent
 import ai.runanywhere.proto.v1.VoiceAgentResult
 import ai.runanywhere.proto.v1.VoiceEvent
 import com.runanywhere.sdk.adapters.VoiceAgentStreamAdapter
+import com.runanywhere.sdk.features.TTS.Services.StreamingAudioPlayer
 import com.runanywhere.sdk.features.VoiceAgent.Services.VoiceAgentMicDriver
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeModelLifecycle
 import com.runanywhere.sdk.foundation.bridge.extensions.CppBridgeVoiceAgent
@@ -33,7 +34,7 @@ import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.flow.emitAll
+import kotlinx.coroutines.flow.collect
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.withContext
@@ -67,6 +68,28 @@ private fun notInitializedException(): SDKException =
         category = ErrorCategory.ERROR_CATEGORY_INTERNAL,
         shouldLog = false,
     )
+
+/**
+ * True when [text] carries no actual speech — it is empty or reduces to nothing
+ * but bracketed / parenthesized non-speech tags, punctuation, or symbols. STT
+ * engines (Whisper especially) emit tags like "[BLANK_AUDIO]", "[wind blowing]",
+ * "(music)", "♪♪♪", "..." when handed silence or ambient noise; treating those
+ * as user utterances makes an always-on voice agent answer its own room noise in
+ * a loop. Real speech always leaves alphanumeric characters OUTSIDE any tag, so
+ * this never suppresses a genuine reply.
+ */
+internal fun transcriptIsNonSpeech(text: String?): Boolean {
+    if (text.isNullOrEmpty()) return true
+    var depth = 0
+    for (c in text) {
+        when (c) {
+            '[', '(', '{', '<' -> depth++
+            ']', ')', '}', '>' -> if (depth > 0) depth--
+            else -> if (depth == 0 && c.isLetterOrDigit()) return false
+        }
+    }
+    return true
+}
 
 private fun isComponentReady(component: SDKComponent): Boolean =
     CppBridgeModelLifecycle.snapshot(component)?.let {
@@ -270,16 +293,44 @@ fun RunAnywhere.streamVoiceAgent(): Flow<VoiceEvent> =
         if (!isInitialized) throw notInitializedException()
         ensureServicesReady()
         val handle = CppBridgeVoiceAgent.getHandle()
+        // Play the spoken reply INCREMENTALLY: as each AudioFrameEvent lands on the
+        // stream, feed its PCM to a streaming AudioTrack so the first sentence/clause
+        // is heard while the rest is still being generated + synthesized. Replaces
+        // VoiceAgentMicDriver's one-shot WAV-blob playback (now disabled). is_final
+        // marks the reply's end; barge-in/teardown hard-stops via player.stop().
+        val player = StreamingAudioPlayer()
         coroutineScope {
             val driver = launch(Dispatchers.IO) { VoiceAgentMicDriver(handle).run() }
             try {
-                emitAll(VoiceAgentStreamAdapter(handle).stream())
+                // Skip playback for a turn whose transcript is an STT non-speech
+                // hallucination ("[BLANK_AUDIO]", "[wind blowing]", …). An always-on
+                // session keeps segmenting silence between real utterances; without
+                // this the agent speaks a reply to its own ambient noise every few
+                // seconds and appears to loop. user_said(is_final) always precedes
+                // that turn's audio frames, so this flag is set before they arrive.
+                var currentTurnSuppressed = false
+                VoiceAgentStreamAdapter(handle).stream().collect { event ->
+                    event.user_said?.let { said ->
+                        if (said.is_final) currentTurnSuppressed = transcriptIsNonSpeech(said.text)
+                    }
+                    if (!currentTurnSuppressed) {
+                        event.audio?.let { audio ->
+                            if (audio.is_final) {
+                                player.markFinal()
+                            } else if (audio.pcm.size > 0) {
+                                player.enqueue(audio.pcm.toByteArray(), audio.sample_rate_hz)
+                            }
+                        }
+                    }
+                    emit(event)
+                }
             } finally {
                 // Cancellation of a coroutine blocked in JNI is cooperative:
                 // wait for the active feed/turn to return and for the driver's
                 // finally block to stop AudioRecord before this stream is
                 // considered closed. This prevents a retained Talk screen from
                 // continuing to feed the shared STT model after navigation.
+                player.stop()
                 withContext(NonCancellable) { driver.cancelAndJoin() }
             }
         }


### PR DESCRIPTION
## Summary

Makes the RunAnywhere voice agent **hybrid + streaming**: the LLM runs on the Hexagon **NPU** (QHexRT) while STT/TTS/VAD run on **CPU** (sherpa). The single NPU slot holds only the LLM (stays warm all session — no per-turn Whisper↔LLM swap), CPU speech overlaps NPU decode, and the spoken reply **streams out sentence/clause-by-clause** as it is generated.

Device-validated on **S25 (SM8750, Hexagon v79)** via acoustic loopback across app builds v25→v29.

## What's in this PR

### Core: hybrid streaming pipeline
- **`voice_agent_d7_abi.cpp`** (commons) — refactors `d7_process_utterance` from blocking-generate + one-shot-TTS to streaming: per-token accumulate → clause chunking → per-sentence synth → incremental `AudioFrameEvent(is_final, chunk_index)`. Backward-compatible `out_result` WAV still returned.
- **`voice_agent_tts_chunking.h`** (commons, new) — header-only C++ clause-aware chunk policy (splits on `.!?` always, `,;:` past 50 chars). Header-only to avoid a CMake reconfigure.
- **`StreamingAudioPlayer.kt`** (SDK, new) — incremental `AudioTrack` `MODE_STREAM` + `ENCODING_PCM_FLOAT`; writer thread paces playback via blocking writes.
- **`RunAnywhereVoiceAgent.kt`** (SDK) — `streamVoiceAgent()` taps each `AudioFrameEvent` into the player.
- **`VoiceAgentMicDriver.kt`** (SDK) — removes the old one-shot WAV-blob playback (audio now incremental).

### App bug fixes
- **Setup downloads ALL models** (`VoiceScreen.kt`) — removes break-on-load-failure so a 2nd model failing to load on the single NPU slot no longer aborts the rest.
- **Recommends sherpa CPU Whisper** for the pipeline (`ModelRecommendation.kt`) — frees the NPU slot for the LLM → the hybrid streaming path (not the all-NPU per-turn-swap path). NPU Whisper is still preferred for standalone dictation.

### Robustness (found during device testing)
- **Clipped reply tail** → `StreamingAudioPlayer` drains the `AudioTrack` (polls the hardware playback head to the full written-frame count) before release, instead of `stop()`+`release()` back-to-back which truncated the last ~0.5s.
- **Echo / self-talk loop** → **`VoiceTtsPlaybackGate.kt`** (new) + `VoiceAgentMicDriver.kt`: the whole reply WAV is already synthesized when the blocking turn returns, so the mic-driver reads its duration and **deterministically mutes the mic** for that duration + tail the instant the turn returns — before reading another frame. Kills the device transcribing its own TTS.
- **Phantom-turn loop** (STT hallucinating `[BLANK_AUDIO]`/`[wind blowing]` on silence between utterances) → `RunAnywhereVoiceAgent.kt` mutes phantom-turn audio and `VoiceViewModel.kt` hides them from the UI (`transcriptIsNonSpeech`). The **commons-side** equivalent (skip the turn before the LLM runs) is also included in `voice_agent_d7_abi.cpp`.

## Device validation (S25 / v79)
- Setup downloads + loads all 4 models (sherpa Whisper, Qwen3.5-0.8B NPU, Piper, Silero).
- Listen = **Sherpa Whisper (CPU)**, not NPU.
- Reply audio streams out; `AudioTrack` delivers every synthesized frame (`frames delivered == samples generated`), including multi-clause streamed replies.
- Deterministic mic mute fires (`reply ~1834ms; muting mic through playback`) → only the user's question is transcribed, no self-talk.
- Stop button tears down cleanly (`mic capture stopped`).

## ⚠️ Reviewer notes
- **The commons `.cpp` change needs a native rebuild to take effect.** The fast app build path uses `-x buildLocalJniLibs` (prebuilt `.so`), so the streaming refactor + commons non-speech filter only compile in via `scripts/build/build-core-android.sh`. The Kotlin app-side phantom suppression works without it.
- **Overlap:** `origin/siddhesh/voice-agent-quality` rewrites several of the same files independently — expect a merge conflict to reconcile.
- Layer decision follows the existing proto contract (`VoiceEvent`/`AudioFrameEvent` already carry `chunk_index`/`is_final`), so other SDKs (Swift/Flutter/Python) inherit the streaming path; only mic-in + PCM playback stay platform-specific. The all-CPU path stays byte-identical (additive, no C-ABI break).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added incremental, sentence/clause-based voice playback for quicker reply feedback.
  * Enabled streaming LLM→TTS so assistant audio is produced continuously during generation.
* **Bug Fixes**
  * Suppress non-speech/“phantom” transcripts to prevent empty or spurious assistant turns.
  * Voice model preparation is now best-effort across components, continuing even if one fails.
  * STT/TTS routing no longer prefers NPU paths (CPU-first behavior).
* **Improvements**
  * Added mic suppression during TTS playback to reduce self-capture/feedback loops.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->