### PR TITLE
llm: constrained tool-call decoding, parallel tool calls, agent-loop wiring

### DIFF
--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ToolCallingModelPolicy.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ToolCallingModelPolicy.kt
@@ -139,5 +139,9 @@ internal object ToolCallingExecutionPolicy {
         auto_execute = true,
         keep_tools_available = false,
         disable_thinking = true,
+        // Match the iOS example (LLMViewModel+ToolCalling.swift): one model
+        // turn may request multiple tools (e.g. weather + time) and get them
+        // all executed before a single follow-up reply.
+        parallel_tool_calls = true,
     )
 }

--- a/examples/android/RunAnywhereAI/app/src/test/java/com/runanywhere/runanywhereai/ui/screens/chat/ToolCallingModelPolicyTest.kt
+++ b/examples/android/RunAnywhereAI/app/src/test/java/com/runanywhere/runanywhereai/ui/screens/chat/ToolCallingModelPolicyTest.kt
@@ -116,6 +116,7 @@ class ToolCallingModelPolicyTest {
         assertEquals(0f, plan.toolOptions.temperature)
         assertTrue(plan.toolOptions.disable_thinking == true)
         assertFalse(plan.toolOptions.keep_tools_available)
+        assertTrue(plan.toolOptions.parallel_tool_calls)
     }
 
     private fun model(name: String, contextLength: Int): ModelInfo = ModelInfo(

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI.xcodeproj/project.pbxproj
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI.xcodeproj/project.pbxproj
@@ -12,6 +12,8 @@
 		54398D222F4939A7009D6B51 /* WidgetKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54398D212F4939A7009D6B51 /* WidgetKit.framework */; };
 		54398D242F4939A7009D6B51 /* SwiftUI.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 54398D232F4939A7009D6B51 /* SwiftUI.framework */; };
 		54398D332F4939A7009D6B51 /* RunAnywhereActivityExtensionExtension.appex in Embed Foundation Extensions */ = {isa = PBXBuildFile; fileRef = 54398D202F4939A7009D6B51 /* RunAnywhereActivityExtensionExtension.appex */; platformFilter = ios; settings = {ATTRIBUTES = (RemoveHeadersOnCopy, ); }; };
+		5AEA17002EAB250200337F01 /* HealthKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AEA17012EAB250200337F02 /* HealthKit.framework */; platformFilter = ios; };
+		5AEA17032EAB250200337F04 /* EventKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 5AEA17042EAB250200337F05 /* EventKit.framework */; };
 		58ABEDD22ED16DA40058D033 /* RunAnywhereONNX in Frameworks */ = {isa = PBXBuildFile; productRef = 58ABEDD12ED16DA40058D033 /* RunAnywhereONNX */; };
 		58LLAMACPP12ED16DA40058D0 /* RunAnywhereLlamaCPP in Frameworks */ = {isa = PBXBuildFile; productRef = 58LLAMACPP02ED16DA40058D0 /* RunAnywhereLlamaCPP */; };
 		58MLX00012ED16DA40058D0 /* RunAnywhereMLX in Frameworks */ = {isa = PBXBuildFile; productRef = 58MLX00002ED16DA40058D0 /* RunAnywhereMLX */; };
@@ -68,6 +70,8 @@
 
 /* Begin PBXFileReference section */
 		0C5E8414EC72B380DADD6717 /* Accelerate.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Accelerate.framework; path = System/Library/Frameworks/Accelerate.framework; sourceTree = SDKROOT; };
+		5AEA17012EAB250200337F02 /* HealthKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = HealthKit.framework; path = System/Library/Frameworks/HealthKit.framework; sourceTree = SDKROOT; };
+		5AEA17042EAB250200337F05 /* EventKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = EventKit.framework; path = System/Library/Frameworks/EventKit.framework; sourceTree = SDKROOT; };
 		0D23254BCD6273187BD2441C /* libbz2.tbd */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libbz2.tbd; path = usr/lib/libbz2.tbd; sourceTree = SDKROOT; };
 		502F1BAB2C2556A11E24EA6F /* libc++.tbd */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = "libc++.tbd"; path = "usr/lib/libc++.tbd"; sourceTree = SDKROOT; };
 		54398ABE2F492D1D009D6B51 /* RunAnywhereKeyboard.appex */ = {isa = PBXFileReference; explicitFileType = "wrapper.app-extension"; includeInIndex = 0; path = RunAnywhereKeyboard.appex; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -165,6 +169,8 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				5AEA17002EAB250200337F01 /* HealthKit.framework in Frameworks */,
+				5AEA17032EAB250200337F04 /* EventKit.framework in Frameworks */,
 				58ABEDD22ED16DA40058D033 /* RunAnywhereONNX in Frameworks */,
 				541C59DA2E63772A00DD7839 /* RunAnywhere in Frameworks */,
 				58LLAMACPP12ED16DA40058D0 /* RunAnywhereLlamaCPP in Frameworks */,
@@ -206,6 +212,8 @@
 				0D23254BCD6273187BD2441C /* libbz2.tbd */,
 				502F1BAB2C2556A11E24EA6F /* libc++.tbd */,
 				0C5E8414EC72B380DADD6717 /* Accelerate.framework */,
+				5AEA17012EAB250200337F02 /* HealthKit.framework */,
+				5AEA17042EAB250200337F05 /* EventKit.framework */,
 				54398D212F4939A7009D6B51 /* WidgetKit.framework */,
 				54398D232F4939A7009D6B51 /* SwiftUI.framework */,
 			);
@@ -778,7 +786,9 @@
 				INFOPLIST_FILE = RunAnywhereAI/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = RunAnywhere;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "RunAnywhere AI reads your Calendar events so the on-device assistant can answer questions about your schedule and upcoming events.";
 				INFOPLIST_KEY_NSCameraUsageDescription = "RunAnywhere AI needs access to your camera for vision language model features to analyze images.";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "RunAnywhere AI reads Apple Health data (steps, sleep, heart rate, activity, and workouts) so the on-device assistant can answer questions about your health and fitness.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "RunAnywhere AI needs access to your microphone to transcribe your voice input and provide voice-based interactions.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "RunAnywhere AI uses speech recognition to convert your voice to text for processing.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
@@ -830,7 +840,9 @@
 				INFOPLIST_FILE = RunAnywhereAI/Info.plist;
 				INFOPLIST_KEY_CFBundleDisplayName = RunAnywhere;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
+				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "RunAnywhere AI reads your Calendar events so the on-device assistant can answer questions about your schedule and upcoming events.";
 				INFOPLIST_KEY_NSCameraUsageDescription = "RunAnywhere AI needs access to your camera for vision language model features to analyze images.";
+				INFOPLIST_KEY_NSHealthShareUsageDescription = "RunAnywhere AI reads Apple Health data (steps, sleep, heart rate, activity, and workouts) so the on-device assistant can answer questions about your health and fitness.";
 				INFOPLIST_KEY_NSMicrophoneUsageDescription = "RunAnywhere AI needs access to your microphone to transcribe your voice input and provide voice-based interactions.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "RunAnywhere AI uses speech recognition to convert your voice to text for processing.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+ToolCalling.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel+ToolCalling.swift
@@ -19,7 +19,14 @@ extension LLMViewModel {
     ) async throws {
         // The SDK derives the tool-calling format from the loaded model and
         // orchestrates the tool call → execute → respond loop internally.
-        let result = try await RunAnywhere.generateWithTools(prompt: prompt, options: options)
+        // parallelToolCalls: true lets one turn request multiple tools (e.g.
+        // weather + time) and get them all executed before one follow-up
+        // reply, instead of one round-trip per tool.
+        let result = try await RunAnywhere.generateWithTools(
+            prompt: prompt,
+            options: options,
+            parallelToolCalls: true
+        )
         let toolCallInfo = ToolCallInfo(from: result)
 
         // Drop the write if this generation was superseded while awaiting.

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Chat/ViewModels/LLMViewModel.swift
@@ -736,7 +736,31 @@ final class LLMViewModel {
             maxTokens: savedMaxTokens != 0 ? savedMaxTokens : Self.defaultMaxTokensValue
         )
 
-        let effectiveSystemPrompt = (savedSystemPrompt?.isEmpty == false) ? savedSystemPrompt : nil
+        var effectiveSystemPrompt = (savedSystemPrompt?.isEmpty == false) ? savedSystemPrompt : nil
+
+        #if os(iOS)
+        // The get_health_data tool surfaces real vitals (heart rate, SpO2,
+        // resting heart rate, ...). Without guidance, a small on-device model
+        // asked to comment on those numbers will readily improvise a medical
+        // opinion. This instruction is appended (not swapped in) so it holds
+        // even when the user has set their own custom system prompt.
+        if ToolSettingsViewModel.shared.toolCallingEnabled, ToolSettingsViewModel.shared.healthToolEnabled {
+            let healthSafetyInstructions = """
+                You have access to the user's real Apple Health data via get_health_data. \
+                Never provide a medical diagnosis, treatment recommendation, or interpret \
+                vitals as indicating a health condition. If the user describes concerning \
+                symptoms (e.g. chest pain, severe dizziness, fainting, difficulty breathing), \
+                tell them to seek medical attention immediately instead of analyzing their \
+                Health data for it. Present Health data factually and encourage consulting a \
+                qualified healthcare professional for any medical concerns. Only state \
+                numbers that literally appear in a get_health_data tool result — if a field \
+                is missing, say the data isn't available rather than estimating a number.
+                """
+            effectiveSystemPrompt = [effectiveSystemPrompt, healthSafetyInstructions]
+                .compactMap { $0 }
+                .joined(separator: "\n\n")
+        }
+        #endif
 
         let systemPromptInfo: String = {
             guard let prompt = effectiveSystemPrompt else { return "nil" }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/CalendarTool.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/CalendarTool.swift
@@ -1,0 +1,202 @@
+//
+//  CalendarTool.swift
+//  RunAnywhereAI
+//
+//  Calendar tool — lets the on-device assistant answer simple questions
+//  about the user's own schedule ("what's on my calendar today", "am I
+//  free this week"). Read-only, single tool, on purpose: this mirrors the
+//  scope of get_current_time / get_weather rather than trying to be a full
+//  calendar client.
+//
+
+import EventKit
+import Foundation
+import RunAnywhere
+
+// MARK: - Calendar Manager
+
+/// Read-only EventKit access for the `get_calendar_events` tool. Actor-isolated
+/// for the same reason as HealthKitManager: EventKit's authorization callback
+/// lands on a background queue. Unlike HealthKit, EventKit is a plain native
+/// framework on both iOS and macOS, so this file needs no `#if os(iOS)` guard.
+actor CalendarManager {
+    static let shared = CalendarManager()
+
+    private let store = EKEventStore()
+
+    /// Requests full read/write access to Calendars. This tool only reads,
+    /// but EventKit does not offer a read-only grant — write access is
+    /// simply unused.
+    func requestAuthorization() async throws {
+        _ = try await store.requestFullAccessToEvents()
+    }
+
+    private struct CalendarDateRange {
+        let start: Date
+        let end: Date
+        let label: String
+    }
+
+    private static let isoDayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Calendar.current.timeZone
+        return formatter
+    }()
+
+    static var todayString: String { isoDayFormatter.string(from: Date()) }
+
+    private func parseISODay(_ string: String) -> Date? {
+        CalendarManager.isoDayFormatter.date(from: string)
+    }
+
+    /// Same resolution strategy as HealthKitManager.resolveRange (explicit
+    /// range wins, then keywords, then a single explicit day, then "today"),
+    /// with calendar-appropriate keywords instead of health ones — a
+    /// schedule question skews forward-looking ("this week", "tomorrow")
+    /// rather than backward-looking.
+    private func resolveRange(dateSpec: String?, startDate: String?, endDate: String?) -> CalendarDateRange {
+        let calendar = Calendar.current
+        let now = Date()
+        let startOfToday = calendar.startOfDay(for: now)
+
+        let effectiveStartDate = startDate ?? (endDate != nil ? dateSpec : nil)
+        if let effectiveStartDate, let parsedStart = parseISODay(effectiveStartDate) {
+            let startDay = calendar.startOfDay(for: parsedStart)
+            let endDay: Date
+            let label: String
+            if let endDate, let parsedEnd = parseISODay(endDate), parsedEnd != parsedStart {
+                endDay = calendar.date(byAdding: .day, value: 1, to: calendar.startOfDay(for: parsedEnd)) ?? startDay
+                label = "\(effectiveStartDate) to \(endDate)"
+            } else {
+                endDay = calendar.date(byAdding: .day, value: 1, to: startDay) ?? startDay
+                label = effectiveStartDate
+            }
+            return CalendarDateRange(start: startDay, end: max(endDay, startDay), label: label)
+        }
+
+        switch dateSpec?.lowercased() {
+        case "tomorrow":
+            let start = calendar.date(byAdding: .day, value: 1, to: startOfToday) ?? startOfToday
+            let end = calendar.date(byAdding: .day, value: 1, to: start) ?? start
+            return CalendarDateRange(start: start, end: end, label: "tomorrow")
+        case "this_week":
+            let end = calendar.dateInterval(of: .weekOfYear, for: now)?.end ?? startOfToday
+            return CalendarDateRange(start: startOfToday, end: max(end, startOfToday), label: "this_week")
+        case "next_7_days":
+            let end = calendar.date(byAdding: .day, value: 7, to: startOfToday) ?? startOfToday
+            return CalendarDateRange(start: startOfToday, end: end, label: "next_7_days")
+        case "today", .none:
+            let end = calendar.date(byAdding: .day, value: 1, to: startOfToday) ?? startOfToday
+            return CalendarDateRange(start: startOfToday, end: end, label: "today")
+        case .some(let explicitDay):
+            if let parsed = parseISODay(explicitDay) {
+                let day = calendar.startOfDay(for: parsed)
+                let end = calendar.date(byAdding: .day, value: 1, to: day) ?? day
+                return CalendarDateRange(start: day, end: end, label: explicitDay)
+            }
+            let end = calendar.date(byAdding: .day, value: 1, to: startOfToday) ?? startOfToday
+            return CalendarDateRange(start: startOfToday, end: end, label: "today")
+        }
+    }
+
+    func fetchEvents(dateSpec: String?, startDate: String?, endDate: String?) async throws -> [String: RAToolValue] {
+        let range = resolveRange(dateSpec: dateSpec, startDate: startDate, endDate: endDate)
+
+        // EventKit caps predicateForEvents at a 4-year span; every range this
+        // tool builds is well inside that, so no clamping needed here.
+        let predicate = store.predicateForEvents(withStart: range.start, end: range.end, calendars: nil)
+        let events = store.events(matching: predicate).sorted { $0.startDate < $1.startDate }
+
+        let timeFormatter = DateFormatter()
+        timeFormatter.dateStyle = .none
+        timeFormatter.timeStyle = .short
+
+        let summaries = events.map { event -> String in
+            let timeText: String
+            if event.isAllDay {
+                timeText = "all day"
+            } else {
+                timeText = "\(timeFormatter.string(from: event.startDate)) - \(timeFormatter.string(from: event.endDate))"
+            }
+            let locationText = event.location.map { " at \($0)" } ?? ""
+            return "\(event.title ?? "Untitled") (\(timeText)\(locationText))"
+        }
+
+        return [
+            "event_count": RAToolValue(Double(events.count)),
+            "events": RAToolValue(summaries.joined(separator: "; ")),
+            "date": RAToolValue(range.label)
+        ]
+    }
+}
+
+// MARK: - get_calendar_events Tool
+
+enum CalendarTool {
+    static var definition: RAToolDefinition {
+        let todayString = CalendarManager.todayString
+        return RAToolDefinition(
+            name: "get_calendar_events",
+            description: """
+                Gets the user's own Calendar events (meetings, appointments, plans) for a \
+                specific day or date range. Use whenever the user asks about their schedule, \
+                what's on their calendar, upcoming meetings, or free time (e.g. "what's on my \
+                calendar today", "am I free this week", "do I have anything tomorrow"). Today's \
+                date is \(todayString) — use that as your only source of truth for "today", \
+                never guess or recall a date from memory. This tool has no access to any other \
+                person's calendar. State only events that literally appear in this tool's \
+                result — if event_count is 0, say the user's schedule is free instead of \
+                inventing an event.
+                """,
+            parameters: [
+                RAToolParameter(
+                    name: "date",
+                    type: .string,
+                    description: """
+                        Which period to check. Accepts a keyword — "today" (default), \
+                        "tomorrow", "this_week", "next_7_days" — OR a specific day as \
+                        "YYYY-MM-DD". For a custom multi-day range, use start_date/end_date \
+                        instead of this field.
+                        """,
+                    required: false
+                ),
+                RAToolParameter(
+                    name: "start_date",
+                    type: .string,
+                    description: """
+                        Start of a specific custom date range, as "YYYY-MM-DD". When set, this \
+                        overrides `date`. Pair with end_date for a multi-day range, or omit \
+                        end_date to query just this one day.
+                        """,
+                    required: false
+                ),
+                RAToolParameter(
+                    name: "end_date",
+                    type: .string,
+                    description: "End of the custom date range (inclusive), as \"YYYY-MM-DD\". Only used together with start_date.",
+                    required: false
+                )
+            ],
+            category: "Calendar"
+        )
+    }
+
+    static var executor: ToolExecutor {
+        { args in
+            let date = args["date"]?.string
+            let startDate = args["start_date"]?.string
+            let endDate = args["end_date"]?.string
+            do {
+                return try await CalendarManager.shared.fetchEvents(
+                    dateSpec: date,
+                    startDate: startDate,
+                    endDate: endDate
+                )
+            } catch {
+                return ["error": RAToolValue(error.localizedDescription)]
+            }
+        }
+    }
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/HealthKitTool.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/HealthKitTool.swift
@@ -1,0 +1,726 @@
+//
+//  HealthKitTool.swift
+//  RunAnywhereAI
+//
+//  Apple Health tool — lets the on-device assistant answer questions about
+//  the user's own activity, vitals, body measurements, and wellbeing data,
+//  for any specific day or custom date range.
+//
+
+import Foundation
+import RunAnywhere
+
+// HealthKit only exists on iOS (and watchOS/Catalyst) — this app also ships
+// as a native macOS target, which has no HealthKit.framework at all.
+#if os(iOS)
+import HealthKit
+
+// MARK: - HealthKit Manager
+
+/// Read-only HealthKit access for the `get_health_data` tool. Actor-isolated
+/// because HKHealthStore's completion handlers land on background queues.
+actor HealthKitManager {
+    static let shared = HealthKitManager()
+
+    private let store = HKHealthStore()
+
+    enum HealthKitToolError: LocalizedError {
+        case notAvailable
+        case unknownMetric(String)
+
+        var errorDescription: String? {
+            switch self {
+            case .notAvailable:
+                return "Health data is not available on this device."
+            case .unknownMetric(let metric):
+                return "Unknown health metric: \(metric)"
+            }
+        }
+    }
+
+    // Read-only types this tool ever asks for. Kept in one place so the
+    // authorization request and the app's usage-description string
+    // (Info.plist NSHealthShareUsageDescription) stay honest about scope.
+    private var readTypes: Set<HKObjectType> {
+        var types: Set<HKObjectType> = [
+            HKObjectType.quantityType(forIdentifier: .stepCount)!,
+            HKObjectType.quantityType(forIdentifier: .activeEnergyBurned)!,
+            HKObjectType.quantityType(forIdentifier: .heartRate)!,
+            HKObjectType.quantityType(forIdentifier: .distanceWalkingRunning)!,
+            HKObjectType.quantityType(forIdentifier: .environmentalAudioExposure)!,
+            HKObjectType.quantityType(forIdentifier: .headphoneAudioExposure)!,
+            HKObjectType.quantityType(forIdentifier: .restingHeartRate)!,
+            HKObjectType.quantityType(forIdentifier: .heartRateVariabilitySDNN)!,
+            HKObjectType.quantityType(forIdentifier: .oxygenSaturation)!,
+            HKObjectType.quantityType(forIdentifier: .respiratoryRate)!,
+            HKObjectType.quantityType(forIdentifier: .vo2Max)!,
+            HKObjectType.quantityType(forIdentifier: .flightsClimbed)!,
+            HKObjectType.quantityType(forIdentifier: .bodyMass)!,
+            HKObjectType.quantityType(forIdentifier: .height)!,
+            HKObjectType.quantityType(forIdentifier: .bodyMassIndex)!,
+            HKObjectType.quantityType(forIdentifier: .bodyFatPercentage)!,
+            HKObjectType.quantityType(forIdentifier: .bodyTemperature)!,
+            HKObjectType.categoryType(forIdentifier: .sleepAnalysis)!,
+            HKObjectType.categoryType(forIdentifier: .mindfulSession)!,
+            HKObjectType.activitySummaryType()
+        ]
+        types.insert(HKObjectType.workoutType())
+        return types
+    }
+
+    static var isAvailable: Bool { HKHealthStore.isHealthDataAvailable() }
+
+    /// Requests read access for every type this tool can query. HealthKit
+    /// deliberately never reports per-type grant/deny back to the app (a
+    /// privacy design choice) — this only throws for device-level
+    /// unavailability, not for the user declining individual permissions in
+    /// the system sheet. A denied read simply comes back as "no samples"
+    /// later, which every fetcher below already treats as a valid,
+    /// zero-value result rather than an error.
+    func requestAuthorization() async throws {
+        guard HealthKitManager.isAvailable else {
+            throw HealthKitToolError.notAvailable
+        }
+        try await store.requestAuthorization(toShare: [], read: readTypes)
+    }
+
+    /// A resolved query window plus the label to echo back to the model, so
+    /// it doesn't have to re-derive "today"/"last_7_days" from raw dates.
+    private struct HealthDateRange {
+        let start: Date
+        let end: Date
+        let label: String
+    }
+
+    fileprivate static let isoDayFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateFormat = "yyyy-MM-dd"
+        // Fixed POSIX locale + device time zone: parses/formats calendar
+        // days the way the user experiences them, independent of the
+        // device's region settings (which could otherwise reorder
+        // day/month or use a non-Gregorian calendar).
+        formatter.locale = Locale(identifier: "en_US_POSIX")
+        formatter.timeZone = Calendar.current.timeZone
+        return formatter
+    }()
+
+    private func parseISODay(_ string: String) -> Date? {
+        HealthKitManager.isoDayFormatter.date(from: string)
+    }
+
+    /// Resolves the request's date arguments into a concrete query window.
+    /// Priority: an explicit range start (optionally paired with an end)
+    /// always wins, so the model can ask about any specific day or custom
+    /// range ("2026-06-01" to "2026-06-14"). Otherwise `dateSpec` is checked
+    /// against the keyword shortcuts ("today"/"yesterday"/"last_7_days"/
+    /// "last_30_days") and, failing that, parsed as a single explicit day.
+    /// Falls back to "today" only when nothing given is recognizable.
+    ///
+    /// The range start is read from `startDate` OR — if that's missing but
+    /// `endDate` is present — from `dateSpec` itself. Models don't reliably
+    /// follow the "pair start_date with end_date" instruction; a common
+    /// observed mistake is putting the range's start day in `date` and only
+    /// the end in `end_date` (e.g. `{"date": "2026-03-01", "end_date":
+    /// "2026-03-20"}` instead of using `start_date`). Treating any explicit
+    /// day paired with an `end_date` as a range start — regardless of which
+    /// field it arrived in — makes the tool work with what the model
+    /// actually sends instead of what its description merely asks for.
+    private func resolveRange(dateSpec: String?, startDate: String?, endDate: String?) -> HealthDateRange {
+        let calendar = Calendar.current
+        let now = Date()
+        let startOfToday = calendar.startOfDay(for: now)
+
+        // Health data cannot exist for a day that hasn't happened yet.
+        // Small models occasionally hand-type a future date despite the
+        // tool description anchoring "today" for them (observed: a model
+        // asked for "today" once produced "2024-01-01" — the same failure
+        // mode can just as easily land in the future). Clamping here is a
+        // second line of defense that doesn't depend on the model getting
+        // the prompt guidance right.
+        func clampToToday(_ date: Date) -> Date { min(date, now) }
+
+        let effectiveStartDate = startDate ?? (endDate != nil ? dateSpec : nil)
+        if let effectiveStartDate, let parsedStart = parseISODay(effectiveStartDate) {
+            let startDate = effectiveStartDate
+            let startDay = calendar.startOfDay(for: clampToToday(parsedStart))
+            let endDay: Date
+            let label: String
+            if let endDate, let parsedEnd = parseISODay(endDate), parsedEnd != parsedStart {
+                let clampedEndDay = calendar.startOfDay(for: clampToToday(parsedEnd))
+                endDay = calendar.date(byAdding: .day, value: 1, to: clampedEndDay) ?? startDay
+                label = "\(startDate) to \(endDate)"
+            } else {
+                endDay = calendar.date(byAdding: .day, value: 1, to: startDay) ?? startDay
+                label = startDate
+            }
+            return HealthDateRange(start: startDay, end: max(endDay, startDay), label: label)
+        }
+
+        switch dateSpec?.lowercased() {
+        case "yesterday":
+            let start = calendar.date(byAdding: .day, value: -1, to: startOfToday) ?? startOfToday
+            return HealthDateRange(start: start, end: startOfToday, label: "yesterday")
+        case "last_7_days":
+            let start = calendar.date(byAdding: .day, value: -7, to: now) ?? now
+            return HealthDateRange(start: start, end: now, label: "last_7_days")
+        case "last_30_days":
+            let start = calendar.date(byAdding: .day, value: -30, to: now) ?? now
+            return HealthDateRange(start: start, end: now, label: "last_30_days")
+        case "today", .none:
+            let end = calendar.date(byAdding: .day, value: 1, to: startOfToday) ?? startOfToday
+            return HealthDateRange(start: startOfToday, end: end, label: "today")
+        case .some(let explicitDay):
+            // Not a keyword — try it as a single explicit "YYYY-MM-DD" day
+            // (covers models that pass a date through `date` instead of
+            // `start_date`).
+            if let parsed = parseISODay(explicitDay) {
+                let day = calendar.startOfDay(for: clampToToday(parsed))
+                let end = calendar.date(byAdding: .day, value: 1, to: day) ?? day
+                return HealthDateRange(start: day, end: end, label: explicitDay)
+            }
+            let end = calendar.date(byAdding: .day, value: 1, to: startOfToday) ?? startOfToday
+            return HealthDateRange(start: startOfToday, end: end, label: "today")
+        }
+    }
+
+    /// Dispatches to the right fetcher for `metric`, resolving the date
+    /// arguments into a query window (see `resolveRange`).
+    func fetch(
+        metric: String,
+        dateSpec: String?,
+        startDate: String? = nil,
+        endDate: String? = nil
+    ) async throws -> [String: RAToolValue] {
+        let range = resolveRange(dateSpec: dateSpec, startDate: startDate, endDate: endDate)
+        switch metric.lowercased() {
+        case "steps":
+            return try await fetchSteps(range: range)
+        case "active_energy":
+            return try await fetchActiveEnergy(range: range)
+        case "heart_rate":
+            return try await fetchHeartRate(range: range)
+        case "distance":
+            return try await fetchDistance(range: range)
+        case "sleep":
+            return try await fetchSleep(range: range)
+        case "workouts":
+            return try await fetchWorkouts(range: range)
+        case "noise_exposure":
+            return try await fetchNoiseExposure(range: range)
+        case "activity_rings":
+            return try await fetchActivityRings(range: range)
+        case "resting_heart_rate":
+            return try await fetchAverage(
+                identifier: .restingHeartRate, key: "resting_bpm",
+                unit: HKUnit.count().unitDivided(by: .minute()), range: range
+            )
+        case "heart_rate_variability":
+            return try await fetchAverage(
+                identifier: .heartRateVariabilitySDNN, key: "hrv_ms",
+                unit: HKUnit.secondUnit(with: .milli), range: range
+            )
+        case "blood_oxygen":
+            return try await fetchAverage(
+                identifier: .oxygenSaturation, key: "spo2_percent",
+                unit: HKUnit.percent(), range: range, scale: 100
+            )
+        case "respiratory_rate":
+            return try await fetchAverage(
+                identifier: .respiratoryRate, key: "breaths_per_minute",
+                unit: HKUnit.count().unitDivided(by: .minute()), range: range
+            )
+        case "vo2_max":
+            let vo2MaxUnit = HKUnit.literUnit(with: .milli)
+                .unitDivided(by: HKUnit.gramUnit(with: .kilo).unitMultiplied(by: .minute()))
+            return try await fetchAverage(identifier: .vo2Max, key: "vo2_max_ml_kg_min", unit: vo2MaxUnit, range: range)
+        case "flights_climbed":
+            return try await fetchSum(identifier: .flightsClimbed, key: "flights", unit: .count(), range: range)
+        case "weight":
+            return try await fetchAverage(
+                identifier: .bodyMass, key: "weight_kg", unit: HKUnit.gramUnit(with: .kilo), range: range
+            )
+        case "height":
+            return try await fetchAverage(
+                identifier: .height, key: "height_cm", unit: HKUnit.meterUnit(with: .centi), range: range
+            )
+        case "bmi":
+            return try await fetchAverage(identifier: .bodyMassIndex, key: "bmi", unit: .count(), range: range)
+        case "body_fat_percentage":
+            return try await fetchAverage(
+                identifier: .bodyFatPercentage, key: "body_fat_percent",
+                unit: HKUnit.percent(), range: range, scale: 100
+            )
+        case "body_temperature":
+            return try await fetchAverage(
+                identifier: .bodyTemperature, key: "temperature_celsius", unit: HKUnit.degreeCelsius(), range: range
+            )
+        case "mindful_minutes":
+            return try await fetchMindfulMinutes(range: range)
+        default:
+            throw HealthKitToolError.unknownMetric(metric)
+        }
+    }
+
+    /// Cumulative quantities (steps, calories, flights climbed, ...): total
+    /// over the whole range.
+    private func fetchSum(
+        identifier: HKQuantityTypeIdentifier, key: String, unit: HKUnit, range: HealthDateRange
+    ) async throws -> [String: RAToolValue] {
+        let type = HKQuantityType.quantityType(forIdentifier: identifier)!
+        let predicate = HKQuery.predicateForSamples(withStart: range.start, end: range.end)
+        let value = try await sumQuantity(type: type, predicate: predicate, unit: unit)
+        return [key: RAToolValue(value), "date": RAToolValue(range.label)]
+    }
+
+    /// Point-in-time quantities (weight, resting heart rate, SpO2, ...):
+    /// averaged over the range. `scale` converts HealthKit's 0-1 fraction
+    /// units (percent-based ones like oxygen saturation) into a human-scale
+    /// number — 87% is far less error-prone for a model to report than 0.87.
+    private func fetchAverage(
+        identifier: HKQuantityTypeIdentifier, key: String, unit: HKUnit, range: HealthDateRange, scale: Double = 1
+    ) async throws -> [String: RAToolValue] {
+        let type = HKQuantityType.quantityType(forIdentifier: identifier)!
+        let predicate = HKQuery.predicateForSamples(withStart: range.start, end: range.end)
+        let value = try await averageQuantity(type: type, predicate: predicate, unit: unit)
+        return [key: RAToolValue(value * scale), "date": RAToolValue(range.label)]
+    }
+
+    private func fetchSteps(range: HealthDateRange) async throws -> [String: RAToolValue] {
+        try await fetchSum(identifier: .stepCount, key: "steps", unit: .count(), range: range)
+    }
+
+    private func fetchActiveEnergy(range: HealthDateRange) async throws -> [String: RAToolValue] {
+        try await fetchSum(identifier: .activeEnergyBurned, key: "active_energy_kcal", unit: .kilocalorie(), range: range)
+    }
+
+    private func fetchHeartRate(range: HealthDateRange) async throws -> [String: RAToolValue] {
+        let type = HKQuantityType.quantityType(forIdentifier: .heartRate)!
+        let predicate = HKQuery.predicateForSamples(withStart: range.start, end: range.end)
+        let unit = HKUnit.count().unitDivided(by: .minute())
+
+        let (average, minimum, maximum) = try await withCheckedThrowingContinuation {
+            (continuation: CheckedContinuation<(Double, Double, Double), Error>) in
+            let query = HKStatisticsQuery(
+                quantityType: type,
+                quantitySamplePredicate: predicate,
+                options: [.discreteAverage, .discreteMin, .discreteMax]
+            ) { _, stats, error in
+                if let error, !self.isNoDataError(error) {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                let avg = stats?.averageQuantity()?.doubleValue(for: unit) ?? 0
+                let min = stats?.minimumQuantity()?.doubleValue(for: unit) ?? 0
+                let max = stats?.maximumQuantity()?.doubleValue(for: unit) ?? 0
+                continuation.resume(returning: (avg, min, max))
+            }
+            store.execute(query)
+        }
+
+        return [
+            "average_bpm": RAToolValue(average),
+            "min_bpm": RAToolValue(minimum),
+            "max_bpm": RAToolValue(maximum),
+            "date": RAToolValue(range.label)
+        ]
+    }
+
+    private func fetchDistance(range: HealthDateRange) async throws -> [String: RAToolValue] {
+        try await fetchSum(
+            identifier: .distanceWalkingRunning, key: "distance_km", unit: HKUnit.meterUnit(with: .kilo), range: range
+        )
+    }
+
+    private func fetchWorkouts(range: HealthDateRange) async throws -> [String: RAToolValue] {
+        let predicate = HKQuery.predicateForSamples(withStart: range.start, end: range.end)
+
+        let workouts: [HKWorkout] = try await withCheckedThrowingContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: .workoutType(),
+                predicate: predicate,
+                limit: HKObjectQueryNoLimit,
+                sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)]
+            ) { _, results, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: (results as? [HKWorkout]) ?? [])
+            }
+            store.execute(query)
+        }
+
+        let summaries = workouts.map { workout -> String in
+            let minutes = Int(workout.duration / 60)
+            let kcal = workout.statistics(for: HKQuantityType.quantityType(forIdentifier: .activeEnergyBurned)!)?
+                .sumQuantity()?.doubleValue(for: .kilocalorie())
+            let kcalText = kcal.map { ", \(Int($0)) kcal" } ?? ""
+            return "\(workout.workoutActivityType.name) — \(minutes) min\(kcalText)"
+        }
+
+        return [
+            "workout_count": RAToolValue(Double(workouts.count)),
+            "workouts": RAToolValue(summaries.joined(separator: "; ")),
+            "date": RAToolValue(range.label)
+        ]
+    }
+
+    private func fetchSleep(range: HealthDateRange) async throws -> [String: RAToolValue] {
+        let type = HKCategoryType.categoryType(forIdentifier: .sleepAnalysis)!
+        // A night's sleep starts well before midnight of the day it's
+        // attributed to, so widen the query window backward instead of
+        // using the same start the other metrics query with.
+        let queryStart = Calendar.current.date(byAdding: .hour, value: -12, to: range.start) ?? range.start
+        let predicate = HKQuery.predicateForSamples(withStart: queryStart, end: range.end)
+
+        let samples: [HKCategorySample] = try await withCheckedThrowingContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: type,
+                predicate: predicate,
+                limit: HKObjectQueryNoLimit,
+                sortDescriptors: [NSSortDescriptor(key: HKSampleSortIdentifierStartDate, ascending: true)]
+            ) { _, results, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: (results as? [HKCategorySample]) ?? [])
+            }
+            store.execute(query)
+        }
+
+        // TODO(human): Aggregate `samples` into a total-sleep-duration result.
+        //
+        // Each sample is one HealthKit-recorded sleep segment:
+        //   - sample.value is an HKCategoryValueSleepAnalysis raw value:
+        //     .inBed, .asleepUnspecified, .asleepCore, .asleepDeep,
+        //     .asleepREM, or .awake
+        //   - sample.startDate / sample.endDate give that segment's span
+        //
+        // Decide which values count as "asleep" time (note: .inBed does NOT
+        // mean asleep — it can include time spent awake in bed), sum the
+        // duration of the segments you count, and return a dict such as:
+        //   ["hours_asleep": RAToolValue(...), "segment_count": RAToolValue(...),
+        //    "date": RAToolValue(range.label)]
+        // Handle the empty-samples case (no data / no permission) by
+        // returning zeros rather than throwing — HealthKit can't distinguish
+        // "no permission" from "no data" for reads, so treating both the
+        // same way here is the only option. Returning an empty dict here is
+        // NOT a safe placeholder — always include at least "date" so the
+        // model has something to reason about.
+        return ["date": RAToolValue(range.label)]
+    }
+
+    /// Sums Mindfulness app session durations. Unlike sleep, a mindful
+    /// session's category value carries no sub-classification worth
+    /// distinguishing — every recorded session counts, so this needs no
+    /// judgment call the way `fetchSleep` does.
+    private func fetchMindfulMinutes(range: HealthDateRange) async throws -> [String: RAToolValue] {
+        let type = HKCategoryType.categoryType(forIdentifier: .mindfulSession)!
+        let predicate = HKQuery.predicateForSamples(withStart: range.start, end: range.end)
+
+        let samples: [HKCategorySample] = try await withCheckedThrowingContinuation { continuation in
+            let query = HKSampleQuery(
+                sampleType: type,
+                predicate: predicate,
+                limit: HKObjectQueryNoLimit,
+                sortDescriptors: nil
+            ) { _, results, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: (results as? [HKCategorySample]) ?? [])
+            }
+            store.execute(query)
+        }
+
+        let totalMinutes = samples.reduce(0.0) { $0 + $1.endDate.timeIntervalSince($1.startDate) / 60 }
+        return [
+            "mindful_minutes": RAToolValue(totalMinutes),
+            "session_count": RAToolValue(Double(samples.count)),
+            "date": RAToolValue(range.label)
+        ]
+    }
+
+    private func fetchNoiseExposure(range: HealthDateRange) async throws -> [String: RAToolValue] {
+        let dbUnit = HKUnit.decibelAWeightedSoundPressureLevel()
+        let predicate = HKQuery.predicateForSamples(withStart: range.start, end: range.end)
+        async let environmental = averageQuantity(
+            type: HKQuantityType.quantityType(forIdentifier: .environmentalAudioExposure)!,
+            predicate: predicate,
+            unit: dbUnit
+        )
+        async let headphone = averageQuantity(
+            type: HKQuantityType.quantityType(forIdentifier: .headphoneAudioExposure)!,
+            predicate: predicate,
+            unit: dbUnit
+        )
+        let (environmentalDb, headphoneDb) = try await (environmental, headphone)
+        return [
+            "environmental_avg_db": RAToolValue(environmentalDb),
+            "headphone_avg_db": RAToolValue(headphoneDb),
+            "date": RAToolValue(range.label)
+        ]
+    }
+
+    /// Builds an OR-of-single-day predicates for `HKActivitySummaryQuery`,
+    /// which — unlike every other query here — has no start/end-date
+    /// predicate helper, only a per-day one. Capped at 31 days so an
+    /// oversized custom range can't build an unbounded predicate list.
+    private func activitySummaryPredicate(for range: HealthDateRange) -> NSPredicate {
+        let calendar = Calendar.current
+        var day = range.start
+        var predicates: [NSPredicate] = []
+        var daysAdded = 0
+        while day < range.end, daysAdded < 31 {
+            var components = calendar.dateComponents([.year, .month, .day, .era], from: day)
+            components.calendar = calendar
+            predicates.append(HKQuery.predicateForActivitySummary(with: components))
+            day = calendar.date(byAdding: .day, value: 1, to: day) ?? range.end
+            daysAdded += 1
+        }
+        return NSCompoundPredicate(orPredicateWithSubpredicates: predicates)
+    }
+
+    /// Move/exercise/stand ring totals — the source data behind the Fitness
+    /// app's activity rings. Summed across every day in `range` rather than
+    /// just returning the last day, so "how has my activity been this week"
+    /// gets one meaningful answer instead of the model having to call this
+    /// tool seven times.
+    private func fetchActivityRings(range: HealthDateRange) async throws -> [String: RAToolValue] {
+        let predicate = activitySummaryPredicate(for: range)
+        let summaries: [HKActivitySummary] = try await withCheckedThrowingContinuation { continuation in
+            let query = HKActivitySummaryQuery(predicate: predicate) { _, results, error in
+                if let error {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: results ?? [])
+            }
+            store.execute(query)
+        }
+
+        guard !summaries.isEmpty else {
+            return ["days_with_data": RAToolValue(0.0), "date": RAToolValue(range.label)]
+        }
+
+        let kcalUnit = HKUnit.kilocalorie()
+        let minuteUnit = HKUnit.minute()
+        let countUnit = HKUnit.count()
+        var moveKcal = 0.0, moveGoalKcal = 0.0
+        var exerciseMinutes = 0.0, exerciseGoalMinutes = 0.0
+        var standHours = 0.0, standGoalHours = 0.0
+        var perfectDays = 0
+
+        for summary in summaries {
+            let move = summary.activeEnergyBurned.doubleValue(for: kcalUnit)
+            let moveGoal = summary.activeEnergyBurnedGoal.doubleValue(for: kcalUnit)
+            let exercise = summary.appleExerciseTime.doubleValue(for: minuteUnit)
+            let exerciseGoal = summary.appleExerciseTimeGoal.doubleValue(for: minuteUnit)
+            let stand = summary.appleStandHours.doubleValue(for: countUnit)
+            let standGoal = summary.appleStandHoursGoal.doubleValue(for: countUnit)
+
+            moveKcal += move
+            moveGoalKcal += moveGoal
+            exerciseMinutes += exercise
+            exerciseGoalMinutes += exerciseGoal
+            standHours += stand
+            standGoalHours += standGoal
+            if moveGoal > 0, move >= moveGoal, exercise >= exerciseGoal, stand >= standGoal {
+                perfectDays += 1
+            }
+        }
+
+        return [
+            "days_with_data": RAToolValue(Double(summaries.count)),
+            "perfect_days": RAToolValue(Double(perfectDays)),
+            "move_kcal": RAToolValue(moveKcal),
+            "move_goal_kcal": RAToolValue(moveGoalKcal),
+            "exercise_minutes": RAToolValue(exerciseMinutes),
+            "exercise_goal_minutes": RAToolValue(exerciseGoalMinutes),
+            "stand_hours": RAToolValue(standHours),
+            "stand_goal_hours": RAToolValue(standGoalHours),
+            "date": RAToolValue(range.label)
+        ]
+    }
+
+    /// `HKStatisticsQuery` doesn't always resolve "nothing recorded in this
+    /// window" the way `HKSampleQuery` does (an empty result array) — for
+    /// some quantity types it instead completes with an actual `HKError
+    /// .errorNoData`. That's not a failure from this tool's point of view;
+    /// it's the same answer as "0 samples", so every call site below treats
+    /// it as zero instead of surfacing an "error" the model has to explain
+    /// away to the user.
+    private nonisolated func isNoDataError(_ error: Error) -> Bool {
+        (error as? HKError)?.code == .errorNoData
+    }
+
+    private func sumQuantity(type: HKQuantityType, predicate: NSPredicate, unit: HKUnit) async throws -> Double {
+        try await withCheckedThrowingContinuation { continuation in
+            let query = HKStatisticsQuery(
+                quantityType: type,
+                quantitySamplePredicate: predicate,
+                options: .cumulativeSum
+            ) { _, stats, error in
+                if let error, !self.isNoDataError(error) {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: stats?.sumQuantity()?.doubleValue(for: unit) ?? 0)
+            }
+            store.execute(query)
+        }
+    }
+
+    private func averageQuantity(type: HKQuantityType, predicate: NSPredicate, unit: HKUnit) async throws -> Double {
+        try await withCheckedThrowingContinuation { continuation in
+            let query = HKStatisticsQuery(
+                quantityType: type,
+                quantitySamplePredicate: predicate,
+                options: .discreteAverage
+            ) { _, stats, error in
+                if let error, !self.isNoDataError(error) {
+                    continuation.resume(throwing: error)
+                    return
+                }
+                continuation.resume(returning: stats?.averageQuantity()?.doubleValue(for: unit) ?? 0)
+            }
+            store.execute(query)
+        }
+    }
+}
+
+private extension HKWorkoutActivityType {
+    var name: String {
+        switch self {
+        case .running: return "Running"
+        case .walking: return "Walking"
+        case .cycling: return "Cycling"
+        case .swimming: return "Swimming"
+        case .yoga: return "Yoga"
+        case .traditionalStrengthTraining, .functionalStrengthTraining: return "Strength Training"
+        case .hiking: return "Hiking"
+        default: return "Workout"
+        }
+    }
+}
+
+// MARK: - get_health_data Tool
+
+enum HealthKitTool {
+    // `definition` is computed (not a stored `let`) so the description
+    // always embeds *today's actual date*. Small on-device models have no
+    // real notion of "now" and will otherwise confidently invent a wrong
+    // one (observed in testing: a model asked for "today" produced
+    // "2024-01-01" out of thin air). Anchoring the tool description itself
+    // to a concrete, correct date — and steering the model toward the
+    // keyword shortcuts instead of hand-typing a date — is the same fix
+    // already used for get_current_time's "don't re-derive time yourself"
+    // guidance above.
+    static var definition: RAToolDefinition {
+        let todayString = HealthKitManager.isoDayFormatter.string(from: Date())
+        return RAToolDefinition(
+            name: "get_health_data",
+            description: """
+                Gets the user's own Apple Health data: activity (steps, active energy, \
+                distance, flights climbed, workouts, Activity ring move/exercise/stand \
+                progress), vitals (heart rate, resting heart rate, heart rate \
+                variability, blood oxygen, respiratory rate, VO2 max, body \
+                temperature), body measurements (weight, height, BMI, body fat \
+                percentage), and wellbeing (sleep, mindful minutes, noise exposure). \
+                Today's date is \(todayString) — use that as your only source of truth \
+                for "today", never guess or recall a date from memory. Supports any \
+                specific day or custom date range, not just today. Use this whenever \
+                the user asks about their own health, fitness, body, or wellbeing \
+                (e.g. "how did I sleep last night", "how many steps did I take \
+                between June 1st and June 14th", "did I close my rings this week", \
+                "what's my resting heart rate", "how much have I weighed lately"). \
+                For a whole named month (e.g. "how many steps in March"), set \
+                start_date to that month's 1st and end_date to its last day — \
+                always set BOTH together, never end_date alone. This tool has no \
+                access to any other person's data. IMPORTANT: only state numbers \
+                that literally appear as fields in this tool's JSON result. If the \
+                field you need is missing or the value is 0, that means the data is \
+                genuinely unavailable — say so honestly ("I don't have that data") \
+                instead of estimating, guessing, or inventing a plausible-sounding \
+                number.
+                """,
+            parameters: [
+                RAToolParameter(
+                    name: "metric",
+                    type: .string,
+                    description: "Which health metric to retrieve",
+                    required: true,
+                    enumValues: [
+                        "steps", "sleep", "heart_rate", "resting_heart_rate", "heart_rate_variability",
+                        "active_energy", "distance", "workouts", "noise_exposure", "activity_rings",
+                        "blood_oxygen", "respiratory_rate", "vo2_max", "flights_climbed",
+                        "weight", "height", "bmi", "body_fat_percentage", "body_temperature",
+                        "mindful_minutes"
+                    ]
+                ),
+                RAToolParameter(
+                    name: "date",
+                    type: .string,
+                    description: """
+                        Which period to retrieve data for. STRONGLY PREFER one of the keywords — \
+                        "today" (default), "yesterday", "last_7_days", "last_30_days" — since \
+                        those are computed correctly for you. Only pass an explicit \
+                        "YYYY-MM-DD" day when the user names a real calendar date (e.g. "June \
+                        14th", "my birthday on the 3rd") — never invent, guess, or recall a date \
+                        from memory; every date you type here must be derived from today's date \
+                        (\(todayString)) stated above or from a date the user explicitly gave \
+                        you. For a custom multi-day range, use start_date/end_date instead of \
+                        this field.
+                        """,
+                    required: false
+                ),
+                RAToolParameter(
+                    name: "start_date",
+                    type: .string,
+                    description: """
+                        Start of a specific custom date range, as "YYYY-MM-DD", derived from \
+                        today's date (\(todayString)) or a date the user explicitly named — \
+                        never guessed. When set, this overrides `date`. Pair with end_date for \
+                        a multi-day range, or omit end_date to query just this one day.
+                        """,
+                    required: false
+                ),
+                RAToolParameter(
+                    name: "end_date",
+                    type: .string,
+                    description: """
+                        End of the custom date range (inclusive), as "YYYY-MM-DD". Only used \
+                        together with start_date; same rule applies — derive it from today's \
+                        date (\(todayString)) or the user's own words, never guess.
+                        """,
+                    required: false
+                )
+            ],
+            category: "Health"
+        )
+    }
+
+    static var executor: ToolExecutor {
+        { args in
+            guard let metric = args["metric"]?.string else {
+                return ["error": RAToolValue("Missing required argument: metric")]
+            }
+            let date = args["date"]?.string
+            let startDate = args["start_date"]?.string
+            let endDate = args["end_date"]?.string
+            do {
+                return try await HealthKitManager.shared.fetch(
+                    metric: metric,
+                    dateSpec: date,
+                    startDate: startDate,
+                    endDate: endDate
+                )
+            } catch {
+                return ["error": RAToolValue(error.localizedDescription)]
+            }
+        }
+    }
+}
+#endif

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/ToolSettingsView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/ToolSettingsView.swift
@@ -62,9 +62,11 @@ class ToolSettingsViewModel: ObservableObject {
                     // that's off by exactly that offset. Stating the
                     // no-location, already-local contract up front heads
                     // that off at the source, not just in the result note.
-                    description: "Gets the device's current date, time, and timezone. Returns "
-                        + "only the device's own local time — it has no location parameter and "
-                        + "cannot look up another city's time.",
+                    description: """
+                        Gets the device's current date, time, and timezone. Returns \
+                        only the device's own local time — it has no location parameter and \
+                        cannot look up another city's time.
+                        """,
                     parameters: [],
                     category: "Utility"
                 ),
