### PR TITLE
fix(llamacpp): revert llama.cpp pin to upstream b9959 to resolve GGUF…

### DIFF
--- a/sdk/runanywhere-commons/VERSIONS
+++ b/sdk/runanywhere-commons/VERSIONS
@@ -213,17 +213,12 @@ SHERPA_ONNX_COMMIT_WEB=142807252687d81b40d6315f23470a1512a00de3
 # =============================================================================
 # llama.cpp (LLM inference)
 # =============================================================================
-# (2026-07-15 Bonsai pin): PrismML fork, NOT an upstream ggerganov b-tag.
-# Tag prism-b9591-62061f9 = upstream b9591 + PrismML Bonsai patches
-# (LLM_ARCH_QWEN35 GatedDeltaNet + GGML_TYPE_Q1_0), required to load
-# prism-ml/Bonsai-27B-gguf Q1_0 artifacts. Additive changes only — existing
-# GGUF type IDs are unchanged. Known trade-off vs the previous upstream
-# b9959 pin: upstream b9591..b9959 work (newer mtmd/OCR models, ARMv7
-# table-lookup fallback) is not included.
-LLAMACPP_VERSION=prism-b9591-62061f9
+# Upstream release pin. b9959 includes the ARMv7 table-lookup fallback required by Android builds.
+LLAMACPP_VERSION=b9959
 # Repository the llama.cpp FetchContent clones. Consumed by
 # engines/llamacpp/CMakeLists.txt via LoadVersions (RAC_LLAMACPP_GIT_REPOSITORY).
-LLAMACPP_GIT_REPOSITORY=https://github.com/PrismML-Eng/llama.cpp.git
+LLAMACPP_GIT_REPOSITORY=https://github.com/ggerganov/llama.cpp.git
+
 
 # =============================================================================
 # nlohmann/json


### PR DESCRIPTION
## Summary
Fixes a native process crash (`SIGSEGV` in `je_free` / `SIGABRT` with truncated tagged pointers) during `RunAnywhere.loadModel(...)` on GGUF models (#577).

## Problem
In v0.20.10, `LLAMACPP_VERSION` was switched to a fork (`PrismML-Eng/llama.cpp.git` @ `prism-b9591-62061f9`). GGUF metadata parsing in that build introduced a heap corruption / invalid `free()` inside `gguf_kv_to_str` when `llama_model_loader` processed key-value metadata arrays during model initialization.

## Fix
Revert `LLAMACPP_VERSION` and `LLAMACPP_GIT_REPOSITORY` in `sdk/runanywhere-commons/VERSIONS` back to upstream `ggerganov/llama.cpp.git` at tag `b9959`.

## Changes Made
- `sdk/runanywhere-commons/VERSIONS`: Restored `LLAMACPP_VERSION=b9959` and `LLAMACPP_GIT_REPOSITORY=https://github.com/ggerganov/llama.cpp.git`.

## Related Issues
Closes #577

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the bundled llama.cpp integration to a newer upstream release.
  * Switched the source to the official llama.cpp repository for improved alignment with upstream updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->