### PR TITLE
limit down oss to just once a day and not on every PR

### DIFF
--- a/.github/workflows/oss-keyless-telemetry.yml
+++ b/.github/workflows/oss-keyless-telemetry.yml
@@ -4,26 +4,21 @@
 # Primary CI for the open-source contract: build rcli in this public repo and
 # keyless-blast all 12 modalities at the staging backend (PUBLIC org). No API
 # key. Staging origin comes from repo secrets/vars — not hardcoded hosts.
+#
+# Intentionally NOT on pull_request — each run writes real events into staging
+# and would dirty the DB under PR load. Daily + manual only.
 # =============================================================================
 
 name: OSS keyless telemetry
 
 on:
-  pull_request:
-    paths:
-      - ".github/workflows/oss-keyless-telemetry.yml"
-      - "scripts/ci/oss_keyless_telemetry_blast.sh"
-      - "sdk/runanywhere-cli/**"
-      - "sdk/runanywhere-commons/src/infrastructure/network/**"
-      - "sdk/runanywhere-commons/src/lifecycle/**"
-      - "sdk/runanywhere-commons/src/core/sdk_state.cpp"
   schedule:
     # Daily 08:00 UTC — light cadence for Staging drift.
     - cron: "0 8 * * *"
   workflow_dispatch: {}
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
 permissions:


### PR DESCRIPTION
limit down the cadence of the OSS action

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated telemetry workflow scheduling to run daily or when manually triggered.
  - Removed automatic execution for pull request events.
  - Improved workflow concurrency handling to prevent overlapping runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->