### PR TITLE
fix(ci): unbreak the ktlint and SwiftLint gates that are red on main

### DIFF
--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/foundation/connect/AndroidConnectTransport.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/foundation/connect/AndroidConnectTransport.kt
@@ -446,6 +446,7 @@ internal class AndroidConnectSocket(
         const val HANDSHAKE_TIMEOUT_MS = 5_000
         const val HEARTBEAT_INTERVAL_MS = 3_000L
         const val HEARTBEAT_TIMEOUT_MS = 2_000
+
         /** Generous inter-frame timeout so a stalled host is visible without false positives. */
         val GENERATION_READ_TIMEOUT_MS = RADefaults.Connect.GENERATION_READ_TIMEOUT_MS
     }

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Connect/ConnectSession.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Connect/ConnectSession.swift
@@ -282,7 +282,11 @@ public final class ConnectSession: ObservableObject {
                         "Timed out connecting to \(hostDisplayName)."
                     )
                 }
-                let value = try await group.next()!
+                guard let value = try await group.next() else {
+                    throw ConnectTransportError.network(
+                        "Connecting to \(hostDisplayName) finished without a response."
+                    )
+                }
                 group.cancelAll()
                 return value
             }


### PR DESCRIPTION
## What

Two one-line lint fixes, both for violations that currently fail CI on `main`. Both were introduced by #604 (merged 2026-07-30); nothing else in that PR's behaviour is touched.

**1. `kotlin-android` — `ktlintMainSourceSetCheck`**

```
AndroidConnectTransport.kt:449:9 Declarations and declarations with comments
should have an empty space between. (standard:spacing-between-declarations-with-comments)
```

The KDoc on `GENERATION_READ_TIMEOUT_MS` sits directly against the preceding `const val` in the companion object. Added the blank line ktlint asks for.

**2. `swift-spm` — SwiftLint (error-level rule)**

```
ConnectSession.swift:285:51: error: Force Unwrapping Violation:
Force unwrapping should be avoided (force_unwrapping)
```

`try await group.next()!` force-unwraps the first result of the connect/timeout task group. Replaced with a `guard` that throws the same `ConnectTransportError.network` the timeout child task already throws, so the race-the-handshake behaviour is unchanged on the real path.

## Why

These are not branch-specific — they redden CI for every PR on current `main`:

- `main`'s own `pr-build` run at `3becbae5` is failing.
- `swift-spm` is currently red on #600, #588 and #608; `kotlin-android` on #588 and #608.
- #608 is a Dart-only change and fails both jobs purely by inheritance.

Grouped in one PR because the concern is identical (unbreak the lint gates) and merging only half of it still leaves CI red.

## Testing

- `./gradlew ktlintMainSourceSetCheck` in `sdk/runanywhere-kotlin` (JDK 17) — **BUILD SUCCESSFUL**. Re-run with the change stashed — **BUILD FAILED** on exactly the line above, confirming this is the fix.
- `kotlin-android` already passed on this PR's first commit in CI.
- Swift: **I could not run SwiftLint locally** — this host has only the Command Line Tools, and SwiftLint 0.65 aborts loading `sourcekitdInProc`. I verified `swiftc -parse` on the file is clean and that no force unwrap remains, and am relying on CI's `swift-spm` job for the authoritative lint check. Flagging that explicitly rather than implying a gate I did not run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved connection handling by safely reporting network errors when a connection attempt does not return a result.
  * Reduced the risk of unexpected failures during connection races.

* **Style**
  * Improved code formatting for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->