@@ -89,9 +91,11 @@ class ToolSettingsViewModel: ObservableObject {
                         // (the field a model is most tempted to "apply")
                         // stops the double-conversion at the point of use.
                         "note": RAToolValue(
-                            "\"time\" is already this device's local wall-clock time in the "
-                                + "\"timezone\"/\"utc_offset\" below — do NOT apply utc_offset to "
-                                + "it again."
+                            """
+                            "time" is already this device's local wall-clock time in the \
+                            "timezone"/"utc_offset" below — do NOT apply utc_offset to \
+                            it again.
+                            """
                         )
                     ]
                 }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/ToolSettingsView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/ToolSettingsView.swift
@@ -50,11 +50,21 @@ class ToolSettingsViewModel: ObservableObject {
                     try await WeatherService.fetchWeather(for: args["location"]?.string ?? "San Francisco")
                 }
             ),
-            // Time Tool - Real system time with timezone
+            // Time Tool - Real system time with timezone.
             (
                 definition: RAToolDefinition(
                     name: "get_current_time",
-                    description: "Gets the current date, time, and timezone information",
+                    // Directive, not just descriptive (same reasoning as the
+                    // search_web tool): small models tend to "helpfully"
+                    // re-convert an already-local timestamp against its own
+                    // timezone label (e.g. subtracting the GMT offset from a
+                    // value that is already local), producing a wrong time
+                    // that's off by exactly that offset. Stating the
+                    // no-location, already-local contract up front heads
+                    // that off at the source, not just in the result note.
+                    description: "Gets the device's current date, time, and timezone. Returns "
+                        + "only the device's own local time — it has no location parameter and "
+                        + "cannot look up another city's time.",
                     parameters: [],
                     category: "Utility"
                 ),
@@ -73,7 +83,16 @@ class ToolSettingsViewModel: ObservableObject {
                         "time": RAToolValue(timeFormatter.string(from: now)),
                         "timestamp": RAToolValue(ISO8601DateFormatter().string(from: now)),
                         "timezone": RAToolValue(timeZone.identifier),
-                        "utc_offset": RAToolValue(timeZone.abbreviation() ?? "UTC")
+                        "utc_offset": RAToolValue(timeZone.abbreviation() ?? "UTC"),
+                        // Explicit anti-reconversion guard: "time" above is
+                        // already local. Restating that next to the offset
+                        // (the field a model is most tempted to "apply")
+                        // stops the double-conversion at the point of use.
+                        "note": RAToolValue(
+                            "\"time\" is already this device's local wall-clock time in the "
+                                + "\"timezone\"/\"utc_offset\" below — do NOT apply utc_offset to "
+                                + "it again."
+                        )
                     ]
                 }
             ),

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/ToolSettingsView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Settings/ToolSettingsView.swift
@@ -29,6 +29,49 @@ class ToolSettingsViewModel: ObservableObject {
         }
     }
 
