### PR TITLE
fix: unblock main SwiftLint/ktlint

### DIFF
--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Infrastructure/Device/Models/Domain/DeviceInfo.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Infrastructure/Device/Models/Domain/DeviceInfo.swift
@@ -232,7 +232,7 @@ public enum DeviceInfoFactory {
             // IOKit's IOPSGetPowerSourceDescription returns an untyped CFDictionary.
             // swiftlint:disable avoid_any_type
             guard let description = IOPSGetPowerSourceDescription(snapshot, source)?
-                .takeUnretainedValue() as? [String: Any],
+                .takeUnretainedValue() as? NSDictionary,
                   description[kIOPSTypeKey] as? String == kIOPSInternalBatteryType else {
                 continue
             }

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Infrastructure/Device/Models/Domain/DeviceInfo.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Infrastructure/Device/Models/Domain/DeviceInfo.swift
@@ -230,13 +230,11 @@ public enum DeviceInfoFactory {
         }
         for source in sources {
             // IOKit's IOPSGetPowerSourceDescription returns an untyped CFDictionary.
-            // swiftlint:disable avoid_any_type
             guard let description = IOPSGetPowerSourceDescription(snapshot, source)?
                 .takeUnretainedValue() as? NSDictionary,
                   description[kIOPSTypeKey] as? String == kIOPSInternalBatteryType else {
                 continue
             }
-            // swiftlint:enable avoid_any_type
             var level: Float?
             if let current = description[kIOPSCurrentCapacityKey] as? Int,
                let maxCapacity = description[kIOPSMaxCapacityKey] as? Int,


### PR DESCRIPTION
## Summary
- Fix three pre-existing SwiftLint/ktlint failures on `main` in the Swift and Kotlin SDKs.
- Keep this PR intentionally separate from the Python and Electron branches so unrelated CI stays unblocked.
- These failures were already present on `main` and were not introduced by the Python/Electron PRs.

## Test plan
- [x] Let pre-commit run on the lint-only commit
- [x] Confirm the diff contains only the three requested one-line fixes

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved macOS battery information handling for more reliable battery level and charging-state reporting.
  * Added clearer confirmation when SDK environment URL validation succeeds.
  * Maintained consistent service initialization behavior across supported platforms.

* **Refactor**
  * Improved code formatting and readability without changing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->