### PR TITLE
Cosmos3-Edge on Hexagon v79 (SM8750)

### DIFF
--- a/engines/qhexrt/qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/qhexrt_model_catalog.cpp
@@ -86,9 +86,9 @@ constexpr ModelPolicy kModelPolicies[] = {
     {"nemoguard_topic_8b", kV81, false},
     {"qwen3_vl_2b_text", kV81, false},
     {"qwen3_vl", kV75V79, false},
-    {"cosmos3_edge_text", kV81, false},   // Cosmos3-Edge reasoning/text AR path (sharded fp16 decode, split_generate); v81 device-validated greedy-exact
-    {"cosmos3_edge_vlm", kV81, false},    // Cosmos3-Edge image-understanding path (SigLIP vision + W8 decode via cosmos3vl_generate); v81 device-validated
-    {"cosmos3_edge_diffusion", kV81, false},  // Cosmos3-Edge text->image (4-shard W8 DiT + UniPC denoise + tiled VAE via cosmos3_diffusion_generate); v81
+    {"cosmos3_edge_text", kV79V81, false},   // Cosmos3-Edge reasoning/text AR path (split_generate); v81 greedy-exact, v79 W8-mono decode + fp16 lm-head
+    {"cosmos3_edge_vlm", kV79V81, false},    // Cosmos3-Edge image-understanding path (SigLIP vision + W8 decode via cosmos3vl_generate); v79 + v81
+    {"cosmos3_edge_diffusion", kV79V81, false},  // Cosmos3-Edge text->image (4-shard W8 DiT + UniPC denoise + tiled VAE via cosmos3_diffusion_generate); v79 + v81
     {"internvl3_5_1b", kAllSupportedArches, false},
     {"gemma4_e2b_vlm", kV79V81, false},
     {"gemma4_e4b_vlm", kV81, false},

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -79,9 +79,12 @@ internal object ModelCatalog {
         // separate generation repo.
         // supportsThinking=false: the text manifest bakes a closed empty-think block for concise,
         // self-terminating replies, so the app shows the answer rather than an always-empty reasoning section.
-        SingleFileModel("cosmos3_edge_text", "Cosmos3-Edge Text (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_HNPU/v81/cosmos3-edge-text.manifest.json", QHEXRT, LANGUAGE, 2513105364L, contextLength = 2_048, supportsThinking = false),
-        SingleFileModel("cosmos3_edge_vlm", "Cosmos3-Edge Vision (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_HNPU/v81/cosmos3-edge-vlm.json", QHEXRT, MULTIMODAL, 3505000000L, contextLength = 2_048),
-        SingleFileModel("cosmos3_edge_diffusion", "Cosmos3-Edge Image (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_image_HNPU/v81/cosmos3-edge-diffusion.json", QHEXRT, IMAGE_GENERATION, 4_450_000_000L),
+        // The arch segment is intentionally OMITTED: native commons resolves the device's own
+        // child dir (v79/ or v81/) from the manifest leaf, so one row serves both chips. Both
+        // repos now ship v79/ alongside v81/ (v79 device-validated on SM8750).
+        SingleFileModel("cosmos3_edge_text", "Cosmos3-Edge Text (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_HNPU/cosmos3-edge-text.manifest.json", QHEXRT, LANGUAGE, 2513105364L, contextLength = 2_048, supportsThinking = false),
+        SingleFileModel("cosmos3_edge_vlm", "Cosmos3-Edge Vision (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_HNPU/cosmos3-edge-vlm.json", QHEXRT, MULTIMODAL, 3505000000L, contextLength = 2_048),
+        SingleFileModel("cosmos3_edge_diffusion", "Cosmos3-Edge Image (HNPU)", "https://huggingface.co/runanywhere/cosmos3_edge_image_HNPU/cosmos3-edge-diffusion.json", QHEXRT, IMAGE_GENERATION, 4_450_000_000L),
         SingleFileModel("nemoguard_content_8b", "NemoGuard 8B Content Safety (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_content_safety_HNPU/nemoguard-content-8b.json", QHEXRT, LANGUAGE, 8_610_354_023L),
         SingleFileModel("nemoguard_topic_8b", "NemoGuard 8B Topic Control (HNPU)", "https://huggingface.co/runanywhere/nemoguard_8b_topic_control_HNPU/nemoguard-topic-8b.json", QHEXRT, LANGUAGE, 8_609_694_527L),
         SingleFileModel("qwen3_vl_2b_text", "Qwen3-VL 2B Text (HNPU)", "https://huggingface.co/runanywhere/qwen3_vl_HNPU/qwen3vl-2b-text-512.json", QHEXRT, LANGUAGE, 2_364_667_194L, contextLength = 512),


### PR DESCRIPTION
Enables the Cosmos3-Edge rows added in #583 on **Hexagon v79** (SM8750 / Galaxy S25), alongside the existing v81 support. Both HNPU repos now ship a `v79/` child dir next to `v81/`.

### Changes (2 files, +9/-6)
- **`engines/qhexrt/qhexrt_model_catalog.cpp`** — the three cosmos rows go `kV81` → `kV79V81`.
- **`examples/.../data/ModelCatalog.kt`** — drop the hardcoded `/v81/` segment from the three URLs so native commons resolves the device's own arch child dir. One row now serves both chips, which also matches the documented catalog design (no duplicate hard-coded per-arch URLs).

No new models, screens, or harness code — #583 already shipped the Diffusion screen, the `generateImage` route, the packaging fix, and the `t2i_reference_smoke` metric.

### Device validation — SM8750 / v79, public SDK lifecycle
`registerModel → downloadModel → loadModel → generate/generateImage → deleteModel`, all reporting `framework=INFERENCE_FRAMEWORK_QHEXRT`, `arch=v79`:

| Model | Result | Notes |
|---|---|---|
| `cosmos3_edge_text` | SMOKE_PASS **9/9 gates** | decode 15.28 tok/s (min 15.18 ≥ 15.0), TTFT 1462 ms, peak RSS 2237 MB |
| `cosmos3_edge_vlm` | SMOKE_PASS **all gates** | vision + splice + decode; peak RSS 3174 MB |
| `cosmos3_edge_diffusion` | SMOKE_PASS **9/9 gates** | `t2i_case_0` + `t2i_pass_fraction` pass; load 5483 ms, peak RSS 3578 MB |

Scope is `smoke_only` (acceptance additionally requires an exact-hash local bundle; HF download resolves mutable remote state).

The matching `cosmos3_edge_{text,vlm,diffusion}_v79.json` suites live in the QHexRT repo per convention; detailed per-modality benchmarks stay there too.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded Cosmos3-Edge text, vision, and diffusion model support to include both v79 and v81 architectures.
  * Updated Android model downloads to automatically resolve the appropriate device-specific model variant.
* **Bug Fixes**
  * Corrected model catalog and manifest paths to support devices using the v79 architecture.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->