### PR TITLE
fix(flutter): stop deleteAllModels from reporting success when listing fails

### DIFF
--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/public/capabilities/runanywhere_downloads.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/public/capabilities/runanywhere_downloads.dart
@@ -281,12 +281,23 @@ class RunAnywhereDownloads {
     if (!DartBridge.isInitialized) {
       throw SDKException.notInitialized();
     }
-    final metrics = await list();
+    // Read the models through the result-bearing API rather than `list()`:
+    // `list()` reports a failed lookup as an empty list, which would become a
+    // delete request carrying no model ids. Commons no-ops on that and reports
+    // no error, so the caller is told a destructive operation succeeded when
+    // nothing was examined, let alone deleted.
+    final infoResult = await getStorageInfoResult(
+      StorageInfoRequest(includeModels: true),
+    );
+    if (infoResult.hasError()) {
+      return StorageDeleteResult(error: infoResult.error);
+    }
+
     // `delete_files` was renamed with an inverted polarity to
     // `keep_files_on_disk` (idl/storage_types.proto) — see [delete].
     return DartBridgeStorage.instance.deleteProto(
       StorageDeleteRequest(
-        modelIds: metrics.map((m) => m.modelId),
+        modelIds: infoResult.info.models.map((m) => m.modelId),
         clearRegistryPaths: true,
         unloadIfLoaded: true,
         allowPlatformDelete: true,


### PR DESCRIPTION
## What

`RunAnywhereDownloads.deleteAllModels()` built its delete request from `list()`, which reports a failed storage lookup as an empty list. When the lookup failed, the request went out with **no model ids**, commons had nothing to delete, and the caller received `StorageDeleteResult(success: true)` having deleted nothing.

This changes only the destructive path to read through `getStorageInfoResult()`, which carries `success` / `error_message` (`storage_types.proto`), and to surface a failed lookup as `StorageDeleteResult(success: false)` with the underlying message.

## Why

A silent no-op is the worst outcome for a destructive call: a caller that asks to free space is told it succeeded while every model is still on disk, and there is nothing in the return value to retry on. `list()` already logs the failure, but the log is not visible to the caller and the `[]` is indistinguishable from "no models are downloaded".

`list()` keeps its tolerant empty-list contract — display callers such as the example app's storage view (`storage_view.dart`) legitimately want a list they can render. Only the delete path now requires a successful lookup before it acts.

## Scope

- One file, +17/-2. No API signature changes, no new types, no behavior change when the lookup succeeds.
- No unit test added, per CONTRIBUTING's E2E-through-the-example-apps convention.

## Testing

From `sdk/runanywhere-flutter/packages/runanywhere` (Flutter 3.44.6):
- `flutter pub get` — OK
- `flutter analyze --no-pub` — `No issues found!`

Rebased onto current `main` (`3becbae55`) and re-gated after the rebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when deleting all downloaded models by validating storage information first.
  * Deletion now reports a failure if storage details cannot be retrieved, rather than indicating success without removing models.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->