+    #if os(iOS)
+    // Apple Health is opt-in separately from the other built-in tools since
+    // it requires its own OS permission prompt (HealthKit) rather than just
+    // being added to the in-memory tool registry. HealthKit only exists on
+    // iOS — this app also ships as a native macOS target, so this whole
+    // feature is compiled out there.
+    @Published var healthToolEnabled: Bool = false {
+        didSet {
+            guard healthToolEnabled != oldValue else { return }
+            UserDefaults.standard.set(healthToolEnabled, forKey: "healthToolEnabled")
+            Task {
+                if healthToolEnabled {
+                    await enableHealthTool()
+                } else {
+                    await RunAnywhere.unregisterTool(HealthKitTool.definition.name)
+                    await refreshRegisteredTools()
+                }
+            }
+        }
+    }
+    @Published var healthAuthorizationError: String?
+    #endif
+
+    // Calendar is opt-in separately for the same reason as Apple Health — it
+    // needs its own OS permission prompt (EventKit). Unlike HealthKit,
+    // EventKit is available on both iOS and macOS, so this one is not
+    // platform-gated.
+    @Published var calendarToolEnabled: Bool = false {
+        didSet {
+            guard calendarToolEnabled != oldValue else { return }
+            UserDefaults.standard.set(calendarToolEnabled, forKey: "calendarToolEnabled")
+            Task {
+                if calendarToolEnabled {
+                    await enableCalendarTool()
+                } else {
+                    await RunAnywhere.unregisterTool(CalendarTool.definition.name)
+                    await refreshRegisteredTools()
+                }
+            }
+        }
+    }
+    @Published var calendarAuthorizationError: String?
+
     // App-local tools with real implementations.
     private var builtInTools: [(definition: RAToolDefinition, executor: ToolExecutor)] {
         [
@@ -165,6 +208,10 @@ class ToolSettingsViewModel: ObservableObject {
 
     init() {
         toolCallingEnabled = UserDefaults.standard.bool(forKey: "toolCallingEnabled")
+        #if os(iOS)
+        healthToolEnabled = UserDefaults.standard.bool(forKey: "healthToolEnabled")
+        #endif
+        calendarToolEnabled = UserDefaults.standard.bool(forKey: "calendarToolEnabled")
         Task {
             await refreshRegisteredTools()
         }
@@ -182,12 +229,53 @@ class ToolSettingsViewModel: ObservableObject {
             await RunAnywhere.registerTool(tool.definition, executor: tool.executor)
             logger.info("Registered tool \(tool.definition.name)")
         }
+        #if os(iOS)
+        if healthToolEnabled {
+            await enableHealthTool()
+        }
+        #endif
+        if calendarToolEnabled {
+            await enableCalendarTool()
+        }
         await refreshRegisteredTools()
     }
 
     func clearAllTools() async {
         await RunAnywhere.clearTools()
         await refreshRegisteredTools()
+    }
+
+    #if os(iOS)
+    func enableHealthTool() async {
+        guard HealthKitManager.isAvailable else {
+            healthAuthorizationError = "Health data is not available on this device."
+            healthToolEnabled = false
+            return
+        }
+        do {
+            try await HealthKitManager.shared.requestAuthorization()
+            healthAuthorizationError = nil
+            await RunAnywhere.registerTool(HealthKitTool.definition, executor: HealthKitTool.executor)
+            logger.info("Registered tool \(HealthKitTool.definition.name)")
+            await refreshRegisteredTools()
+        } catch {
+            healthAuthorizationError = error.localizedDescription
+            healthToolEnabled = false
+        }
+    }
+    #endif
+
+    func enableCalendarTool() async {
+        do {
+            try await CalendarManager.shared.requestAuthorization()
+            calendarAuthorizationError = nil
+            await RunAnywhere.registerTool(CalendarTool.definition, executor: CalendarTool.executor)
+            logger.info("Registered tool \(CalendarTool.definition.name)")
+            await refreshRegisteredTools()
+        } catch {
+            calendarAuthorizationError = error.localizedDescription
+            calendarToolEnabled = false
+        }
     }
 }
 
@@ -201,6 +289,26 @@ struct ToolSettingsSection: View {
             Toggle("Enable Tool Calling", isOn: $viewModel.toolCallingEnabled)
 
             if viewModel.toolCallingEnabled {
+                #if os(iOS)
+                Toggle(isOn: $viewModel.healthToolEnabled) {
+                    Label("Apple Health", systemImage: "heart.fill")
+                }
+                if let error = viewModel.healthAuthorizationError {
+                    Text(error)
+                        .font(AppTypography.caption)
+                        .foregroundColor(AppColors.primaryRed)
+                }
+                #endif
+
+                Toggle(isOn: $viewModel.calendarToolEnabled) {
+                    Label("Calendar", systemImage: "calendar")
+                }
+                if let error = viewModel.calendarAuthorizationError {
+                    Text(error)
+                        .font(AppTypography.caption)
+                        .foregroundColor(AppColors.primaryRed)
+                }
+
                 HStack {
                     Text("Registered Tools")
                     Spacer()
@@ -238,7 +346,9 @@ struct ToolSettingsSection: View {
         } footer: {
             Text(
                 "Allow the LLM to use registered tools to perform actions like "
-                + "web lookup, weather, time, or calculations."
+                + "web lookup, weather, time, calculations, your Apple Health data, or your "
+                + "Calendar. iOS does not reveal which Health categories were granted, so if "
+                + "answers seem empty, check Settings > Privacy & Security > Health."
             )
             .font(AppTypography.caption)
         }
@@ -269,6 +379,18 @@ struct ToolSettingsCard: View {
 
                 if viewModel.toolCallingEnabled {
                     Divider()
+
+                    HStack {
+                        Text("Calendar")
+                            .frame(width: 150, alignment: .leading)
+                        Toggle("", isOn: $viewModel.calendarToolEnabled)
+                        Spacer()
+                        if let error = viewModel.calendarAuthorizationError {
+                            Text(error)
+                                .font(AppTypography.caption)
+                                .foregroundColor(AppColors.primaryRed)
+                        }
+                    }
 
                     HStack {
                         Text("Registered Tools")

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/RunAnywhereAI.entitlements
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/RunAnywhereAI.entitlements
@@ -26,5 +26,10 @@
     <array>
         <string>group.com.runanywhere.runanywhereai</string>
     </array>
+    <!-- iOS HealthKit read access for the get_health_data tool -->
+    <key>com.apple.developer.healthkit</key>
+    <true/>
+    <key>com.apple.developer.healthkit.access</key>
+    <array/>
 </dict>
 </plist>

--- a/idl/tool_calling.proto
+++ b/idl/tool_calling.proto
@@ -187,7 +187,7 @@ message ToolCallingOptions {
     // its registered tools (per-SDK convention).
     repeated ToolDefinition tools    = 1;
 
-    reserved 2, 9, 11, 15;
+    reserved 2, 9, 11;
 
     // Whether to auto-execute tools or hand them back to the caller.
     bool   auto_execute              = 3;
@@ -211,6 +211,13 @@ message ToolCallingOptions {
 
     // Typed tool-call format. Unset lets commons select the model default.
     optional ToolCallFormatName format = 10;
+
+    // When true, one model turn may emit multiple tool-call envelopes;
+    // commons parses and executes all of them before building a single
+    // follow-up prompt. Default false preserves the historical
+    // one-call-per-turn behavior. (Reclaims the field number that
+    // originally carried this flag before it was reserved.)
+    bool parallel_tool_calls = 15;
 
     // Maximum tool calls in one conversation turn. Unset/0 = SDK default
     // (typically 5).
@@ -399,6 +406,12 @@ message ToolCallingSessionCreateRequest {
     // ChatMessage history (llm_service.proto history=27), inlined as strings to avoid a
     // cross-proto import cycle.
     repeated string history = 19;
+
+    // Mirrors ToolCallingOptions.parallel_tool_calls for the run-loop /
+    // session envelope: when true, one model turn may emit multiple
+    // tool-call envelopes and commons executes all of them before one
+    // follow-up prompt. Default false = historical single-call behavior.
+    bool parallel_tool_calls = 20;
 }
 
 message ToolCallingSessionCreateResult {

--- a/sdk/runanywhere-commons/CMakeLists.txt
+++ b/sdk/runanywhere-commons/CMakeLists.txt
@@ -890,6 +890,9 @@ set(RAC_FEATURES_SOURCES
     # execute -> follow-up). Collapses Swift's ~100 LOC generateWithTools
     # to ~10 LOC; same loop will benefit Kotlin/RN over the same ABI.
     src/features/llm/tool_calling_run_loop.cpp
+    # TC-1: derives grammar-constrained-decoding specs (llamacpp GBNF /
+    # qhexrt kind-prefixed) from the live tool set for tool_calling_run_loop.
+    src/features/llm/tool_calling_grammar.cpp
     # Proto-byte LLM stream ABI (mirrors
     # voice_agent/rac_voice_event_abi.cpp; replaces per-SDK hand-rolled
     # AsyncThrowingStream / callbackFlow / tokenQueue shims).

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling.cpp
@@ -2099,9 +2099,26 @@ extern "C" rac_result_t rac_tool_call_parse_proto(const uint8_t* request_proto_b
         // The C parser extracts one envelope per invocation, so re-parse the
         // clean text it hands back until no envelope remains. Only the caller
         // that opted in pays this cost; the default path stays single-parse.
+        //
+        // Guardrails against a real failure mode observed with small models
+        // under AUTO (no grammar constraint): the model repeats the SAME
+        // tool call verbatim several times instead of moving on (a known
+        // small-model repetition/looping artifact, not distinct intent).
+        // Without a stop condition, harvesting every envelope in the output
+        // turns one stutter into N "legitimate" parallel calls, burns the
+        // max_tool_calls budget on duplicates, and starves the rest of the
+        // user's request. Stop harvesting the moment a call repeats the
+        // immediately-preceding (name, arguments) pair, and never harvest
+        // more than the request's own max_tool_calls budget.
         if (request.has_options() && request.options().parallel_tool_calls()) {
+            const int32_t budget =
+                request.options().has_max_tool_calls() && request.options().max_tool_calls() > 0
+                    ? request.options().max_tool_calls()
+                    : 5;
+            std::string last_name = parsed.tool_name ? parsed.tool_name : "";
+            std::string last_args = parsed.arguments_json ? parsed.arguments_json : "{}";
             std::string remainder = parsed.clean_text ? parsed.clean_text : "";
-            while (!remainder.empty()) {
+            while (!remainder.empty() && result.tool_calls_size() < budget) {
                 rac_tool_call_t next{};
                 const rac_result_t next_rc =
                     use_explicit_format
@@ -2115,8 +2132,18 @@ extern "C" rac_result_t rac_tool_call_parse_proto(const uint8_t* request_proto_b
                     rac_tool_call_free(&next);
                     break;
                 }
+                const std::string next_name = next.tool_name ? next.tool_name : "";
+                const std::string next_args = next.arguments_json ? next.arguments_json : "{}";
+                if (next_name == last_name && next_args == last_args) {
+                    // Repetition, not a second distinct call — stop here
+                    // rather than treat the stutter as further intent.
+                    rac_tool_call_free(&next);
+                    break;
+                }
                 append_parsed_call(next);
                 remainder = next.clean_text ? next.clean_text : "";
+                last_name = next_name;
+                last_args = next_args;
                 rac_tool_call_free(&next);
             }
             result.set_remaining_text(remainder);

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling.cpp
@@ -2077,18 +2077,50 @@ extern "C" rac_result_t rac_tool_call_parse_proto(const uint8_t* request_proto_b
     const bool has_tool_call = parsed.has_tool_call == RAC_TRUE;
     result.set_has_tool_call(has_tool_call);
     result.set_remaining_text(parsed.clean_text ? parsed.clean_text : request.text());
-    if (has_tool_call) {
-        const int64_t call_number = parsed.call_id != 0 ? parsed.call_id : next_tool_call_id();
+
+    const auto append_parsed_call = [&result, &request](const rac_tool_call_t& call) {
+        const int64_t call_number = call.call_id != 0 ? call.call_id : next_tool_call_id();
         const int64_t created_at_ms = static_cast<int64_t>(std::time(nullptr)) * 1000;
         std::string call_id = "call_";
         call_id += std::to_string(call_number);
         auto* tool_call = result.add_tool_calls();
         tool_call->set_id(call_id);
-        tool_call->set_name(parsed.tool_name ? parsed.tool_name : "");
-        tool_call->set_arguments_json(parsed.arguments_json ? parsed.arguments_json : "{}");
+        tool_call->set_name(call.tool_name ? call.tool_name : "");
+        tool_call->set_arguments_json(call.arguments_json ? call.arguments_json : "{}");
         tool_call->set_type("function");
         tool_call->set_created_at_ms(created_at_ms);
         tool_call->set_raw_text(request.text());
+    };
+
+    if (has_tool_call) {
+        append_parsed_call(parsed);
+
+        // parallel_tool_calls: one model turn may emit several envelopes.
+        // The C parser extracts one envelope per invocation, so re-parse the
+        // clean text it hands back until no envelope remains. Only the caller
+        // that opted in pays this cost; the default path stays single-parse.
+        if (request.has_options() && request.options().parallel_tool_calls()) {
+            std::string remainder = parsed.clean_text ? parsed.clean_text : "";
+            while (!remainder.empty()) {
+                rac_tool_call_t next{};
+                const rac_result_t next_rc =
+                    use_explicit_format
+                        ? rac_tool_call_parse_with_format(
+                              remainder.c_str(),
+                              rac_tool_call_format_from_name(
+                                  tool_format_key_from_proto(request.options().format())),
+                              &next)
+                        : rac_tool_call_parse(remainder.c_str(), &next);
+                if (next_rc != RAC_SUCCESS || next.has_tool_call != RAC_TRUE) {
+                    rac_tool_call_free(&next);
+                    break;
+                }
+                append_parsed_call(next);
+                remainder = next.clean_text ? next.clean_text : "";
+                rac_tool_call_free(&next);
+            }
+            result.set_remaining_text(remainder);
+        }
     }
     result.set_error_code(static_cast<int32_t>(RAC_SUCCESS));
     rac_tool_call_free(&parsed);

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling.cpp
@@ -57,6 +57,19 @@ static const char* FORMAT_NAMES[] = {
     "Pythonic (bare)",  // RAC_TOOL_FORMAT_PYTHONIC
 };
 
+// Shared synthesis-turn grounding rule, appended wherever tool results are
+// handed back to the model for a final answer. Small models "helpfully"
+// fabricate a plausible number when the field they need is absent from the
+// result (observed live: a sleep query whose result carried only {"date":...}
+// was answered with an invented "7 hours"). Stating the rule at the exact
+// point of use — next to the result payload — is the strongest prompt-level
+// counter available, and living in commons it protects every SDK and every
+// model family, not just one example app.
+static const char* kToolResultGroundingRule =
+    "State only values literally present in the tool result. If the result lacks the value the "
+    "user asked for (or it is empty), say that data is unavailable - never estimate, invent, or "
+    "recall a plausible number.";
+
 static int64_t next_tool_call_id() {
     static std::atomic<int64_t> next{1};
     return next.fetch_add(1, std::memory_order_relaxed);
@@ -2321,10 +2334,11 @@ static rac_result_t format_prompt_proto_impl(const uint8_t* request_proto_bytes,
             }
             followup += "\nUsing all results above, answer the original question. ";
             if (keep_tools == RAC_TRUE) {
-                followup += "You may use another tool if needed.";
+                followup += "You may use another tool if needed. ";
             } else {
-                followup += "Do not emit tool calls or tool tags.";
+                followup += "Do not emit tool calls or tool tags. ";
             }
+            followup += kToolResultGroundingRule;
             prompt = dup_owned_string(followup);
             rc = prompt ? RAC_SUCCESS : RAC_ERROR_OUT_OF_MEMORY;
         }
@@ -2940,6 +2954,29 @@ extern "C" rac_result_t rac_tool_call_validate_json(const rac_tool_call_t* call,
     return finalize_tool_validation(out_validation, errors, &args, &matched_tool_json);
 }
 
+// Today's date in UTC, formatted YYYY-MM-DD. Embedded into every tool prompt
+// (and the final web-search synthesis turn) because on-device models have no
+// notion of "now": with a 2023-era training cutoff they confidently invent
+// dates like "2024-01-01" when a tool argument or an answer needs one.
+// Grounding the prompt itself is the only fix that works across every model
+// family and every SDK — it cannot be forgotten by an app author.
+static std::string current_utc_date() {
+    const std::time_t now = std::time(nullptr);
+    std::tm utc{};
+#if defined(_WIN32)
+    if (gmtime_s(&utc, &now) != 0) {
+        return "unknown";
+    }
+#else
+    if (gmtime_r(&now, &utc) == nullptr) {
+        return "unknown";
+    }
+#endif
+    char value[11]{};
+    return std::strftime(value, sizeof(value), "%Y-%m-%d", &utc) == 10 ? std::string(value)
+                                                                       : std::string("unknown");
+}
+
 /**
  * @brief Generate format-specific tool calling instructions
  *
@@ -3135,7 +3172,12 @@ extern "C" rac_result_t rac_tool_call_format_prompt_json_with_format(const char*
     std::string prompt;
     prompt.reserve(1024 + strlen(tools_json));
 
-    prompt += "# TOOLS\n";
+    // Date grounding must precede everything else: models fill date-shaped
+    // tool arguments from training-data memory unless the true current date
+    // is right in front of them (see current_utc_date's rationale).
+    prompt += "Current date (UTC): ";
+    prompt += current_utc_date();
+    prompt += "\n\n# TOOLS\n";
     prompt += tools_json;
     prompt += "\n\n";
 
@@ -3143,8 +3185,14 @@ extern "C" rac_result_t rac_tool_call_format_prompt_json_with_format(const char*
     prompt += get_format_example_json(actual_format);
 
     prompt += "\n\n## RULES\n";
+    // Soft AUTO framing (RUN-80): do not hard-code per-tool "ALWAYS call"
+    // rules here — that reintroduces small-model over-calling. Date grounding
+    // is additive and tool-agnostic.
     prompt += "- Call a tool only when it is needed to answer; otherwise reply normally.\n";
     prompt += "- Use only the tools listed above, with their exact names and parameters.\n";
+    prompt +=
+        "- Any date argument MUST be derived from the Current date above or from a date the "
+        "user explicitly stated. NEVER guess or recall dates from memory.\n";
 
     // Format-specific tag instructions (the parser keys on these exact tags, so a
     // tool call must always be wrapped in them — but this does NOT mean a tool must
@@ -3333,23 +3381,6 @@ static std::string compact_web_evidence_json(const char* tool_result_json) {
     return compact.empty() ? std::string(tool_result_json) : compact.dump();
 }
 
-static std::string current_utc_date() {
-    const std::time_t now = std::time(nullptr);
-    std::tm utc{};
-#if defined(_WIN32)
-    if (gmtime_s(&utc, &now) != 0) {
-        return "unknown";
-    }
-#else
-    if (gmtime_r(&now, &utc) == nullptr) {
-        return "unknown";
-    }
-#endif
-    char value[11]{};
-    return std::strftime(value, sizeof(value), "%Y-%m-%d", &utc) == 10 ? std::string(value)
-                                                                       : std::string("unknown");
-}
-
 extern "C" rac_result_t
 rac_tool_call_build_followup_prompt(const char* original_user_prompt, const char* tools_prompt,
                                     const char* tool_name, const char* tool_result_json,
@@ -3407,11 +3438,13 @@ rac_tool_call_build_followup_prompt(const char* original_user_prompt, const char
 
     if (keep_tools_available != 0) {
         prompt += "Using this information, respond to the user's original question. ";
-        prompt += "You may use additional tools if needed.";
+        prompt += "You may use additional tools if needed. ";
+        prompt += kToolResultGroundingRule;
     } else if (!is_final_web_search) {
         prompt +=
             "Using this information, provide a natural response to the user's original question. ";
-        prompt += "Do not use any tool tags in your response - just respond naturally.";
+        prompt += "Do not use any tool tags in your response - just respond naturally. ";
+        prompt += kToolResultGroundingRule;
     }
 
     *out_prompt = static_cast<char*>(malloc(prompt.size() + 1));

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_generation_internal.h
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_generation_internal.h
@@ -41,11 +41,14 @@ struct GenerationState {
     // llm_module's history normalizer, this is already current-turn-free and
     // pre-alternated, so run_generate_once forwards it as-is (no trailing pop).
     std::vector<std::string> history;
-    // Names of the tools advertised this turn (RUN-80). Used ONLY to build the
-    // QHexRT grammar spec ("toolcall_opt:<names>") when the backend supports
-    // grammar-constrained decoding; empty ⇒ no grammar attached. Non-grammar
-    // engines ignore it.
-    std::vector<std::string> tool_names;
+    // Pre-built grammar dialects (TC-1 + RUN-80). Empty = unconstrained.
+    // Built via build_tool_call_grammar(); scoped per turn by clearing both
+    // when tools are not live. run_generate_once attaches the dialect that
+    // matches the acquired engine (supports_grammar → qhexrt, else gbnf).
+    // Two dialects because llamacpp and qhexrt read rac_llm_options_t.grammar
+    // with incompatible conventions (raw GBNF vs kind-prefixed toolcall:).
+    std::string grammar_gbnf;
+    std::string grammar_qhexrt;
 };
 
 struct GenerationCancelBinding {
@@ -221,12 +224,12 @@ struct ToolLoopTelemetryScope {
     ~ToolLoopTelemetryScope() { publish_tool_loop_telemetry(agg); }
 };
 
-// Whether this turn's decoding should be grammar-constrained to the live tool set
-// (QHexRT). Returns false — leave decoding unconstrained — when tool calls are
-// forbidden this turn (@p none_veto = tool_choice==NONE) or this is a pure
-// synthesis turn (@p a_call_was_made and tools are not kept available). The run
-// loop and the session are parallel implementations, so both derive their
-// tool_names-clearing decision from this ONE predicate to stay in lockstep.
+// Whether this turn's decoding should be grammar-constrained to the live tool set.
+// Returns false — leave decoding unconstrained — when tool calls are forbidden
+// this turn (@p none_veto = tool_choice==NONE) or this is a pure synthesis turn
+// (@p a_call_was_made and tools are not kept available). The run loop and the
+// session are parallel implementations, so both derive their grammar-clearing
+// decision from this ONE predicate to stay in lockstep.
 inline bool tool_grammar_constrained_this_turn(bool none_veto, bool a_call_was_made,
                                                bool keep_tools_available) {
     if (none_veto) {
@@ -315,6 +318,16 @@ inline bool run_generate_once(GenerationState& generation,
         generation.system_prompt.empty() ? nullptr : generation.system_prompt.c_str();
     options.disable_thinking = generation.disable_thinking ? RAC_TRUE : RAC_FALSE;
 
+    // Attach the pre-built grammar dialect for this engine. Grammar backends
+    // (QHexRT, supports_grammar=true) consume the kind-prefixed qhexrt spec;
+    // other engines that honor grammar (llamacpp GBNF) use grammar_gbnf.
+    // Empty specs leave decoding unconstrained.
+    if (ref.supports_grammar && !generation.grammar_qhexrt.empty()) {
+        options.grammar = generation.grammar_qhexrt.c_str();
+    } else if (!generation.grammar_gbnf.empty()) {
+        options.grammar = generation.grammar_gbnf.c_str();
+    }
+
     // Prior conversation turns (tool_calling.proto ToolCallingSessionCreateRequest.history).
     // Already excludes the current turn and is pre-alternated [user,asst,...], so unlike
     // llm_module's normalizer we forward it verbatim (no leading/trailing role fixups). The
@@ -329,27 +342,6 @@ inline bool run_generate_once(GenerationState& generation,
     }
     options.history = history_ptrs.empty() ? nullptr : history_ptrs.data();
     options.n_history = static_cast<int32_t>(history_ptrs.size());
-
-    // QHexRT grammar-constrained tool decoding (RUN-80). When the backend honors
-    // options.grammar AND a tool set is live, constrain decoding to "free chat OR
-    // exactly one [name(args)] call over the enumerated tools" (ToolCallOptional).
-    // This makes over-calling structurally impossible on QHexRT — the model can
-    // still answer in plain text; it just cannot invent or misformat a call. The
-    // spec string must outlive ops->generate (options.grammar aliases it), so it
-    // lives in this call frame. supports_grammar is false for llama.cpp/onnx/cloud
-    // (set per-framework in the lifecycle accessor), so options.grammar stays NULL
-    // there and behavior is byte-for-byte unchanged for non-grammar engines.
-    std::string grammar_spec;
-    if (ref.supports_grammar && !generation.tool_names.empty()) {
-        grammar_spec = "toolcall_opt:";
-        for (size_t i = 0; i < generation.tool_names.size(); ++i) {
-            if (i != 0) {
-                grammar_spec += ',';
-            }
-            grammar_spec += generation.tool_names[i];
-        }
-        options.grammar = grammar_spec.c_str();
-    }
 
     clear_lifecycle_llm_cancel(&ref);
 

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_generation_internal.h
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_generation_internal.h
@@ -94,6 +94,11 @@ inline GenerationState generation_for_tool_step(const GenerationState& base, uin
                                                 runanywhere::v1::ToolChoiceMode tool_choice,
                                                 runanywhere::v1::ToolCallFormatName format) {
     GenerationState step = base;
+    // Grammar lifetime is owned by the run-loop / session via
+    // tool_grammar_constrained_this_turn (clear when tools are not live,
+    // including pure synthesis turns). Do NOT unconditionally clear here on
+    // iteration > 1 — that would drop grammar when keep_tools_available keeps
+    // tools live across multiple decision turns.
     const bool forced_decision = iteration == 1 && has_tool_choice &&
                                  tool_choice == runanywhere::v1::TOOL_CHOICE_MODE_SPECIFIC;
     if (!forced_decision) {

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_grammar.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_grammar.cpp
@@ -46,7 +46,7 @@ constexpr const char* kJsonValueRules =
 ToolCallGrammar build_tool_call_grammar(const runanywhere::v1::ToolCallingOptions& tool_options,
                                         bool has_tool_choice,
                                         runanywhere::v1::ToolChoiceMode tool_choice,
-                                        const std::string& forced_tool_name) {
+                                        const std::string& forced_tool_name, bool parallel) {
     ToolCallGrammar result;
     if (tool_options.tools_size() == 0) {
         return result;
@@ -97,16 +97,24 @@ ToolCallGrammar build_tool_call_grammar(const runanywhere::v1::ToolCallingOption
     // ordinary chat responses; qhexrt's native toolcall_opt kind covers the
     // AUTO case on that engine instead.
     if (must_call) {
-        // Root: the fixed <tool_call>{"tool":...,"arguments":{...}}</tool_call>
+        // `call`: the fixed <tool_call>{"tool":...,"arguments":{...}}</tool_call>
         // envelope with exactly two free choices — which tool name, and what
         // the arguments object contains. Each quoted fragment below is a GBNF
         // string literal matched verbatim against the output text; `tool-name`
         // and `object` are rule references (defined below / in kJsonValueRules).
-        // Concatenated, root produces exactly:
+        // Concatenated, `call` produces exactly:
         //   <tool_call>{"tool":"<name>","arguments":<object>}</tool_call>
+        //
+        // `root` is `call` for a single required call, or `call+` when the
+        // caller opted into parallel_tool_calls — letting the model emit
+        // several back-to-back envelopes in one grammar-constrained
+        // generation instead of being capped at exactly one by the grammar
+        // itself (the parser's own duplicate-call guard still applies on
+        // top of whatever the grammar allows through).
         std::ostringstream gbnf;
+        gbnf << "root ::= " << (parallel ? "call+" : "call") << "\n";
         gbnf
-            << R"(root ::= "<tool_call>{\"tool\":" tool-name ",\"arguments\":" object "}</tool_call>")"
+            << R"(call ::= "<tool_call>{\"tool\":" tool-name ",\"arguments\":" object "}</tool_call>")"
             << "\n";
 
         // tool-name ::= "\"nameA\"" | "\"nameB\"" | ...

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_grammar.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_grammar.cpp
@@ -1,0 +1,139 @@
+#include "features/llm/tool_calling_grammar.h"
+
+#include <sstream>
+#include <vector>
+
+namespace rac::llm::tool_calling {
+
+#if defined(RAC_HAVE_PROTOBUF)
+
+namespace {
+
+// Escapes a string for use inside a GBNF double-quoted literal ("...").
+// Tool names are developer-declared identifiers in practice, but this stays
+// defensive rather than assuming well-formed input reaches here.
+std::string escape_gbnf_literal(const std::string& raw) {
+    std::string out;
+    out.reserve(raw.size());
+    for (char c : raw) {
+        if (c == '"' || c == '\\') {
+            out.push_back('\\');
+        }
+        out.push_back(c);
+    }
+    return out;
+}
+
+// A permissive GBNF production for an arbitrary JSON value — this is what
+// "arguments" decodes against. Argument SHAPE is intentionally
+// unconstrained in this pass (TC-1 only constrains tool name + envelope,
+// not per-parameter argument shape — see tool_calling_grammar.h). Mirrors
+// the standard permissive JSON grammar shipped as llama.cpp's own
+// grammars/json.gbnf, inlined here (not as a separate root) so it can be
+// referenced from the tool-call root built below.
+constexpr const char* kJsonValueRules =
+    "ws ::= [ \\t\\n]*\n"
+    "value ::= object | array | string | number | (\"true\" | \"false\" | \"null\")\n"
+    "object ::= \"{\" ws (member (ws \",\" ws member)*)? ws \"}\"\n"
+    "member ::= string ws \":\" ws value\n"
+    "array ::= \"[\" ws (value (ws \",\" ws value)*)? ws \"]\"\n"
+    "string ::= \"\\\"\" ([^\"\\\\\\x00-\\x1f] | \"\\\\\" ([\"\\\\/bfnrt] | \"u\" [0-9a-fA-F]"
+    "[0-9a-fA-F] [0-9a-fA-F] [0-9a-fA-F]))* \"\\\"\"\n"
+    "number ::= \"-\"? (\"0\" | [1-9] [0-9]*) (\".\" [0-9]+)? ([eE] [+-]? [0-9]+)?\n";
+
+}  // namespace
+
+ToolCallGrammar build_tool_call_grammar(const runanywhere::v1::ToolCallingOptions& tool_options,
+                                        bool has_tool_choice,
+                                        runanywhere::v1::ToolChoiceMode tool_choice,
+                                        const std::string& forced_tool_name) {
+    ToolCallGrammar result;
+    if (tool_options.tools_size() == 0) {
+        return result;
+    }
+    if (has_tool_choice && tool_choice == runanywhere::v1::TOOL_CHOICE_MODE_NONE) {
+        return result;
+    }
+
+    // Determine the live tool-name set this generation step may call.
+    const bool is_specific = has_tool_choice &&
+                             tool_choice == runanywhere::v1::TOOL_CHOICE_MODE_SPECIFIC &&
+                             !forced_tool_name.empty();
+    std::vector<std::string> names;
+    if (is_specific) {
+        names.push_back(forced_tool_name);
+    } else {
+        for (const auto& tool : tool_options.tools()) {
+            names.push_back(tool.name());
+        }
+    }
+    if (names.empty()) {
+        return result;
+    }
+
+    const bool must_call =
+        is_specific ||
+        (has_tool_choice && tool_choice == runanywhere::v1::TOOL_CHOICE_MODE_REQUIRED);
+
+    // --- qhexrt dialect: the native toolcall:/toolcall_opt: GrammarKinds
+    // already do exactly this at the engine level (qhexrt_llm_ops.cpp), so
+    // this half needs no grammar authoring — just the prefix + comma-joined
+    // name list.
+    {
+        std::ostringstream joined;
+        for (size_t i = 0; i < names.size(); ++i) {
+            if (i > 0) {
+                joined << ",";
+            }
+            joined << names[i];
+        }
+        result.qhexrt = (must_call ? "toolcall:" : "toolcall_opt:") + joined.str();
+    }
+
+    // --- llamacpp (GBNF) dialect: only constrain when the model is already
+    // committed to calling a tool (REQUIRED/SPECIFIC). AUTO is left
+    // unconstrained on this engine — GBNF has no clean "structured tool call
+    // OR free natural-language text" root, so forcing one here would corrupt
+    // ordinary chat responses; qhexrt's native toolcall_opt kind covers the
+    // AUTO case on that engine instead.
+    if (must_call) {
+        // Root: the fixed <tool_call>{"tool":...,"arguments":{...}}</tool_call>
+        // envelope with exactly two free choices — which tool name, and what
+        // the arguments object contains. Each quoted fragment below is a GBNF
+        // string literal matched verbatim against the output text; `tool-name`
+        // and `object` are rule references (defined below / in kJsonValueRules).
+        // Concatenated, root produces exactly:
+        //   <tool_call>{"tool":"<name>","arguments":<object>}</tool_call>
+        std::ostringstream gbnf;
+        gbnf
+            << R"(root ::= "<tool_call>{\"tool\":" tool-name ",\"arguments\":" object "}</tool_call>")"
+            << "\n";
+
+        // tool-name ::= "\"nameA\"" | "\"nameB\"" | ...
+        // Each alternative is a GBNF literal that matches the tool name
+        // WITH its surrounding quote characters (so the concatenation above
+        // doesn't need to add them). R"(" \")" / R"(\"")" are raw strings —
+        // no C++ escaping — so they read as the literal GBNF text `"\"` and
+        // `\""` respectively.
+        gbnf << "tool-name ::= ";
+        for (size_t i = 0; i < names.size(); ++i) {
+            if (i > 0) {
+                gbnf << " | ";
+            }
+            gbnf << R"("\")" << escape_gbnf_literal(names[i]) << R"(\"")";
+        }
+        gbnf << "\n";
+
+        // `object` (not the looser `value`) keeps "arguments" to a JSON
+        // object, matching ToolCall.arguments_json's documented contract
+        // ("JSON-encoded arguments... Empty object {} if no args").
+        gbnf << kJsonValueRules;
+        result.gbnf = gbnf.str();
+    }
+
+    return result;
+}
+
+#endif  // RAC_HAVE_PROTOBUF
+
+}  // namespace rac::llm::tool_calling

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_grammar.h
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_grammar.h
@@ -44,10 +44,16 @@ struct ToolCallGrammar {
 //
 // Returns an all-empty ToolCallGrammar when tool_options.tools() is empty
 // or tool_choice == NONE (matches today's unconstrained behavior).
+//
+// `parallel` mirrors ToolCallingOptions.parallel_tool_calls: when true, the
+// llama.cpp root rule accepts one-or-more back-to-back envelopes instead of
+// exactly one, so a REQUIRED/SPECIFIC turn can still emit a genuine
+// multi-call batch under grammar constraint (qhexrt's toolcall/toolcall_opt
+// kinds already read one full generation as a unit and need no change).
 ToolCallGrammar build_tool_call_grammar(const runanywhere::v1::ToolCallingOptions& tool_options,
                                         bool has_tool_choice,
                                         runanywhere::v1::ToolChoiceMode tool_choice,
-                                        const std::string& forced_tool_name);
+                                        const std::string& forced_tool_name, bool parallel);
 
 #endif  // RAC_HAVE_PROTOBUF
 

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_grammar.h
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_grammar.h
@@ -1,0 +1,56 @@
+/**
+ * @file tool_calling_grammar.h
+ * @brief TC-1: derives grammar-constrained-decoding specs for the tool-calling
+ * run-loop from the live tool set + tool_choice policy.
+ *
+ * Two independent dialects because llamacpp and qhexrt read
+ * rac_llm_options_t.grammar with incompatible conventions — see
+ * tool_calling_generation_internal.h::GenerationState for the split and
+ * engines/llamacpp/llamacpp_backend.cpp / engines/qhexrt/qhexrt_llm_ops.cpp
+ * for how each engine consumes its dialect. Scoped to the default JSON
+ * <tool_call>{"tool":...,"arguments":{...}}</tool_call> wire format
+ * (tool_calling.cpp's TAG_DEFAULT_START path) — callers must leave this
+ * empty for the LFM2 wire format, which keeps today's post-hoc validation.
+ */
+
+#ifndef RAC_FEATURES_LLM_TOOL_CALLING_GRAMMAR_H
+#define RAC_FEATURES_LLM_TOOL_CALLING_GRAMMAR_H
+
+#include <string>
+
+#if defined(RAC_HAVE_PROTOBUF)
+#include "tool_calling.pb.h"
+#endif
+
+namespace rac::llm::tool_calling {
+
+#if defined(RAC_HAVE_PROTOBUF)
+
+struct ToolCallGrammar {
+    // llama.cpp dialect (raw GBNF, root rule name "root"). Empty = run
+    // unconstrained on this engine.
+    std::string gbnf;
+    // qhexrt dialect (kind-prefixed spec: "toolcall:<names>" /
+    // "toolcall_opt:<names>"). Empty = run unconstrained on this engine.
+    std::string qhexrt;
+};
+
+// Builds the grammar pair that constrains the model to emit ONLY a
+// tool-name-and-envelope-valid tool call from `tool_options.tools()` (or
+// just `forced_tool_name` under TOOL_CHOICE_MODE_SPECIFIC). Tool argument
+// *shapes* are left unconstrained (permissive JSON object) — full
+// per-parameter JSON-Schema-driven argument grammar is separate follow-up
+// work (see the source doc's gso-1/D02).
+//
+// Returns an all-empty ToolCallGrammar when tool_options.tools() is empty
+// or tool_choice == NONE (matches today's unconstrained behavior).
+ToolCallGrammar build_tool_call_grammar(const runanywhere::v1::ToolCallingOptions& tool_options,
+                                        bool has_tool_choice,
+                                        runanywhere::v1::ToolChoiceMode tool_choice,
+                                        const std::string& forced_tool_name);
+
+#endif  // RAC_HAVE_PROTOBUF
+
+}  // namespace rac::llm::tool_calling
+
+#endif  // RAC_FEATURES_LLM_TOOL_CALLING_GRAMMAR_H

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_run_loop.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_run_loop.cpp
@@ -525,8 +525,12 @@ static rac_result_t run_loop_impl(const uint8_t* in_request_bytes, size_t in_siz
     // needs the qhexrt dialect whenever tools are advertised — its prompt path
     // uses bare-Pythonic regardless of the declared format enum.
     if (ctx.format == runanywhere::v1::TOOL_CALL_FORMAT_NAME_JSON || ctx.grammar_backend) {
+        // parallel only affects the llamacpp GBNF root (call vs call+). QHexRT's
+        // native toolcall/toolcall_opt kinds still admit at most one call per
+        // generation; GBNF is cleared on grammar_backend below.
         auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
-            ctx.tool_options, ctx.has_tool_choice, ctx.tool_choice, ctx.forced_tool_name);
+            ctx.tool_options, ctx.has_tool_choice, ctx.tool_choice, ctx.forced_tool_name,
+            ctx.parallel_tool_calls);
         // GBNF encodes the JSON <tool_call> envelope; skip it on grammar
         // backends that speak bare-Pythonic instead.
         ctx.generation.grammar_gbnf = ctx.grammar_backend ? std::string() : std::move(grammar.gbnf);
@@ -586,7 +590,8 @@ static rac_result_t run_loop_impl(const uint8_t* in_request_bytes, size_t in_siz
             // tool so decoding can only emit that call (or free text on
             // toolcall_opt). Without this the spec still lists every tool.
             auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
-                ctx.tool_options, ctx.has_tool_choice, ctx.tool_choice, ctx.forced_tool_name);
+                ctx.tool_options, ctx.has_tool_choice, ctx.tool_choice, ctx.forced_tool_name,
+                ctx.parallel_tool_calls);
             step_generation.grammar_gbnf =
                 ctx.grammar_backend ? std::string() : std::move(grammar.gbnf);
             step_generation.grammar_qhexrt = std::move(grammar.qhexrt);

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_run_loop.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_run_loop.cpp
@@ -35,6 +35,7 @@
 
 #include "features/llm/rac_llm_lifecycle_bridge.h"
 #include "features/llm/tool_calling_generation_internal.h"
+#include "features/llm/tool_calling_grammar.h"
 #include "features/llm/tool_calling_internal.h"
 #include "features/llm/tool_calling_result_internal.h"
 #include "rac/core/rac_logger.h"
@@ -120,6 +121,12 @@ struct LoopContext {
     // When true, the tool-call prompt is built AND parsed in the bare-Pythonic
     // `[name(args)]` format the toolcall_opt grammar enforces (RUN-80).
     bool grammar_backend = false;
+    // TC-2: when true, one model turn may emit multiple tool-call envelopes;
+    // the loop parses and executes all of them before one follow-up prompt.
+    // On QHexRT the native toolcall/toolcall_opt grammar still admits at most
+    // one call per generation; parallel harvesting applies to unconstrained /
+    // GBNF (llamacpp) paths.
+    bool parallel_tool_calls = false;
     rac::llm::tool_calling::GenerationState generation;
 
     // request-level tool_choice / forced_tool_name overrides.
@@ -243,6 +250,7 @@ runanywhere::v1::ToolCallingOptions build_options_snapshot(const LoopContext& ct
     options.set_auto_execute(ctx.auto_execute);
     options.set_replace_system_prompt(ctx.replace_system_prompt);
     options.set_require_json_arguments(ctx.require_json_arguments);
+    options.set_parallel_tool_calls(ctx.parallel_tool_calls);
     return options;
 }
 
@@ -293,7 +301,7 @@ std::string format_prompt_proto(const LoopContext& ctx,
 
 bool parse_tool_call_from_output(const LoopContext& ctx, const std::string& llm_output,
                                  std::string* out_clean_text,
-                                 runanywhere::v1::ToolCall* out_tool_call) {
+                                 std::vector<runanywhere::v1::ToolCall>* out_tool_calls) {
     runanywhere::v1::ToolParseRequest request;
     request.set_text(llm_output);
     *request.mutable_options() = build_options_snapshot(ctx);
@@ -328,8 +336,15 @@ bool parse_tool_call_from_output(const LoopContext& ctx, const std::string& llm_
         *out_clean_text = result.remaining_text();
     }
     if (result.has_tool_call() && result.tool_calls_size() > 0) {
-        if (out_tool_call) {
-            *out_tool_call = result.tool_calls(0);
+        if (out_tool_calls) {
+            out_tool_calls->clear();
+            // The parse ABI emits one call unless parallel_tool_calls was set
+            // on the options snapshot; either way, forward everything.
+            const int limit = ctx.parallel_tool_calls ? result.tool_calls_size() : 1;
+            out_tool_calls->reserve(static_cast<size_t>(limit));
+            for (int i = 0; i < limit; ++i) {
+                out_tool_calls->push_back(result.tool_calls(i));
+            }
         }
         return true;
     }
@@ -495,15 +510,27 @@ static rac_result_t run_loop_impl(const uint8_t* in_request_bytes, size_t in_siz
     if (request.has_forced_tool_name()) {
         ctx.forced_tool_name = request.forced_tool_name();
     }
+    ctx.parallel_tool_calls = request.parallel_tool_calls();
     for (const auto& tool : request.tools()) {
         *ctx.tool_options.add_tools() = tool;
-        // Names drive the QHexRT grammar spec (RUN-80); ignored by non-grammar engines.
-        ctx.generation.tool_names.push_back(tool.name());
     }
     std::string tool_choice_error;
     if (!apply_explicit_tool_choice(&ctx, &tool_choice_error)) {
         emit_failure(out_result, RAC_ERROR_INVALID_ARGUMENT, tool_choice_error);
         return RAC_ERROR_INVALID_ARGUMENT;
+    }
+
+    // TC-1: pre-build grammar dialects. Scoped to the default JSON wire format
+    // for GBNF (LFM2 keeps post-hoc validation). QHexRT (grammar_backend) also
+    // needs the qhexrt dialect whenever tools are advertised — its prompt path
+    // uses bare-Pythonic regardless of the declared format enum.
+    if (ctx.format == runanywhere::v1::TOOL_CALL_FORMAT_NAME_JSON || ctx.grammar_backend) {
+        auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
+            ctx.tool_options, ctx.has_tool_choice, ctx.tool_choice, ctx.forced_tool_name);
+        // GBNF encodes the JSON <tool_call> envelope; skip it on grammar
+        // backends that speak bare-Pythonic instead.
+        ctx.generation.grammar_gbnf = ctx.grammar_backend ? std::string() : std::move(grammar.gbnf);
+        ctx.generation.grammar_qhexrt = std::move(grammar.qhexrt);
     }
 
     runanywhere::v1::ToolCallingResult final_result;
@@ -550,15 +577,19 @@ static rac_result_t run_loop_impl(const uint8_t* in_request_bytes, size_t in_siz
                 ctx.has_tool_choice && ctx.tool_choice == runanywhere::v1::TOOL_CHOICE_MODE_NONE,
                 final_result.tool_calls_size() > 0, ctx.keep_tools_available);
         if (!tools_live_this_turn) {
-            step_generation.tool_names.clear();
+            step_generation.grammar_gbnf.clear();
+            step_generation.grammar_qhexrt.clear();
         } else if (ctx.has_tool_choice &&
                    ctx.tool_choice == runanywhere::v1::TOOL_CHOICE_MODE_SPECIFIC &&
                    !ctx.forced_tool_name.empty()) {
-            // tool_choice=SPECIFIC: narrow the QHexRT grammar spec to the ONE forced tool so
-            // the grammar can only emit `[<forced>(...)]` (or free text). Without this the
-            // spec still lists every tool and the model could emit a different call that the
-            // SPECIFIC policy then rejects instead of being structurally prevented (RUN-80).
-            step_generation.tool_names = {ctx.forced_tool_name};
+            // tool_choice=SPECIFIC: rebuild grammars narrowed to the ONE forced
+            // tool so decoding can only emit that call (or free text on
+            // toolcall_opt). Without this the spec still lists every tool.
+            auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
+                ctx.tool_options, ctx.has_tool_choice, ctx.tool_choice, ctx.forced_tool_name);
+            step_generation.grammar_gbnf =
+                ctx.grammar_backend ? std::string() : std::move(grammar.gbnf);
+            step_generation.grammar_qhexrt = std::move(grammar.qhexrt);
         }
         // Stop over-calling (RUN-80): on the AUTO decision path add the device-proven
         // "only call when genuinely needed" hint to the system prompt so a small model
@@ -608,8 +639,9 @@ static rac_result_t run_loop_impl(const uint8_t* in_request_bytes, size_t in_siz
         }
 
         std::string clean_text;
-        runanywhere::v1::ToolCall parsed_call;
-        const bool has_call = parse_tool_call_from_output(ctx, response, &clean_text, &parsed_call);
+        std::vector<runanywhere::v1::ToolCall> parsed_calls;
+        const bool has_call =
+            parse_tool_call_from_output(ctx, response, &clean_text, &parsed_calls);
         final_text = clean_text;
 
         if (!has_call) {
@@ -625,15 +657,11 @@ static rac_result_t run_loop_impl(const uint8_t* in_request_bytes, size_t in_siz
             break;
         }
 
-        if (static_cast<uint32_t>(final_result.tool_calls_size()) >= ctx.max_tool_calls) {
-            constexpr const char* kLimitMessage =
-                "model requested another tool after max_tool_calls was reached";
-            final_result.set_error_code(RAC_ERROR_VALIDATION_FAILED);
-            final_result.set_error_message(kLimitMessage);
-            is_complete = false;
-            break;
-        }
-        if (final_result.tool_calls_size() > 0 && !ctx.keep_tools_available) {
+        // "another tool after tools were removed" is a cross-TURN constraint:
+        // calls parsed from THIS turn's output are one batch, so the check
+        // keys off the count recorded before this batch, not mid-batch.
+        const int calls_before_batch = final_result.tool_calls_size();
+        if (calls_before_batch > 0 && !ctx.keep_tools_available) {
             constexpr const char* kToolsUnavailableMessage =
                 "model requested another tool after tools were removed";
             final_result.set_error_code(RAC_ERROR_VALIDATION_FAILED);
@@ -642,39 +670,31 @@ static rac_result_t run_loop_impl(const uint8_t* in_request_bytes, size_t in_siz
             break;
         }
 
-        // Tool-choice policy is an authorization constraint, not optional
-        // schema validation. It must run even when validate_calls=false.
-        const std::string policy_error = tool_choice_policy_error(ctx, parsed_call);
-        if (!policy_error.empty()) {
-            runanywhere::v1::ToolResult failed;
-            failed.set_tool_call_id(parsed_call.id());
-            failed.set_name(parsed_call.name());
-            failed.set_error(policy_error);
-            failed.set_success(false);
-            failed.set_started_at_ms(now_ms());
-            failed.set_completed_at_ms(now_ms());
-            *final_result.add_tool_calls() = parsed_call;
-            *final_result.add_tool_results() = failed;
-            is_complete = false;
-            final_result.set_error_code(RAC_ERROR_VALIDATION_FAILED);
-            final_result.set_error_message(policy_error);
-            break;
-        }
+        // Per-call pipeline: policy -> validate -> execute. With
+        // parallel_tool_calls the batch runs sequentially under the same
+        // policy/limits; the parallelism win is one LLM round-trip for N
+        // calls, not concurrent executors. stop_loop breaks the outer
+        // while(true) after the batch unwinds.
+        bool stop_loop = false;
+        for (runanywhere::v1::ToolCall& parsed_call : parsed_calls) {
+            if (static_cast<uint32_t>(final_result.tool_calls_size()) >= ctx.max_tool_calls) {
+                constexpr const char* kLimitMessage =
+                    "model requested another tool after max_tool_calls was reached";
+                final_result.set_error_code(RAC_ERROR_VALIDATION_FAILED);
+                final_result.set_error_message(kLimitMessage);
+                is_complete = false;
+                stop_loop = true;
+                break;
+            }
 
-        if (ctx.validate_calls) {
-            auto validation = validate_tool_call(ctx, parsed_call);
-            if (!validation.is_valid()) {
-                std::string msg = validation.error_message();
-                if (msg.empty() && validation.validation_errors_size() > 0) {
-                    msg = validation.validation_errors(0);
-                }
-                if (msg.empty()) {
-                    msg = "tool call validation failed";
-                }
+            // Tool-choice policy is an authorization constraint, not optional
+            // schema validation. It must run even when validate_calls=false.
+            const std::string policy_error = tool_choice_policy_error(ctx, parsed_call);
+            if (!policy_error.empty()) {
                 runanywhere::v1::ToolResult failed;
                 failed.set_tool_call_id(parsed_call.id());
                 failed.set_name(parsed_call.name());
-                failed.set_error(msg);
+                failed.set_error(policy_error);
                 failed.set_success(false);
                 failed.set_started_at_ms(now_ms());
                 failed.set_completed_at_ms(now_ms());
@@ -682,93 +702,128 @@ static rac_result_t run_loop_impl(const uint8_t* in_request_bytes, size_t in_siz
                 *final_result.add_tool_results() = failed;
                 is_complete = false;
                 final_result.set_error_code(RAC_ERROR_VALIDATION_FAILED);
-                final_result.set_error_message(msg);
+                final_result.set_error_message(policy_error);
+                stop_loop = true;
                 break;
             }
-            if (!validation.normalized_arguments_json().empty()) {
-                parsed_call.set_arguments_json(validation.normalized_arguments_json());
+
+            if (ctx.validate_calls) {
+                auto validation = validate_tool_call(ctx, parsed_call);
+                if (!validation.is_valid()) {
+                    std::string msg = validation.error_message();
+                    if (msg.empty() && validation.validation_errors_size() > 0) {
+                        msg = validation.validation_errors(0);
+                    }
+                    if (msg.empty()) {
+                        msg = "tool call validation failed";
+                    }
+                    runanywhere::v1::ToolResult failed;
+                    failed.set_tool_call_id(parsed_call.id());
+                    failed.set_name(parsed_call.name());
+                    failed.set_error(msg);
+                    failed.set_success(false);
+                    failed.set_started_at_ms(now_ms());
+                    failed.set_completed_at_ms(now_ms());
+                    *final_result.add_tool_calls() = parsed_call;
+                    *final_result.add_tool_results() = failed;
+                    is_complete = false;
+                    final_result.set_error_code(RAC_ERROR_VALIDATION_FAILED);
+                    final_result.set_error_message(msg);
+                    stop_loop = true;
+                    break;
+                }
+                if (!validation.normalized_arguments_json().empty()) {
+                    parsed_call.set_arguments_json(validation.normalized_arguments_json());
+                }
             }
-        }
 
-        if (!ctx.auto_execute) {
-            *final_result.add_tool_calls() = parsed_call;
-            is_complete = false;
-            break;
-        }
-
-        // Synchronous tool execution via host callback.
-        std::vector<uint8_t> call_bytes;
-        if (!serialize(parsed_call, &call_bytes)) {
-            emit_failure(out_result, RAC_ERROR_INTERNAL,
-                         "failed to serialize ToolCall for callback");
-            return RAC_ERROR_INTERNAL;
-        }
-
-        rac_proto_buffer_t exec_out;
-        rac_proto_buffer_init(&exec_out);
-        rac_result_t exec_rc = RAC_SUCCESS;
-        {
-            std::lock_guard<std::recursive_mutex> admission_guard(
-                cancel_state->side_effect_admission_mu);
-            if (cancel_state->cancel_requested.load(std::memory_order_acquire)) {
-                return finish_cancelled();
+            if (!ctx.auto_execute) {
+                *final_result.add_tool_calls() = parsed_call;
+                is_complete = false;
+                stop_loop = true;
+                continue;  // hand back every parsed call, execute none
             }
-            exec_rc = on_execute(call_bytes.empty() ? nullptr : call_bytes.data(),
-                                 call_bytes.size(), &exec_out, on_execute_user_data);
-        }
 
-        runanywhere::v1::ToolResult tool_result;
-        std::string executor_error;
-        if (exec_rc == RAC_SUCCESS && exec_out.status != RAC_SUCCESS) {
-            exec_rc = exec_out.status;
-            executor_error = exec_out.error_message ? exec_out.error_message
-                                                    : "tool executor returned an error buffer";
-        } else if (exec_rc == RAC_SUCCESS && (!exec_out.data || exec_out.size == 0)) {
-            exec_rc = RAC_ERROR_DECODING_ERROR;
-            executor_error = "tool executor returned an empty ToolResult";
-        } else if (exec_rc == RAC_SUCCESS &&
-                   !tool_result.ParseFromArray(exec_out.data, static_cast<int>(exec_out.size))) {
-            exec_rc = RAC_ERROR_DECODING_ERROR;
-            executor_error = "tool executor returned malformed ToolResult bytes";
-        } else if (exec_rc == RAC_SUCCESS && !tool_result.tool_call_id().empty() &&
-                   tool_result.tool_call_id() != parsed_call.id()) {
-            exec_rc = RAC_ERROR_VALIDATION_FAILED;
-            executor_error = "tool executor returned a mismatched tool_call_id";
-        } else if (exec_rc == RAC_SUCCESS && !tool_result.name().empty() &&
-                   tool_result.name() != parsed_call.name()) {
-            exec_rc = RAC_ERROR_VALIDATION_FAILED;
-            executor_error = "tool executor returned a mismatched tool name";
-        }
+            // Synchronous tool execution via host callback.
+            std::vector<uint8_t> call_bytes;
+            if (!serialize(parsed_call, &call_bytes)) {
+                emit_failure(out_result, RAC_ERROR_INTERNAL,
+                             "failed to serialize ToolCall for callback");
+                return RAC_ERROR_INTERNAL;
+            }
 
-        if (exec_rc != RAC_SUCCESS) {
-            if (executor_error.empty()) {
+            rac_proto_buffer_t exec_out;
+            rac_proto_buffer_init(&exec_out);
+            rac_result_t exec_rc = RAC_SUCCESS;
+            {
+                std::lock_guard<std::recursive_mutex> admission_guard(
+                    cancel_state->side_effect_admission_mu);
+                if (cancel_state->cancel_requested.load(std::memory_order_acquire)) {
+                    return finish_cancelled();
+                }
+                exec_rc = on_execute(call_bytes.empty() ? nullptr : call_bytes.data(),
+                                     call_bytes.size(), &exec_out, on_execute_user_data);
+            }
+
+            runanywhere::v1::ToolResult tool_result;
+            std::string executor_error;
+            if (exec_rc == RAC_SUCCESS && exec_out.status != RAC_SUCCESS) {
+                exec_rc = exec_out.status;
                 executor_error = exec_out.error_message ? exec_out.error_message
-                                                        : "tool executor returned an error";
+                                                        : "tool executor returned an error buffer";
+            } else if (exec_rc == RAC_SUCCESS && (!exec_out.data || exec_out.size == 0)) {
+                exec_rc = RAC_ERROR_DECODING_ERROR;
+                executor_error = "tool executor returned an empty ToolResult";
+            } else if (exec_rc == RAC_SUCCESS &&
+                       !tool_result.ParseFromArray(exec_out.data,
+                                                   static_cast<int>(exec_out.size))) {
+                exec_rc = RAC_ERROR_DECODING_ERROR;
+                executor_error = "tool executor returned malformed ToolResult bytes";
+            } else if (exec_rc == RAC_SUCCESS && !tool_result.tool_call_id().empty() &&
+                       tool_result.tool_call_id() != parsed_call.id()) {
+                exec_rc = RAC_ERROR_VALIDATION_FAILED;
+                executor_error = "tool executor returned a mismatched tool_call_id";
+            } else if (exec_rc == RAC_SUCCESS && !tool_result.name().empty() &&
+                       tool_result.name() != parsed_call.name()) {
+                exec_rc = RAC_ERROR_VALIDATION_FAILED;
+                executor_error = "tool executor returned a mismatched tool name";
             }
-            tool_result.Clear();
-            tool_result.set_success(false);
-            tool_result.set_error(executor_error);
+
+            if (exec_rc != RAC_SUCCESS) {
+                if (executor_error.empty()) {
+                    executor_error = exec_out.error_message ? exec_out.error_message
+                                                            : "tool executor returned an error";
+                }
+                tool_result.Clear();
+                tool_result.set_success(false);
+                tool_result.set_error(executor_error);
+            }
+            tool_result.set_tool_call_id(parsed_call.id());
+            tool_result.set_name(parsed_call.name());
+            if (tool_result.started_at_ms() == 0)
+                tool_result.set_started_at_ms(now_ms());
+            if (tool_result.completed_at_ms() == 0)
+                tool_result.set_completed_at_ms(now_ms());
+
+            rac_proto_buffer_free(&exec_out);
+
+            *final_result.add_tool_calls() = parsed_call;
+            *final_result.add_tool_results() = tool_result;
+
+            if (exec_rc != RAC_SUCCESS) {
+                final_result.set_error_code(static_cast<int32_t>(exec_rc));
+                final_result.set_error_message(tool_result.error());
+                is_complete = false;
+                stop_loop = true;
+                break;
+            }
         }
-        tool_result.set_tool_call_id(parsed_call.id());
-        tool_result.set_name(parsed_call.name());
-        if (tool_result.started_at_ms() == 0)
-            tool_result.set_started_at_ms(now_ms());
-        if (tool_result.completed_at_ms() == 0)
-            tool_result.set_completed_at_ms(now_ms());
-
-        rac_proto_buffer_free(&exec_out);
-
-        *final_result.add_tool_calls() = parsed_call;
-        *final_result.add_tool_results() = tool_result;
-
-        if (exec_rc != RAC_SUCCESS) {
-            final_result.set_error_code(static_cast<int32_t>(exec_rc));
-            final_result.set_error_message(tool_result.error());
-            is_complete = false;
+        if (stop_loop) {
             break;
         }
 
-        // Build follow-up prompt from the executed tool result.
+        // Build ONE follow-up prompt from every tool result executed so far
+        // (single call, or the whole parallel batch).
         std::vector<runanywhere::v1::ToolResult> trs;
         trs.reserve(static_cast<size_t>(final_result.tool_results_size()));
         for (const auto& recorded_result : final_result.tool_results()) {

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_session.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_session.cpp
@@ -32,6 +32,7 @@
 
 #include "features/llm/rac_llm_lifecycle_bridge.h"
 #include "features/llm/tool_calling_generation_internal.h"
+#include "features/llm/tool_calling_grammar.h"
 #include "features/llm/tool_calling_internal.h"
 #include "features/llm/tool_calling_result_internal.h"
 #include "rac/core/rac_logger.h"
@@ -617,14 +618,19 @@ void run_generate_loop(ToolCallingSession& session) {
         session.has_tool_choice && session.tool_choice == runanywhere::v1::TOOL_CHOICE_MODE_NONE,
         !session.all_tool_calls.empty(), session.keep_tools_available);
     if (!tools_live_this_turn) {
-        step_generation.tool_names.clear();
+        step_generation.grammar_gbnf.clear();
+        step_generation.grammar_qhexrt.clear();
     } else if (session.has_tool_choice &&
                session.tool_choice == runanywhere::v1::TOOL_CHOICE_MODE_SPECIFIC &&
                !session.forced_tool_name.empty()) {
-        // tool_choice=SPECIFIC: narrow the QHexRT grammar spec to the ONE forced tool so the
-        // grammar can only emit `[<forced>(...)]` (or free text), rather than letting the
-        // model pick a tool the SPECIFIC policy then rejects (see the run-loop path). RUN-80.
-        step_generation.tool_names = {session.forced_tool_name};
+        // tool_choice=SPECIFIC: rebuild grammars narrowed to the ONE forced tool
+        // so decoding can only emit that call (see the run-loop path).
+        auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
+            session.tool_options, session.has_tool_choice, session.tool_choice,
+            session.forced_tool_name);
+        step_generation.grammar_gbnf =
+            session.grammar_backend ? std::string() : std::move(grammar.gbnf);
+        step_generation.grammar_qhexrt = std::move(grammar.qhexrt);
     }
     // Stop over-calling (RUN-80): on the AUTO decision path add the device-proven
     // "only call when genuinely needed" hint to the system prompt (see the run-loop path).
@@ -862,13 +868,22 @@ extern "C" rac_result_t rac_tool_calling_session_create_proto(
 
     for (const auto& tool : request.tools()) {
         *session->tool_options.add_tools() = tool;
-        // Names drive the QHexRT grammar spec (RUN-80); ignored by non-grammar engines.
-        session->generation.tool_names.push_back(tool.name());
     }
 
     std::string tool_choice_error;
     if (!apply_explicit_tool_choice(session.get(), &tool_choice_error)) {
         return RAC_ERROR_INVALID_ARGUMENT;
+    }
+
+    // TC-1: pre-build grammar dialects (same contract as the run-loop path).
+    if (session->format == runanywhere::v1::TOOL_CALL_FORMAT_NAME_JSON ||
+        session->grammar_backend) {
+        auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
+            session->tool_options, session->has_tool_choice, session->tool_choice,
+            session->forced_tool_name);
+        session->generation.grammar_gbnf =
+            session->grammar_backend ? std::string() : std::move(grammar.gbnf);
+        session->generation.grammar_qhexrt = std::move(grammar.qhexrt);
     }
 
     auto& reg = registry();

--- a/sdk/runanywhere-commons/src/features/llm/tool_calling_session.cpp
+++ b/sdk/runanywhere-commons/src/features/llm/tool_calling_session.cpp
@@ -627,7 +627,7 @@ void run_generate_loop(ToolCallingSession& session) {
         // so decoding can only emit that call (see the run-loop path).
         auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
             session.tool_options, session.has_tool_choice, session.tool_choice,
-            session.forced_tool_name);
+            session.forced_tool_name, /*parallel=*/false);
         step_generation.grammar_gbnf =
             session.grammar_backend ? std::string() : std::move(grammar.gbnf);
         step_generation.grammar_qhexrt = std::move(grammar.qhexrt);
@@ -880,7 +880,7 @@ extern "C" rac_result_t rac_tool_calling_session_create_proto(
         session->grammar_backend) {
         auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
             session->tool_options, session->has_tool_choice, session->tool_choice,
-            session->forced_tool_name);
+            session->forced_tool_name, /*parallel=*/false);
         session->generation.grammar_gbnf =
             session->grammar_backend ? std::string() : std::move(grammar.gbnf);
         session->generation.grammar_qhexrt = std::move(grammar.qhexrt);

--- a/sdk/runanywhere-commons/src/generated/proto/tool_calling.pb.cc
+++ b/sdk/runanywhere-commons/src/generated/proto/tool_calling.pb.cc
@@ -3414,11 +3414,11 @@ constexpr ToolCallingSessionCreateRequest::ParseTableT_ ToolCallingSessionCreate
     {
       PROTOBUF_FIELD_OFFSET(ToolCallingSessionCreateRequest, _impl_._has_bits_),
       0, // no _extensions_
-      19, 248,  // max_field_number, fast_idx_mask
+      20, 248,  // max_field_number, fast_idx_mask
       offsetof(ParseTableT_, field_lookup_table),
-      4294443776,  // skipmap
+      4293919488,  // skipmap
       offsetof(ParseTableT_, field_entries),
-      17,  // num_field_entries
+      18,  // num_field_entries
       1,  // num_aux_entries
       offsetof(ParseTableT_, aux_entries),
       class_data,
@@ -3499,7 +3499,10 @@ constexpr ToolCallingSessionCreateRequest::ParseTableT_ ToolCallingSessionCreate
       {::_pbi::TcParser::FastUR2,
        {410, 1, 0,
         PROTOBUF_FIELD_OFFSET(ToolCallingSessionCreateRequest, _impl_.history_)}},
-      {::_pbi::TcParser::MiniParse, {}},
+      // bool parallel_tool_calls = 20;
+      {::_pbi::TcParser::FastV8S2,
+       {416, 17, 0,
+        PROTOBUF_FIELD_OFFSET(ToolCallingSessionCreateRequest, _impl_.parallel_tool_calls_)}},
       {::_pbi::TcParser::MiniParse, {}},
       {::_pbi::TcParser::MiniParse, {}},
       {::_pbi::TcParser::MiniParse, {}},
@@ -3548,6 +3551,8 @@ constexpr ToolCallingSessionCreateRequest::ParseTableT_ ToolCallingSessionCreate
       {PROTOBUF_FIELD_OFFSET(ToolCallingSessionCreateRequest, _impl_.require_json_arguments_), _Internal::kHasBitsOffset + 16, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
       // repeated string history = 19;
       {PROTOBUF_FIELD_OFFSET(ToolCallingSessionCreateRequest, _impl_.history_), _Internal::kHasBitsOffset + 1, 0, (0 | ::_fl::kFcRepeated | ::_fl::kUtf8String | ::_fl::kRepSString)},
+      // bool parallel_tool_calls = 20;
+      {PROTOBUF_FIELD_OFFSET(ToolCallingSessionCreateRequest, _impl_.parallel_tool_calls_), _Internal::kHasBitsOffset + 17, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
     }},
     {{
         #ifndef PROTOBUF_MESSAGE_GLOBALS
@@ -3602,7 +3607,8 @@ inline constexpr ToolCallingSessionCreateRequest::Impl_::Impl_(
         temperature_{0},
         top_p_{0},
         replace_system_prompt_{false},
-        require_json_arguments_{false} {}
+        require_json_arguments_{false},
+        parallel_tool_calls_{false} {}
 
 template <typename>
 constexpr ToolCallingSessionCreateRequest::ToolCallingSessionCreateRequest(::_pbi::ConstantInitialized,
@@ -3710,9 +3716,9 @@ constexpr ToolCallingOptions::ParseTableT_ ToolCallingOptions::InternalGenerateP
       0, // no _extensions_
       17, 120,  // max_field_number, fast_idx_mask
       offsetof(ParseTableT_, field_lookup_table),
-      4294853890,  // skipmap
+      4294837506,  // skipmap
       offsetof(ParseTableT_, field_entries),
-      13,  // num_field_entries
+      14,  // num_field_entries
       1,  // num_aux_entries
       offsetof(ParseTableT_, aux_entries),
       class_data,
@@ -3724,7 +3730,7 @@ constexpr ToolCallingOptions::ParseTableT_ ToolCallingOptions::InternalGenerateP
     }, {{
       // bool require_json_arguments = 16;
       {::_pbi::TcParser::FastV8S2,
-       {384, 8, 0,
+       {384, 12, 0,
         PROTOBUF_FIELD_OFFSET(ToolCallingOptions, _impl_.require_json_arguments_)}},
       // repeated .runanywhere.v1.ToolDefinition tools = 1;
       {::_pbi::TcParser::FastMtR1,
@@ -3773,7 +3779,10 @@ constexpr ToolCallingOptions::ParseTableT_ ToolCallingOptions::InternalGenerateP
       {::_pbi::TcParser::FastUS1,
        {114, 2, 0,
         PROTOBUF_FIELD_OFFSET(ToolCallingOptions, _impl_.forced_tool_name_)}},
-      {::_pbi::TcParser::MiniParse, {}},
+      // bool parallel_tool_calls = 15;
+      {::_pbi::TcParser::SingularVarintNoZag1<bool, offsetof(ToolCallingOptions, _impl_.parallel_tool_calls_), 8>(),
+       {120, 8, 0,
+        PROTOBUF_FIELD_OFFSET(ToolCallingOptions, _impl_.parallel_tool_calls_)}},
     }}, {{
       65535, 65535
     }}, {{
@@ -3799,10 +3808,12 @@ constexpr ToolCallingOptions::ParseTableT_ ToolCallingOptions::InternalGenerateP
       {PROTOBUF_FIELD_OFFSET(ToolCallingOptions, _impl_.tool_choice_), _Internal::kHasBitsOffset + 11, 0, (0 | ::_fl::kFcOptional | ::_fl::kOpenEnum)},
       // optional string forced_tool_name = 14;
       {PROTOBUF_FIELD_OFFSET(ToolCallingOptions, _impl_.forced_tool_name_), _Internal::kHasBitsOffset + 2, 0, (0 | ::_fl::kFcOptional | ::_fl::kUtf8String | ::_fl::kRepAString)},
+      // bool parallel_tool_calls = 15;
+      {PROTOBUF_FIELD_OFFSET(ToolCallingOptions, _impl_.parallel_tool_calls_), _Internal::kHasBitsOffset + 8, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
       // bool require_json_arguments = 16;
-      {PROTOBUF_FIELD_OFFSET(ToolCallingOptions, _impl_.require_json_arguments_), _Internal::kHasBitsOffset + 8, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
+      {PROTOBUF_FIELD_OFFSET(ToolCallingOptions, _impl_.require_json_arguments_), _Internal::kHasBitsOffset + 12, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
       // optional bool disable_thinking = 17;
-      {PROTOBUF_FIELD_OFFSET(ToolCallingOptions, _impl_.disable_thinking_), _Internal::kHasBitsOffset + 12, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
+      {PROTOBUF_FIELD_OFFSET(ToolCallingOptions, _impl_.disable_thinking_), _Internal::kHasBitsOffset + 13, 0, (0 | ::_fl::kFcOptional | ::_fl::kBool)},
     }},
     {{
         #ifndef PROTOBUF_MESSAGE_GLOBALS
@@ -3841,10 +3852,11 @@ inline constexpr ToolCallingOptions::Impl_::Impl_(
         auto_execute_{false},
         replace_system_prompt_{false},
         keep_tools_available_{false},
-        require_json_arguments_{false},
+        parallel_tool_calls_{false},
         format_{static_cast< ::runanywhere::v1::ToolCallFormatName >(0)},
         max_tool_calls_{0},
         tool_choice_{static_cast< ::runanywhere::v1::ToolChoiceMode >(0)},
+        require_json_arguments_{false},
         disable_thinking_{false} {}
 
 template <typename>
@@ -4752,7 +4764,7 @@ const ::uint32_t
         5,
         0x081, // bitmap
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingOptions, _impl_._has_bits_),
-        16, // hasbit index offset
+        17, // hasbit index offset
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingOptions, _impl_.tools_),
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingOptions, _impl_.auto_execute_),
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingOptions, _impl_.temperature_),
@@ -4761,6 +4773,7 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingOptions, _impl_.replace_system_prompt_),
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingOptions, _impl_.keep_tools_available_),
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingOptions, _impl_.format_),
+        PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingOptions, _impl_.parallel_tool_calls_),
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingOptions, _impl_.max_tool_calls_),
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingOptions, _impl_.tool_choice_),
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingOptions, _impl_.forced_tool_name_),
@@ -4774,11 +4787,12 @@ const ::uint32_t
         6,
         7,
         9,
+        8,
         10,
         11,
         2,
-        8,
         12,
+        13,
         0x081, // bitmap
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingResult, _impl_._has_bits_),
         13, // hasbit index offset
@@ -4898,7 +4912,7 @@ const ::uint32_t
         1,
         0x081, // bitmap
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingSessionCreateRequest, _impl_._has_bits_),
-        20, // hasbit index offset
+        21, // hasbit index offset
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingSessionCreateRequest, _impl_.prompt_),
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingSessionCreateRequest, _impl_.max_tokens_),
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingSessionCreateRequest, _impl_.temperature_),
@@ -4916,6 +4930,7 @@ const ::uint32_t
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingSessionCreateRequest, _impl_.replace_system_prompt_),
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingSessionCreateRequest, _impl_.require_json_arguments_),
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingSessionCreateRequest, _impl_.history_),
+        PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingSessionCreateRequest, _impl_.parallel_tool_calls_),
         2,
         12,
         13,
@@ -4933,6 +4948,7 @@ const ::uint32_t
         15,
         16,
         1,
+        17,
         0x081, // bitmap
         PROTOBUF_FIELD_OFFSET(::runanywhere::v1::ToolCallingSessionCreateResult, _impl_._has_bits_),
         4, // hasbit index offset
@@ -4984,20 +5000,20 @@ static const ::_pbi::MigrationSchema
         {70, sizeof(::runanywhere::v1::ToolCall)},
         {85, sizeof(::runanywhere::v1::ToolResult)},
         {102, sizeof(::runanywhere::v1::ToolCallingOptions)},
-        {131, sizeof(::runanywhere::v1::ToolCallingResult)},
-        {154, sizeof(::runanywhere::v1::ToolParseRequest)},
-        {161, sizeof(::runanywhere::v1::ToolParseResult)},
-        {174, sizeof(::runanywhere::v1::ToolPromptFormatRequest)},
-        {185, sizeof(::runanywhere::v1::ToolPromptFormatResult)},
-        {196, sizeof(::runanywhere::v1::ToolCallValidationRequest)},
-        {203, sizeof(::runanywhere::v1::ToolCallValidationResult)},
-        {218, sizeof(::runanywhere::v1::ToolCallingStreamEvent)},
-        {241, sizeof(::runanywhere::v1::ToolRegistrySnapshot)},
-        {248, sizeof(::runanywhere::v1::ToolCallingSessionCreateRequest)},
-        {285, sizeof(::runanywhere::v1::ToolCallingSessionCreateResult)},
-        {290, sizeof(::runanywhere::v1::ToolCallingSessionEvent)},
-        {305, sizeof(::runanywhere::v1::ToolCallingSessionStepWithResultRequest)},
-        {316, sizeof(::runanywhere::v1::ToolCallingSessionDestroyRequest)},
+        {133, sizeof(::runanywhere::v1::ToolCallingResult)},
+        {156, sizeof(::runanywhere::v1::ToolParseRequest)},
+        {163, sizeof(::runanywhere::v1::ToolParseResult)},
+        {176, sizeof(::runanywhere::v1::ToolPromptFormatRequest)},
+        {187, sizeof(::runanywhere::v1::ToolPromptFormatResult)},
+        {198, sizeof(::runanywhere::v1::ToolCallValidationRequest)},
+        {205, sizeof(::runanywhere::v1::ToolCallValidationResult)},
+        {220, sizeof(::runanywhere::v1::ToolCallingStreamEvent)},
+        {243, sizeof(::runanywhere::v1::ToolRegistrySnapshot)},
+        {250, sizeof(::runanywhere::v1::ToolCallingSessionCreateRequest)},
+        {289, sizeof(::runanywhere::v1::ToolCallingSessionCreateResult)},
+        {294, sizeof(::runanywhere::v1::ToolCallingSessionEvent)},
+        {309, sizeof(::runanywhere::v1::ToolCallingSessionStepWithResultRequest)},
+        {320, sizeof(::runanywhere::v1::ToolCallingSessionDestroyRequest)},
 };
 static const ::_pbi::MessageGlobalsBase* PROTOBUF_NONNULL const
     file_message_globals[] = {
@@ -5063,7 +5079,7 @@ const char descriptor_table_protodef_tool_5fcalling_2eproto[] ABSL_ATTRIBUTE_SEC
     "\030\001 \001(\t\022\014\n\004name\030\002 \001(\t\022\023\n\013result_json\030\003 \001("
     "\t\022\022\n\005error\030\004 \001(\tH\000\210\001\001\022\017\n\007success\030\005 \001(\010\022\025"
     "\n\rstarted_at_ms\030\010 \001(\003\022\027\n\017completed_at_ms"
-    "\030\t \001(\003B\010\n\006_errorJ\004\010\006\020\007J\004\010\007\020\010\"\337\004\n\022ToolCal"
+    "\030\t \001(\003B\010\n\006_errorJ\004\010\006\020\007J\004\010\007\020\010\"\366\004\n\022ToolCal"
     "lingOptions\022-\n\005tools\030\001 \003(\0132\036.runanywhere"
     ".v1.ToolDefinition\022\024\n\014auto_execute\030\003 \001(\010"
     "\022\030\n\013temperature\030\004 \001(\002H\000\210\001\001\022\027\n\nmax_tokens"
@@ -5071,130 +5087,132 @@ const char descriptor_table_protodef_tool_5fcalling_2eproto[] ABSL_ATTRIBUTE_SEC
     "\035\n\025replace_system_prompt\030\007 \001(\010\022\034\n\024keep_t"
     "ools_available\030\010 \001(\010\0227\n\006format\030\n \001(\0162\".r"
     "unanywhere.v1.ToolCallFormatNameH\003\210\001\001\022\033\n"
-    "\016max_tool_calls\030\014 \001(\005H\004\210\001\001\0223\n\013tool_choic"
-    "e\030\r \001(\0162\036.runanywhere.v1.ToolChoiceMode\022"
-    "\035\n\020forced_tool_name\030\016 \001(\tH\005\210\001\001\022\036\n\026requir"
-    "e_json_arguments\030\020 \001(\010\022\035\n\020disable_thinki"
-    "ng\030\021 \001(\010H\006\210\001\001B\016\n\014_temperatureB\r\n\013_max_to"
-    "kensB\020\n\016_system_promptB\t\n\007_formatB\021\n\017_ma"
-    "x_tool_callsB\023\n\021_forced_tool_nameB\023\n\021_di"
-    "sable_thinkingJ\004\010\002\020\003J\004\010\t\020\nJ\004\010\013\020\014J\004\010\017\020\020\"\351"
-    "\002\n\021ToolCallingResult\022\014\n\004text\030\001 \001(\t\022,\n\nto"
-    "ol_calls\030\002 \003(\0132\030.runanywhere.v1.ToolCall"
-    "\0220\n\014tool_results\030\003 \003(\0132\032.runanywhere.v1."
-    "ToolResult\022\023\n\013is_complete\030\004 \001(\010\022\034\n\017conve"
-    "rsation_id\030\005 \001(\tH\000\210\001\001\022\027\n\017iterations_used"
-    "\030\006 \001(\005\022\032\n\rerror_message\030\007 \001(\tH\001\210\001\001\022\022\n\ner"
-    "ror_code\030\010 \001(\005\022\020\n\010raw_text\030\t \001(\t\022\035\n\020thin"
-    "king_content\030\n \001(\tH\002\210\001\001B\022\n\020_conversation"
-    "_idB\020\n\016_error_messageB\023\n\021_thinking_conte"
-    "nt\"f\n\020ToolParseRequest\022\014\n\004text\030\001 \001(\t\0228\n\007"
-    "options\030\002 \001(\0132\".runanywhere.v1.ToolCalli"
-    "ngOptionsH\000\210\001\001B\n\n\010_options\"\260\001\n\017ToolParse"
-    "Result\022\025\n\rhas_tool_call\030\001 \001(\010\022,\n\ntool_ca"
-    "lls\030\002 \003(\0132\030.runanywhere.v1.ToolCall\022\026\n\016r"
-    "emaining_text\030\003 \001(\t\022\032\n\rerror_message\030\004 \001"
-    "(\tH\000\210\001\001\022\022\n\nerror_code\030\005 \001(\005B\020\n\016_error_me"
-    "ssage\"\326\001\n\027ToolPromptFormatRequest\022\023\n\013use"
-    "r_prompt\030\001 \001(\t\0228\n\007options\030\002 \001(\0132\".runany"
-    "where.v1.ToolCallingOptionsH\000\210\001\001\0220\n\014tool"
-    "_results\030\003 \003(\0132\032.runanywhere.v1.ToolResu"
-    "lt\022\033\n\016assistant_text\030\004 \001(\tH\001\210\001\001B\n\n\010_opti"
-    "onsB\021\n\017_assistant_text\"\256\001\n\026ToolPromptFor"
-    "matResult\022\030\n\020formatted_prompt\030\001 \001(\t\0222\n\006f"
-    "ormat\030\002 \001(\0162\".runanywhere.v1.ToolCallFor"
-    "matName\022\032\n\rerror_message\030\004 \001(\tH\000\210\001\001\022\022\n\ne"
-    "rror_code\030\005 \001(\005B\020\n\016_error_messageJ\004\010\003\020\004\""
-    "\216\001\n\031ToolCallValidationRequest\022+\n\ttool_ca"
-    "ll\030\001 \001(\0132\030.runanywhere.v1.ToolCall\0228\n\007op"
-    "tions\030\002 \001(\0132\".runanywhere.v1.ToolCalling"
-    "OptionsH\000\210\001\001B\n\n\010_options\"\370\001\n\030ToolCallVal"
-    "idationResult\022\020\n\010is_valid\030\001 \001(\010\022\031\n\021valid"
-    "ation_errors\030\002 \003(\t\0229\n\014matched_tool\030\003 \001(\013"
-    "2\036.runanywhere.v1.ToolDefinitionH\000\210\001\001\022!\n"
-    "\031normalized_arguments_json\030\004 \001(\t\022\032\n\rerro"
-    "r_message\030\005 \001(\tH\001\210\001\001\022\022\n\nerror_code\030\006 \001(\005"
-    "B\017\n\r_matched_toolB\020\n\016_error_message\"\250\003\n\026"
-    "ToolCallingStreamEvent\022\013\n\003seq\030\001 \001(\004\022\024\n\014t"
-    "imestamp_us\030\002 \001(\003\022\027\n\017conversation_id\030\003 \001"
-    "(\t\0228\n\004kind\030\004 \001(\0162*.runanywhere.v1.ToolCa"
-    "llingStreamEventKind\022\r\n\005token\030\005 \001(\t\0220\n\tt"
-    "ool_call\030\006 \001(\0132\030.runanywhere.v1.ToolCall"
-    "H\000\210\001\001\0224\n\013tool_result\030\007 \001(\0132\032.runanywhere"
-    ".v1.ToolResultH\001\210\001\001\0226\n\006result\030\010 \001(\0132!.ru"
-    "nanywhere.v1.ToolCallingResultH\002\210\001\001\022\032\n\re"
-    "rror_message\030\t \001(\tH\003\210\001\001\022\022\n\nerror_code\030\n "
-    "\001(\005B\014\n\n_tool_callB\016\n\014_tool_resultB\t\n\007_re"
-    "sultB\020\n\016_error_message\"\\\n\024ToolRegistrySn"
-    "apshot\022-\n\005tools\030\001 \003(\0132\036.runanywhere.v1.T"
-    "oolDefinition\022\025\n\rupdated_at_ms\030\002 \001(\003\"\343\004\n"
-    "\037ToolCallingSessionCreateRequest\022\016\n\006prom"
-    "pt\030\001 \001(\t\022\022\n\nmax_tokens\030\013 \001(\005\022\023\n\013temperat"
-    "ure\030\014 \001(\002\022\r\n\005top_p\030\r \001(\002\022\025\n\rsystem_promp"
-    "t\030\016 \001(\t\022-\n\005tools\030\002 \003(\0132\036.runanywhere.v1."
-    "ToolDefinition\0222\n\006format\030\003 \001(\0162\".runanyw"
-    "here.v1.ToolCallFormatName\022\026\n\016max_tool_c"
-    "alls\030\004 \001(\r\022\034\n\024keep_tools_available\030\005 \001(\010"
-    "\022\033\n\016validate_calls\030\006 \001(\010H\000\210\001\001\0228\n\013tool_ch"
-    "oice\030\007 \001(\0162\036.runanywhere.v1.ToolChoiceMo"
-    "deH\001\210\001\001\022\035\n\020forced_tool_name\030\010 \001(\tH\002\210\001\001\022\030"
-    "\n\020disable_thinking\030\017 \001(\010\022\031\n\014auto_execute"
-    "\030\020 \001(\010H\003\210\001\001\022\035\n\025replace_system_prompt\030\021 \001"
-    "(\010\022\036\n\026require_json_arguments\030\022 \001(\010\022\017\n\007hi"
-    "story\030\023 \003(\tB\021\n\017_validate_callsB\016\n\014_tool_"
-    "choiceB\023\n\021_forced_tool_nameB\017\n\r_auto_exe"
-    "cuteJ\004\010\t\020\013\"8\n\036ToolCallingSessionCreateRe"
-    "sult\022\026\n\016session_handle\030\001 \001(\004\"\321\001\n\027ToolCal"
-    "lingSessionEvent\022 \n\026llm_stream_event_byt"
-    "es\030\001 \001(\014H\000\022-\n\ttool_call\030\002 \001(\0132\030.runanywh"
-    "ere.v1.ToolCallH\000\0229\n\014final_result\030\003 \001(\0132"
-    "!.runanywhere.v1.ToolCallingResultH\000\022\025\n\013"
-    "error_bytes\030\004 \001(\014H\000\022\013\n\003seq\030\005 \001(\004B\006\n\004kind"
-    "\"\212\001\n\'ToolCallingSessionStepWithResultReq"
-    "uest\022\026\n\016session_handle\030\001 \001(\004\022\024\n\014tool_cal"
-    "l_id\030\002 \001(\t\022\023\n\013result_json\030\003 \001(\t\022\022\n\005error"
-    "\030\004 \001(\tH\000\210\001\001B\010\n\006_error\":\n ToolCallingSess"
-    "ionDestroyRequest\022\026\n\016session_handle\030\001 \001("
-    "\004*\330\001\n\021ToolParameterType\022#\n\037TOOL_PARAMETE"
-    "R_TYPE_UNSPECIFIED\020\000\022\036\n\032TOOL_PARAMETER_T"
-    "YPE_STRING\020\001\022\036\n\032TOOL_PARAMETER_TYPE_NUMB"
-    "ER\020\002\022\037\n\033TOOL_PARAMETER_TYPE_BOOLEAN\020\003\022\036\n"
-    "\032TOOL_PARAMETER_TYPE_OBJECT\020\004\022\035\n\031TOOL_PA"
-    "RAMETER_TYPE_ARRAY\020\005*\201\001\n\022ToolCallFormatN"
-    "ame\022%\n!TOOL_CALL_FORMAT_NAME_UNSPECIFIED"
-    "\020\000\022\036\n\032TOOL_CALL_FORMAT_NAME_JSON\020\001\022\036\n\032TO"
-    "OL_CALL_FORMAT_NAME_LFM2\020\007\"\004\010\002\020\006*\246\001\n\016Too"
-    "lChoiceMode\022 \n\034TOOL_CHOICE_MODE_UNSPECIF"
-    "IED\020\000\022\031\n\025TOOL_CHOICE_MODE_AUTO\020\001\022\031\n\025TOOL"
-    "_CHOICE_MODE_NONE\020\002\022\035\n\031TOOL_CHOICE_MODE_"
-    "REQUIRED\020\003\022\035\n\031TOOL_CHOICE_MODE_SPECIFIC\020"
-    "\004*\201\003\n\032ToolCallingStreamEventKind\022.\n*TOOL"
-    "_CALLING_STREAM_EVENT_KIND_UNSPECIFIED\020\000"
-    "\022.\n*TOOL_CALLING_STREAM_EVENT_KIND_MODEL"
-    "_TOKEN\020\001\0223\n/TOOL_CALLING_STREAM_EVENT_KI"
-    "ND_TOOL_CALL_PARSED\020\002\0229\n5TOOL_CALLING_ST"
-    "REAM_EVENT_KIND_TOOL_EXECUTION_STARTED\020\003"
-    "\022;\n7TOOL_CALLING_STREAM_EVENT_KIND_TOOL_"
-    "EXECUTION_COMPLETED\020\004\022,\n(TOOL_CALLING_ST"
-    "REAM_EVENT_KIND_COMPLETED\020\005\022(\n$TOOL_CALL"
-    "ING_STREAM_EVENT_KIND_ERROR\020\0062\237\002\n\013ToolCa"
-    "lling\022J\n\005Parse\022 .runanywhere.v1.ToolPars"
-    "eRequest\032\037.runanywhere.v1.ToolParseResul"
-    "t\022_\n\014FormatPrompt\022\'.runanywhere.v1.ToolP"
-    "romptFormatRequest\032&.runanywhere.v1.Tool"
-    "PromptFormatResult\022c\n\014ValidateCall\022).run"
-    "anywhere.v1.ToolCallValidationRequest\032(."
-    "runanywhere.v1.ToolCallValidationResultB"
-    "\213\001\n\027ai.runanywhere.proto.v1B\020ToolCalling"
-    "ProtoP\001Z<github.com/runanywhere/runanywh"
-    "ere-sdks/idl/v1;runanywherev1\370\001\001\242\002\004RAV1\252"
-    "\002\016Runanywhere.V1\272\002\002RAb\006proto3"
+    "\023parallel_tool_calls\030\017 \001(\010\022\033\n\016max_tool_c"
+    "alls\030\014 \001(\005H\004\210\001\001\0223\n\013tool_choice\030\r \001(\0162\036.r"
+    "unanywhere.v1.ToolChoiceMode\022\035\n\020forced_t"
+    "ool_name\030\016 \001(\tH\005\210\001\001\022\036\n\026require_json_argu"
+    "ments\030\020 \001(\010\022\035\n\020disable_thinking\030\021 \001(\010H\006\210"
+    "\001\001B\016\n\014_temperatureB\r\n\013_max_tokensB\020\n\016_sy"
+    "stem_promptB\t\n\007_formatB\021\n\017_max_tool_call"
+    "sB\023\n\021_forced_tool_nameB\023\n\021_disable_think"
+    "ingJ\004\010\002\020\003J\004\010\t\020\nJ\004\010\013\020\014\"\351\002\n\021ToolCallingRes"
+    "ult\022\014\n\004text\030\001 \001(\t\022,\n\ntool_calls\030\002 \003(\0132\030."
+    "runanywhere.v1.ToolCall\0220\n\014tool_results\030"
+    "\003 \003(\0132\032.runanywhere.v1.ToolResult\022\023\n\013is_"
+    "complete\030\004 \001(\010\022\034\n\017conversation_id\030\005 \001(\tH"
+    "\000\210\001\001\022\027\n\017iterations_used\030\006 \001(\005\022\032\n\rerror_m"
+    "essage\030\007 \001(\tH\001\210\001\001\022\022\n\nerror_code\030\010 \001(\005\022\020\n"
+    "\010raw_text\030\t \001(\t\022\035\n\020thinking_content\030\n \001("
+    "\tH\002\210\001\001B\022\n\020_conversation_idB\020\n\016_error_mes"
+    "sageB\023\n\021_thinking_content\"f\n\020ToolParseRe"
+    "quest\022\014\n\004text\030\001 \001(\t\0228\n\007options\030\002 \001(\0132\".r"
+    "unanywhere.v1.ToolCallingOptionsH\000\210\001\001B\n\n"
+    "\010_options\"\260\001\n\017ToolParseResult\022\025\n\rhas_too"
+    "l_call\030\001 \001(\010\022,\n\ntool_calls\030\002 \003(\0132\030.runan"
+    "ywhere.v1.ToolCall\022\026\n\016remaining_text\030\003 \001"
+    "(\t\022\032\n\rerror_message\030\004 \001(\tH\000\210\001\001\022\022\n\nerror_"
+    "code\030\005 \001(\005B\020\n\016_error_message\"\326\001\n\027ToolPro"
+    "mptFormatRequest\022\023\n\013user_prompt\030\001 \001(\t\0228\n"
+    "\007options\030\002 \001(\0132\".runanywhere.v1.ToolCall"
+    "ingOptionsH\000\210\001\001\0220\n\014tool_results\030\003 \003(\0132\032."
+    "runanywhere.v1.ToolResult\022\033\n\016assistant_t"
+    "ext\030\004 \001(\tH\001\210\001\001B\n\n\010_optionsB\021\n\017_assistant"
+    "_text\"\256\001\n\026ToolPromptFormatResult\022\030\n\020form"
+    "atted_prompt\030\001 \001(\t\0222\n\006format\030\002 \001(\0162\".run"
+    "anywhere.v1.ToolCallFormatName\022\032\n\rerror_"
+    "message\030\004 \001(\tH\000\210\001\001\022\022\n\nerror_code\030\005 \001(\005B\020"
+    "\n\016_error_messageJ\004\010\003\020\004\"\216\001\n\031ToolCallValid"
+    "ationRequest\022+\n\ttool_call\030\001 \001(\0132\030.runany"
+    "where.v1.ToolCall\0228\n\007options\030\002 \001(\0132\".run"
+    "anywhere.v1.ToolCallingOptionsH\000\210\001\001B\n\n\010_"
+    "options\"\370\001\n\030ToolCallValidationResult\022\020\n\010"
+    "is_valid\030\001 \001(\010\022\031\n\021validation_errors\030\002 \003("
+    "\t\0229\n\014matched_tool\030\003 \001(\0132\036.runanywhere.v1"
+    ".ToolDefinitionH\000\210\001\001\022!\n\031normalized_argum"
+    "ents_json\030\004 \001(\t\022\032\n\rerror_message\030\005 \001(\tH\001"
+    "\210\001\001\022\022\n\nerror_code\030\006 \001(\005B\017\n\r_matched_tool"
+    "B\020\n\016_error_message\"\250\003\n\026ToolCallingStream"
+    "Event\022\013\n\003seq\030\001 \001(\004\022\024\n\014timestamp_us\030\002 \001(\003"
+    "\022\027\n\017conversation_id\030\003 \001(\t\0228\n\004kind\030\004 \001(\0162"
+    "*.runanywhere.v1.ToolCallingStreamEventK"
+    "ind\022\r\n\005token\030\005 \001(\t\0220\n\ttool_call\030\006 \001(\0132\030."
+    "runanywhere.v1.ToolCallH\000\210\001\001\0224\n\013tool_res"
+    "ult\030\007 \001(\0132\032.runanywhere.v1.ToolResultH\001\210"
+    "\001\001\0226\n\006result\030\010 \001(\0132!.runanywhere.v1.Tool"
+    "CallingResultH\002\210\001\001\022\032\n\rerror_message\030\t \001("
+    "\tH\003\210\001\001\022\022\n\nerror_code\030\n \001(\005B\014\n\n_tool_call"
+    "B\016\n\014_tool_resultB\t\n\007_resultB\020\n\016_error_me"
+    "ssage\"\\\n\024ToolRegistrySnapshot\022-\n\005tools\030\001"
+    " \003(\0132\036.runanywhere.v1.ToolDefinition\022\025\n\r"
+    "updated_at_ms\030\002 \001(\003\"\200\005\n\037ToolCallingSessi"
+    "onCreateRequest\022\016\n\006prompt\030\001 \001(\t\022\022\n\nmax_t"
+    "okens\030\013 \001(\005\022\023\n\013temperature\030\014 \001(\002\022\r\n\005top_"
+    "p\030\r \001(\002\022\025\n\rsystem_prompt\030\016 \001(\t\022-\n\005tools\030"
+    "\002 \003(\0132\036.runanywhere.v1.ToolDefinition\0222\n"
+    "\006format\030\003 \001(\0162\".runanywhere.v1.ToolCallF"
+    "ormatName\022\026\n\016max_tool_calls\030\004 \001(\r\022\034\n\024kee"
+    "p_tools_available\030\005 \001(\010\022\033\n\016validate_call"
+    "s\030\006 \001(\010H\000\210\001\001\0228\n\013tool_choice\030\007 \001(\0162\036.runa"
+    "nywhere.v1.ToolChoiceModeH\001\210\001\001\022\035\n\020forced"
+    "_tool_name\030\010 \001(\tH\002\210\001\001\022\030\n\020disable_thinkin"
+    "g\030\017 \001(\010\022\031\n\014auto_execute\030\020 \001(\010H\003\210\001\001\022\035\n\025re"
+    "place_system_prompt\030\021 \001(\010\022\036\n\026require_jso"
+    "n_arguments\030\022 \001(\010\022\017\n\007history\030\023 \003(\t\022\033\n\023pa"
+    "rallel_tool_calls\030\024 \001(\010B\021\n\017_validate_cal"
+    "lsB\016\n\014_tool_choiceB\023\n\021_forced_tool_nameB"
+    "\017\n\r_auto_executeJ\004\010\t\020\013\"8\n\036ToolCallingSes"
+    "sionCreateResult\022\026\n\016session_handle\030\001 \001(\004"
+    "\"\321\001\n\027ToolCallingSessionEvent\022 \n\026llm_stre"
+    "am_event_bytes\030\001 \001(\014H\000\022-\n\ttool_call\030\002 \001("
+    "\0132\030.runanywhere.v1.ToolCallH\000\0229\n\014final_r"
+    "esult\030\003 \001(\0132!.runanywhere.v1.ToolCalling"
+    "ResultH\000\022\025\n\013error_bytes\030\004 \001(\014H\000\022\013\n\003seq\030\005"
+    " \001(\004B\006\n\004kind\"\212\001\n\'ToolCallingSessionStepW"
+    "ithResultRequest\022\026\n\016session_handle\030\001 \001(\004"
+    "\022\024\n\014tool_call_id\030\002 \001(\t\022\023\n\013result_json\030\003 "
+    "\001(\t\022\022\n\005error\030\004 \001(\tH\000\210\001\001B\010\n\006_error\":\n Too"
+    "lCallingSessionDestroyRequest\022\026\n\016session"
+    "_handle\030\001 \001(\004*\330\001\n\021ToolParameterType\022#\n\037T"
+    "OOL_PARAMETER_TYPE_UNSPECIFIED\020\000\022\036\n\032TOOL"
+    "_PARAMETER_TYPE_STRING\020\001\022\036\n\032TOOL_PARAMET"
+    "ER_TYPE_NUMBER\020\002\022\037\n\033TOOL_PARAMETER_TYPE_"
+    "BOOLEAN\020\003\022\036\n\032TOOL_PARAMETER_TYPE_OBJECT\020"
+    "\004\022\035\n\031TOOL_PARAMETER_TYPE_ARRAY\020\005*\201\001\n\022Too"
+    "lCallFormatName\022%\n!TOOL_CALL_FORMAT_NAME"
+    "_UNSPECIFIED\020\000\022\036\n\032TOOL_CALL_FORMAT_NAME_"
+    "JSON\020\001\022\036\n\032TOOL_CALL_FORMAT_NAME_LFM2\020\007\"\004"
+    "\010\002\020\006*\246\001\n\016ToolChoiceMode\022 \n\034TOOL_CHOICE_M"
+    "ODE_UNSPECIFIED\020\000\022\031\n\025TOOL_CHOICE_MODE_AU"
+    "TO\020\001\022\031\n\025TOOL_CHOICE_MODE_NONE\020\002\022\035\n\031TOOL_"
+    "CHOICE_MODE_REQUIRED\020\003\022\035\n\031TOOL_CHOICE_MO"
+    "DE_SPECIFIC\020\004*\201\003\n\032ToolCallingStreamEvent"
+    "Kind\022.\n*TOOL_CALLING_STREAM_EVENT_KIND_U"
+    "NSPECIFIED\020\000\022.\n*TOOL_CALLING_STREAM_EVEN"
+    "T_KIND_MODEL_TOKEN\020\001\0223\n/TOOL_CALLING_STR"
+    "EAM_EVENT_KIND_TOOL_CALL_PARSED\020\002\0229\n5TOO"
+    "L_CALLING_STREAM_EVENT_KIND_TOOL_EXECUTI"
+    "ON_STARTED\020\003\022;\n7TOOL_CALLING_STREAM_EVEN"
+    "T_KIND_TOOL_EXECUTION_COMPLETED\020\004\022,\n(TOO"
+    "L_CALLING_STREAM_EVENT_KIND_COMPLETED\020\005\022"
+    "(\n$TOOL_CALLING_STREAM_EVENT_KIND_ERROR\020"
+    "\0062\237\002\n\013ToolCalling\022J\n\005Parse\022 .runanywhere"
+    ".v1.ToolParseRequest\032\037.runanywhere.v1.To"
+    "olParseResult\022_\n\014FormatPrompt\022\'.runanywh"
+    "ere.v1.ToolPromptFormatRequest\032&.runanyw"
+    "here.v1.ToolPromptFormatResult\022c\n\014Valida"
+    "teCall\022).runanywhere.v1.ToolCallValidati"
+    "onRequest\032(.runanywhere.v1.ToolCallValid"
+    "ationResultB\213\001\n\027ai.runanywhere.proto.v1B"
+    "\020ToolCallingProtoP\001Z<github.com/runanywh"
+    "ere/runanywhere-sdks/idl/v1;runanywherev"
+    "1\370\001\001\242\002\004RAV1\252\002\016Runanywhere.V1\272\002\002RAb\006proto"
+    "3"
 };
 static ::absl::once_flag descriptor_table_tool_5fcalling_2eproto_once;
 PROTOBUF_CONSTINIT const ::_pbi::DescriptorTable descriptor_table_tool_5fcalling_2eproto = {
     false,
     false,
-    6389,
+    6441,
     descriptor_table_protodef_tool_5fcalling_2eproto,
     "tool_calling.proto",
     &descriptor_table_tool_5fcalling_2eproto_once,
@@ -8101,10 +8119,10 @@ PROTOBUF_NOINLINE void ToolCallingOptions::Clear() {
         reinterpret_cast<char*>(&_impl_.keep_tools_available_) -
         reinterpret_cast<char*>(&_impl_.temperature_)) + sizeof(_impl_.keep_tools_available_));
   }
-  if (BatchCheckHasBit(cached_has_bits, 0x00001f00U)) {
-    ::memset(&_impl_.require_json_arguments_, 0, static_cast<::size_t>(
+  if (BatchCheckHasBit(cached_has_bits, 0x00003f00U)) {
+    ::memset(&_impl_.parallel_tool_calls_, 0, static_cast<::size_t>(
         reinterpret_cast<char*>(&_impl_.disable_thinking_) -
-        reinterpret_cast<char*>(&_impl_.require_json_arguments_)) + sizeof(_impl_.disable_thinking_));
+        reinterpret_cast<char*>(&_impl_.parallel_tool_calls_)) + sizeof(_impl_.disable_thinking_));
   }
   _impl_._has_bits_.Clear();
   _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
@@ -8222,8 +8240,17 @@ PROTOBUF_NOINLINE void ToolCallingOptions::Clear() {
     target = stream->WriteStringMaybeAliased(14, _s, target);
   }
 
-  // bool require_json_arguments = 16;
+  // bool parallel_tool_calls = 15;
   if (CheckHasBit(cached_has_bits, 0x00000100U)) {
+    if (this_._internal_parallel_tool_calls() != 0) {
+      target = stream->EnsureSpace(target);
+      target = ::_pbi::WireFormatLite::WriteBoolToArray(
+          15, this_._internal_parallel_tool_calls(), target);
+    }
+  }
+
+  // bool require_json_arguments = 16;
+  if (CheckHasBit(cached_has_bits, 0x00001000U)) {
     if (this_._internal_require_json_arguments() != 0) {
       target = stream->EnsureSpace(target);
       target = ::_pbi::WireFormatLite::WriteBoolToArray(
@@ -8232,7 +8259,7 @@ PROTOBUF_NOINLINE void ToolCallingOptions::Clear() {
   }
 
   // optional bool disable_thinking = 17;
-  if (CheckHasBit(cached_has_bits, 0x00001000U)) {
+  if (CheckHasBit(cached_has_bits, 0x00002000U)) {
     target = stream->EnsureSpace(target);
     target = ::_pbi::WireFormatLite::WriteBoolToArray(
         17, this_._internal_disable_thinking(), target);
@@ -8264,7 +8291,7 @@ PROTOBUF_NOINLINE void ToolCallingOptions::Clear() {
   ::_pbi::Prefetch5LinesFrom7Lines(&this_);
   cached_has_bits = this_._impl_._has_bits_[0];
   total_size += static_cast<bool>(0x00000008U & cached_has_bits) * 5;
-  total_size += static_cast<bool>(0x00001000U & cached_has_bits) * 3;
+  total_size += static_cast<bool>(0x00002000U & cached_has_bits) * 3;
   if (BatchCheckHasBit(cached_has_bits, 0x000000f7U)) {
     // repeated .runanywhere.v1.ToolDefinition tools = 1;
     if (CheckHasBit(cached_has_bits, 0x00000001U)) {
@@ -8307,11 +8334,11 @@ PROTOBUF_NOINLINE void ToolCallingOptions::Clear() {
       }
     }
   }
-  if (BatchCheckHasBit(cached_has_bits, 0x00000f00U)) {
-    // bool require_json_arguments = 16;
+  if (BatchCheckHasBit(cached_has_bits, 0x00001f00U)) {
+    // bool parallel_tool_calls = 15;
     if (CheckHasBit(cached_has_bits, 0x00000100U)) {
-      if (this_._internal_require_json_arguments() != 0) {
-        total_size += 3;
+      if (this_._internal_parallel_tool_calls() != 0) {
+        total_size += 2;
       }
     }
     // optional .runanywhere.v1.ToolCallFormatName format = 10;
@@ -8329,6 +8356,12 @@ PROTOBUF_NOINLINE void ToolCallingOptions::Clear() {
       if (this_._internal_tool_choice() != 0) {
         total_size += 1 +
                       ::_pbi::WireFormatLite::EnumSize(this_._internal_tool_choice());
+      }
+    }
+    // bool require_json_arguments = 16;
+    if (CheckHasBit(cached_has_bits, 0x00001000U)) {
+      if (this_._internal_require_json_arguments() != 0) {
+        total_size += 3;
       }
     }
   }
@@ -8384,10 +8417,10 @@ void ToolCallingOptions::MergeImpl(::google::protobuf::MessageLite& to_msg,
       }
     }
   }
-  if (BatchCheckHasBit(cached_has_bits, 0x00001f00U)) {
+  if (BatchCheckHasBit(cached_has_bits, 0x00003f00U)) {
     if (CheckHasBit(cached_has_bits, 0x00000100U)) {
-      if (from._internal_require_json_arguments() != 0) {
-        _this->_impl_.require_json_arguments_ = from._impl_.require_json_arguments_;
+      if (from._internal_parallel_tool_calls() != 0) {
+        _this->_impl_.parallel_tool_calls_ = from._impl_.parallel_tool_calls_;
       }
     }
     if (CheckHasBit(cached_has_bits, 0x00000200U)) {
@@ -8402,6 +8435,11 @@ void ToolCallingOptions::MergeImpl(::google::protobuf::MessageLite& to_msg,
       }
     }
     if (CheckHasBit(cached_has_bits, 0x00001000U)) {
+      if (from._internal_require_json_arguments() != 0) {
+        _this->_impl_.require_json_arguments_ = from._impl_.require_json_arguments_;
+      }
+    }
+    if (CheckHasBit(cached_has_bits, 0x00002000U)) {
       _this->_impl_.disable_thinking_ = from._impl_.disable_thinking_;
     }
   }
@@ -11567,9 +11605,9 @@ ToolCallingSessionCreateRequest::ToolCallingSessionCreateRequest(
                offsetof(Impl_, format_),
            reinterpret_cast<const char*>(&from._impl_) +
                offsetof(Impl_, format_),
-           offsetof(Impl_, require_json_arguments_) -
+           offsetof(Impl_, parallel_tool_calls_) -
                offsetof(Impl_, format_) +
-               sizeof(Impl_::require_json_arguments_));
+               sizeof(Impl_::parallel_tool_calls_));
 
   // @@protoc_insertion_point(copy_constructor:runanywhere.v1.ToolCallingSessionCreateRequest)
 }
@@ -11596,9 +11634,9 @@ inline void ToolCallingSessionCreateRequest::SharedCtor(::_pb::Arena* PROTOBUF_N
   ::memset(reinterpret_cast<char*>(&_impl_) +
                offsetof(Impl_, format_),
            0,
-           offsetof(Impl_, require_json_arguments_) -
+           offsetof(Impl_, parallel_tool_calls_) -
                offsetof(Impl_, format_) +
-               sizeof(Impl_::require_json_arguments_));
+               sizeof(Impl_::parallel_tool_calls_));
 }
 ToolCallingSessionCreateRequest::~ToolCallingSessionCreateRequest() {
   // @@protoc_insertion_point(destructor:runanywhere.v1.ToolCallingSessionCreateRequest)
@@ -11678,7 +11716,11 @@ PROTOBUF_NOINLINE void ToolCallingSessionCreateRequest::Clear() {
         reinterpret_cast<char*>(&_impl_.replace_system_prompt_) -
         reinterpret_cast<char*>(&_impl_.keep_tools_available_)) + sizeof(_impl_.replace_system_prompt_));
   }
-  _impl_.require_json_arguments_ = false;
+  if (BatchCheckHasBit(cached_has_bits, 0x00030000U)) {
+    ::memset(&_impl_.require_json_arguments_, 0, static_cast<::size_t>(
+        reinterpret_cast<char*>(&_impl_.parallel_tool_calls_) -
+        reinterpret_cast<char*>(&_impl_.require_json_arguments_)) + sizeof(_impl_.parallel_tool_calls_));
+  }
   _impl_._has_bits_.Clear();
   _internal_metadata_.Clear<::google::protobuf::UnknownFieldSet>();
 }
@@ -11855,6 +11897,15 @@ PROTOBUF_NOINLINE void ToolCallingSessionCreateRequest::Clear() {
     }
   }
 
+  // bool parallel_tool_calls = 20;
+  if (CheckHasBit(cached_has_bits, 0x00020000U)) {
+    if (this_._internal_parallel_tool_calls() != 0) {
+      target = stream->EnsureSpace(target);
+      target = ::_pbi::WireFormatLite::WriteBoolToArray(
+          20, this_._internal_parallel_tool_calls(), target);
+    }
+  }
+
   if (ABSL_PREDICT_FALSE(this_._internal_metadata_.have_unknown_fields())) {
     target =
         ::_pbi::WireFormat::InternalSerializeUnknownFieldsToArray(
@@ -11977,10 +12028,16 @@ PROTOBUF_NOINLINE void ToolCallingSessionCreateRequest::Clear() {
       }
     }
   }
-   {
+  if (BatchCheckHasBit(cached_has_bits, 0x00030000U)) {
     // bool require_json_arguments = 18;
     if (CheckHasBit(cached_has_bits, 0x00010000U)) {
       if (this_._internal_require_json_arguments() != 0) {
+        total_size += 3;
+      }
+    }
+    // bool parallel_tool_calls = 20;
+    if (CheckHasBit(cached_has_bits, 0x00020000U)) {
+      if (this_._internal_parallel_tool_calls() != 0) {
         total_size += 3;
       }
     }
@@ -12087,9 +12144,16 @@ void ToolCallingSessionCreateRequest::MergeImpl(::google::protobuf::MessageLite&
       }
     }
   }
-  if (CheckHasBit(cached_has_bits, 0x00010000U)) {
-    if (from._internal_require_json_arguments() != 0) {
-      _this->_impl_.require_json_arguments_ = from._impl_.require_json_arguments_;
+  if (BatchCheckHasBit(cached_has_bits, 0x00030000U)) {
+    if (CheckHasBit(cached_has_bits, 0x00010000U)) {
+      if (from._internal_require_json_arguments() != 0) {
+        _this->_impl_.require_json_arguments_ = from._impl_.require_json_arguments_;
+      }
+    }
+    if (CheckHasBit(cached_has_bits, 0x00020000U)) {
+      if (from._internal_parallel_tool_calls() != 0) {
+        _this->_impl_.parallel_tool_calls_ = from._impl_.parallel_tool_calls_;
+      }
     }
   }
   _this->_impl_._has_bits_[0] |= cached_has_bits;
@@ -12117,8 +12181,8 @@ void ToolCallingSessionCreateRequest::InternalSwap(ToolCallingSessionCreateReque
   ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.forced_tool_name_, &other->_impl_.forced_tool_name_, arena);
   ::_pbi::ArenaStringPtr::InternalSwap(&_impl_.system_prompt_, &other->_impl_.system_prompt_, arena);
   ::google::protobuf::internal::memswap<
-      PROTOBUF_FIELD_OFFSET(ToolCallingSessionCreateRequest, _impl_.require_json_arguments_)
-      + sizeof(ToolCallingSessionCreateRequest::_impl_.require_json_arguments_)
+      PROTOBUF_FIELD_OFFSET(ToolCallingSessionCreateRequest, _impl_.parallel_tool_calls_)
+      + sizeof(ToolCallingSessionCreateRequest::_impl_.parallel_tool_calls_)
       - PROTOBUF_FIELD_OFFSET(ToolCallingSessionCreateRequest, _impl_.format_)>(
           reinterpret_cast<char*>(&_impl_.format_),
           reinterpret_cast<char*>(&other->_impl_.format_));

--- a/sdk/runanywhere-commons/src/generated/proto/tool_calling.pb.h
+++ b/sdk/runanywhere-commons/src/generated/proto/tool_calling.pb.h
@@ -5283,6 +5283,7 @@ class  PROTOBUF_FUTURE_ADD_EARLY_WARN_UNUSED ToolCallingSessionCreateRequest fin
     kTopPFieldNumber = 13,
     kReplaceSystemPromptFieldNumber = 17,
     kRequireJsonArgumentsFieldNumber = 18,
+    kParallelToolCallsFieldNumber = 20,
   };
   // repeated .runanywhere.v1.ToolDefinition tools = 2;
   [[nodiscard]] int tools_size()
@@ -5505,11 +5506,21 @@ class  PROTOBUF_FUTURE_ADD_EARLY_WARN_UNUSED ToolCallingSessionCreateRequest fin
   void _internal_set_require_json_arguments(bool value);
 
   public:
+  // bool parallel_tool_calls = 20;
+  void clear_parallel_tool_calls() ;
+  [[nodiscard]] bool parallel_tool_calls() const;
+  void set_parallel_tool_calls(bool value);
+
+  private:
+  bool _internal_parallel_tool_calls() const;
+  void _internal_set_parallel_tool_calls(bool value);
+
+  public:
   // @@protoc_insertion_point(class_scope:runanywhere.v1.ToolCallingSessionCreateRequest)
  private:
   class _Internal;
   using ParseTableT_ =
-      ::google::protobuf::internal::TcParseTable<5, 17,
+      ::google::protobuf::internal::TcParseTable<5, 18,
                           1, 113,
                           2>;
   static constexpr ParseTableT_ InternalGenerateParseTable_(
@@ -5555,6 +5566,7 @@ class  PROTOBUF_FUTURE_ADD_EARLY_WARN_UNUSED ToolCallingSessionCreateRequest fin
     float top_p_;
     bool replace_system_prompt_;
     bool require_json_arguments_;
+    bool parallel_tool_calls_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
   union { Impl_ _impl_; };
@@ -5718,10 +5730,11 @@ class  PROTOBUF_FUTURE_ADD_EARLY_WARN_UNUSED ToolCallingOptions final : public :
     kAutoExecuteFieldNumber = 3,
     kReplaceSystemPromptFieldNumber = 7,
     kKeepToolsAvailableFieldNumber = 8,
-    kRequireJsonArgumentsFieldNumber = 16,
+    kParallelToolCallsFieldNumber = 15,
     kFormatFieldNumber = 10,
     kMaxToolCallsFieldNumber = 12,
     kToolChoiceFieldNumber = 13,
+    kRequireJsonArgumentsFieldNumber = 16,
     kDisableThinkingFieldNumber = 17,
   };
   // repeated .runanywhere.v1.ToolDefinition tools = 1;
@@ -5833,14 +5846,14 @@ class  PROTOBUF_FUTURE_ADD_EARLY_WARN_UNUSED ToolCallingOptions final : public :
   void _internal_set_keep_tools_available(bool value);
 
   public:
-  // bool require_json_arguments = 16;
-  void clear_require_json_arguments() ;
-  [[nodiscard]] bool require_json_arguments() const;
-  void set_require_json_arguments(bool value);
+  // bool parallel_tool_calls = 15;
+  void clear_parallel_tool_calls() ;
+  [[nodiscard]] bool parallel_tool_calls() const;
+  void set_parallel_tool_calls(bool value);
 
   private:
-  bool _internal_require_json_arguments() const;
-  void _internal_set_require_json_arguments(bool value);
+  bool _internal_parallel_tool_calls() const;
+  void _internal_set_parallel_tool_calls(bool value);
 
   public:
   // optional .runanywhere.v1.ToolCallFormatName format = 10;
@@ -5877,6 +5890,16 @@ class  PROTOBUF_FUTURE_ADD_EARLY_WARN_UNUSED ToolCallingOptions final : public :
   void _internal_set_tool_choice(::runanywhere::v1::ToolChoiceMode value);
 
   public:
+  // bool require_json_arguments = 16;
+  void clear_require_json_arguments() ;
+  [[nodiscard]] bool require_json_arguments() const;
+  void set_require_json_arguments(bool value);
+
+  private:
+  bool _internal_require_json_arguments() const;
+  void _internal_set_require_json_arguments(bool value);
+
+  public:
   // optional bool disable_thinking = 17;
   [[nodiscard]] bool has_disable_thinking()
       const;
@@ -5893,7 +5916,7 @@ class  PROTOBUF_FUTURE_ADD_EARLY_WARN_UNUSED ToolCallingOptions final : public :
  private:
   class _Internal;
   using ParseTableT_ =
-      ::google::protobuf::internal::TcParseTable<4, 13,
+      ::google::protobuf::internal::TcParseTable<4, 14,
                           1, 79,
                           2>;
   static constexpr ParseTableT_ InternalGenerateParseTable_(
@@ -5930,10 +5953,11 @@ class  PROTOBUF_FUTURE_ADD_EARLY_WARN_UNUSED ToolCallingOptions final : public :
     bool auto_execute_;
     bool replace_system_prompt_;
     bool keep_tools_available_;
-    bool require_json_arguments_;
+    bool parallel_tool_calls_;
     int format_;
     ::int32_t max_tool_calls_;
     int tool_choice_;
+    bool require_json_arguments_;
     bool disable_thinking_;
     PROTOBUF_TSAN_DECLARE_MEMBER
   };
@@ -9228,6 +9252,30 @@ inline void ToolCallingOptions::_internal_set_format(::runanywhere::v1::ToolCall
   _impl_.format_ = value;
 }
 
+// bool parallel_tool_calls = 15;
+inline void ToolCallingOptions::clear_parallel_tool_calls() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parallel_tool_calls_ = false;
+  ClearHasBit(_impl_._has_bits_[0], 0x00000100U);
+}
+inline bool ToolCallingOptions::parallel_tool_calls() const {
+  // @@protoc_insertion_point(field_get:runanywhere.v1.ToolCallingOptions.parallel_tool_calls)
+  return _internal_parallel_tool_calls();
+}
+inline void ToolCallingOptions::set_parallel_tool_calls(bool value) {
+  _internal_set_parallel_tool_calls(value);
+  SetHasBit(_impl_._has_bits_[0], 0x00000100U);
+  // @@protoc_insertion_point(field_set:runanywhere.v1.ToolCallingOptions.parallel_tool_calls)
+}
+inline bool ToolCallingOptions::_internal_parallel_tool_calls() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.parallel_tool_calls_;
+}
+inline void ToolCallingOptions::_internal_set_parallel_tool_calls(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parallel_tool_calls_ = value;
+}
+
 // optional int32 max_tool_calls = 12;
 inline bool ToolCallingOptions::has_max_tool_calls() const {
   bool value = CheckHasBit(_impl_._has_bits_[0], 0x00000400U);
@@ -9352,7 +9400,7 @@ inline void ToolCallingOptions::set_allocated_forced_tool_name(::std::string* PR
 inline void ToolCallingOptions::clear_require_json_arguments() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.require_json_arguments_ = false;
-  ClearHasBit(_impl_._has_bits_[0], 0x00000100U);
+  ClearHasBit(_impl_._has_bits_[0], 0x00001000U);
 }
 inline bool ToolCallingOptions::require_json_arguments() const {
   // @@protoc_insertion_point(field_get:runanywhere.v1.ToolCallingOptions.require_json_arguments)
@@ -9360,7 +9408,7 @@ inline bool ToolCallingOptions::require_json_arguments() const {
 }
 inline void ToolCallingOptions::set_require_json_arguments(bool value) {
   _internal_set_require_json_arguments(value);
-  SetHasBit(_impl_._has_bits_[0], 0x00000100U);
+  SetHasBit(_impl_._has_bits_[0], 0x00001000U);
   // @@protoc_insertion_point(field_set:runanywhere.v1.ToolCallingOptions.require_json_arguments)
 }
 inline bool ToolCallingOptions::_internal_require_json_arguments() const {
@@ -9374,13 +9422,13 @@ inline void ToolCallingOptions::_internal_set_require_json_arguments(bool value)
 
 // optional bool disable_thinking = 17;
 inline bool ToolCallingOptions::has_disable_thinking() const {
-  bool value = CheckHasBit(_impl_._has_bits_[0], 0x00001000U);
+  bool value = CheckHasBit(_impl_._has_bits_[0], 0x00002000U);
   return value;
 }
 inline void ToolCallingOptions::clear_disable_thinking() {
   ::google::protobuf::internal::TSanWrite(&_impl_);
   _impl_.disable_thinking_ = false;
-  ClearHasBit(_impl_._has_bits_[0], 0x00001000U);
+  ClearHasBit(_impl_._has_bits_[0], 0x00002000U);
 }
 inline bool ToolCallingOptions::disable_thinking() const {
   // @@protoc_insertion_point(field_get:runanywhere.v1.ToolCallingOptions.disable_thinking)
@@ -9388,7 +9436,7 @@ inline bool ToolCallingOptions::disable_thinking() const {
 }
 inline void ToolCallingOptions::set_disable_thinking(bool value) {
   _internal_set_disable_thinking(value);
-  SetHasBit(_impl_._has_bits_[0], 0x00001000U);
+  SetHasBit(_impl_._has_bits_[0], 0x00002000U);
   // @@protoc_insertion_point(field_set:runanywhere.v1.ToolCallingOptions.disable_thinking)
 }
 inline bool ToolCallingOptions::_internal_disable_thinking() const {
@@ -12648,6 +12696,30 @@ inline ::google::protobuf::RepeatedPtrField<::std::string>* PROTOBUF_NONNULL
 ToolCallingSessionCreateRequest::_internal_mutable_history() {
   ::google::protobuf::internal::TSanRead(&_impl_);
   return &_impl_.history_;
+}
+
+// bool parallel_tool_calls = 20;
+inline void ToolCallingSessionCreateRequest::clear_parallel_tool_calls() {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parallel_tool_calls_ = false;
+  ClearHasBit(_impl_._has_bits_[0], 0x00020000U);
+}
+inline bool ToolCallingSessionCreateRequest::parallel_tool_calls() const {
+  // @@protoc_insertion_point(field_get:runanywhere.v1.ToolCallingSessionCreateRequest.parallel_tool_calls)
+  return _internal_parallel_tool_calls();
+}
+inline void ToolCallingSessionCreateRequest::set_parallel_tool_calls(bool value) {
+  _internal_set_parallel_tool_calls(value);
+  SetHasBit(_impl_._has_bits_[0], 0x00020000U);
+  // @@protoc_insertion_point(field_set:runanywhere.v1.ToolCallingSessionCreateRequest.parallel_tool_calls)
+}
+inline bool ToolCallingSessionCreateRequest::_internal_parallel_tool_calls() const {
+  ::google::protobuf::internal::TSanRead(&_impl_);
+  return _impl_.parallel_tool_calls_;
+}
+inline void ToolCallingSessionCreateRequest::_internal_set_parallel_tool_calls(bool value) {
+  ::google::protobuf::internal::TSanWrite(&_impl_);
+  _impl_.parallel_tool_calls_ = value;
 }
 
 // -------------------------------------------------------------------

--- a/sdk/runanywhere-commons/src/solutions/operators/op_engine_backed.cpp
+++ b/sdk/runanywhere-commons/src/solutions/operators/op_engine_backed.cpp
@@ -57,11 +57,13 @@
 #include "pipeline.pb.h"
 #include "rag.pb.h"
 #include "stt_options.pb.h"
+#include "tool_calling.pb.h"
 #include "tts_options.pb.h"
 #include "vad_options.pb.h"
 
 #include "rac/features/embeddings/rac_embeddings_service.h"
 #include "rac/features/llm/rac_llm_service.h"
+#include "rac/features/llm/rac_tool_calling.h"
 #if defined(RAC_HAVE_RAG)
 #include "rac/features/rag/rac_rag.h"
 #endif
@@ -259,6 +261,139 @@ class GenerateTextNode final : public OperatorNode {
     int max_tokens_;
     float temperature_;
     std::string system_prompt_;
+};
+
+// ---------------------------------------------------------------------------
+// agent_loop — text in (text.utf8) → text out (text.utf8) on port "token".
+//
+// AG-2: routes a tools-bearing AgentLoopConfig through the REAL tool-calling
+// run loop (rac_tool_calling_run_loop_proto) instead of the plain
+// generate_text path that silently ignored `tools`. Tool definitions arrive
+// from solution_converter as indexed spec params ("tool.<i>.name" /
+// ".description" / ".json_schema", count in "tool.count") because
+// OperatorSpec.params is the only converter→operator channel today.
+//
+// Solutions pipelines have no host tool-executor callback yet, so the loop
+// runs with auto_execute=false: the model sees the advertised tools, and a
+// requested call surfaces as an explicit structured error naming the tool —
+// replacing the old silent no-tools behavior with an honest contract.
+// ---------------------------------------------------------------------------
+class AgentLoopNode final : public OperatorNode {
+   public:
+    AgentLoopNode(std::string name, const runanywhere::v1::OperatorSpec& spec)
+        : PipelineNode(std::move(name), /*input*/ 8, /*output*/ 8, OverflowPolicy::BlockProducer),
+          max_iterations_(param_int_or(spec, "max_iterations", 0)) {
+        if (const std::string* p = find_param(spec, "system_prompt"); p) {
+            system_prompt_ = *p;
+        }
+        const int tool_count = param_int_or(spec, "tool.count", 0);
+        tools_.reserve(static_cast<size_t>(tool_count));
+        for (int i = 0; i < tool_count; ++i) {
+            const std::string prefix = "tool." + std::to_string(i) + ".";
+            ToolSpecParams tool;
+            if (const std::string* v = find_param(spec, prefix + "name"); v) {
+                tool.name = *v;
+            }
+            if (const std::string* v = find_param(spec, prefix + "description"); v) {
+                tool.description = *v;
+            }
+            if (const std::string* v = find_param(spec, prefix + "json_schema"); v) {
+                tool.json_schema = *v;
+            }
+            if (!tool.name.empty()) {
+                tools_.push_back(std::move(tool));
+            }
+        }
+    }
+
+   protected:
+    void process(Item item, OutputEdge& out) override {
+        if (!item.is_text()) {
+            set_error_detail(name(), "agent_loop expected text.utf8 input but received '" +
+                                         std::string(item.body_type_id()) + "'");
+            cancel_graph(this->cancel_token());
+            return;
+        }
+
+        runanywhere::v1::ToolCallingSessionCreateRequest request;
+        request.set_prompt(item.text());
+        if (!system_prompt_.empty()) {
+            request.set_system_prompt(system_prompt_);
+        }
+        if (max_iterations_ > 0) {
+            request.set_max_tool_calls(static_cast<uint32_t>(max_iterations_));
+        }
+        // No host executor exists in the Solutions DAG context; parse and
+        // validate the call, then hand it back instead of invoking anything.
+        request.set_auto_execute(false);
+        for (const ToolSpecParams& tool : tools_) {
+            auto* def = request.add_tools();
+            def->set_name(tool.name);
+            def->set_description(tool.description);
+            if (!tool.json_schema.empty()) {
+                def->set_json_schema(tool.json_schema);
+            }
+        }
+
+        std::vector<uint8_t> bytes(request.ByteSizeLong());
+        if (!bytes.empty() &&
+            !request.SerializeToArray(bytes.data(), static_cast<int>(bytes.size()))) {
+            set_error_detail(name(), "failed to serialize ToolCallingSessionCreateRequest");
+            cancel_graph(this->cancel_token());
+            return;
+        }
+
+        ProtoBufferGuard buffer;
+        const rac_result_t rc = rac_tool_calling_run_loop_proto(
+            bytes.empty() ? nullptr : bytes.data(), bytes.size(),
+            // Required non-null; unreachable because auto_execute=false.
+            [](const uint8_t*, size_t, rac_proto_buffer_t* exec_out, void*) -> rac_result_t {
+                return rac_proto_buffer_set_error(exec_out, RAC_ERROR_FEATURE_NOT_AVAILABLE,
+                                                  "Solutions pipelines have no host tool executor");
+            },
+            nullptr, [](uint64_t, void*) {}, nullptr, buffer.raw());
+        if (rc != RAC_SUCCESS) {
+            set_error_detail(name(), std::string("rac_tool_calling_run_loop_proto failed: ") +
+                                         rac_error_message(rc));
+            cancel_graph(this->cancel_token());
+            return;
+        }
+
+        runanywhere::v1::ToolCallingResult result;
+        if (!result.ParseFromArray(buffer.data(), static_cast<int>(buffer.size()))) {
+            set_error_detail(name(), "failed to decode ToolCallingResult");
+            cancel_graph(this->cancel_token());
+            return;
+        }
+
+        if (result.tool_calls_size() > 0) {
+            set_error_detail(name(), "agent_loop: model requested tool '" +
+                                         result.tool_calls(0).name() +
+                                         "' but Solutions pipelines cannot execute host tools yet; "
+                                         "run tool-enabled generation through the SDK facade "
+                                         "(generateWithTools) instead");
+            cancel_graph(this->cancel_token());
+            return;
+        }
+        if (!result.error_message().empty() || result.error_code() != 0) {
+            set_error_detail(name(), "agent_loop generation failed: " + result.error_message());
+            cancel_graph(this->cancel_token());
+            return;
+        }
+
+        out.push(Item::text(result.text()), this->cancel_token());
+    }
+
+   private:
+    struct ToolSpecParams {
+        std::string name;
+        std::string description;
+        std::string json_schema;
+    };
+
+    int max_iterations_;
+    std::string system_prompt_;
+    std::vector<ToolSpecParams> tools_;
 };
 
 // ---------------------------------------------------------------------------
@@ -748,6 +883,17 @@ std::size_t register_engine_backed_operators(OperatorRegistry& registry) {
         "generate_text",
         [](const runanywhere::v1::OperatorSpec& spec) {
             return std::make_shared<GenerateTextNode>(spec.name(), spec);
+        },
+        schema({"in"}, {"token"}, kPayloadTextUtf8, kPayloadTextUtf8));
+    ++count;
+
+    // agent_loop — tool-enabled LLM loop. text.utf8 in → text.utf8 out on
+    // port "token" (same edge layout as generate_text, so
+    // solution_converter can swap the op type without new wiring).
+    registry.register_factory(
+        "agent_loop",
+        [](const runanywhere::v1::OperatorSpec& spec) {
+            return std::make_shared<AgentLoopNode>(spec.name(), spec);
         },
         schema({"in"}, {"token"}, kPayloadTextUtf8, kPayloadTextUtf8));
     ++count;

--- a/sdk/runanywhere-commons/src/solutions/pipeline_executor.cpp
+++ b/sdk/runanywhere-commons/src/solutions/pipeline_executor.cpp
@@ -241,8 +241,8 @@ std::string endpoint_key(const EndpointRef& endpoint) {
 
 bool is_known_engine_backed_solution_type(const std::string& type) {
     const char* const kTypes[] = {
-        "anomaly_detect", "detect_voice", "embed",      "generate_text",
-        "retrieve",       "synthesize",   "transcribe",
+        "agent_loop",    "anomaly_detect", "detect_voice", "embed",
+        "generate_text", "retrieve",       "synthesize",   "transcribe",
     };
     for (const char* candidate : kTypes) {
         if (type == candidate)

--- a/sdk/runanywhere-commons/src/solutions/solution_converter.cpp
+++ b/sdk/runanywhere-commons/src/solutions/solution_converter.cpp
@@ -116,16 +116,18 @@ void expand_rag(const runanywhere::v1::RAGConfig& cfg, PipelineSpec* out) {
 }
 
 // ---------------------------------------------------------------------------
-// AgentLoop — multi-turn tool-calling LLM loop. Modelled as a single
-// generate_text operator with auxiliary tokenise/context build. The
-// iterative loop runs inside the LLM operator's engine; the DAG just
-// frames the I/O.
+// AgentLoop — multi-turn tool-calling LLM loop. A tools-bearing config maps
+// to the dedicated `agent_loop` operator, which drives the real tool-calling
+// run loop (rac_tool_calling_run_loop_proto) so `tools` and `max_iterations`
+// are actually consumed. A tool-less config keeps the plain `generate_text`
+// operator — identical to the historical behavior.
 // ---------------------------------------------------------------------------
 void expand_agent_loop(const runanywhere::v1::AgentLoopConfig& cfg, PipelineSpec* out) {
     out->set_name("agent_loop");
 
+    const bool has_tools = cfg.tools_size() > 0;
     add_op(out, "input", "source");
-    auto* llm = add_op(out, "llm", "generate_text", cfg.llm_model_id());
+    auto* llm = add_op(out, "llm", has_tools ? "agent_loop" : "generate_text", cfg.llm_model_id());
     add_op(out, "output", "sink");
 
     if (!cfg.system_prompt().empty()) {
@@ -133,6 +135,20 @@ void expand_agent_loop(const runanywhere::v1::AgentLoopConfig& cfg, PipelineSpec
     }
     if (cfg.max_iterations() > 0) {
         (*llm->mutable_params())["max_iterations"] = std::to_string(cfg.max_iterations());
+    }
+    if (has_tools) {
+        // OperatorSpec.params is the only converter→operator channel, so the
+        // tool set travels as indexed keys mirrored by AgentLoopNode.
+        (*llm->mutable_params())["tool.count"] = std::to_string(cfg.tools_size());
+        for (int i = 0; i < cfg.tools_size(); ++i) {
+            const auto& tool = cfg.tools(i);
+            const std::string prefix = "tool." + std::to_string(i) + ".";
+            (*llm->mutable_params())[prefix + "name"] = tool.name();
+            (*llm->mutable_params())[prefix + "description"] = tool.description();
+            if (!tool.json_schema().empty()) {
+                (*llm->mutable_params())[prefix + "json_schema"] = tool.json_schema();
+            }
+        }
     }
 
     add_edge(out, "input.out", "llm.in");

--- a/sdk/runanywhere-commons/tests/CMakeLists.txt
+++ b/sdk/runanywhere-commons/tests/CMakeLists.txt
@@ -382,6 +382,37 @@ target_compile_features(test_tool_calling_run_loop PRIVATE cxx_std_17)
 rac_test_define_have_protobuf(test_tool_calling_run_loop)
 add_test(NAME tool_calling_run_loop_tests COMMAND test_tool_calling_run_loop)
 
+# --- TC-1: tool-call grammar derivation --------------------------------
+# Pure-function test over build_tool_call_grammar() (no mock LLM plugin
+# needed): verifies the GBNF/qhexrt dialect content per tool_choice policy.
+add_executable(test_tool_calling_grammar test_tool_calling_grammar.cpp)
+target_include_directories(test_tool_calling_grammar PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/sdk/runanywhere-commons/include
+    ${CMAKE_SOURCE_DIR}/sdk/runanywhere-commons/src
+    ${CMAKE_SOURCE_DIR}/sdk/runanywhere-commons/src/generated/proto
+)
+target_link_libraries(test_tool_calling_grammar PRIVATE rac_commons)
+rac_link_archive_deps(test_tool_calling_grammar)
+target_compile_features(test_tool_calling_grammar PRIVATE cxx_std_17)
+rac_test_define_have_protobuf(test_tool_calling_grammar)
+add_test(NAME tool_calling_grammar_tests COMMAND test_tool_calling_grammar)
+
+# --- AG-2: declarative AgentLoop -> real tool run-loop wiring ----------
+# Verifies expand_agent_loop emits the agent_loop operator (tool params
+# consumed) for tools-bearing configs and generate_text otherwise.
+add_executable(test_agent_loop_converter test_agent_loop_converter.cpp)
+target_include_directories(test_agent_loop_converter PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/sdk/runanywhere-commons/include
+    ${CMAKE_SOURCE_DIR}/sdk/runanywhere-commons/src/generated/proto
+)
+target_link_libraries(test_agent_loop_converter PRIVATE rac_commons)
+rac_link_archive_deps(test_agent_loop_converter)
+target_compile_features(test_agent_loop_converter PRIVATE cxx_std_17)
+rac_test_define_have_protobuf(test_agent_loop_converter)
+add_test(NAME agent_loop_converter_tests COMMAND test_agent_loop_converter)
+
 # --- tool-calling cancel ABI concurrency regression -----------
 # Covers the run_loop_with_handle / run_loop_cancel / session_cancel C
 # ABIs. Exercises:

--- a/sdk/runanywhere-commons/tests/test_agent_loop_converter.cpp
+++ b/sdk/runanywhere-commons/tests/test_agent_loop_converter.cpp
@@ -1,0 +1,114 @@
+/**
+ * @file test_agent_loop_converter.cpp
+ * @brief AG-2: verifies expand_agent_loop routes a tools-bearing
+ * AgentLoopConfig to the `agent_loop` operator (with tool params consumed)
+ * and keeps the historical `generate_text` operator when no tools are set.
+ */
+
+#include <cstdio>
+#include <string>
+
+#if defined(RAC_HAVE_PROTOBUF)
+#include "pipeline.pb.h"
+#include "solutions.pb.h"
+
+#include "rac/solutions/solution_converter.hpp"
+#endif
+
+namespace {
+
+int test_count = 0;
+int fail_count = 0;
+
+#define CHECK(cond, label)                                                           \
+    do {                                                                             \
+        ++test_count;                                                                \
+        if (!(cond)) {                                                               \
+            ++fail_count;                                                            \
+            std::fprintf(stderr, "  FAIL: %s (%s:%d)\n", label, __FILE__, __LINE__); \
+        } else {                                                                     \
+            std::fprintf(stdout, "  ok:   %s\n", label);                             \
+        }                                                                            \
+    } while (0)
+
+#if defined(RAC_HAVE_PROTOBUF)
+
+const runanywhere::v1::OperatorSpec* find_op(const runanywhere::v1::PipelineSpec& spec,
+                                             const std::string& name) {
+    for (const auto& op : spec.operators()) {
+        if (op.name() == name) {
+            return &op;
+        }
+    }
+    return nullptr;
+}
+
+std::string param_or_empty(const runanywhere::v1::OperatorSpec& op, const std::string& key) {
+    const auto it = op.params().find(key);
+    return it == op.params().end() ? std::string() : it->second;
+}
+
+void test_tools_config_emits_agent_loop_op() {
+    runanywhere::v1::SolutionConfig config;
+    auto* agent = config.mutable_agent_loop();
+    agent->set_llm_model_id("test-model");
+    agent->set_system_prompt("be helpful");
+    agent->set_max_iterations(4);
+    auto* tool = agent->add_tools();
+    tool->set_name("get_weather");
+    tool->set_description("weather lookup");
+    tool->set_json_schema("{\"type\":\"object\"}");
+
+    runanywhere::v1::PipelineSpec spec;
+    const rac_result_t rc = rac::solutions::convert_solution_to_pipeline(config, &spec);
+    CHECK(rc == RAC_SUCCESS, "tools config converts successfully");
+
+    const auto* llm = find_op(spec, "llm");
+    CHECK(llm != nullptr, "llm op exists");
+    if (llm == nullptr) {
+        return;
+    }
+    CHECK(llm->type() == "agent_loop", "tools present -> op type is agent_loop");
+    CHECK(param_or_empty(*llm, "tool.count") == "1", "tool.count param carries the tool set size");
+    CHECK(param_or_empty(*llm, "tool.0.name") == "get_weather", "tool name param forwarded");
+    CHECK(param_or_empty(*llm, "tool.0.description") == "weather lookup",
+          "tool description param forwarded");
+    CHECK(param_or_empty(*llm, "tool.0.json_schema") == "{\"type\":\"object\"}",
+          "tool schema param forwarded");
+    CHECK(param_or_empty(*llm, "max_iterations") == "4", "max_iterations param forwarded");
+    CHECK(param_or_empty(*llm, "system_prompt") == "be helpful", "system_prompt param forwarded");
+}
+
+void test_toolless_config_keeps_generate_text() {
+    runanywhere::v1::SolutionConfig config;
+    auto* agent = config.mutable_agent_loop();
+    agent->set_llm_model_id("test-model");
+    agent->set_system_prompt("be helpful");
+
+    runanywhere::v1::PipelineSpec spec;
+    const rac_result_t rc = rac::solutions::convert_solution_to_pipeline(config, &spec);
+    CHECK(rc == RAC_SUCCESS, "tool-less config converts successfully");
+
+    const auto* llm = find_op(spec, "llm");
+    CHECK(llm != nullptr, "llm op exists (tool-less)");
+    if (llm != nullptr) {
+        CHECK(llm->type() == "generate_text", "no tools -> historical generate_text op retained");
+        CHECK(param_or_empty(*llm, "tool.count").empty(), "no tool params emitted without tools");
+    }
+}
+
+#endif  // RAC_HAVE_PROTOBUF
+
+}  // namespace
+
+int main() {
+#if defined(RAC_HAVE_PROTOBUF)
+    test_tools_config_emits_agent_loop_op();
+    test_toolless_config_keeps_generate_text();
+#else
+    std::fprintf(stdout, "  skip: RAC_HAVE_PROTOBUF not defined\n");
+#endif
+
+    std::fprintf(stdout, "\n%d/%d checks passed\n", test_count - fail_count, test_count);
+    return fail_count == 0 ? 0 : 1;
+}

--- a/sdk/runanywhere-commons/tests/test_solution_runner.cpp
+++ b/sdk/runanywhere-commons/tests/test_solution_runner.cpp
@@ -1178,9 +1178,9 @@ TEST(retrieve_without_session_handle_fails_honestly) {
     CHECK(had_retrieve_before);  // Built-in stand-in is always present.
 
     const std::size_t registered = rac::solutions::register_engine_backed_operators(registry);
-    // generate_text + transcribe + synthesize + detect_voice + embed +
-    // retrieve = 6 factories.
-    CHECK(registered == 6);
+    // generate_text + agent_loop + transcribe + synthesize + detect_voice +
+    // embed + retrieve = 7 factories.
+    CHECK(registered == 7);
 
     // Schema contract: text.utf8 in → text.utf8 out, output port "results".
     const auto& in_ports = registry.input_ports("retrieve");

--- a/sdk/runanywhere-commons/tests/test_tool_calling_grammar.cpp
+++ b/sdk/runanywhere-commons/tests/test_tool_calling_grammar.cpp
@@ -1,0 +1,165 @@
+/**
+ * @file test_tool_calling_grammar.cpp
+ * @brief TC-1: verifies build_tool_call_grammar() derives the correct
+ * grammar dialect content for each tool_choice policy — a pure function
+ * over ToolCallingOptions, so no mock LLM plugin / lifecycle is needed.
+ */
+
+#include <cstdio>
+#include <cstring>
+#include <string>
+
+#if defined(RAC_HAVE_PROTOBUF)
+#include "tool_calling.pb.h"
+
+#include <vector>
+
+#include "features/llm/tool_calling_grammar.h"
+#include "rac/features/llm/rac_tool_calling.h"
+#include "rac/foundation/rac_proto_buffer.h"
+#endif
+
+namespace {
+
+int test_count = 0;
+int fail_count = 0;
+
+#define CHECK(cond, label)                                                           \
+    do {                                                                             \
+        ++test_count;                                                                \
+        if (!(cond)) {                                                               \
+            ++fail_count;                                                            \
+            std::fprintf(stderr, "  FAIL: %s (%s:%d)\n", label, __FILE__, __LINE__); \
+        } else {                                                                     \
+            std::fprintf(stdout, "  ok:   %s\n", label);                             \
+        }                                                                            \
+    } while (0)
+
+#if defined(RAC_HAVE_PROTOBUF)
+
+runanywhere::v1::ToolCallingOptions two_tool_options() {
+    runanywhere::v1::ToolCallingOptions options;
+    auto* a = options.add_tools();
+    a->set_name("get_weather");
+    a->set_description("Gets current weather");
+    auto* b = options.add_tools();
+    b->set_name("get_current_time");
+    b->set_description("Gets current time");
+    return options;
+}
+
+void test_none_tools_yields_empty_grammar() {
+    runanywhere::v1::ToolCallingOptions empty_options;
+    auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
+        empty_options, /*has_tool_choice=*/false, runanywhere::v1::TOOL_CHOICE_MODE_UNSPECIFIED,
+        /*forced_tool_name=*/"");
+    CHECK(grammar.gbnf.empty() && grammar.qhexrt.empty(), "empty tool set -> no grammar");
+
+    auto options = two_tool_options();
+    auto none_grammar = rac::llm::tool_calling::build_tool_call_grammar(
+        options, /*has_tool_choice=*/true, runanywhere::v1::TOOL_CHOICE_MODE_NONE,
+        /*forced_tool_name=*/"");
+    CHECK(none_grammar.gbnf.empty() && none_grammar.qhexrt.empty(),
+          "tool_choice=NONE -> no grammar");
+}
+
+void test_auto_leaves_gbnf_unconstrained_but_sets_qhexrt_opt() {
+    auto options = two_tool_options();
+    auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
+        options, /*has_tool_choice=*/false, runanywhere::v1::TOOL_CHOICE_MODE_AUTO,
+        /*forced_tool_name=*/"");
+    CHECK(grammar.gbnf.empty(), "AUTO -> llamacpp dialect left unconstrained");
+    CHECK(grammar.qhexrt == "toolcall_opt:get_weather,get_current_time",
+          "AUTO -> qhexrt dialect is toolcall_opt: with both names");
+}
+
+void test_required_constrains_both_dialects_over_all_names() {
+    auto options = two_tool_options();
+    auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
+        options, /*has_tool_choice=*/true, runanywhere::v1::TOOL_CHOICE_MODE_REQUIRED,
+        /*forced_tool_name=*/"");
+    CHECK(grammar.qhexrt == "toolcall:get_weather,get_current_time",
+          "REQUIRED -> qhexrt dialect is toolcall: with both names");
+
+    CHECK(!grammar.gbnf.empty(), "REQUIRED -> llamacpp GBNF is non-empty");
+    CHECK(grammar.gbnf.find("root ::=") != std::string::npos, "GBNF declares a root rule");
+    CHECK(grammar.gbnf.find("<tool_call>{\\\"tool\\\":") != std::string::npos,
+          "GBNF root matches the <tool_call>{\"tool\": envelope prefix");
+    CHECK(grammar.gbnf.find("}</tool_call>") != std::string::npos,
+          "GBNF root matches the }</tool_call> envelope suffix");
+    CHECK(grammar.gbnf.find(R"("\"get_weather\"")") != std::string::npos,
+          "GBNF tool-name alternation includes get_weather");
+    CHECK(grammar.gbnf.find(R"("\"get_current_time\"")") != std::string::npos,
+          "GBNF tool-name alternation includes get_current_time");
+    CHECK(grammar.gbnf.find("object ::=") != std::string::npos,
+          "GBNF appends the permissive JSON object production for arguments");
+}
+
+void test_specific_constrains_to_single_forced_name() {
+    auto options = two_tool_options();
+    auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
+        options, /*has_tool_choice=*/true, runanywhere::v1::TOOL_CHOICE_MODE_SPECIFIC,
+        /*forced_tool_name=*/"get_weather");
+    CHECK(grammar.qhexrt == "toolcall:get_weather",
+          "SPECIFIC -> qhexrt dialect names only the forced tool");
+    CHECK(grammar.gbnf.find(R"("\"get_weather\"")") != std::string::npos,
+          "SPECIFIC GBNF includes the forced tool name");
+    CHECK(grammar.gbnf.find(R"("\"get_current_time\"")") == std::string::npos,
+          "SPECIFIC GBNF excludes the non-forced tool name");
+}
+
+// TC-2: rac_tool_call_parse_proto returns every envelope in one output when
+// parallel_tool_calls is set, and only the first when it is not.
+void test_parallel_parse_returns_all_envelopes() {
+    const char* two_calls =
+        "<tool_call>{\"tool\":\"get_weather\",\"arguments\":{\"location\":\"Ankara\"}}</tool_call>"
+        "<tool_call>{\"tool\":\"get_current_time\",\"arguments\":{}}</tool_call>";
+
+    const auto parse_with = [&](bool parallel) -> runanywhere::v1::ToolParseResult {
+        runanywhere::v1::ToolParseRequest request;
+        request.set_text(two_calls);
+        request.mutable_options()->set_parallel_tool_calls(parallel);
+        std::vector<uint8_t> bytes(request.ByteSizeLong());
+        request.SerializeToArray(bytes.data(), static_cast<int>(bytes.size()));
+
+        rac_proto_buffer_t out;
+        rac_proto_buffer_init(&out);
+        runanywhere::v1::ToolParseResult result;
+        if (rac_tool_call_parse_proto(bytes.data(), bytes.size(), &out) == RAC_SUCCESS &&
+            out.data != nullptr) {
+            result.ParseFromArray(out.data, static_cast<int>(out.size));
+        }
+        rac_proto_buffer_free(&out);
+        return result;
+    };
+
+    const auto serial = parse_with(false);
+    CHECK(serial.tool_calls_size() == 1, "parallel off -> single call parsed (legacy behavior)");
+
+    const auto parallel = parse_with(true);
+    CHECK(parallel.tool_calls_size() == 2, "parallel on -> both envelopes parsed");
+    if (parallel.tool_calls_size() == 2) {
+        CHECK(parallel.tool_calls(0).name() == "get_weather", "first parallel call is get_weather");
+        CHECK(parallel.tool_calls(1).name() == "get_current_time",
+              "second parallel call is get_current_time");
+    }
+}
+
+#endif  // RAC_HAVE_PROTOBUF
+
+}  // namespace
+
+int main() {
+#if defined(RAC_HAVE_PROTOBUF)
+    test_none_tools_yields_empty_grammar();
+    test_auto_leaves_gbnf_unconstrained_but_sets_qhexrt_opt();
+    test_required_constrains_both_dialects_over_all_names();
+    test_specific_constrains_to_single_forced_name();
+    test_parallel_parse_returns_all_envelopes();
+#else
+    std::fprintf(stdout, "  skip: RAC_HAVE_PROTOBUF not defined\n");
+#endif
+
+    std::fprintf(stdout, "\n%d/%d checks passed\n", test_count - fail_count, test_count);
+    return fail_count == 0 ? 0 : 1;
+}

--- a/sdk/runanywhere-commons/tests/test_tool_calling_grammar.cpp
+++ b/sdk/runanywhere-commons/tests/test_tool_calling_grammar.cpp
@@ -145,6 +145,42 @@ void test_parallel_parse_returns_all_envelopes() {
     }
 }
 
+// Regression: a small model can stutter and repeat the SAME tool call
+// verbatim several times in one turn instead of moving on. Without a
+// dedup/stop guard, harvesting every envelope would treat the stutter as N
+// legitimate parallel calls, burning the max_tool_calls budget on
+// duplicates and starving the rest of the request.
+void test_parallel_parse_stops_at_repeated_call() {
+    const char* stuttered =
+        "<tool_call>{\"tool\":\"get_weather\",\"arguments\":{\"location\":\"Ankara\"}}</tool_call>"
+        "<tool_call>{\"tool\":\"get_weather\",\"arguments\":{\"location\":\"Ankara\"}}</tool_call>"
+        "<tool_call>{\"tool\":\"get_weather\",\"arguments\":{\"location\":\"Ankara\"}}</tool_call>"
+        "<tool_call>{\"tool\":\"get_current_time\",\"arguments\":{}}</tool_call>";
+
+    runanywhere::v1::ToolParseRequest request;
+    request.set_text(stuttered);
+    request.mutable_options()->set_parallel_tool_calls(true);
+    std::vector<uint8_t> bytes(request.ByteSizeLong());
+    request.SerializeToArray(bytes.data(), static_cast<int>(bytes.size()));
+
+    rac_proto_buffer_t out;
+    rac_proto_buffer_init(&out);
+    runanywhere::v1::ToolParseResult result;
+    if (rac_tool_call_parse_proto(bytes.data(), bytes.size(), &out) == RAC_SUCCESS &&
+        out.data != nullptr) {
+        result.ParseFromArray(out.data, static_cast<int>(out.size));
+    }
+    rac_proto_buffer_free(&out);
+
+    CHECK(result.tool_calls_size() == 1,
+          "repeated identical call stops harvesting at the first repeat, "
+          "not the later distinct get_current_time call");
+    if (result.tool_calls_size() >= 1) {
+        CHECK(result.tool_calls(0).name() == "get_weather",
+              "the single harvested call is the first (legitimate) occurrence");
+    }
+}
+
 #endif  // RAC_HAVE_PROTOBUF
 
 }  // namespace
@@ -155,6 +191,7 @@ int main() {
     test_auto_leaves_gbnf_unconstrained_but_sets_qhexrt_opt();
     test_required_constrains_both_dialects_over_all_names();
     test_specific_constrains_to_single_forced_name();
+    test_parallel_parse_stops_at_repeated_call();
     test_parallel_parse_returns_all_envelopes();
 #else
     std::fprintf(stdout, "  skip: RAC_HAVE_PROTOBUF not defined\n");

--- a/sdk/runanywhere-commons/tests/test_tool_calling_grammar.cpp
+++ b/sdk/runanywhere-commons/tests/test_tool_calling_grammar.cpp
@@ -14,6 +14,7 @@
 
 #include <vector>
 
+#include "features/llm/tool_calling_generation_internal.h"
 #include "features/llm/tool_calling_grammar.h"
 #include "rac/features/llm/rac_tool_calling.h"
 #include "rac/foundation/rac_proto_buffer.h"
@@ -52,13 +53,13 @@ void test_none_tools_yields_empty_grammar() {
     runanywhere::v1::ToolCallingOptions empty_options;
     auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
         empty_options, /*has_tool_choice=*/false, runanywhere::v1::TOOL_CHOICE_MODE_UNSPECIFIED,
-        /*forced_tool_name=*/"");
+        /*forced_tool_name=*/"", /*parallel=*/false);
     CHECK(grammar.gbnf.empty() && grammar.qhexrt.empty(), "empty tool set -> no grammar");
 
     auto options = two_tool_options();
     auto none_grammar = rac::llm::tool_calling::build_tool_call_grammar(
         options, /*has_tool_choice=*/true, runanywhere::v1::TOOL_CHOICE_MODE_NONE,
-        /*forced_tool_name=*/"");
+        /*forced_tool_name=*/"", /*parallel=*/false);
     CHECK(none_grammar.gbnf.empty() && none_grammar.qhexrt.empty(),
           "tool_choice=NONE -> no grammar");
 }
@@ -67,7 +68,7 @@ void test_auto_leaves_gbnf_unconstrained_but_sets_qhexrt_opt() {
     auto options = two_tool_options();
     auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
         options, /*has_tool_choice=*/false, runanywhere::v1::TOOL_CHOICE_MODE_AUTO,
-        /*forced_tool_name=*/"");
+        /*forced_tool_name=*/"", /*parallel=*/false);
     CHECK(grammar.gbnf.empty(), "AUTO -> llamacpp dialect left unconstrained");
     CHECK(grammar.qhexrt == "toolcall_opt:get_weather,get_current_time",
           "AUTO -> qhexrt dialect is toolcall_opt: with both names");
@@ -77,12 +78,13 @@ void test_required_constrains_both_dialects_over_all_names() {
     auto options = two_tool_options();
     auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
         options, /*has_tool_choice=*/true, runanywhere::v1::TOOL_CHOICE_MODE_REQUIRED,
-        /*forced_tool_name=*/"");
+        /*forced_tool_name=*/"", /*parallel=*/false);
     CHECK(grammar.qhexrt == "toolcall:get_weather,get_current_time",
           "REQUIRED -> qhexrt dialect is toolcall: with both names");
 
     CHECK(!grammar.gbnf.empty(), "REQUIRED -> llamacpp GBNF is non-empty");
-    CHECK(grammar.gbnf.find("root ::=") != std::string::npos, "GBNF declares a root rule");
+    CHECK(grammar.gbnf.find("root ::= call\n") != std::string::npos,
+          "REQUIRED without parallel -> root accepts exactly one call");
     CHECK(grammar.gbnf.find("<tool_call>{\\\"tool\\\":") != std::string::npos,
           "GBNF root matches the <tool_call>{\"tool\": envelope prefix");
     CHECK(grammar.gbnf.find("}</tool_call>") != std::string::npos,
@@ -95,11 +97,24 @@ void test_required_constrains_both_dialects_over_all_names() {
           "GBNF appends the permissive JSON object production for arguments");
 }
 
+// Regression (CodeRabbit review on PR #574): when parallel_tool_calls is
+// requested alongside REQUIRED/SPECIFIC, the GBNF root must accept ONE OR
+// MORE back-to-back envelopes — otherwise the grammar itself caps the
+// model at a single call regardless of what the caller asked for.
+void test_parallel_required_gbnf_allows_repeated_calls() {
+    auto options = two_tool_options();
+    auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
+        options, /*has_tool_choice=*/true, runanywhere::v1::TOOL_CHOICE_MODE_REQUIRED,
+        /*forced_tool_name=*/"", /*parallel=*/true);
+    CHECK(grammar.gbnf.find("root ::= call+\n") != std::string::npos,
+          "REQUIRED with parallel -> root accepts one-or-more calls");
+}
+
 void test_specific_constrains_to_single_forced_name() {
     auto options = two_tool_options();
     auto grammar = rac::llm::tool_calling::build_tool_call_grammar(
         options, /*has_tool_choice=*/true, runanywhere::v1::TOOL_CHOICE_MODE_SPECIFIC,
-        /*forced_tool_name=*/"get_weather");
+        /*forced_tool_name=*/"get_weather", /*parallel=*/false);
     CHECK(grammar.qhexrt == "toolcall:get_weather",
           "SPECIFIC -> qhexrt dialect names only the forced tool");
     CHECK(grammar.gbnf.find(R"("\"get_weather\"")") != std::string::npos,
@@ -181,6 +196,37 @@ void test_parallel_parse_stops_at_repeated_call() {
     }
 }
 
+// Grammar lifetime is owned by tool_grammar_constrained_this_turn (RUN-80),
+// not by unconditionally clearing on iteration > 1. Synthesis turns (a call
+// was made and tools are not kept available) must drop the grammar so the
+// model can produce a final natural-language answer; keep_tools_available
+// must leave grammar live so a subsequent decision turn can still call.
+void test_grammar_scoped_by_tools_live_predicate() {
+    CHECK(rac::llm::tool_calling::tool_grammar_constrained_this_turn(
+              /*none_veto=*/false, /*a_call_was_made=*/false, /*keep_tools_available=*/false),
+          "first decision turn keeps grammar live");
+    CHECK(!rac::llm::tool_calling::tool_grammar_constrained_this_turn(
+              /*none_veto=*/false, /*a_call_was_made=*/true, /*keep_tools_available=*/false),
+          "synthesis turn (call made, tools not kept) clears grammar");
+    CHECK(rac::llm::tool_calling::tool_grammar_constrained_this_turn(
+              /*none_veto=*/false, /*a_call_was_made=*/true, /*keep_tools_available=*/true),
+          "keep_tools_available keeps grammar live after a call");
+    CHECK(!rac::llm::tool_calling::tool_grammar_constrained_this_turn(
+              /*none_veto=*/true, /*a_call_was_made=*/false, /*keep_tools_available=*/true),
+          "tool_choice=NONE veto clears grammar");
+
+    // generation_for_tool_step itself must NOT clear grammars — the loop owns
+    // that decision via the predicate above.
+    rac::llm::tool_calling::GenerationState base;
+    base.grammar_gbnf = "root ::= \"<tool_call>...\"";
+    base.grammar_qhexrt = "toolcall:get_weather";
+    const auto second = rac::llm::tool_calling::generation_for_tool_step(
+        base, /*iteration=*/2, /*has_tool_choice=*/true, runanywhere::v1::TOOL_CHOICE_MODE_REQUIRED,
+        runanywhere::v1::TOOL_CALL_FORMAT_NAME_JSON);
+    CHECK(!second.grammar_gbnf.empty() && !second.grammar_qhexrt.empty(),
+          "generation_for_tool_step preserves grammars; loop clears via predicate");
+}
+
 #endif  // RAC_HAVE_PROTOBUF
 
 }  // namespace
@@ -190,7 +236,9 @@ int main() {
     test_none_tools_yields_empty_grammar();
     test_auto_leaves_gbnf_unconstrained_but_sets_qhexrt_opt();
     test_required_constrains_both_dialects_over_all_names();
+    test_parallel_required_gbnf_allows_repeated_calls();
     test_specific_constrains_to_single_forced_name();
+    test_grammar_scoped_by_tools_live_predicate();
     test_parallel_parse_stops_at_repeated_call();
     test_parallel_parse_returns_all_envelopes();
 #else

--- a/sdk/runanywhere-commons/tests/test_tool_calling_run_loop.cpp
+++ b/sdk/runanywhere-commons/tests/test_tool_calling_run_loop.cpp
@@ -1918,7 +1918,9 @@ int test_specific_narrows_grammar_spec() {
         const auto captures = generation_captures();
         CHECK(!captures.empty(), "SPECIFIC grammar backend generated");
         if (!captures.empty()) {
-            CHECK(captures[0].grammar == "toolcall_opt:get_weather",
+            // TC-1: SPECIFIC uses the must-call dialect (toolcall:) narrowed to
+            // the forced tool — stricter than the always-optional RUN-80 default.
+            CHECK(captures[0].grammar == "toolcall:get_weather",
                   "SPECIFIC narrows the grammar spec to the forced tool only (not calculate)");
         }
         rac_proto_buffer_free(&out);
@@ -1979,7 +1981,9 @@ int test_required_on_grammar_backend() {
                   "REQUIRED grammar prompt is bare-Pythonic");
             CHECK(captures[0].prompt.find("You must call exactly one tool now") != std::string::npos,
                   "REQUIRED grammar prompt carries the firm directive");
-            CHECK(captures[0].grammar == "toolcall_opt:get_weather",
+            // TC-1: REQUIRED uses the must-call dialect (toolcall:), not the
+            // optional toolcall_opt: used for AUTO.
+            CHECK(captures[0].grammar == "toolcall:get_weather",
                   "REQUIRED grammar backend attaches the grammar spec");
         }
         runanywhere::v1::ToolCallingResult result;

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/generated/tool_calling.pb.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/generated/tool_calling.pb.dart
@@ -866,6 +866,7 @@ class ToolCallingOptions extends $pb.GeneratedMessage {
     $core.int? maxToolCalls,
     ToolChoiceMode? toolChoice,
     $core.String? forcedToolName,
+    $core.bool? parallelToolCalls,
     $core.bool? requireJsonArguments,
     $core.bool? disableThinking,
   }) {
@@ -883,6 +884,7 @@ class ToolCallingOptions extends $pb.GeneratedMessage {
     if (maxToolCalls != null) result.maxToolCalls = maxToolCalls;
     if (toolChoice != null) result.toolChoice = toolChoice;
     if (forcedToolName != null) result.forcedToolName = forcedToolName;
+    if (parallelToolCalls != null) result.parallelToolCalls = parallelToolCalls;
     if (requireJsonArguments != null)
       result.requireJsonArguments = requireJsonArguments;
     if (disableThinking != null) result.disableThinking = disableThinking;
@@ -916,6 +918,7 @@ class ToolCallingOptions extends $pb.GeneratedMessage {
     ..aE<ToolChoiceMode>(13, _omitFieldNames ? '' : 'toolChoice',
         enumValues: ToolChoiceMode.values)
     ..aOS(14, _omitFieldNames ? '' : 'forcedToolName')
+    ..aOB(15, _omitFieldNames ? '' : 'parallelToolCalls')
     ..aOB(16, _omitFieldNames ? '' : 'requireJsonArguments')
     ..aOB(17, _omitFieldNames ? '' : 'disableThinking')
     ..hasRequiredFields = false;
@@ -1045,12 +1048,26 @@ class ToolCallingOptions extends $pb.GeneratedMessage {
   @$pb.TagNumber(14)
   void clearForcedToolName() => $_clearField(14);
 
+  /// When true, one model turn may emit multiple tool-call envelopes;
+  /// commons parses and executes all of them before building a single
+  /// follow-up prompt. Default false preserves the historical
+  /// one-call-per-turn behavior. (Reclaims the field number that
+  /// originally carried this flag before it was reserved.)
+  @$pb.TagNumber(15)
+  $core.bool get parallelToolCalls => $_getBF(11);
+  @$pb.TagNumber(15)
+  set parallelToolCalls($core.bool value) => $_setBool(11, value);
+  @$pb.TagNumber(15)
+  $core.bool hasParallelToolCalls() => $_has(11);
+  @$pb.TagNumber(15)
+  void clearParallelToolCalls() => $_clearField(15);
+
   @$pb.TagNumber(16)
-  $core.bool get requireJsonArguments => $_getBF(11);
+  $core.bool get requireJsonArguments => $_getBF(12);
   @$pb.TagNumber(16)
-  set requireJsonArguments($core.bool value) => $_setBool(11, value);
+  set requireJsonArguments($core.bool value) => $_setBool(12, value);
   @$pb.TagNumber(16)
-  $core.bool hasRequireJsonArguments() => $_has(11);
+  $core.bool hasRequireJsonArguments() => $_has(12);
   @$pb.TagNumber(16)
   void clearRequireJsonArguments() => $_clearField(16);
 
@@ -1059,11 +1076,11 @@ class ToolCallingOptions extends $pb.GeneratedMessage {
   /// at the prompt level — same contract as
   /// LLMGenerationOptions.disable_thinking). Default false.
   @$pb.TagNumber(17)
-  $core.bool get disableThinking => $_getBF(12);
+  $core.bool get disableThinking => $_getBF(13);
   @$pb.TagNumber(17)
-  set disableThinking($core.bool value) => $_setBool(12, value);
+  set disableThinking($core.bool value) => $_setBool(13, value);
   @$pb.TagNumber(17)
-  $core.bool hasDisableThinking() => $_has(12);
+  $core.bool hasDisableThinking() => $_has(13);
   @$pb.TagNumber(17)
   void clearDisableThinking() => $_clearField(17);
 }
@@ -2026,6 +2043,7 @@ class ToolCallingSessionCreateRequest extends $pb.GeneratedMessage {
     $core.bool? replaceSystemPrompt,
     $core.bool? requireJsonArguments,
     $core.Iterable<$core.String>? history,
+    $core.bool? parallelToolCalls,
   }) {
     final result = create();
     if (prompt != null) result.prompt = prompt;
@@ -2048,6 +2066,7 @@ class ToolCallingSessionCreateRequest extends $pb.GeneratedMessage {
     if (requireJsonArguments != null)
       result.requireJsonArguments = requireJsonArguments;
     if (history != null) result.history.addAll(history);
+    if (parallelToolCalls != null) result.parallelToolCalls = parallelToolCalls;
     return result;
   }
 
@@ -2086,6 +2105,7 @@ class ToolCallingSessionCreateRequest extends $pb.GeneratedMessage {
     ..aOB(17, _omitFieldNames ? '' : 'replaceSystemPrompt')
     ..aOB(18, _omitFieldNames ? '' : 'requireJsonArguments')
     ..pPS(19, _omitFieldNames ? '' : 'history')
+    ..aOB(20, _omitFieldNames ? '' : 'parallelToolCalls')
     ..hasRequiredFields = false;
 
   @$core.Deprecated('See https://github.com/google/protobuf.dart/issues/998.')
@@ -2273,6 +2293,19 @@ class ToolCallingSessionCreateRequest extends $pb.GeneratedMessage {
   /// cross-proto import cycle.
   @$pb.TagNumber(19)
   $pb.PbList<$core.String> get history => $_getList(16);
+
+  /// Mirrors ToolCallingOptions.parallel_tool_calls for the run-loop /
+  /// session envelope: when true, one model turn may emit multiple
+  /// tool-call envelopes and commons executes all of them before one
+  /// follow-up prompt. Default false = historical single-call behavior.
+  @$pb.TagNumber(20)
+  $core.bool get parallelToolCalls => $_getBF(17);
+  @$pb.TagNumber(20)
+  set parallelToolCalls($core.bool value) => $_setBool(17, value);
+  @$pb.TagNumber(20)
+  $core.bool hasParallelToolCalls() => $_has(17);
+  @$pb.TagNumber(20)
+  void clearParallelToolCalls() => $_clearField(20);
 }
 
 class ToolCallingSessionCreateResult extends $pb.GeneratedMessage {

--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/public/capabilities/runanywhere_tools.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/public/capabilities/runanywhere_tools.dart
@@ -252,6 +252,9 @@ class RunAnywhereTools {
       // Flutter uses the session ABI — commons threads these into every
       // generate in the loop so multi-turn tool use keeps context.
       history: history,
+      // TC-2: mirror options onto request field 20 — commons reads parallel
+      // mode from the session/run-loop request, not from inline options alone.
+      parallelToolCalls: opts.parallelToolCalls,
     );
     // `validate_calls` is `optional bool` on the proto — leave it UNSET when
     // the caller did not supply a value so commons applies its documented

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/generated/ai/runanywhere/proto/v1/ToolCallingOptions.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/generated/ai/runanywhere/proto/v1/ToolCallingOptions.kt
@@ -114,6 +114,21 @@ public class ToolCallingOptions(
   )
   public val format: ToolCallFormatName? = null,
   /**
+   * When true, one model turn may emit multiple tool-call envelopes;
+   * commons parses and executes all of them before building a single
+   * follow-up prompt. Default false preserves the historical
+   * one-call-per-turn behavior. (Reclaims the field number that
+   * originally carried this flag before it was reserved.)
+   */
+  @field:WireField(
+    tag = 15,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    label = WireField.Label.OMIT_IDENTITY,
+    jsonName = "parallelToolCalls",
+    schemaIndex = 8,
+  )
+  public val parallel_tool_calls: Boolean = false,
+  /**
    * Maximum tool calls in one conversation turn. Unset/0 = SDK default
    * (typically 5).
    */
@@ -121,7 +136,7 @@ public class ToolCallingOptions(
     tag = 12,
     adapter = "com.squareup.wire.ProtoAdapter#INT32",
     jsonName = "maxToolCalls",
-    schemaIndex = 8,
+    schemaIndex = 9,
   )
   public val max_tool_calls: Int? = null,
   @field:WireField(
@@ -129,14 +144,14 @@ public class ToolCallingOptions(
     adapter = "ai.runanywhere.proto.v1.ToolChoiceMode#ADAPTER",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "toolChoice",
-    schemaIndex = 9,
+    schemaIndex = 10,
   )
   public val tool_choice: ToolChoiceMode = ToolChoiceMode.TOOL_CHOICE_MODE_UNSPECIFIED,
   @field:WireField(
     tag = 14,
     adapter = "com.squareup.wire.ProtoAdapter#STRING",
     jsonName = "forcedToolName",
-    schemaIndex = 10,
+    schemaIndex = 11,
   )
   public val forced_tool_name: String? = null,
   @field:WireField(
@@ -144,7 +159,7 @@ public class ToolCallingOptions(
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     label = WireField.Label.OMIT_IDENTITY,
     jsonName = "requireJsonArguments",
-    schemaIndex = 11,
+    schemaIndex = 12,
   )
   public val require_json_arguments: Boolean = false,
   /**
@@ -157,7 +172,7 @@ public class ToolCallingOptions(
     tag = 17,
     adapter = "com.squareup.wire.ProtoAdapter#BOOL",
     jsonName = "disableThinking",
-    schemaIndex = 12,
+    schemaIndex = 13,
   )
   public val disable_thinking: Boolean? = null,
   unknownFields: ByteString = ByteString.EMPTY,
@@ -192,6 +207,7 @@ public class ToolCallingOptions(
     if (replace_system_prompt != other.replace_system_prompt) return false
     if (keep_tools_available != other.keep_tools_available) return false
     if (format != other.format) return false
+    if (parallel_tool_calls != other.parallel_tool_calls) return false
     if (max_tool_calls != other.max_tool_calls) return false
     if (tool_choice != other.tool_choice) return false
     if (forced_tool_name != other.forced_tool_name) return false
@@ -212,6 +228,7 @@ public class ToolCallingOptions(
       result = result * 37 + replace_system_prompt.hashCode()
       result = result * 37 + keep_tools_available.hashCode()
       result = result * 37 + (format?.hashCode() ?: 0)
+      result = result * 37 + parallel_tool_calls.hashCode()
       result = result * 37 + (max_tool_calls?.hashCode() ?: 0)
       result = result * 37 + tool_choice.hashCode()
       result = result * 37 + (forced_tool_name?.hashCode() ?: 0)
@@ -232,6 +249,7 @@ public class ToolCallingOptions(
     result += """replace_system_prompt=$replace_system_prompt"""
     result += """keep_tools_available=$keep_tools_available"""
     if (format != null) result += """format=$format"""
+    result += """parallel_tool_calls=$parallel_tool_calls"""
     if (max_tool_calls != null) result += """max_tool_calls=$max_tool_calls"""
     result += """tool_choice=$tool_choice"""
     if (forced_tool_name != null) result += """forced_tool_name=${sanitize(forced_tool_name)}"""
@@ -249,13 +267,14 @@ public class ToolCallingOptions(
     replace_system_prompt: Boolean = this.replace_system_prompt,
     keep_tools_available: Boolean = this.keep_tools_available,
     format: ToolCallFormatName? = this.format,
+    parallel_tool_calls: Boolean = this.parallel_tool_calls,
     max_tool_calls: Int? = this.max_tool_calls,
     tool_choice: ToolChoiceMode = this.tool_choice,
     forced_tool_name: String? = this.forced_tool_name,
     require_json_arguments: Boolean = this.require_json_arguments,
     disable_thinking: Boolean? = this.disable_thinking,
     unknownFields: ByteString = this.unknownFields,
-  ): ToolCallingOptions = ToolCallingOptions(tools, auto_execute, temperature, max_tokens, system_prompt, replace_system_prompt, keep_tools_available, format, max_tool_calls, tool_choice, forced_tool_name, require_json_arguments, disable_thinking, unknownFields)
+  ): ToolCallingOptions = ToolCallingOptions(tools, auto_execute, temperature, max_tokens, system_prompt, replace_system_prompt, keep_tools_available, format, parallel_tool_calls, max_tool_calls, tool_choice, forced_tool_name, require_json_arguments, disable_thinking, unknownFields)
 
   public companion object {
     @JvmField
@@ -284,6 +303,9 @@ public class ToolCallingOptions(
           size += ProtoAdapter.BOOL.encodedSizeWithTag(8, value.keep_tools_available)
         }
         size += ToolCallFormatName.ADAPTER.encodedSizeWithTag(10, value.format)
+        if (value.parallel_tool_calls != false) {
+          size += ProtoAdapter.BOOL.encodedSizeWithTag(15, value.parallel_tool_calls)
+        }
         size += ProtoAdapter.INT32.encodedSizeWithTag(12, value.max_tool_calls)
         if (value.tool_choice != ai.runanywhere.proto.v1.ToolChoiceMode.TOOL_CHOICE_MODE_UNSPECIFIED) {
           size += ToolChoiceMode.ADAPTER.encodedSizeWithTag(13, value.tool_choice)
@@ -311,6 +333,9 @@ public class ToolCallingOptions(
           ProtoAdapter.BOOL.encodeWithTag(writer, 8, value.keep_tools_available)
         }
         ToolCallFormatName.ADAPTER.encodeWithTag(writer, 10, value.format)
+        if (value.parallel_tool_calls != false) {
+          ProtoAdapter.BOOL.encodeWithTag(writer, 15, value.parallel_tool_calls)
+        }
         ProtoAdapter.INT32.encodeWithTag(writer, 12, value.max_tool_calls)
         if (value.tool_choice != ai.runanywhere.proto.v1.ToolChoiceMode.TOOL_CHOICE_MODE_UNSPECIFIED) {
           ToolChoiceMode.ADAPTER.encodeWithTag(writer, 13, value.tool_choice)
@@ -334,6 +359,9 @@ public class ToolCallingOptions(
           ToolChoiceMode.ADAPTER.encodeWithTag(writer, 13, value.tool_choice)
         }
         ProtoAdapter.INT32.encodeWithTag(writer, 12, value.max_tool_calls)
+        if (value.parallel_tool_calls != false) {
+          ProtoAdapter.BOOL.encodeWithTag(writer, 15, value.parallel_tool_calls)
+        }
         ToolCallFormatName.ADAPTER.encodeWithTag(writer, 10, value.format)
         if (value.keep_tools_available != false) {
           ProtoAdapter.BOOL.encodeWithTag(writer, 8, value.keep_tools_available)
@@ -359,6 +387,7 @@ public class ToolCallingOptions(
         var replace_system_prompt: Boolean = false
         var keep_tools_available: Boolean = false
         var format: ToolCallFormatName? = null
+        var parallel_tool_calls: Boolean = false
         var max_tool_calls: Int? = null
         var tool_choice: ToolChoiceMode = ToolChoiceMode.TOOL_CHOICE_MODE_UNSPECIFIED
         var forced_tool_name: String? = null
@@ -378,6 +407,7 @@ public class ToolCallingOptions(
             } catch (e: ProtoAdapter.EnumConstantNotFoundException) {
               reader.addUnknownField(tag, FieldEncoding.VARINT, e.value.toLong())
             }
+            15 -> parallel_tool_calls = ProtoAdapter.BOOL.decode(reader)
             12 -> max_tool_calls = ProtoAdapter.INT32.decode(reader)
             13 -> try {
               tool_choice = ToolChoiceMode.ADAPTER.decode(reader)
@@ -399,6 +429,7 @@ public class ToolCallingOptions(
           replace_system_prompt = replace_system_prompt,
           keep_tools_available = keep_tools_available,
           format = format,
+          parallel_tool_calls = parallel_tool_calls,
           max_tool_calls = max_tool_calls,
           tool_choice = tool_choice,
           forced_tool_name = forced_tool_name,

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/generated/ai/runanywhere/proto/v1/ToolCallingSessionCreateRequest.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/generated/ai/runanywhere/proto/v1/ToolCallingSessionCreateRequest.kt
@@ -181,6 +181,20 @@ public class ToolCallingSessionCreateRequest(
   )
   public val require_json_arguments: Boolean = false,
   history: List<String> = emptyList(),
+  /**
+   * Mirrors ToolCallingOptions.parallel_tool_calls for the run-loop /
+   * session envelope: when true, one model turn may emit multiple
+   * tool-call envelopes and commons executes all of them before one
+   * follow-up prompt. Default false = historical single-call behavior.
+   */
+  @field:WireField(
+    tag = 20,
+    adapter = "com.squareup.wire.ProtoAdapter#BOOL",
+    label = WireField.Label.OMIT_IDENTITY,
+    jsonName = "parallelToolCalls",
+    schemaIndex = 17,
+  )
+  public val parallel_tool_calls: Boolean = false,
   unknownFields: ByteString = ByteString.EMPTY,
 ) : Message<ToolCallingSessionCreateRequest, Nothing>(ADAPTER, unknownFields) {
   @field:WireField(
@@ -233,6 +247,7 @@ public class ToolCallingSessionCreateRequest(
     if (replace_system_prompt != other.replace_system_prompt) return false
     if (require_json_arguments != other.require_json_arguments) return false
     if (history != other.history) return false
+    if (parallel_tool_calls != other.parallel_tool_calls) return false
     return true
   }
 
@@ -257,6 +272,7 @@ public class ToolCallingSessionCreateRequest(
       result = result * 37 + replace_system_prompt.hashCode()
       result = result * 37 + require_json_arguments.hashCode()
       result = result * 37 + history.hashCode()
+      result = result * 37 + parallel_tool_calls.hashCode()
       super.hashCode = result
     }
     return result
@@ -281,6 +297,7 @@ public class ToolCallingSessionCreateRequest(
     result += """replace_system_prompt=$replace_system_prompt"""
     result += """require_json_arguments=$require_json_arguments"""
     if (history.isNotEmpty()) result += """history=${sanitize(history)}"""
+    result += """parallel_tool_calls=$parallel_tool_calls"""
     return result.joinToString(prefix = "ToolCallingSessionCreateRequest{", separator = ", ", postfix = "}")
   }
 
@@ -302,8 +319,9 @@ public class ToolCallingSessionCreateRequest(
     replace_system_prompt: Boolean = this.replace_system_prompt,
     require_json_arguments: Boolean = this.require_json_arguments,
     history: List<String> = this.history,
+    parallel_tool_calls: Boolean = this.parallel_tool_calls,
     unknownFields: ByteString = this.unknownFields,
-  ): ToolCallingSessionCreateRequest = ToolCallingSessionCreateRequest(prompt, max_tokens, temperature, top_p, system_prompt, tools, format, max_tool_calls, keep_tools_available, validate_calls, tool_choice, forced_tool_name, disable_thinking, auto_execute, replace_system_prompt, require_json_arguments, history, unknownFields)
+  ): ToolCallingSessionCreateRequest = ToolCallingSessionCreateRequest(prompt, max_tokens, temperature, top_p, system_prompt, tools, format, max_tool_calls, keep_tools_available, validate_calls, tool_choice, forced_tool_name, disable_thinking, auto_execute, replace_system_prompt, require_json_arguments, history, parallel_tool_calls, unknownFields)
 
   public companion object {
     @JvmField
@@ -357,6 +375,9 @@ public class ToolCallingSessionCreateRequest(
           size += ProtoAdapter.BOOL.encodedSizeWithTag(18, value.require_json_arguments)
         }
         size += ProtoAdapter.STRING.asRepeated().encodedSizeWithTag(19, value.history)
+        if (value.parallel_tool_calls != false) {
+          size += ProtoAdapter.BOOL.encodedSizeWithTag(20, value.parallel_tool_calls)
+        }
         return size
       }
 
@@ -400,11 +421,17 @@ public class ToolCallingSessionCreateRequest(
           ProtoAdapter.BOOL.encodeWithTag(writer, 18, value.require_json_arguments)
         }
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 19, value.history)
+        if (value.parallel_tool_calls != false) {
+          ProtoAdapter.BOOL.encodeWithTag(writer, 20, value.parallel_tool_calls)
+        }
         writer.writeBytes(value.unknownFields)
       }
 
       override fun encode(writer: ReverseProtoWriter, `value`: ToolCallingSessionCreateRequest) {
         writer.writeBytes(value.unknownFields)
+        if (value.parallel_tool_calls != false) {
+          ProtoAdapter.BOOL.encodeWithTag(writer, 20, value.parallel_tool_calls)
+        }
         ProtoAdapter.STRING.asRepeated().encodeWithTag(writer, 19, value.history)
         if (value.require_json_arguments != false) {
           ProtoAdapter.BOOL.encodeWithTag(writer, 18, value.require_json_arguments)
@@ -464,6 +491,7 @@ public class ToolCallingSessionCreateRequest(
         var replace_system_prompt: Boolean = false
         var require_json_arguments: Boolean = false
         val history = mutableListOf<String>()
+        var parallel_tool_calls: Boolean = false
         val unknownFields = reader.forEachTag { tag ->
           when (tag) {
             1 -> prompt = ProtoAdapter.STRING.decode(reader)
@@ -491,6 +519,7 @@ public class ToolCallingSessionCreateRequest(
             17 -> replace_system_prompt = ProtoAdapter.BOOL.decode(reader)
             18 -> require_json_arguments = ProtoAdapter.BOOL.decode(reader)
             19 -> history.add(ProtoAdapter.STRING.decode(reader))
+            20 -> parallel_tool_calls = ProtoAdapter.BOOL.decode(reader)
             else -> reader.readUnknownField(tag)
           }
         }
@@ -512,6 +541,7 @@ public class ToolCallingSessionCreateRequest(
           replace_system_prompt = replace_system_prompt,
           require_json_arguments = require_json_arguments,
           history = history,
+          parallel_tool_calls = parallel_tool_calls,
           unknownFields = unknownFields
         )
       }

--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/LLM/ToolCallingOrchestrator.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/LLM/ToolCallingOrchestrator.kt
@@ -189,6 +189,9 @@ internal fun makeToolCallingRunLoopRequest(
         replace_system_prompt = options.replace_system_prompt,
         require_json_arguments = options.require_json_arguments,
         history = history,
+        // TC-2: mirror options onto request field 20 — commons reads parallel
+        // mode from the session/run-loop request, not from inline options alone.
+        parallel_tool_calls = options.parallel_tool_calls,
     )
 
 /**

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Generated/tool_calling.pb.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Generated/tool_calling.pb.swift
@@ -603,6 +603,13 @@ public nonisolated struct RAToolCallingOptions: Sendable {
   /// Clears the value of `format`. Subsequent reads from it will return its default value.
   public mutating func clearFormat() {self._format = nil}
 
+  /// When true, one model turn may emit multiple tool-call envelopes;
+  /// commons parses and executes all of them before building a single
+  /// follow-up prompt. Default false preserves the historical
+  /// one-call-per-turn behavior. (Reclaims the field number that
+  /// originally carried this flag before it was reserved.)
+  public var parallelToolCalls: Bool = false
+
   /// Maximum tool calls in one conversation turn. Unset/0 = SDK default
   /// (typically 5).
   public var maxToolCalls: Int32 {
@@ -770,45 +777,50 @@ public nonisolated struct RAToolParseResult: Sendable {
   fileprivate var _errorMessage: String? = nil
 }
 
-public nonisolated struct RAToolPromptFormatRequest: Sendable {
+public nonisolated struct RAToolPromptFormatRequest: @unchecked Sendable {
   // SwiftProtobuf.Message conformance is added in an extension below. See the
   // `Message` and `Message+*Additions` files in the SwiftProtobuf library for
   // methods supported on all messages.
 
   /// User prompt to merge with tool instructions. Empty means return only
   /// the tool-instruction block for the selected format.
-  public var userPrompt: String = String()
+  public var userPrompt: String {
+    get {_storage._userPrompt}
+    set {_uniqueStorage()._userPrompt = newValue}
+  }
 
   /// Carries available tools plus format/choice/iteration constraints.
   public var options: RAToolCallingOptions {
-    get {_options ?? RAToolCallingOptions()}
-    set {_options = newValue}
+    get {_storage._options ?? RAToolCallingOptions()}
+    set {_uniqueStorage()._options = newValue}
   }
   /// Returns true if `options` has been explicitly set.
-  public var hasOptions: Bool {self._options != nil}
+  public var hasOptions: Bool {_storage._options != nil}
   /// Clears the value of `options`. Subsequent reads from it will return its default value.
-  public mutating func clearOptions() {self._options = nil}
+  public mutating func clearOptions() {_uniqueStorage()._options = nil}
 
   /// Tool results to include when formatting a follow-up prompt after host
   /// execution. Empty means an initial tool-enabled prompt.
-  public var toolResults: [RAToolResult] = []
+  public var toolResults: [RAToolResult] {
+    get {_storage._toolResults}
+    set {_uniqueStorage()._toolResults = newValue}
+  }
 
   /// Assistant text emitted before tool execution, when available.
   public var assistantText: String {
-    get {_assistantText ?? String()}
-    set {_assistantText = newValue}
+    get {_storage._assistantText ?? String()}
+    set {_uniqueStorage()._assistantText = newValue}
   }
   /// Returns true if `assistantText` has been explicitly set.
-  public var hasAssistantText: Bool {self._assistantText != nil}
+  public var hasAssistantText: Bool {_storage._assistantText != nil}
   /// Clears the value of `assistantText`. Subsequent reads from it will return its default value.
-  public mutating func clearAssistantText() {self._assistantText = nil}
+  public mutating func clearAssistantText() {_uniqueStorage()._assistantText = nil}
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
 
   public init() {}
 
-  fileprivate var _options: RAToolCallingOptions? = nil
-  fileprivate var _assistantText: String? = nil
+  fileprivate var _storage = _StorageClass.defaultInstance
 }
 
 public nonisolated struct RAToolPromptFormatResult: Sendable {
@@ -1127,6 +1139,15 @@ public nonisolated struct RAToolCallingSessionCreateRequest: @unchecked Sendable
   public var history: [String] {
     get {_storage._history}
     set {_uniqueStorage()._history = newValue}
+  }
+
+  /// Mirrors ToolCallingOptions.parallel_tool_calls for the run-loop /
+  /// session envelope: when true, one model turn may emit multiple
+  /// tool-call envelopes and commons executes all of them before one
+  /// follow-up prompt. Default false = historical single-call behavior.
+  public var parallelToolCalls: Bool {
+    get {_storage._parallelToolCalls}
+    set {_uniqueStorage()._parallelToolCalls = newValue}
   }
 
   public var unknownFields = SwiftProtobuf.UnknownStorage()
@@ -1718,7 +1739,7 @@ nonisolated extension RAToolResult: SwiftProtobuf.Message, SwiftProtobuf._Messag
 
 nonisolated extension RAToolCallingOptions: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ToolCallingOptions"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}tools\0\u{4}\u{2}auto_execute\0\u{1}temperature\0\u{3}max_tokens\0\u{3}system_prompt\0\u{3}replace_system_prompt\0\u{3}keep_tools_available\0\u{2}\u{2}format\0\u{4}\u{2}max_tool_calls\0\u{3}tool_choice\0\u{3}forced_tool_name\0\u{4}\u{2}require_json_arguments\0\u{3}disable_thinking\0\u{c}\u{2}\u{1}\u{c}\u{9}\u{1}\u{c}\u{b}\u{1}\u{c}\u{f}\u{1}")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}tools\0\u{4}\u{2}auto_execute\0\u{1}temperature\0\u{3}max_tokens\0\u{3}system_prompt\0\u{3}replace_system_prompt\0\u{3}keep_tools_available\0\u{2}\u{2}format\0\u{4}\u{2}max_tool_calls\0\u{3}tool_choice\0\u{3}forced_tool_name\0\u{3}parallel_tool_calls\0\u{3}require_json_arguments\0\u{3}disable_thinking\0\u{c}\u{2}\u{1}\u{c}\u{9}\u{1}\u{c}\u{b}\u{1}")
 
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
     while let fieldNumber = try decoder.nextFieldNumber() {
@@ -1737,6 +1758,7 @@ nonisolated extension RAToolCallingOptions: SwiftProtobuf.Message, SwiftProtobuf
       case 12: try { try decoder.decodeSingularInt32Field(value: &self._maxToolCalls) }()
       case 13: try { try decoder.decodeSingularEnumField(value: &self.toolChoice) }()
       case 14: try { try decoder.decodeSingularStringField(value: &self._forcedToolName) }()
+      case 15: try { try decoder.decodeSingularBoolField(value: &self.parallelToolCalls) }()
       case 16: try { try decoder.decodeSingularBoolField(value: &self.requireJsonArguments) }()
       case 17: try { try decoder.decodeSingularBoolField(value: &self._disableThinking) }()
       default: break
@@ -1782,6 +1804,9 @@ nonisolated extension RAToolCallingOptions: SwiftProtobuf.Message, SwiftProtobuf
     try { if let v = self._forcedToolName {
       try visitor.visitSingularStringField(value: v, fieldNumber: 14)
     } }()
+    if self.parallelToolCalls != false {
+      try visitor.visitSingularBoolField(value: self.parallelToolCalls, fieldNumber: 15)
+    }
     if self.requireJsonArguments != false {
       try visitor.visitSingularBoolField(value: self.requireJsonArguments, fieldNumber: 16)
     }
@@ -1800,6 +1825,7 @@ nonisolated extension RAToolCallingOptions: SwiftProtobuf.Message, SwiftProtobuf
     if lhs.replaceSystemPrompt != rhs.replaceSystemPrompt {return false}
     if lhs.keepToolsAvailable != rhs.keepToolsAvailable {return false}
     if lhs._format != rhs._format {return false}
+    if lhs.parallelToolCalls != rhs.parallelToolCalls {return false}
     if lhs._maxToolCalls != rhs._maxToolCalls {return false}
     if lhs.toolChoice != rhs.toolChoice {return false}
     if lhs._forcedToolName != rhs._forcedToolName {return false}
@@ -1986,46 +2012,88 @@ nonisolated extension RAToolPromptFormatRequest: SwiftProtobuf.Message, SwiftPro
   public static let protoMessageName: String = _protobuf_package + ".ToolPromptFormatRequest"
   public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{3}user_prompt\0\u{1}options\0\u{3}tool_results\0\u{3}assistant_text\0")
 
+  fileprivate class _StorageClass {
+    var _userPrompt: String = String()
+    var _options: RAToolCallingOptions? = nil
+    var _toolResults: [RAToolResult] = []
+    var _assistantText: String? = nil
+
+      // This property is used as the initial default value for new instances of the type.
+      // The type itself is protecting the reference to its storage via CoW semantics.
+      // This will force a copy to be made of this reference when the first mutation occurs;
+      // hence, it is safe to mark this as `nonisolated(unsafe)`.
+      static nonisolated(unsafe) let defaultInstance = _StorageClass()
+
+    private init() {}
+
+    init(copying source: _StorageClass) {
+      _userPrompt = source._userPrompt
+      _options = source._options
+      _toolResults = source._toolResults
+      _assistantText = source._assistantText
+    }
+  }
+
+  fileprivate mutating func _uniqueStorage() -> _StorageClass {
+    if !isKnownUniquelyReferenced(&_storage) {
+      _storage = _StorageClass(copying: _storage)
+    }
+    return _storage
+  }
+
   public mutating func decodeMessage<D: SwiftProtobuf.Decoder>(decoder: inout D) throws {
-    while let fieldNumber = try decoder.nextFieldNumber() {
-      // The use of inline closures is to circumvent an issue where the compiler
-      // allocates stack space for every case branch when no optimizations are
-      // enabled. https://github.com/apple/swift-protobuf/issues/1034
-      switch fieldNumber {
-      case 1: try { try decoder.decodeSingularStringField(value: &self.userPrompt) }()
-      case 2: try { try decoder.decodeSingularMessageField(value: &self._options) }()
-      case 3: try { try decoder.decodeRepeatedMessageField(value: &self.toolResults) }()
-      case 4: try { try decoder.decodeSingularStringField(value: &self._assistantText) }()
-      default: break
+    _ = _uniqueStorage()
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      while let fieldNumber = try decoder.nextFieldNumber() {
+        // The use of inline closures is to circumvent an issue where the compiler
+        // allocates stack space for every case branch when no optimizations are
+        // enabled. https://github.com/apple/swift-protobuf/issues/1034
+        switch fieldNumber {
+        case 1: try { try decoder.decodeSingularStringField(value: &_storage._userPrompt) }()
+        case 2: try { try decoder.decodeSingularMessageField(value: &_storage._options) }()
+        case 3: try { try decoder.decodeRepeatedMessageField(value: &_storage._toolResults) }()
+        case 4: try { try decoder.decodeSingularStringField(value: &_storage._assistantText) }()
+        default: break
+        }
       }
     }
   }
 
   public func traverse<V: SwiftProtobuf.Visitor>(visitor: inout V) throws {
-    // The use of inline closures is to circumvent an issue where the compiler
-    // allocates stack space for every if/case branch local when no optimizations
-    // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
-    // https://github.com/apple/swift-protobuf/issues/1182
-    if !self.userPrompt.isEmpty {
-      try visitor.visitSingularStringField(value: self.userPrompt, fieldNumber: 1)
+    try withExtendedLifetime(_storage) { (_storage: _StorageClass) in
+      // The use of inline closures is to circumvent an issue where the compiler
+      // allocates stack space for every if/case branch local when no optimizations
+      // are enabled. https://github.com/apple/swift-protobuf/issues/1034 and
+      // https://github.com/apple/swift-protobuf/issues/1182
+      if !_storage._userPrompt.isEmpty {
+        try visitor.visitSingularStringField(value: _storage._userPrompt, fieldNumber: 1)
+      }
+      try { if let v = _storage._options {
+        try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
+      } }()
+      if !_storage._toolResults.isEmpty {
+        try visitor.visitRepeatedMessageField(value: _storage._toolResults, fieldNumber: 3)
+      }
+      try { if let v = _storage._assistantText {
+        try visitor.visitSingularStringField(value: v, fieldNumber: 4)
+      } }()
     }
-    try { if let v = self._options {
-      try visitor.visitSingularMessageField(value: v, fieldNumber: 2)
-    } }()
-    if !self.toolResults.isEmpty {
-      try visitor.visitRepeatedMessageField(value: self.toolResults, fieldNumber: 3)
-    }
-    try { if let v = self._assistantText {
-      try visitor.visitSingularStringField(value: v, fieldNumber: 4)
-    } }()
     try unknownFields.traverse(visitor: &visitor)
   }
 
   public static func ==(lhs: RAToolPromptFormatRequest, rhs: RAToolPromptFormatRequest) -> Bool {
-    if lhs.userPrompt != rhs.userPrompt {return false}
-    if lhs._options != rhs._options {return false}
-    if lhs.toolResults != rhs.toolResults {return false}
-    if lhs._assistantText != rhs._assistantText {return false}
+    if lhs._storage !== rhs._storage {
+      let storagesAreEqual: Bool = withExtendedLifetime((lhs._storage, rhs._storage)) { (_args: (_StorageClass, _StorageClass)) in
+        let _storage = _args.0
+        let rhs_storage = _args.1
+        if _storage._userPrompt != rhs_storage._userPrompt {return false}
+        if _storage._options != rhs_storage._options {return false}
+        if _storage._toolResults != rhs_storage._toolResults {return false}
+        if _storage._assistantText != rhs_storage._assistantText {return false}
+        return true
+      }
+      if !storagesAreEqual {return false}
+    }
     if lhs.unknownFields != rhs.unknownFields {return false}
     return true
   }
@@ -2386,7 +2454,7 @@ nonisolated extension RAToolRegistrySnapshot: SwiftProtobuf.Message, SwiftProtob
 
 nonisolated extension RAToolCallingSessionCreateRequest: SwiftProtobuf.Message, SwiftProtobuf._MessageImplementationBase, SwiftProtobuf._ProtoNameProviding {
   public static let protoMessageName: String = _protobuf_package + ".ToolCallingSessionCreateRequest"
-  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}prompt\0\u{1}tools\0\u{1}format\0\u{3}max_tool_calls\0\u{3}keep_tools_available\0\u{3}validate_calls\0\u{3}tool_choice\0\u{3}forced_tool_name\0\u{4}\u{3}max_tokens\0\u{1}temperature\0\u{3}top_p\0\u{3}system_prompt\0\u{3}disable_thinking\0\u{3}auto_execute\0\u{3}replace_system_prompt\0\u{3}require_json_arguments\0\u{1}history\0\u{c}\u{9}\u{2}")
+  public static let _protobuf_nameMap = SwiftProtobuf._NameMap(bytecode: "\0\u{1}prompt\0\u{1}tools\0\u{1}format\0\u{3}max_tool_calls\0\u{3}keep_tools_available\0\u{3}validate_calls\0\u{3}tool_choice\0\u{3}forced_tool_name\0\u{4}\u{3}max_tokens\0\u{1}temperature\0\u{3}top_p\0\u{3}system_prompt\0\u{3}disable_thinking\0\u{3}auto_execute\0\u{3}replace_system_prompt\0\u{3}require_json_arguments\0\u{1}history\0\u{3}parallel_tool_calls\0\u{c}\u{9}\u{2}")
 
   fileprivate class _StorageClass {
     var _prompt: String = String()
@@ -2406,6 +2474,7 @@ nonisolated extension RAToolCallingSessionCreateRequest: SwiftProtobuf.Message, 
     var _replaceSystemPrompt: Bool = false
     var _requireJsonArguments: Bool = false
     var _history: [String] = []
+    var _parallelToolCalls: Bool = false
 
       // This property is used as the initial default value for new instances of the type.
       // The type itself is protecting the reference to its storage via CoW semantics.
@@ -2433,6 +2502,7 @@ nonisolated extension RAToolCallingSessionCreateRequest: SwiftProtobuf.Message, 
       _replaceSystemPrompt = source._replaceSystemPrompt
       _requireJsonArguments = source._requireJsonArguments
       _history = source._history
+      _parallelToolCalls = source._parallelToolCalls
     }
   }
 
@@ -2468,6 +2538,7 @@ nonisolated extension RAToolCallingSessionCreateRequest: SwiftProtobuf.Message, 
         case 17: try { try decoder.decodeSingularBoolField(value: &_storage._replaceSystemPrompt) }()
         case 18: try { try decoder.decodeSingularBoolField(value: &_storage._requireJsonArguments) }()
         case 19: try { try decoder.decodeRepeatedStringField(value: &_storage._history) }()
+        case 20: try { try decoder.decodeSingularBoolField(value: &_storage._parallelToolCalls) }()
         default: break
         }
       }
@@ -2531,6 +2602,9 @@ nonisolated extension RAToolCallingSessionCreateRequest: SwiftProtobuf.Message, 
       if !_storage._history.isEmpty {
         try visitor.visitRepeatedStringField(value: _storage._history, fieldNumber: 19)
       }
+      if _storage._parallelToolCalls != false {
+        try visitor.visitSingularBoolField(value: _storage._parallelToolCalls, fieldNumber: 20)
+      }
     }
     try unknownFields.traverse(visitor: &visitor)
   }
@@ -2557,6 +2631,7 @@ nonisolated extension RAToolCallingSessionCreateRequest: SwiftProtobuf.Message, 
         if _storage._replaceSystemPrompt != rhs_storage._replaceSystemPrompt {return false}
         if _storage._requireJsonArguments != rhs_storage._requireJsonArguments {return false}
         if _storage._history != rhs_storage._history {return false}
+        if _storage._parallelToolCalls != rhs_storage._parallelToolCalls {return false}
         return true
       }
       if !storagesAreEqual {return false}

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+ToolCalling.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+ToolCalling.swift
@@ -253,6 +253,11 @@ public extension RunAnywhere {
         toolChoice: RAToolChoiceMode? = nil,
         forcedToolName: String? = nil,
         validateCalls: Bool? = nil,
+        // TC-2: when true, one model turn may request multiple tools; commons
+        // executes the whole batch before one follow-up prompt instead of
+        // one LLM round-trip per tool. Default false preserves the
+        // historical single-call-per-turn behavior.
+        parallelToolCalls: Bool? = nil,
         history: [String] = []
     ) async throws -> RAToolCallingResult {
         guard isInitialized else {
@@ -266,6 +271,9 @@ public extension RunAnywhere {
         }
         if let forcedToolName {
             tcOpts.forcedToolName = forcedToolName
+        }
+        if let parallelToolCalls {
+            tcOpts.parallelToolCalls = parallelToolCalls
         }
         let registeredTools = await ToolRegistry.shared.getAll()
         let tools = tcOpts.tools.isEmpty ? registeredTools : tcOpts.tools
@@ -433,6 +441,11 @@ public extension RunAnywhere {
         request.replaceSystemPrompt = toolOptions.replaceSystemPrompt
         request.requireJsonArguments = toolOptions.requireJsonArguments
         request.keepToolsAvailable = toolOptions.keepToolsAvailable
+        // TC-2: mirrors ToolCallingOptions.parallelToolCalls onto the
+        // session-create envelope (proto field 20) — the run-loop reads
+        // parallel_tool_calls from THIS request, not from the inline
+        // ToolCallingOptions snapshot.
+        request.parallelToolCalls = toolOptions.parallelToolCalls
         // `validate_calls` is `optional bool` on the proto so
         // hosts that delegate validation/authorization to their executor (or
         // use dynamic tool registries where argument inspection happens

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+WebSearchTool.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+WebSearchTool.swift
@@ -25,7 +25,23 @@ public extension RunAnywhere {
 private enum WebSearchTool {
     private enum Tool {
         static let name = "search_web"
-        static let description = "Searches the web for current information using DuckDuckGo Instant Answer API"
+        // Directive, not just descriptive: under AUTO tool_choice the model
+        // decides on its own whether to call a tool, so the wording itself
+        // is what makes that decision reliable. Explicitly naming the
+        // trigger conditions (recency, post-cutoff events, prices, live
+        // data) measurably improves AUTO-mode call rate versus a purely
+        // descriptive sentence — this is the Perplexity-style "does the
+        // question need current info" heuristic, expressed in the one
+        // channel the model actually reads.
+        static let description = """
+            Searches the live web via DuckDuckGo. Call this whenever the question needs \
+            information that could have changed after your training data, or that you are \
+            not certain about: current events or news, today's date or "latest"/"current"/\
+            "recent" anything, prices, scores, weather (if no weather tool is available), \
+            release dates, or facts about people/products/versions newer than your \
+            knowledge. Do not call this for general knowledge, definitions, math, or \
+            anything you already know with confidence.
+            """
         static let category = "Web"
     }
 

--- a/sdk/runanywhere-web/packages/core/src/Public/Extensions/RunAnywhere+ToolCalling.ts
+++ b/sdk/runanywhere-web/packages/core/src/Public/Extensions/RunAnywhere+ToolCalling.ts
@@ -469,6 +469,10 @@ function buildSessionCreateRequest(
     // these into every generate in the session loop so multi-turn tool use keeps
     // context — Kotlin parity (makeToolCallingRunLoopRequest history param).
     history: extra.history ?? [],
+    // TC-2: mirror options onto request field 20 — commons reads parallel
+    // mode from the session/run-loop request, not from inline options alone.
+    // Swift parity: RunAnywhere+ToolCalling.swift makeRunLoopRequest.
+    parallelToolCalls: effectiveOptions.parallelToolCalls ?? false,
   });
   return ToolCallingSessionCreateRequestMessage.encode(request).finish();
 }

--- a/sdk/shared/proto-ts/dist/tool_calling.d.ts
+++ b/sdk/shared/proto-ts/dist/tool_calling.d.ts
@@ -216,6 +216,14 @@ export interface ToolCallingOptions {
     /** Typed tool-call format. Unset lets commons select the model default. */
     format?: ToolCallFormatName | undefined;
     /**
+     * When true, one model turn may emit multiple tool-call envelopes;
+     * commons parses and executes all of them before building a single
+     * follow-up prompt. Default false preserves the historical
+     * one-call-per-turn behavior. (Reclaims the field number that
+     * originally carried this flag before it was reserved.)
+     */
+    parallelToolCalls: boolean;
+    /**
      * Maximum tool calls in one conversation turn. Unset/0 = SDK default
      * (typically 5).
      */
@@ -370,6 +378,13 @@ export interface ToolCallingSessionCreateRequest {
      * cross-proto import cycle.
      */
     history: string[];
+    /**
+     * Mirrors ToolCallingOptions.parallel_tool_calls for the run-loop /
+     * session envelope: when true, one model turn may emit multiple
+     * tool-call envelopes and commons executes all of them before one
+     * follow-up prompt. Default false = historical single-call behavior.
+     */
+    parallelToolCalls: boolean;
 }
 export interface ToolCallingSessionCreateResult {
     sessionHandle: number;

--- a/sdk/shared/proto-ts/dist/tool_calling.js
+++ b/sdk/shared/proto-ts/dist/tool_calling.js
@@ -1342,6 +1342,7 @@ function createBaseToolCallingOptions() {
         replaceSystemPrompt: false,
         keepToolsAvailable: false,
         format: undefined,
+        parallelToolCalls: false,
         maxToolCalls: undefined,
         toolChoice: 0,
         forcedToolName: undefined,
@@ -1374,6 +1375,9 @@ exports.ToolCallingOptions = {
         }
         if (message.format !== undefined) {
             writer.uint32(80).int32(message.format);
+        }
+        if (message.parallelToolCalls !== false) {
+            writer.uint32(120).bool(message.parallelToolCalls);
         }
         if (message.maxToolCalls !== undefined) {
             writer.uint32(96).int32(message.maxToolCalls);
@@ -1455,6 +1459,13 @@ exports.ToolCallingOptions = {
                     message.format = reader.int32();
                     continue;
                 }
+                case 15: {
+                    if (tag !== 120) {
+                        break;
+                    }
+                    message.parallelToolCalls = reader.bool();
+                    continue;
+                }
                 case 12: {
                     if (tag !== 96) {
                         break;
@@ -1528,6 +1539,11 @@ exports.ToolCallingOptions = {
                     ? globalThis.Boolean(object.keep_tools_available)
                     : false,
             format: isSet(object.format) ? toolCallFormatNameFromJSON(object.format) : undefined,
+            parallelToolCalls: isSet(object.parallelToolCalls)
+                ? globalThis.Boolean(object.parallelToolCalls)
+                : isSet(object.parallel_tool_calls)
+                    ? globalThis.Boolean(object.parallel_tool_calls)
+                    : false,
             maxToolCalls: isSet(object.maxToolCalls)
                 ? globalThis.Number(object.maxToolCalls)
                 : isSet(object.max_tool_calls)
@@ -1581,6 +1597,9 @@ exports.ToolCallingOptions = {
         if (message.format !== undefined) {
             obj.format = toolCallFormatNameToJSON(message.format);
         }
+        if (message.parallelToolCalls !== false) {
+            obj.parallelToolCalls = message.parallelToolCalls;
+        }
         if (message.maxToolCalls !== undefined) {
             obj.maxToolCalls = Math.round(message.maxToolCalls);
         }
@@ -1611,6 +1630,7 @@ exports.ToolCallingOptions = {
         message.replaceSystemPrompt = object.replaceSystemPrompt ?? false;
         message.keepToolsAvailable = object.keepToolsAvailable ?? false;
         message.format = object.format ?? undefined;
+        message.parallelToolCalls = object.parallelToolCalls ?? false;
         message.maxToolCalls = object.maxToolCalls ?? undefined;
         message.toolChoice = object.toolChoice ?? 0;
         message.forcedToolName = object.forcedToolName ?? undefined;
@@ -2836,6 +2856,7 @@ function createBaseToolCallingSessionCreateRequest() {
         replaceSystemPrompt: false,
         requireJsonArguments: false,
         history: [],
+        parallelToolCalls: false,
     };
 }
 exports.ToolCallingSessionCreateRequest = {
@@ -2890,6 +2911,9 @@ exports.ToolCallingSessionCreateRequest = {
         }
         for (const v of message.history) {
             writer.uint32(154).string(v);
+        }
+        if (message.parallelToolCalls !== false) {
+            writer.uint32(160).bool(message.parallelToolCalls);
         }
         return writer;
     },
@@ -3019,6 +3043,13 @@ exports.ToolCallingSessionCreateRequest = {
                     message.history.push(reader.string());
                     continue;
                 }
+                case 20: {
+                    if (tag !== 160) {
+                        break;
+                    }
+                    message.parallelToolCalls = reader.bool();
+                    continue;
+                }
             }
             if ((tag & 7) === 4 || tag === 0) {
                 break;
@@ -3098,6 +3129,11 @@ exports.ToolCallingSessionCreateRequest = {
             history: globalThis.Array.isArray(object?.history)
                 ? object.history.map((e) => globalThis.String(e))
                 : [],
+            parallelToolCalls: isSet(object.parallelToolCalls)
+                ? globalThis.Boolean(object.parallelToolCalls)
+                : isSet(object.parallel_tool_calls)
+                    ? globalThis.Boolean(object.parallel_tool_calls)
+                    : false,
         };
     },
     toJSON(message) {
@@ -3153,6 +3189,9 @@ exports.ToolCallingSessionCreateRequest = {
         if (message.history?.length) {
             obj.history = message.history;
         }
+        if (message.parallelToolCalls !== false) {
+            obj.parallelToolCalls = message.parallelToolCalls;
+        }
         return obj;
     },
     create(base) {
@@ -3177,6 +3216,7 @@ exports.ToolCallingSessionCreateRequest = {
         message.replaceSystemPrompt = object.replaceSystemPrompt ?? false;
         message.requireJsonArguments = object.requireJsonArguments ?? false;
         message.history = object.history?.map((e) => e) || [];
+        message.parallelToolCalls = object.parallelToolCalls ?? false;
         return message;
     },
 };

--- a/sdk/shared/proto-ts/src/tool_calling.ts
+++ b/sdk/shared/proto-ts/src/tool_calling.ts
@@ -412,6 +412,14 @@ export interface ToolCallingOptions {
     | ToolCallFormatName
     | undefined;
   /**
+   * When true, one model turn may emit multiple tool-call envelopes;
+   * commons parses and executes all of them before building a single
+   * follow-up prompt. Default false preserves the historical
+   * one-call-per-turn behavior. (Reclaims the field number that
+   * originally carried this flag before it was reserved.)
+   */
+  parallelToolCalls: boolean;
+  /**
    * Maximum tool calls in one conversation turn. Unset/0 = SDK default
    * (typically 5).
    */
@@ -586,6 +594,13 @@ export interface ToolCallingSessionCreateRequest {
    * cross-proto import cycle.
    */
   history: string[];
+  /**
+   * Mirrors ToolCallingOptions.parallel_tool_calls for the run-loop /
+   * session envelope: when true, one model turn may emit multiple
+   * tool-call envelopes and commons executes all of them before one
+   * follow-up prompt. Default false = historical single-call behavior.
+   */
+  parallelToolCalls: boolean;
 }
 
 export interface ToolCallingSessionCreateResult {
@@ -1838,6 +1853,7 @@ function createBaseToolCallingOptions(): ToolCallingOptions {
     replaceSystemPrompt: false,
     keepToolsAvailable: false,
     format: undefined,
+    parallelToolCalls: false,
     maxToolCalls: undefined,
     toolChoice: 0,
     forcedToolName: undefined,
@@ -1871,6 +1887,9 @@ export const ToolCallingOptions: MessageFns<ToolCallingOptions> = {
     }
     if (message.format !== undefined) {
       writer.uint32(80).int32(message.format);
+    }
+    if (message.parallelToolCalls !== false) {
+      writer.uint32(120).bool(message.parallelToolCalls);
     }
     if (message.maxToolCalls !== undefined) {
       writer.uint32(96).int32(message.maxToolCalls);
@@ -1961,6 +1980,14 @@ export const ToolCallingOptions: MessageFns<ToolCallingOptions> = {
           message.format = reader.int32() as any;
           continue;
         }
+        case 15: {
+          if (tag !== 120) {
+            break;
+          }
+
+          message.parallelToolCalls = reader.bool();
+          continue;
+        }
         case 12: {
           if (tag !== 96) {
             break;
@@ -2040,6 +2067,11 @@ export const ToolCallingOptions: MessageFns<ToolCallingOptions> = {
         ? globalThis.Boolean(object.keep_tools_available)
         : false,
       format: isSet(object.format) ? toolCallFormatNameFromJSON(object.format) : undefined,
+      parallelToolCalls: isSet(object.parallelToolCalls)
+        ? globalThis.Boolean(object.parallelToolCalls)
+        : isSet(object.parallel_tool_calls)
+        ? globalThis.Boolean(object.parallel_tool_calls)
+        : false,
       maxToolCalls: isSet(object.maxToolCalls)
         ? globalThis.Number(object.maxToolCalls)
         : isSet(object.max_tool_calls)
@@ -2094,6 +2126,9 @@ export const ToolCallingOptions: MessageFns<ToolCallingOptions> = {
     if (message.format !== undefined) {
       obj.format = toolCallFormatNameToJSON(message.format);
     }
+    if (message.parallelToolCalls !== false) {
+      obj.parallelToolCalls = message.parallelToolCalls;
+    }
     if (message.maxToolCalls !== undefined) {
       obj.maxToolCalls = Math.round(message.maxToolCalls);
     }
@@ -2125,6 +2160,7 @@ export const ToolCallingOptions: MessageFns<ToolCallingOptions> = {
     message.replaceSystemPrompt = object.replaceSystemPrompt ?? false;
     message.keepToolsAvailable = object.keepToolsAvailable ?? false;
     message.format = object.format ?? undefined;
+    message.parallelToolCalls = object.parallelToolCalls ?? false;
     message.maxToolCalls = object.maxToolCalls ?? undefined;
     message.toolChoice = object.toolChoice ?? 0;
     message.forcedToolName = object.forcedToolName ?? undefined;
@@ -3450,6 +3486,7 @@ function createBaseToolCallingSessionCreateRequest(): ToolCallingSessionCreateRe
     replaceSystemPrompt: false,
     requireJsonArguments: false,
     history: [],
+    parallelToolCalls: false,
   };
 }
 
@@ -3505,6 +3542,9 @@ export const ToolCallingSessionCreateRequest: MessageFns<ToolCallingSessionCreat
     }
     for (const v of message.history) {
       writer.uint32(154).string(v!);
+    }
+    if (message.parallelToolCalls !== false) {
+      writer.uint32(160).bool(message.parallelToolCalls);
     }
     return writer;
   },
@@ -3652,6 +3692,14 @@ export const ToolCallingSessionCreateRequest: MessageFns<ToolCallingSessionCreat
           message.history.push(reader.string());
           continue;
         }
+        case 20: {
+          if (tag !== 160) {
+            break;
+          }
+
+          message.parallelToolCalls = reader.bool();
+          continue;
+        }
       }
       if ((tag & 7) === 4 || tag === 0) {
         break;
@@ -3732,6 +3780,11 @@ export const ToolCallingSessionCreateRequest: MessageFns<ToolCallingSessionCreat
       history: globalThis.Array.isArray(object?.history)
         ? object.history.map((e: any) => globalThis.String(e))
         : [],
+      parallelToolCalls: isSet(object.parallelToolCalls)
+        ? globalThis.Boolean(object.parallelToolCalls)
+        : isSet(object.parallel_tool_calls)
+        ? globalThis.Boolean(object.parallel_tool_calls)
+        : false,
     };
   },
 
@@ -3788,6 +3841,9 @@ export const ToolCallingSessionCreateRequest: MessageFns<ToolCallingSessionCreat
     if (message.history?.length) {
       obj.history = message.history;
     }
+    if (message.parallelToolCalls !== false) {
+      obj.parallelToolCalls = message.parallelToolCalls;
+    }
     return obj;
   },
 
@@ -3815,6 +3871,7 @@ export const ToolCallingSessionCreateRequest: MessageFns<ToolCallingSessionCreat
     message.replaceSystemPrompt = object.replaceSystemPrompt ?? false;
     message.requireJsonArguments = object.requireJsonArguments ?? false;
     message.history = object.history?.map((e) => e) || [];
+    message.parallelToolCalls = object.parallelToolCalls ?? false;
     return message;
   },
 };


### PR DESCRIPTION
## Summary
Continuation of #574 (closed) on `shubham/tool-calling-agents`.

- Grammar-constrained tool-call decoding (llamacpp GBNF + qhexrt)
- Parallel tool calls (+ stutter/repetition guard)
- Agent-loop wiring for tools-bearing configs
- iOS Health/Calendar example tools + grounding fixes

## Note
Conflicts with current `main` (overlapping RUN-80 grammar work) — will rebase/resolve in follow-up commits.

## Test plan
- [ ] Rebase onto `main` and resolve grammar-path conflicts
- [ ] Commons tool_calling / agent_loop tests green
- [ ] CI matrix green


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added iOS tool support for Apple Health (`get_health_data`) and Calendar (`get_calendar_events`), including required entitlements and Privacy usage strings.
  * Added tool-enabled agent loop support (`agent_loop`) when tools are configured.
  * Enabled parallel tool calls across the SDKs so multiple tool requests can run within a single turn.

* **Enhancements**
  * Improved tool-call safety/date grounding and tightened current-time + web-search guidance.
  * Updated tool settings with persisted Health/Calendar toggles and authorization error feedback (iOS-only Health; Calendar on macOS too).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->