### PR TITLE
docs(kotlin): note GGUF model support incl. Gemma in the llama.cpp module README

### DIFF
--- a/sdk/runanywhere-kotlin/modules/runanywhere-core-llamacpp/README.md
+++ b/sdk/runanywhere-kotlin/modules/runanywhere-core-llamacpp/README.md
@@ -50,6 +50,20 @@ For registration, downloads, streaming, and model catalogs, see the [Kotlin SDK 
 
 ---
 
+## Supported models
+
+Any GGUF that llama.cpp can load — Gemma, Llama, Qwen, Phi, SmolLM. The backend is
+format-generic; the catalogs are conveniences, not a whitelist.
+
+For known-good entries with download URLs, see the example app catalog in
+[`ModelCatalog.kt`](../../../../examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt),
+which includes text and vision GGUF models (Gemma 4 E2B/E4B among them).
+
+On Snapdragon, the [QHexRT backend](../runanywhere-core-qhexrt/README.md) additionally
+runs NPU-accelerated bundles, including Gemma 3n/4 and EmbeddingGemma.
+
+---
+
 ## Requirements
 
 - Android API 24+ (ARM64 recommended)


### PR DESCRIPTION
Closes #464.

#464 asked whether Gemma is supported on Android. It is, and has been — but nothing in the module docs says so, which is why the question sat open.

`runanywhere-core-llamacpp/README.md` documents loading a GGUF (`model_id = "my-gguf-model"`) and defers catalogs to the parent README, so a user checking the llama.cpp backend for model support finds nothing. Meanwhile the example app already ships `gemma-4-e2b-it-q8_0` and `gemma-4-e4b-it-q4_k_m` (`ModelCatalog.kt:415-440`), and QHexRT ships four Gemma bundles (`ModelCatalog.kt:60-63`, `engines/qhexrt/qhexrt_model_catalog.cpp:75-97`).

This adds one "Supported models" section pointing at both, and states that the backend is GGUF-generic rather than a fixed list. Docs only — nothing else.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Documented supported GGUF models for the llama.cpp backend.
  * Clarified that model catalogs are convenience lists, not restrictions.
  * Added references to known-good text and vision model examples.
  * Documented additional NPU-accelerated model support on Snapdragon devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->