### PR TITLE
feat(ios): offline Notes with on-device capture and digest

### DIFF
--- a/examples/ios/RunAnywhereAI/.swiftlint.yml
+++ b/examples/ios/RunAnywhereAI/.swiftlint.yml
@@ -38,7 +38,8 @@ opt_in_rules:
 # Directories to include
 included:
   - RunAnywhereAI
-  - RunAnywhereAITests
+  - RunAnywhereActivityExtension
+  - RunAnywhereAIUnitTests
   - RunAnywhereAIUITests
 
 # Directories to exclude

--- a/examples/ios/RunAnywhereAI/Package.swift
+++ b/examples/ios/RunAnywhereAI/Package.swift
@@ -68,6 +68,13 @@ let package = Package(
             name: "RunAnywhereAITests",
             dependencies: ["RunAnywhereAI"],
             path: "RunAnywhereAIUITests"
+        ),
+        // Pure app-logic tests (model routing, records, retention). Kept out of
+        // the UI test target so they run without a simulator.
+        .testTarget(
+            name: "RunAnywhereAIUnitTests",
+            dependencies: ["RunAnywhereAI"],
+            path: "RunAnywhereAIUnitTests"
         )
     ]
 )

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI.xcodeproj/project.pbxproj
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI.xcodeproj/project.pbxproj
@@ -18,6 +18,10 @@
 		58LLAMACPP12ED16DA40058D0 /* RunAnywhereLlamaCPP in Frameworks */ = {isa = PBXBuildFile; productRef = 58LLAMACPP02ED16DA40058D0 /* RunAnywhereLlamaCPP */; };
 		58MLX00012ED16DA40058D0 /* RunAnywhereMLX in Frameworks */ = {isa = PBXBuildFile; productRef = 58MLX00002ED16DA40058D0 /* RunAnywhereMLX */; };
 		RACACTIVITY01ACTIVITY01RAC /* DictationActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = RACACTIVITY02ACTIVITY02RAC /* DictationActivityAttributes.swift */; };
+		RACAMBIENT01AMBIENT01RAC /* AmbientActivityAttributes.swift in Sources */ = {isa = PBXBuildFile; fileRef = RACAMBIENT02AMBIENT02RAC /* AmbientActivityAttributes.swift */; };
+		RACAMBIENT03AMBIENT03RAC /* AmbientStopIntent.swift in Sources */ = {isa = PBXBuildFile; fileRef = RACAMBIENT04AMBIENT04RAC /* AmbientStopIntent.swift */; };
+		RACAMBIENT05AMBIENT05RAC /* SharedConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = RACSHARED02RACSHARED02RACS /* SharedConstants.swift */; };
+		RACAMBIENT06AMBIENT06RAC /* SharedDataBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = RACSHARED04RACSHARED04RACS /* SharedDataBridge.swift */; };
 		RACSHARED01RACSHARED01RACS /* SharedConstants.swift in Sources */ = {isa = PBXBuildFile; fileRef = RACSHARED02RACSHARED02RACS /* SharedConstants.swift */; };
 		RACSHARED03RACSHARED03RACS /* SharedDataBridge.swift in Sources */ = {isa = PBXBuildFile; fileRef = RACSHARED04RACSHARED04RACS /* SharedDataBridge.swift */; };
 /* End PBXBuildFile section */
@@ -83,6 +87,8 @@
 		5480A2082E2F250400337F2F /* RunAnywhereAIUITests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = RunAnywhereAIUITests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
 		F8388285B0D64126DD4540F8 /* libarchive.tbd */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = "sourcecode.text-based-dylib-definition"; name = libarchive.tbd; path = usr/lib/libarchive.tbd; sourceTree = SDKROOT; };
 		RACACTIVITY02ACTIVITY02RAC /* DictationActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = DictationActivityAttributes.swift; path = RunAnywhereAI/Features/VoiceKeyboard/DictationActivityAttributes.swift; sourceTree = SOURCE_ROOT; };
+		RACAMBIENT02AMBIENT02RAC /* AmbientActivityAttributes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AmbientActivityAttributes.swift; path = RunAnywhereAI/Features/AmbientMemory/AmbientActivityAttributes.swift; sourceTree = SOURCE_ROOT; };
+		RACAMBIENT04AMBIENT04RAC /* AmbientStopIntent.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AmbientStopIntent.swift; path = RunAnywhereAI/Features/AmbientMemory/AmbientStopIntent.swift; sourceTree = SOURCE_ROOT; };
 		RACSHARED02RACSHARED02RACS /* SharedConstants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SharedConstants.swift; path = RunAnywhereAI/Shared/SharedConstants.swift; sourceTree = SOURCE_ROOT; };
 		RACSHARED04RACSHARED04RACS /* SharedDataBridge.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = SharedDataBridge.swift; path = RunAnywhereAI/Shared/SharedDataBridge.swift; sourceTree = SOURCE_ROOT; };
 /* End PBXFileReference section */
@@ -136,9 +142,9 @@
 			path = RunAnywhereAI;
 			sourceTree = "<group>";
 		};
-		5480A2012E2F250400337F2F /* RunAnywhereAITests */ = {
+		5480A2012E2F250400337F2F /* RunAnywhereAIUnitTests */ = {
 			isa = PBXFileSystemSynchronizedRootGroup;
-			path = RunAnywhereAITests;
+			path = RunAnywhereAIUnitTests;
 			sourceTree = "<group>";
 		};
 		5480A20B2E2F250400337F2F /* RunAnywhereAIUITests */ = {
@@ -201,6 +207,8 @@
 				RACSHARED02RACSHARED02RACS /* SharedConstants.swift */,
 				RACSHARED04RACSHARED04RACS /* SharedDataBridge.swift */,
 				RACACTIVITY02ACTIVITY02RAC /* DictationActivityAttributes.swift */,
+				RACAMBIENT02AMBIENT02RAC /* AmbientActivityAttributes.swift */,
+				RACAMBIENT04AMBIENT04RAC /* AmbientStopIntent.swift */,
 			);
 			name = "Recovered References";
 			sourceTree = "<group>";
@@ -224,7 +232,7 @@
 			isa = PBXGroup;
 			children = (
 				5480A1F22E2F250200337F2F /* RunAnywhereAI */,
-				5480A2012E2F250400337F2F /* RunAnywhereAITests */,
+				5480A2012E2F250400337F2F /* RunAnywhereAIUnitTests */,
 				5480A20B2E2F250400337F2F /* RunAnywhereAIUITests */,
 				54398ABF2F492D1D009D6B51 /* RunAnywhereKeyboard */,
 				54398D252F4939A7009D6B51 /* RunAnywhereActivityExtension */,
@@ -336,7 +344,7 @@
 				5480A2002E2F250400337F2F /* PBXTargetDependency */,
 			);
 			fileSystemSynchronizedGroups = (
-				5480A2012E2F250400337F2F /* RunAnywhereAITests */,
+				5480A2012E2F250400337F2F /* RunAnywhereAIUnitTests */,
 			);
 			name = RunAnywhereAITests;
 			productName = RunAnywhereAITests;
@@ -472,6 +480,10 @@
 			buildActionMask = 2147483647;
 			files = (
 				RACACTIVITY01ACTIVITY01RAC /* DictationActivityAttributes.swift in Sources */,
+				RACAMBIENT01AMBIENT01RAC /* AmbientActivityAttributes.swift in Sources */,
+				RACAMBIENT03AMBIENT03RAC /* AmbientStopIntent.swift in Sources */,
+				RACAMBIENT05AMBIENT05RAC /* SharedConstants.swift in Sources */,
+				RACAMBIENT06AMBIENT06RAC /* SharedDataBridge.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -789,7 +801,7 @@
 				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "RunAnywhere AI reads your Calendar events so the on-device assistant can answer questions about your schedule and upcoming events.";
 				INFOPLIST_KEY_NSCameraUsageDescription = "RunAnywhere AI needs access to your camera for vision language model features to analyze images.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "RunAnywhere AI reads Apple Health data (steps, sleep, heart rate, activity, and workouts) so the on-device assistant can answer questions about your health and fitness.";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "RunAnywhere AI needs access to your microphone to transcribe your voice input and provide voice-based interactions.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "RunAnywhere AI uses your microphone for voice input and for ambient memory sessions you start yourself, which keep listening until you stop them. Audio, transcripts, and memories stay on this device, and raw audio is kept only while you turn on dogfood audio retention.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "RunAnywhere AI uses speech recognition to convert your voice to text for processing.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;
@@ -843,7 +855,7 @@
 				INFOPLIST_KEY_NSCalendarsFullAccessUsageDescription = "RunAnywhere AI reads your Calendar events so the on-device assistant can answer questions about your schedule and upcoming events.";
 				INFOPLIST_KEY_NSCameraUsageDescription = "RunAnywhere AI needs access to your camera for vision language model features to analyze images.";
 				INFOPLIST_KEY_NSHealthShareUsageDescription = "RunAnywhere AI reads Apple Health data (steps, sleep, heart rate, activity, and workouts) so the on-device assistant can answer questions about your health and fitness.";
-				INFOPLIST_KEY_NSMicrophoneUsageDescription = "RunAnywhere AI needs access to your microphone to transcribe your voice input and provide voice-based interactions.";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "RunAnywhere AI uses your microphone for voice input and for ambient memory sessions you start yourself, which keep listening until you stop them. Audio, transcripts, and memories stay on this device, and raw audio is kept only while you turn on dogfood audio retention.";
 				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "RunAnywhere AI uses speech recognition to convert your voice to text for processing.";
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphoneos*]" = YES;
 				"INFOPLIST_KEY_UIApplicationSceneManifest_Generation[sdk=iphonesimulator*]" = YES;

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/App/ConsumerAdvancedHubView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/App/ConsumerAdvancedHubView.swift
@@ -76,6 +76,23 @@ struct ConsumerAdvancedHubView: View {
             }
             #endif
 
+            #if os(iOS)
+            Section {
+                NavigationLink(destination: AmbientMemoryView()) {
+                    AdvancedFeatureRow(
+                        icon: "note.text",
+                        color: AppColors.primaryAccent,
+                        title: "Notes",
+                        subtitle: "Record, transcribe, and summarize — entirely on device"
+                    )
+                }
+            } header: {
+                Text("Notes")
+            } footer: {
+                Text("Recording is explicit and stays visible in a Live Activity until you stop it.")
+            }
+            #endif
+
             Section {
                 NavigationLink(destination: BenchmarkDashboardView()) {
                     AdvancedFeatureRow(

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/App/RunAnywhereAIApp.swift
@@ -29,6 +29,7 @@ struct RunAnywhereAIApp: App {
     private let logger = Logger(subsystem: "com.runanywhere.RunAnywhereAI", category: "RunAnywhereAIApp")
     #if os(iOS)
     @StateObject private var flowSession = FlowSessionManager.shared
+    @StateObject private var ambientRouter = AmbientRouter.shared
     @State private var showFlowActivation = false
     #endif
     @State private var isSDKInitialized = false
@@ -44,15 +45,32 @@ struct RunAnywhereAIApp: App {
                         #if os(iOS)
                         .environmentObject(flowSession)
                         .onOpenURL { url in
-                            guard url.scheme == SharedConstants.urlScheme,
-                                  url.host == "startFlow" else { return }
-                            logger.info("Received startFlow deep link")
-                            showFlowActivation = true
-                            Task { await flowSession.handleStartFlow() }
+                            guard url.scheme == SharedConstants.urlScheme else { return }
+                            switch url.host {
+                            case "startFlow":
+                                logger.info("Received startFlow deep link")
+                                showFlowActivation = true
+                                Task { await flowSession.handleStartFlow() }
+                            case "ambient", "startAmbient":
+                                logger.info("Received \(url.host ?? "", privacy: .public) deep link")
+                                ambientRouter.open(autoStart: url.host == "startAmbient")
+                            default:
+                                break
+                            }
                         }
                         .fullScreenCover(isPresented: $showFlowActivation) {
                             FlowActivationView(isPresented: $showFlowActivation)
                                 .environmentObject(flowSession)
+                        }
+                        .sheet(isPresented: $ambientRouter.isPresented) {
+                            NavigationStack {
+                                AmbientMemoryView(autoStartRequested: ambientRouter.consumeAutoStart())
+                                    .toolbar {
+                                        ToolbarItem(placement: .navigationBarLeading) {
+                                            Button("Done") { ambientRouter.isPresented = false }
+                                        }
+                                    }
+                            }
                         }
                         #endif
                         .onAppear {

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/AmbientActivityAttributes.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/AmbientActivityAttributes.swift
@@ -1,0 +1,41 @@
+//
+//  AmbientActivityAttributes.swift
+//  RunAnywhereAI + RunAnywhereActivityExtension
+//
+//  Data contract for the Ambient Memory Lab's Live Activity.
+//
+//  Deliberately carries no transcript, summary, speaker name, or memory text.
+//  The Lock Screen and Dynamic Island are visible to anyone holding the phone,
+//  so the ambient surface shows only that recording is happening, for how
+//  long, and how much it has captured.
+//
+//  TARGET MEMBERSHIP: RunAnywhereAI (main app) + RunAnywhereActivityExtension
+//  (widget extension), wired manually in the pbxproj like
+//  DictationActivityAttributes.swift.
+//
+
+#if os(iOS)
+import ActivityKit
+#endif
+import Foundation
+
+#if os(iOS)
+@available(iOS 16.1, *)
+struct AmbientActivityAttributes: ActivityAttributes {
+    struct ContentState: Codable, Hashable {
+        /// "preparing" | "listening" | "speech" | "processing" | "paused"
+        var phase: String
+        var elapsedSeconds: Int
+        /// Number of speech segments captured so far.
+        var segmentCount: Int
+        /// Number of action items found so far.
+        var actionItemCount: Int
+        /// Set when the session stopped itself (thermal, storage, interruption)
+        /// so the user is not left believing it is still recording.
+        var isStopped: Bool
+    }
+
+    /// Session identifier — set once at start.
+    var sessionId: String
+}
+#endif

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/AmbientAppIntents.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/AmbientAppIntents.swift
@@ -1,0 +1,113 @@
+//
+//  AmbientAppIntents.swift
+//  RunAnywhereAI
+//
+//  Action Button / Shortcuts entry points for the Ambient Memory Lab.
+//
+//  The start intent deliberately uses `openAppWhenRun`. iOS will not let a
+//  background App Intent start `AVAudioEngine`, and a covert capture path is
+//  not something this feature should offer even if it could: the user must see
+//  the Lab, the preparation state, and the active recording indicator. The
+//  Action Button is a faster way into the same explicit flow, not an exception
+//  to it.
+//
+
+#if os(iOS)
+import AppIntents
+import Combine
+import Foundation
+import SwiftUI
+
+// MARK: - Router
+
+/// Bridges an intent invocation to the SwiftUI hierarchy.
+///
+/// The intent runs in the app process once `openAppWhenRun` brings it forward,
+/// so it can flip this flag and let the root scene present the Lab.
+@MainActor
+final class AmbientRouter: ObservableObject {
+    static let shared = AmbientRouter()
+
+    /// Set when the Lab should be on screen.
+    @Published var isPresented = false
+    /// Set when the Lab should begin a session as soon as it appears.
+    @Published var shouldAutoStart = false
+
+    private init() {}
+
+    func open(autoStart: Bool) {
+        shouldAutoStart = autoStart
+        isPresented = true
+    }
+
+    /// Consume the auto-start request so returning to the Lab later does not
+    /// silently begin another recording.
+    func consumeAutoStart() -> Bool {
+        defer { shouldAutoStart = false }
+        return shouldAutoStart
+    }
+}
+
+// MARK: - Intents
+
+struct StartAmbientMemoryIntent: AppIntent {
+    static var title: LocalizedStringResource = "Start Memory Lab"
+    static var description = IntentDescription(
+        "Opens RunAnywhere and starts an on-device ambient memory session.",
+        categoryName: "Ambient"
+    )
+
+    /// Capture is only ever started from a visible screen, so the intent opens
+    /// the app rather than trying to record in the background.
+    static var openAppWhenRun: Bool = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        AmbientRouter.shared.open(autoStart: true)
+        return .result()
+    }
+}
+
+struct OpenAmbientMemoryIntent: AppIntent {
+    static var title: LocalizedStringResource = "Open Memory Lab"
+    static var description = IntentDescription(
+        "Opens the RunAnywhere Memory Lab without starting a recording.",
+        categoryName: "Ambient"
+    )
+
+    static var openAppWhenRun: Bool = true
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        AmbientRouter.shared.open(autoStart: false)
+        return .result()
+    }
+}
+
+// MARK: - Shortcuts
+
+/// Published so the user can assign "Start Memory Lab" to the Action Button on
+/// supported iPhones through Settings › Action Button › Shortcut.
+struct AmbientAppShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: StartAmbientMemoryIntent(),
+            phrases: [
+                "Start \(.applicationName) Memory Lab",
+                "Start remembering with \(.applicationName)",
+            ],
+            shortTitle: "Start Memory Lab",
+            systemImageName: "brain.head.profile"
+        )
+        AppShortcut(
+            intent: StopAmbientMemoryIntent(),
+            phrases: [
+                "Stop \(.applicationName) Memory Lab",
+                "Stop remembering with \(.applicationName)",
+            ],
+            shortTitle: "Stop Memory Lab",
+            systemImageName: "stop.circle"
+        )
+    }
+}
+#endif

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/AmbientStopIntent.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/AmbientStopIntent.swift
@@ -1,0 +1,37 @@
+//
+//  AmbientStopIntent.swift
+//  RunAnywhereAI + RunAnywhereActivityExtension
+//
+//  Stopping an ambient session, reachable from Shortcuts, Siri, and the Live
+//  Activity's Stop button.
+//
+//  Kept in its own file because the widget extension needs it too, and the
+//  rest of the ambient intents pull in main-app SwiftUI state. Stopping is the
+//  one ambient action that is safe to run outside the app: it tears capture
+//  down rather than starting it, so it does not need `openAppWhenRun`.
+//
+//  TARGET MEMBERSHIP: RunAnywhereAI (main app) + RunAnywhereActivityExtension,
+//  wired manually in the pbxproj like DictationActivityAttributes.swift.
+//
+
+#if os(iOS)
+import AppIntents
+import Foundation
+
+struct StopAmbientMemoryIntent: AppIntent {
+    static var title: LocalizedStringResource = "Stop Memory Lab"
+    static var description = IntentDescription(
+        "Stops the active ambient memory session and saves it.",
+        categoryName: "Ambient"
+    )
+
+    static var openAppWhenRun: Bool = false
+
+    func perform() async throws -> some IntentResult & ProvidesDialog {
+        DarwinNotificationCenter.shared.post(
+            name: SharedConstants.DarwinNotifications.ambientStopRequested
+        )
+        return .result(dialog: "Stopping the Memory Lab session.")
+    }
+}
+#endif

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Models/AmbientModelProfile.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Models/AmbientModelProfile.swift
@@ -1,0 +1,254 @@
+//
+//  AmbientModelProfile.swift
+//  RunAnywhereAI
+//
+//  Testable model profiles for the Ambient Memory Lab plus the device-aware
+//  routing that picks one. Model ids come from `ModelCatalogBootstrap`; no
+//  iPhone-family assumptions are hard-coded, because the same chip generation
+//  ships with very different memory budgets.
+//
+
+import Foundation
+import RunAnywhere
+#if canImport(UIKit)
+import UIKit
+#endif
+
+// MARK: - Background Safety
+
+extension RAInferenceFramework {
+    /// Whether this framework can keep working once the app is backgrounded.
+    ///
+    /// MLX and Core ML are Metal. llama.cpp in this app also schedules Metal
+    /// via ggml — iOS refuses those command buffers from a backgrounded
+    /// process. Only ONNX/Sherpa-style CPU backends are safe for lock-screen
+    /// work (ASR/VAD). Summarization always waits for the foreground anyway.
+    var isBackgroundSafe: Bool {
+        switch self {
+        case .mlx, .coreml, .llamaCpp:
+            return false
+        default:
+            return true
+        }
+    }
+}
+
+extension RAModelInfo {
+    var isBackgroundSafe: Bool { framework.isBackgroundSafe }
+}
+
+// MARK: - Profile
+
+/// A complete notes stack: what detects speech, what transcribes it, and what
+/// summarizes it into a note.
+struct AmbientModelProfile: Identifiable, Sendable, Equatable {
+    let id: String
+    let displayName: String
+    let summary: String
+    let vadModelID: String
+    /// Ordered ASR candidates, best first. Used only when a tester explicitly
+    /// applies this profile in Developer — the main Notes UI never auto-fills
+    /// from these lists.
+    let asrCandidateIDs: [String]
+    /// Ordered LLM candidates for the summary-and-action-items digest. A GPU
+    /// model is allowed here because digesting is not always-on; it just gets
+    /// deferred to the foreground.
+    let digestCandidateIDs: [String]
+    /// Lowest tier this profile is allowed to auto-select on.
+    let minimumTier: HardwareTier
+    /// Approximate resident footprint of the always-on stack, used to reject a
+    /// profile that cannot fit in the memory currently available.
+    let residentBudgetBytes: Int64
+
+    static let allProfiles: [AmbientModelProfile] = [.compatibility, .quality, .highEnd]
+
+    static func profile(id: String) -> AmbientModelProfile? {
+        allProfiles.first { $0.id == id }
+    }
+
+    /// The ASR the tester should download when nothing usable is installed.
+    var preferredASRModelID: String { asrCandidateIDs.first ?? "" }
+
+    /// Smallest testable stack. Everything is serialized; use it to confirm the
+    /// pipeline runs at all before judging quality.
+    static let compatibility = AmbientModelProfile(
+        id: "compatibility",
+        displayName: "Compatibility",
+        summary: "Whisper Tiny + Qwen3 0.6B. Smallest download, serialized jobs.",
+        vadModelID: "silero-vad",
+        asrCandidateIDs: [
+            "sherpa-onnx-whisper-tiny.en",
+        ],
+        digestCandidateIDs: [
+            "qwen3-0.6b-q4_k_m",
+            "mlx-qwen3-0.6b-4bit",
+        ],
+        minimumTier: .lowEnd,
+        residentBudgetBytes: 1_200_000_000
+    )
+
+    /// The dogfood default. Optimized for end-to-end quality rather than the
+    /// smallest possible footprint, so what you judge is the ceiling of the
+    /// idea and not the floor of the models.
+    static let quality = AmbientModelProfile(
+        id: "quality",
+        displayName: "Quality",
+        summary: "Parakeet TDT 0.6B + Qwen3 1.7B. Best end-to-end quality.",
+        vadModelID: "silero-vad",
+        asrCandidateIDs: [
+            "sherpa-nemo-parakeet-tdt-0.6b-v3-int8",
+            "sherpa-onnx-whisper-tiny.en",
+        ],
+        digestCandidateIDs: [
+            "qwen3-1.7b-q4_k_m",
+            "qwen3-0.6b-q4_k_m",
+            "mlx-qwen3-0.6b-4bit",
+        ],
+        minimumTier: .midRange,
+        residentBudgetBytes: 2_600_000_000
+    )
+
+    /// Quality capture with a 4B model doing the summarizing, for devices with
+    /// the memory to hold it.
+    static let highEnd = AmbientModelProfile(
+        id: "high-end",
+        displayName: "High-end",
+        summary: "Quality capture with Qwen3 4B writing the summaries.",
+        vadModelID: "silero-vad",
+        asrCandidateIDs: AmbientModelProfile.quality.asrCandidateIDs,
+        digestCandidateIDs: [
+            "qwen3-4b-q4_k_m",
+            "mlx-qwen3-4b-4bit",
+        ] + AmbientModelProfile.quality.digestCandidateIDs,
+        minimumTier: .highEnd,
+        residentBudgetBytes: 3_200_000_000
+    )
+}
+
+// MARK: - Resolved Selection
+
+/// The concrete model ids a session will run — whatever the user picked (and
+/// optionally seeded from an explicit Developer profile apply).
+struct AmbientModelSelection: Sendable, Equatable {
+    var profileID: String
+    var vadModelID: String
+    var asrModelID: String
+    var digestModelID: String?
+    /// False when the ASR runs on the GPU; capture is still allowed so limits
+    /// can be tested, but the UI warns that lock-screen transcription may stall.
+    var isASRBackgroundSafe: Bool = true
+    /// False when the digest model runs on the GPU, which means its work has to
+    /// wait for the foreground.
+    var isDigestBackgroundSafe: Bool = true
+
+    /// IDs are chosen; the view model still requires the files to be on disk
+    /// before Record is enabled.
+    var canStartCapture: Bool {
+        !vadModelID.isEmpty && !asrModelID.isEmpty
+    }
+
+    var supportsDigest: Bool { digestModelID != nil }
+}
+
+// MARK: - Device Conditions
+
+/// Live device state that gates which profile is safe to run right now.
+struct AmbientDeviceConditions: Sendable, Equatable {
+    var tier: HardwareTier
+    var availableMemoryBytes: Int64
+    var thermalState: ProcessInfo.ThermalState
+    var isLowPowerModeEnabled: Bool
+    var batteryLevel: Float
+
+    /// Summarizing is suspended while the device is hot or the user asked for
+    /// maximum battery life. Capture and transcription keep running so the
+    /// note stays useful.
+    var shouldSuspendDerivedWork: Bool {
+        thermalState == .serious || thermalState == .critical || isLowPowerModeEnabled
+    }
+
+    /// Capture itself stops only at critical thermals.
+    var shouldStopCapture: Bool {
+        thermalState == .critical
+    }
+
+    var thermalDescription: String {
+        switch thermalState {
+        case .nominal: return "nominal"
+        case .fair: return "fair"
+        case .serious: return "serious"
+        case .critical: return "critical"
+        @unknown default: return "unknown"
+        }
+    }
+}
+
+// MARK: - Resolver
+
+/// Maps device conditions plus the live catalog onto a concrete selection.
+/// Pure and synchronous so it can be unit tested without the SDK.
+struct AmbientModelProfileResolver {
+
+    /// Highest profile the device can currently sustain.
+    func recommendedProfile(
+        for conditions: AmbientDeviceConditions,
+        available models: [RAModelInfo]
+    ) -> AmbientModelProfile {
+        let candidates = AmbientModelProfile.allProfiles
+            .filter { $0.minimumTier <= conditions.tier }
+            .filter { $0.residentBudgetBytes <= max(conditions.availableMemoryBytes, 0) }
+            .filter { resolve(profile: $0, available: models).canStartCapture }
+
+        // Under thermal pressure or Low Power Mode, deliberately step down to
+        // the lightest viable stack rather than the best one.
+        if conditions.shouldSuspendDerivedWork {
+            return candidates.first ?? .compatibility
+        }
+        return candidates.last ?? .compatibility
+    }
+
+    /// Bind a profile to real catalog ids, keeping the first candidate that is
+    /// actually registered for each role. Any framework is accepted — dogfooding
+    /// includes GPU ASR — and `isASRBackgroundSafe` / `isDigestBackgroundSafe`
+    /// flag risk for the UI and deferred digest path.
+    func resolve(profile: AmbientModelProfile, available models: [RAModelInfo]) -> AmbientModelSelection {
+        let byID = Dictionary(models.map { ($0.id, $0) }, uniquingKeysWith: { first, _ in first })
+        func firstAvailable(_ ids: [String]) -> RAModelInfo? {
+            ids.lazy.compactMap { byID[$0] }.first
+        }
+
+        let vad = firstAvailable([profile.vadModelID])
+        let asr = firstAvailable(profile.asrCandidateIDs)
+        let digest = firstAvailable(profile.digestCandidateIDs)
+
+        return AmbientModelSelection(
+            profileID: profile.id,
+            vadModelID: vad?.id ?? "",
+            asrModelID: asr?.id ?? "",
+            digestModelID: digest?.id,
+            isASRBackgroundSafe: asr?.isBackgroundSafe ?? true,
+            isDigestBackgroundSafe: digest?.isBackgroundSafe ?? true
+        )
+    }
+
+    /// Read current conditions from the device. Battery monitoring is enabled
+    /// on demand; the level is `-1` when the platform will not report it.
+    @MainActor
+    func currentConditions(deviceInfo: SystemDeviceInfo?) -> AmbientDeviceConditions {
+        let processInfo = ProcessInfo.processInfo
+        #if canImport(UIKit) && !os(macOS)
+        UIDevice.current.isBatteryMonitoringEnabled = true
+        let batteryLevel = UIDevice.current.batteryLevel
+        #else
+        let batteryLevel: Float = -1
+        #endif
+
+        return AmbientDeviceConditions(
+            tier: HardwareTierResolver().resolve(from: deviceInfo),
+            availableMemoryBytes: deviceInfo?.availableMemory ?? 0,
+            thermalState: processInfo.thermalState,
+            isLowPowerModeEnabled: processInfo.isLowPowerModeEnabled,
+            batteryLevel: batteryLevel
+        )
+    }
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Models/AmbientRecords.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Models/AmbientRecords.swift
@@ -1,0 +1,446 @@
+//
+//  AmbientRecords.swift
+//  RunAnywhereAI
+//
+//  Codable records persisted by the notes feature. Every id is derived from the
+//  SDK's session/segment ids so a retried write updates the same record instead
+//  of creating a duplicate.
+//
+//  Type names stay `AmbientSessionRecord` and friends to match the SDK's
+//  ambient solution; everything a user reads says "note".
+//
+
+import Foundation
+import RunAnywhere
+
+// MARK: - Retention
+
+/// Whether a note keeps its recording. Audio is a dogfood affordance for
+/// judging capture quality, not something a shipping product would default to.
+enum AmbientRetentionPolicy: String, Codable, CaseIterable, Sendable, Identifiable {
+    /// Keep the note text; discard audio as soon as it is transcribed.
+    case transcriptsOnly
+    /// Keep the recording alongside the transcript so the tester can hear what
+    /// the model heard.
+    case retainAudio
+
+    var id: String { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .transcriptsOnly: return "Text only"
+        case .retainAudio: return "Text and recording"
+        }
+    }
+
+    /// The voice memo is the point of dogfooding right now, so a fresh install
+    /// keeps audio until the tester says otherwise.
+    static let `default`: AmbientRetentionPolicy = .retainAudio
+
+    var retainsAudio: Bool { self == .retainAudio }
+}
+
+/// Age after which a note's *recording* is deleted to reclaim space. Note text
+/// is never reaped: transcripts, summaries, and action items live until the
+/// tester deletes the note by hand.
+enum AmbientRetentionWindow: Int, Codable, CaseIterable, Sendable, Identifiable {
+    case oneDay = 1
+    case sevenDays = 7
+    case thirtyDays = 30
+    case keepUntilDeleted = 0
+
+    /// Recordings are the dogfood evidence, so nothing expires unless the
+    /// tester opts in.
+    static let `default`: AmbientRetentionWindow = .keepUntilDeleted
+
+    var id: Int { rawValue }
+
+    var displayName: String {
+        switch self {
+        case .oneDay: return "After 1 day"
+        case .sevenDays: return "After 7 days"
+        case .thirtyDays: return "After 30 days"
+        case .keepUntilDeleted: return "Never"
+        }
+    }
+
+    /// Cutoff date for expiry, or `nil` when no recording expires on its own.
+    func expiryCutoff(from now: Date) -> Date? {
+        guard rawValue > 0 else { return nil }
+        return now.addingTimeInterval(-Double(rawValue) * 24 * 60 * 60)
+    }
+}
+
+// MARK: - Capture Context
+
+/// Free-form labels the tester attaches so multi-hour dogfood runs stay
+/// comparable across environments.
+struct AmbientCaptureContext: Codable, Sendable, Equatable {
+    var environment: String
+    var placement: String
+    var note: String
+
+    static let empty = AmbientCaptureContext(environment: "", placement: "", note: "")
+
+    var isEmpty: Bool {
+        environment.isEmpty && placement.isEmpty && note.isEmpty
+    }
+
+    var summary: String {
+        [environment, placement].filter { !$0.isEmpty }.joined(separator: " · ")
+    }
+}
+
+// MARK: - Segment
+
+/// One finalized speech segment plus its transcription outcome.
+struct AmbientSegmentRecord: Codable, Sendable, Identifiable, Equatable {
+    let id: String
+    let sessionID: String
+    let index: Int
+    let startedAt: Date
+    let endedAt: Date
+    let durationMs: Int
+    let sampleRate: Int
+    let peakConfidence: Float
+
+    var transcript: String?
+    var transcriptConfidence: Float?
+    var languageCode: String?
+    var sttModelID: String?
+    var transcriptionMs: Int?
+    var speakerLabel: String?
+
+    var realTimeFactor: Double? {
+        guard let transcriptionMs, durationMs > 0 else { return nil }
+        return Double(transcriptionMs) / Double(durationMs)
+    }
+
+    init(from segment: RAAmbientSegment) {
+        self.id = segment.id
+        self.sessionID = segment.sessionID
+        self.index = segment.index
+        self.startedAt = segment.startedAt
+        self.endedAt = segment.endedAt
+        self.durationMs = segment.durationMs
+        self.sampleRate = segment.sampleRate
+        // JSONEncoder rejects NaN/Inf; Sherpa confidence often arrives as NaN.
+        self.peakConfidence = Self.jsonSafe(segment.peakConfidence)
+    }
+
+    init(
+        id: String,
+        sessionID: String,
+        index: Int,
+        startedAt: Date,
+        endedAt: Date,
+        durationMs: Int,
+        sampleRate: Int,
+        peakConfidence: Float
+    ) {
+        self.id = id
+        self.sessionID = sessionID
+        self.index = index
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.durationMs = durationMs
+        self.sampleRate = sampleRate
+        self.peakConfidence = Self.jsonSafe(peakConfidence)
+    }
+
+    mutating func apply(_ transcript: RAAmbientTranscript) {
+        self.transcript = transcript.text
+        self.transcriptConfidence = Self.jsonSafeOptional(transcript.confidence)
+        self.languageCode = transcript.languageCode.isEmpty ? nil : transcript.languageCode
+        self.sttModelID = transcript.modelID
+        self.transcriptionMs = transcript.transcriptionMs
+    }
+
+    /// JSON has no NaN/Inf; map them to 0 so a note can still be written.
+    private static func jsonSafe(_ value: Float) -> Float {
+        value.isFinite ? value : 0
+    }
+
+    private static func jsonSafeOptional(_ value: Float) -> Float? {
+        value.isFinite ? value : nil
+    }
+}
+
+// MARK: - Action Item
+
+/// One thing the note says somebody still has to do.
+struct AmbientActionItem: Codable, Sendable, Identifiable, Equatable {
+    let id: String
+    var text: String
+    var isDone: Bool
+    /// Set for items the tester typed. A later digest rewrites the machine
+    /// list, and manual items are carried across untouched so a re-run never
+    /// erases something a person added by hand.
+    var isManual: Bool
+
+    init(id: String = UUID().uuidString, text: String, isDone: Bool = false, isManual: Bool = false) {
+        self.id = id
+        self.text = text
+        self.isDone = isDone
+        self.isManual = isManual
+    }
+
+    /// Case- and whitespace-insensitive identity, used to keep the same item
+    /// from arriving twice across chunk digests and the final merge.
+    var dedupeKey: String {
+        text.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    }
+}
+
+// MARK: - Note
+
+/// One note: everything captured by a single recording.
+struct AmbientSessionRecord: Codable, Sendable, Identifiable, Equatable {
+    let id: String
+    let startedAt: Date
+    var endedAt: Date?
+    var profileID: String
+    var vadModelID: String
+    var sttModelID: String
+    var digestModelID: String?
+    var retentionPolicy: AmbientRetentionPolicy
+    var context: AmbientCaptureContext
+    var deviceModel: String
+    var osVersion: String
+    var segments: [AmbientSegmentRecord]
+
+    /// The note-level summary, written by the merge pass at stop.
+    var summary: String
+    var actionItems: [AmbientActionItem]
+    /// Output of each chunk digest, persisted as it lands so a crash or a
+    /// deferred merge still leaves something readable behind.
+    var partialSummaries: [String]
+    /// The one continuous recording for this note, relative to the ambient
+    /// root. Cleared when audio expires; the note itself survives.
+    var audioRelativePath: String?
+    /// Set when the tester renames the note.
+    var customTitle: String?
+    /// True when the merge pass was skipped because the app was backgrounded
+    /// with a GPU-only digest model. The next foreground finishes it.
+    var summaryPending: Bool
+    /// Terminal reason recorded when the session stopped for anything other
+    /// than a plain user stop, so failures leave a visible audit record.
+    var stopReason: String?
+
+    init(
+        id: String,
+        startedAt: Date,
+        endedAt: Date? = nil,
+        profileID: String,
+        vadModelID: String,
+        sttModelID: String,
+        digestModelID: String? = nil,
+        retentionPolicy: AmbientRetentionPolicy,
+        context: AmbientCaptureContext,
+        deviceModel: String,
+        osVersion: String,
+        segments: [AmbientSegmentRecord] = [],
+        summary: String = "",
+        actionItems: [AmbientActionItem] = [],
+        partialSummaries: [String] = [],
+        audioRelativePath: String? = nil,
+        customTitle: String? = nil,
+        summaryPending: Bool = false,
+        stopReason: String? = nil
+    ) {
+        self.id = id
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.profileID = profileID
+        self.vadModelID = vadModelID
+        self.sttModelID = sttModelID
+        self.digestModelID = digestModelID
+        self.retentionPolicy = retentionPolicy
+        self.context = context
+        self.deviceModel = deviceModel
+        self.osVersion = osVersion
+        self.segments = segments
+        self.summary = summary
+        self.actionItems = actionItems
+        self.partialSummaries = partialSummaries
+        self.audioRelativePath = audioRelativePath
+        self.customTitle = customTitle
+        self.summaryPending = summaryPending
+        self.stopReason = stopReason
+    }
+
+    /// Notes written before summaries existed carry none of the new keys, and
+    /// losing a tester's recording history to a schema change is worse than
+    /// showing an old note without a summary. Everything added since decodes
+    /// with a default instead of failing the file.
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        startedAt = try container.decode(Date.self, forKey: .startedAt)
+        endedAt = try container.decodeIfPresent(Date.self, forKey: .endedAt)
+        profileID = try container.decode(String.self, forKey: .profileID)
+        vadModelID = try container.decode(String.self, forKey: .vadModelID)
+        sttModelID = try container.decode(String.self, forKey: .sttModelID)
+        digestModelID = try container.decodeIfPresent(String.self, forKey: .digestModelID)
+        retentionPolicy = try container.decode(AmbientRetentionPolicy.self, forKey: .retentionPolicy)
+        context = try container.decode(AmbientCaptureContext.self, forKey: .context)
+        deviceModel = try container.decode(String.self, forKey: .deviceModel)
+        osVersion = try container.decode(String.self, forKey: .osVersion)
+        segments = try container.decodeIfPresent([AmbientSegmentRecord].self, forKey: .segments) ?? []
+        summary = try container.decodeIfPresent(String.self, forKey: .summary) ?? ""
+        actionItems = try container.decodeIfPresent([AmbientActionItem].self, forKey: .actionItems) ?? []
+        partialSummaries = try container.decodeIfPresent([String].self, forKey: .partialSummaries) ?? []
+        audioRelativePath = try container.decodeIfPresent(String.self, forKey: .audioRelativePath)
+        customTitle = try container.decodeIfPresent(String.self, forKey: .customTitle)
+        summaryPending = try container.decodeIfPresent(Bool.self, forKey: .summaryPending) ?? false
+        stopReason = try container.decodeIfPresent(String.self, forKey: .stopReason)
+    }
+
+    /// Wall-clock length of a finished note. Incomplete orphans (never got a
+    /// mic) report zero so the list does not show a duration that grows forever.
+    var duration: TimeInterval {
+        guard let endedAt else { return 0 }
+        return max(0, endedAt.timeIntervalSince(startedAt))
+    }
+
+    /// True when the note was never filled in — typically a failed start that
+    /// wrote the JSON before the microphone opened.
+    var isEmptyOrphan: Bool {
+        endedAt == nil
+            && segments.isEmpty
+            && summary.isEmpty
+            && actionItems.isEmpty
+            && audioRelativePath == nil
+            && !summaryPending
+    }
+
+    var transcribedSegments: [AmbientSegmentRecord] {
+        segments.filter { !($0.transcript ?? "").isEmpty }
+    }
+
+    /// The whole note as one string, so the detail view and search both read a
+    /// single body instead of walking segments.
+    var fullTranscript: String {
+        transcribedSegments
+            .compactMap { $0.transcript?.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
+    }
+
+    var hasAudio: Bool { audioRelativePath != nil }
+
+    var title: String {
+        if let customTitle, !customTitle.isEmpty { return customTitle }
+        if let clause = Self.firstClause(of: summary) { return clause }
+        return Self.titleFormatter.string(from: startedAt)
+    }
+
+    /// The first sentence of the summary, capped so a model that ignores the
+    /// sentence break still yields a list row rather than a paragraph.
+    private static func firstClause(of summary: String) -> String? {
+        let trimmed = summary.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return nil }
+        let sentence = trimmed.prefix { $0 != "." && $0 != "\n" && $0 != "!" && $0 != "?" }
+        let clause = sentence.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !clause.isEmpty else { return nil }
+        return clause.count > 80 ? String(clause.prefix(80)) + "…" : clause
+    }
+
+    private static let titleFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
+
+    /// Upsert by id so a replayed event never appends a second copy.
+    mutating func upsert(_ segment: AmbientSegmentRecord) {
+        if let index = segments.firstIndex(where: { $0.id == segment.id }) {
+            segments[index] = segment
+        } else {
+            segments.append(segment)
+        }
+    }
+
+    /// Fold freshly digested items into the list, keeping every manual item and
+    /// every tick the tester already made.
+    mutating func mergeActionItems(_ incoming: [String]) {
+        var seen = Set(actionItems.map(\.dedupeKey))
+        for text in incoming {
+            let candidate = AmbientActionItem(text: text)
+            guard !candidate.dedupeKey.isEmpty, seen.insert(candidate.dedupeKey).inserted else { continue }
+            actionItems.append(candidate)
+        }
+    }
+
+    /// Replace the machine-written items with the merge pass's list while
+    /// preserving manual items and completion state.
+    mutating func replaceMachineActionItems(with incoming: [String]) {
+        let manual = actionItems.filter(\.isManual)
+        let previousState = Dictionary(
+            actionItems.map { ($0.dedupeKey, $0) },
+            uniquingKeysWith: { first, _ in first }
+        )
+        var seen = Set(manual.map(\.dedupeKey))
+        var rebuilt: [AmbientActionItem] = []
+        for text in incoming {
+            let candidate = AmbientActionItem(text: text)
+            guard !candidate.dedupeKey.isEmpty, seen.insert(candidate.dedupeKey).inserted else { continue }
+            if let previous = previousState[candidate.dedupeKey] {
+                rebuilt.append(AmbientActionItem(id: previous.id, text: text, isDone: previous.isDone))
+            } else {
+                rebuilt.append(candidate)
+            }
+        }
+        actionItems = manual + rebuilt
+    }
+}
+
+// MARK: - Benchmark Sample
+
+/// One instrumented ambient run, exported alongside the standard benchmark
+/// suite but kept separate so the synthetic STT benchmark keeps its meaning.
+struct AmbientBenchmarkSample: Codable, Sendable, Identifiable, Equatable {
+    let id: UUID
+    let recordedAt: Date
+    let sessionID: String
+    let profileID: String
+    let deviceModel: String
+    let chipName: String
+    let osVersion: String
+    let audioRoute: String
+    let environment: String
+    let placement: String
+
+    let sessionSeconds: Double
+    let speechSeconds: Double
+    let segmentCount: Int
+    let transcribedSegmentCount: Int
+    let droppedSegmentCount: Int
+    let actionItemCount: Int
+    let completedActionItemCount: Int
+
+    let medianTranscriptionMs: Double
+    let medianRealTimeFactor: Double
+    let medianExtractionMs: Double
+    let firstTranscriptLatencyMs: Double
+
+    let peakMemoryBytes: Int64
+    let batteryDeltaPerHour: Double
+    let thermalState: String
+    let interruptionCount: Int
+    let retainedAudioBytes: Int64
+
+    /// Fraction of the session that carried detected speech.
+    var speechRatio: Double {
+        guard sessionSeconds > 0 else { return 0 }
+        return speechSeconds / sessionSeconds
+    }
+
+    /// Fraction of the note's action items the tester ticked off, which stands
+    /// in for how many of them were worth extracting at all.
+    var completedActionItemRate: Double {
+        guard actionItemCount > 0 else { return 0 }
+        return Double(completedActionItemCount) / Double(actionItemCount)
+    }
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Services/AmbientBenchmarkRecorder.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Services/AmbientBenchmarkRecorder.swift
@@ -1,0 +1,184 @@
+//
+//  AmbientBenchmarkRecorder.swift
+//  RunAnywhereAI
+//
+//  Instrumentation for a live ambient session.
+//
+//  Deliberately separate from `BenchmarkRunner`: that suite measures
+//  deterministic synthetic scenarios, and folding a multi-hour, environment-
+//  dependent ambient run into it would change what its STT numbers mean.
+//  This recorder produces `AmbientBenchmarkSample`s that export alongside them.
+//
+
+import Foundation
+import RunAnywhere
+#if os(iOS)
+import AVFoundation
+#endif
+#if canImport(UIKit)
+import UIKit
+#endif
+
+/// Accumulates per-session timings while a session runs, then reduces them to
+/// one exportable sample when it ends.
+@MainActor
+final class AmbientBenchmarkRecorder {
+
+    private var sessionID: String?
+    private var startedAt: Date?
+    private var conditions: AmbientDeviceConditions?
+    private var startBatteryLevel: Float = -1
+    private var audioRoute: String = "unknown"
+
+    private var speechMilliseconds = 0
+    private var segmentCount = 0
+    private var droppedSegmentCount = 0
+    private var interruptionCount = 0
+    private var transcriptionMs: [Double] = []
+    private var realTimeFactors: [Double] = []
+    private var extractionMs: [Double] = []
+    private var firstTranscriptLatencyMs: Double?
+    private var peakMemoryBytes: Int64 = 0
+
+    // MARK: - Lifecycle
+
+    func begin(sessionID: String, conditions: AmbientDeviceConditions) {
+        self.sessionID = sessionID
+        self.startedAt = Date()
+        self.conditions = conditions
+        self.startBatteryLevel = conditions.batteryLevel
+        self.audioRoute = Self.currentAudioRoute()
+
+        speechMilliseconds = 0
+        segmentCount = 0
+        droppedSegmentCount = 0
+        interruptionCount = 0
+        transcriptionMs.removeAll()
+        realTimeFactors.removeAll()
+        extractionMs.removeAll()
+        firstTranscriptLatencyMs = nil
+        peakMemoryBytes = 0
+    }
+
+    func markSpeechStarted() {
+        peakMemoryBytes = max(peakMemoryBytes, Self.residentMemoryBytes())
+    }
+
+    func markSpeechEnded(durationMs: Int) {
+        speechMilliseconds += durationMs
+    }
+
+    func markSegment() {
+        segmentCount += 1
+        peakMemoryBytes = max(peakMemoryBytes, Self.residentMemoryBytes())
+    }
+
+    func markTranscript(_ transcript: RAAmbientTranscript) {
+        transcriptionMs.append(Double(transcript.transcriptionMs))
+        realTimeFactors.append(transcript.realTimeFactor)
+        if firstTranscriptLatencyMs == nil, let startedAt {
+            firstTranscriptLatencyMs = Date().timeIntervalSince(startedAt) * 1000
+        }
+    }
+
+    func markDigest(_ digest: RAAmbientNoteDigest) {
+        extractionMs.append(Double(digest.extractionMs))
+        peakMemoryBytes = max(peakMemoryBytes, Self.residentMemoryBytes())
+    }
+
+    func markGate(_ gate: RAAmbientResourceGate) {
+        guard gate.isActive, gate.reason == .backpressure else { return }
+        droppedSegmentCount += 1
+    }
+
+    func markInterruption() {
+        interruptionCount += 1
+    }
+
+    /// Reduce the run to one sample and persist it. No-op when the session was
+    /// never started (e.g. a failed model load).
+    func finish(record: AmbientSessionRecord, store: AmbientMemoryStore) async {
+        guard let sessionID, let startedAt, let conditions else { return }
+
+        let now = Date()
+        let elapsedHours = max(now.timeIntervalSince(startedAt) / 3600, 0.0001)
+        let endBattery = Self.currentBatteryLevel()
+        let batteryDeltaPerHour = (startBatteryLevel >= 0 && endBattery >= 0)
+            ? Double(startBatteryLevel - endBattery) * 100 / elapsedHours
+            : 0
+
+        let deviceInfo = DeviceInfoService.shared.deviceInfo
+        let sample = AmbientBenchmarkSample(
+            id: UUID(),
+            recordedAt: now,
+            sessionID: sessionID,
+            profileID: record.profileID,
+            deviceModel: deviceInfo?.modelName ?? record.deviceModel,
+            chipName: deviceInfo?.chipName ?? "",
+            osVersion: record.osVersion,
+            audioRoute: audioRoute,
+            environment: record.context.environment,
+            placement: record.context.placement,
+            sessionSeconds: now.timeIntervalSince(startedAt),
+            speechSeconds: Double(speechMilliseconds) / 1000.0,
+            segmentCount: segmentCount,
+            transcribedSegmentCount: record.transcribedSegments.count,
+            droppedSegmentCount: droppedSegmentCount,
+            actionItemCount: record.actionItems.count,
+            completedActionItemCount: record.actionItems.filter(\.isDone).count,
+            medianTranscriptionMs: Self.median(transcriptionMs),
+            medianRealTimeFactor: Self.median(realTimeFactors),
+            medianExtractionMs: Self.median(extractionMs),
+            firstTranscriptLatencyMs: firstTranscriptLatencyMs ?? 0,
+            peakMemoryBytes: peakMemoryBytes,
+            batteryDeltaPerHour: batteryDeltaPerHour,
+            thermalState: conditions.thermalDescription,
+            interruptionCount: interruptionCount,
+            retainedAudioBytes: await store.retainedAudioBytes()
+        )
+
+        await store.append(sample)
+        self.sessionID = nil
+        self.startedAt = nil
+    }
+
+    // MARK: - Measurement Helpers
+
+    /// Median rather than mean: one cold-start segment or a thermal spike
+    /// should not define the headline number for a multi-hour run.
+    static func median(_ values: [Double]) -> Double {
+        let sorted = values.filter { $0.isFinite }.sorted()
+        guard !sorted.isEmpty else { return 0 }
+        let mid = sorted.count / 2
+        return sorted.count % 2 == 1 ? sorted[mid] : (sorted[mid - 1] + sorted[mid]) / 2
+    }
+
+    private static func residentMemoryBytes() -> Int64 {
+        var info = task_vm_info_data_t()
+        var count = mach_msg_type_number_t(MemoryLayout<task_vm_info_data_t>.size / MemoryLayout<natural_t>.size)
+        let result = withUnsafeMutablePointer(to: &info) { pointer in
+            pointer.withMemoryRebound(to: integer_t.self, capacity: Int(count)) {
+                task_info(mach_task_self_, task_flavor_t(TASK_VM_INFO), $0, &count)
+            }
+        }
+        return result == KERN_SUCCESS ? Int64(info.phys_footprint) : 0
+    }
+
+    private static func currentBatteryLevel() -> Float {
+        #if canImport(UIKit) && !os(macOS)
+        UIDevice.current.isBatteryMonitoringEnabled = true
+        return UIDevice.current.batteryLevel
+        #else
+        return -1
+        #endif
+    }
+
+    private static func currentAudioRoute() -> String {
+        #if os(iOS)
+        let outputs = AVAudioSession.sharedInstance().currentRoute.inputs
+        return outputs.first?.portType.rawValue ?? "unknown"
+        #else
+        return "unknown"
+        #endif
+    }
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Services/AmbientMemoryStore.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Services/AmbientMemoryStore.swift
@@ -1,0 +1,391 @@
+//
+//  AmbientMemoryStore.swift
+//  RunAnywhereAI
+//
+//  Local persistence for notes: note documents, the one recording each note
+//  owns, audio expiry, search, and purge.
+//
+//  Written with until-first-unlock protection so a note can keep appending
+//  and saving while the screen is locked (the point of background capture).
+//  Bytes stay encrypted until the first unlock after boot. Nothing here
+//  talks to the network.
+//
+
+import Foundation
+import os
+
+/// Serialised owner of the Lab's on-disk state.
+///
+/// An actor rather than a main-actor singleton: transcription and audio writes
+/// happen while the UI is scrolling, and the write path must never block the
+/// main thread.
+actor AmbientMemoryStore {
+    static let shared = AmbientMemoryStore()
+
+    private let logger = Logger(subsystem: "com.runanywhere", category: "AmbientMemoryStore")
+    private let fileManager = FileManager.default
+
+    private let rootDirectory: URL
+    private let sessionsDirectory: URL
+    private let audioDirectory: URL
+    private let benchmarksURL: URL
+
+    private let encoder: JSONEncoder = {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.sortedKeys]
+        return encoder
+    }()
+
+    private let decoder: JSONDecoder = {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }()
+
+    /// Sessions the caller deleted this run. A late write from an in-flight
+    /// transcription must not resurrect them.
+    private var deletedSessionIDs: Set<String> = []
+
+    /// The recording currently being appended to, if a note is capturing.
+    private var activeRecording: WAVFileWriter?
+
+    private init() {
+        let documents = fileManager.urls(for: .documentDirectory, in: .userDomainMask)[0]
+        rootDirectory = documents.appendingPathComponent("AmbientMemory", isDirectory: true)
+        sessionsDirectory = rootDirectory.appendingPathComponent("Sessions", isDirectory: true)
+        audioDirectory = rootDirectory.appendingPathComponent("Audio", isDirectory: true)
+        benchmarksURL = rootDirectory.appendingPathComponent("benchmarks.json")
+        createDirectories()
+    }
+
+    // MARK: - Sessions
+
+    /// All sessions, newest first. Empty orphans from a failed mic start are
+    /// deleted on load so the list never shows date-only husks.
+    func loadSessions() -> [AmbientSessionRecord] {
+        let files = (try? fileManager.contentsOfDirectory(
+            at: sessionsDirectory,
+            includingPropertiesForKeys: nil
+        )) ?? []
+
+        return files
+            .filter { $0.pathExtension == "json" }
+            .compactMap { url -> AmbientSessionRecord? in
+                guard let data = try? Data(contentsOf: url) else { return nil }
+                return try? decoder.decode(AmbientSessionRecord.self, from: data)
+            }
+            .filter { !deletedSessionIDs.contains($0.id) }
+            .compactMap { session -> AmbientSessionRecord? in
+                guard session.isEmptyOrphan else { return session }
+                delete(sessionID: session.id)
+                logger.info("Removed empty orphan note \(session.id, privacy: .public)")
+                return nil
+            }
+            .sorted { $0.startedAt > $1.startedAt }
+    }
+
+    func loadSession(id: String) -> AmbientSessionRecord? {
+        guard !deletedSessionIDs.contains(id),
+              let data = try? Data(contentsOf: sessionURL(id)) else { return nil }
+        return try? decoder.decode(AmbientSessionRecord.self, from: data)
+    }
+
+    /// Write a session document atomically. Tombstoned sessions are ignored so
+    /// a deletion during an active recording stays deleted.
+    func save(_ session: AmbientSessionRecord) {
+        guard !deletedSessionIDs.contains(session.id) else { return }
+        do {
+            let data = try encoder.encode(session)
+            try write(data, to: sessionURL(session.id))
+        } catch let encoding as EncodingError {
+            let detail = Self.describe(encoding)
+            logger.error(
+                "Ambient session encode failed for \(session.id, privacy: .public): \(detail, privacy: .public)"
+            )
+        } catch {
+            logger.error("Ambient session write failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private static func describe(_ error: EncodingError) -> String {
+        switch error {
+        case .invalidValue(let value, let context):
+            let path = context.codingPath.map(\.stringValue).joined(separator: ".")
+            return "invalidValue(\(String(describing: value))) at \(path): \(context.debugDescription)"
+        @unknown default:
+            return String(describing: error)
+        }
+    }
+
+    /// Delete one note and every artifact it owns. The only path besides an
+    /// explicit purge that destroys note text, and both are user-initiated.
+    func delete(sessionID: String) {
+        deletedSessionIDs.insert(sessionID)
+        try? fileManager.removeItem(at: sessionURL(sessionID))
+        removeAudio(sessionID: sessionID)
+    }
+
+    /// Remove every note, recording, and benchmark sample. Never touches the
+    /// app's shared RAG index, which belongs to Chat.
+    func purgeEverything() {
+        finishRecording()
+        try? fileManager.removeItem(at: sessionsDirectory)
+        try? fileManager.removeItem(at: audioDirectory)
+        try? fileManager.removeItem(at: benchmarksURL)
+        deletedSessionIDs.removeAll()
+        createDirectories()
+        logger.info("Ambient memory purged")
+    }
+
+    /// Delete the *recordings* of notes older than the window, leaving the
+    /// notes themselves untouched. Returns the ids whose audio went, so the
+    /// caller can refresh its in-memory list.
+    ///
+    /// Expiry is scoped to audio on purpose: a recording is a temporary
+    /// dogfood artifact that costs roughly 115 MB an hour, while the note is
+    /// the thing the tester came for and outlives every window.
+    @discardableResult
+    func expireAudio(olderThan window: AmbientRetentionWindow, now: Date = Date()) -> [String] {
+        guard let cutoff = window.expiryCutoff(from: now) else { return [] }
+
+        var expired: [String] = []
+        for var session in loadSessions() where session.hasAudio {
+            guard (session.endedAt ?? session.startedAt) < cutoff else { continue }
+            removeAudio(sessionID: session.id)
+            session.audioRelativePath = nil
+            save(session)
+            expired.append(session.id)
+        }
+        if !expired.isEmpty {
+            logger.info("Audio expiry removed \(expired.count) recording(s), notes kept")
+        }
+        return expired
+    }
+
+    // MARK: - Note Audio
+
+    /// Open the note's recording. Every ingested buffer is appended to this one
+    /// file, so playback is a real voice memo rather than a stitched-together
+    /// set of speech fragments.
+    func beginRecording(sessionID: String, sampleRate: Int) -> String? {
+        finishRecording()
+        let relativePath = Self.audioRelativePath(sessionID: sessionID)
+        do {
+            activeRecording = try WAVFileWriter(
+                url: rootDirectory.appendingPathComponent(relativePath),
+                sampleRate: sampleRate
+            )
+            return relativePath
+        } catch {
+            logger.error("Recording could not be opened: \(error.localizedDescription, privacy: .public)")
+            return nil
+        }
+    }
+
+    func appendRecording(_ pcm16: Data) {
+        guard let activeRecording else { return }
+        do {
+            try activeRecording.append(pcm16)
+        } catch {
+            // Keep the writer — a single failed append (e.g. brief lock race)
+            // must not kill the rest of a multi-hour note.
+            logger.error("Recording append failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    /// Close the recording and stamp its real length into the header.
+    func finishRecording() {
+        guard let activeRecording else { return }
+        self.activeRecording = nil
+        do {
+            try activeRecording.close()
+        } catch {
+            logger.error("Recording could not be finalized: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    func removeAudio(sessionID: String) {
+        try? fileManager.removeItem(
+            at: rootDirectory.appendingPathComponent(Self.audioRelativePath(sessionID: sessionID))
+        )
+        // Notes recorded before the switch to one file per note kept a
+        // directory of per-segment clips under the same id.
+        try? fileManager.removeItem(at: audioDirectory.appendingPathComponent(sessionID, isDirectory: true))
+    }
+
+    func audioURL(for relativePath: String) -> URL {
+        rootDirectory.appendingPathComponent(relativePath)
+    }
+
+    private static func audioRelativePath(sessionID: String) -> String {
+        "Audio/\(sessionID).wav"
+    }
+
+    // MARK: - Storage Accounting
+
+    /// Bytes currently used by retained audio.
+    func retainedAudioBytes() -> Int64 {
+        directorySize(audioDirectory)
+    }
+
+    /// Bytes used by session documents plus retained audio.
+    func totalBytes() -> Int64 {
+        directorySize(rootDirectory)
+    }
+
+    /// Free space on the volume backing the Lab's storage.
+    func availableCapacityBytes() -> Int64 {
+        let values = try? rootDirectory.resourceValues(forKeys: [.volumeAvailableCapacityForImportantUsageKey])
+        return values?.volumeAvailableCapacityForImportantUsage ?? 0
+    }
+
+    // MARK: - Search
+
+    /// Case-insensitive substring match across every note's title, summary,
+    /// action items, and transcript, newest first. One hit per note, carrying
+    /// the snippet around the match so the list can show why it matched.
+    ///
+    /// Deliberately plain text: the app's RAG index is single-tenant and
+    /// belongs to Chat, so notes never touch it.
+    nonisolated func search(_ query: String, in sessions: [AmbientSessionRecord]) -> [AmbientSearchHit] {
+        let needle = query.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        guard !needle.isEmpty else { return [] }
+
+        return sessions.compactMap { session -> AmbientSearchHit? in
+            guard let match = Self.firstMatch(for: needle, in: session) else { return nil }
+            return AmbientSearchHit(
+                id: session.id,
+                sessionID: session.id,
+                kind: match.kind,
+                snippet: match.snippet,
+                timestamp: session.startedAt,
+                sessionTitle: session.title
+            )
+        }
+        .sorted { $0.timestamp > $1.timestamp }
+    }
+
+    /// Fields are checked most-summarized first so the snippet shown is the
+    /// most readable place the term appears, not the first place it happens to
+    /// occur in a raw transcript.
+    private static func firstMatch(
+        for needle: String,
+        in session: AmbientSessionRecord
+    ) -> (kind: AmbientSearchHit.Kind, snippet: String)? {
+        if session.title.lowercased().contains(needle) {
+            return (.title, session.title)
+        }
+        if session.summary.lowercased().contains(needle) {
+            return (.summary, snippet(of: session.summary, around: needle))
+        }
+        if let item = session.actionItems.first(where: { $0.text.lowercased().contains(needle) }) {
+            return (.actionItem, item.text)
+        }
+        let transcript = session.fullTranscript
+        if transcript.lowercased().contains(needle) {
+            return (.transcript, snippet(of: transcript, around: needle))
+        }
+        return nil
+    }
+
+    /// A window of text centered on the match, so a two-hour transcript shows
+    /// the sentence that matched rather than its opening words.
+    private static func snippet(of text: String, around needle: String, radius: Int = 60) -> String {
+        guard let range = text.lowercased().range(of: needle) else { return String(text.prefix(140)) }
+        let start = text.index(range.lowerBound, offsetBy: -radius, limitedBy: text.startIndex) ?? text.startIndex
+        let end = text.index(range.upperBound, offsetBy: radius, limitedBy: text.endIndex) ?? text.endIndex
+        let body = text[start..<end].trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefix = start == text.startIndex ? "" : "…"
+        let suffix = end == text.endIndex ? "" : "…"
+        return prefix + body + suffix
+    }
+
+    // MARK: - Benchmarks
+
+    func loadBenchmarkSamples() -> [AmbientBenchmarkSample] {
+        guard let data = try? Data(contentsOf: benchmarksURL) else { return [] }
+        return (try? decoder.decode([AmbientBenchmarkSample].self, from: data)) ?? []
+    }
+
+    func append(_ sample: AmbientBenchmarkSample) {
+        var samples = loadBenchmarkSamples()
+        samples.append(sample)
+        if samples.count > Self.maxBenchmarkSamples {
+            samples = Array(samples.suffix(Self.maxBenchmarkSamples))
+        }
+        do {
+            try write(try encoder.encode(samples), to: benchmarksURL)
+        } catch {
+            logger.error("Ambient benchmark write failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    func clearBenchmarkSamples() {
+        try? fileManager.removeItem(at: benchmarksURL)
+    }
+
+    // MARK: - Private
+
+    private static let maxBenchmarkSamples = 200
+
+    private func createDirectories() {
+        try? fileManager.createDirectory(at: sessionsDirectory, withIntermediateDirectories: true)
+        try? fileManager.createDirectory(at: audioDirectory, withIntermediateDirectories: true)
+    }
+
+    private func sessionURL(_ id: String) -> URL {
+        sessionsDirectory.appendingPathComponent("\(id).json")
+    }
+
+    /// Atomic write that stays writable after the screen locks. Complete
+    /// protection refuses every write while locked, which silently destroys
+    /// mid-note transcripts for a background session.
+    private func write(_ data: Data, to url: URL) throws {
+        try data.write(to: url, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+    }
+
+    private func directorySize(_ url: URL) -> Int64 {
+        guard let enumerator = fileManager.enumerator(
+            at: url,
+            includingPropertiesForKeys: [.fileSizeKey],
+            options: [.skipsHiddenFiles]
+        ) else { return 0 }
+
+        var total: Int64 = 0
+        for case let fileURL as URL in enumerator {
+            let size = (try? fileURL.resourceValues(forKeys: [.fileSizeKey]))?.fileSize ?? 0
+            total += Int64(size)
+        }
+        return total
+    }
+}
+
+// MARK: - Search Hit
+
+/// One matching note plus the snippet that matched, so the list can show why
+/// the note came back before the tester opens it.
+struct AmbientSearchHit: Identifiable, Sendable, Equatable {
+    enum Kind: String, Sendable {
+        case title
+        case summary
+        case actionItem
+        case transcript
+
+        var label: String {
+            switch self {
+            case .title: return "Title"
+            case .summary: return "Summary"
+            case .actionItem: return "Action item"
+            case .transcript: return "Transcript"
+            }
+        }
+    }
+
+    let id: String
+    let sessionID: String
+    let kind: Kind
+    let snippet: String
+    let timestamp: Date
+    let sessionTitle: String
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Services/AmbientSessionManager.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Services/AmbientSessionManager.swift
@@ -1,0 +1,1038 @@
+//
+//  AmbientSessionManager.swift
+//  RunAnywhereAI
+//
+//  The one owner of ambient capture and session state.
+//
+//  Only the microphone lifecycle, iOS background policy, Live Activity, and
+//  storage policy live here. VAD debounce, segmentation, and transcription all
+//  belong to `RunAnywhere.ambient`, which this manager drives with a single
+//  start call and consumes as an event stream.
+//
+//  iOS background rules this encodes:
+//    - AVAudioEngine must be started while the app is foregrounded. iOS blocks
+//      engine.start() from the background, so `start()` refuses to run when the
+//      scene is not active.
+//    - `UIBackgroundModes: audio` keeps an already-running engine alive after
+//      the screen locks; it does not grant a covert always-on service.
+//    - A Live Activity keeps the session visible for as long as it records.
+//
+
+#if os(iOS)
+import ActivityKit
+import AVFoundation
+import CallKit
+import Combine
+import Foundation
+import RunAnywhere
+import UIKit
+import os
+
+@MainActor
+final class AmbientSessionManager: ObservableObject {
+    static let shared = AmbientSessionManager()
+
+    // MARK: - Published State
+
+    @Published private(set) var phase: AmbientSessionPhase = .idle
+    @Published private(set) var sessionRecord: AmbientSessionRecord?
+    @Published private(set) var elapsedSeconds = 0
+    @Published private(set) var audioLevel: Float = 0
+    @Published private(set) var liveTranscript: String = ""
+    @Published private(set) var activeGates: [RAAmbientResourceGate.Reason: String] = [:]
+    @Published private(set) var statusMessage: String = ""
+    @Published private(set) var lastError: String?
+
+    /// Selection the active (or most recent) session ran with.
+    @Published private(set) var selection: AmbientModelSelection?
+    @Published private(set) var retentionPolicy: AmbientRetentionPolicy = .retainAudio
+
+    /// Fires when a note that stopped in the background finally gets the
+    /// summary it had to defer, so the notes list can refresh that row.
+    let didFinishDeferredMerge = PassthroughSubject<String, Never>()
+
+    var isRecording: Bool { phase.isRecording }
+
+    /// True whenever the Lab still owns the audio engine and the Live Activity,
+    /// including while paused or finishing up. Anything else that wants the
+    /// microphone or a Live Activity must wait for this to clear.
+    var isCapturing: Bool { phase.holdsAudioSession }
+
+    // MARK: - Collaborators
+
+    private let logger = Logger(subsystem: "com.runanywhere", category: "AmbientSession")
+    private let audioCapture = AudioCaptureManager()
+    private let store = AmbientMemoryStore.shared
+    private let benchmarkRecorder = AmbientBenchmarkRecorder()
+
+    private var session: RAAmbientSession?
+    private var eventTask: Task<Void, Never>?
+    private var elapsedTask: Task<Void, Never>?
+    private var digestTask: Task<Void, Never>?
+    private var audioWriteTask: Task<Void, Never>?
+    private var interruptionObservers: [NSObjectProtocol] = []
+
+    /// Transcript accumulated since the last chunk digest. Summarizing every
+    /// segment would run the LLM on single sentences; batching gives the model
+    /// enough context to write something worth reading.
+    private var pendingChunk = ""
+    /// True while the note is recording audio to disk, so a storage gate can
+    /// stop writing without ending the note.
+    private var isWritingAudio = false
+
+    @available(iOS 16.1, *)
+    private var liveActivity: Activity<AmbientActivityAttributes>? {
+        get { liveActivityStorage as? Activity<AmbientActivityAttributes> }
+        set { liveActivityStorage = newValue }
+    }
+    private var liveActivityStorage: Any?
+
+    private init() {
+        observeInterruptions()
+        observeStopRequests()
+        observeForeground()
+    }
+
+    // MARK: - Start
+
+    /// Begin a visible ambient session. Must be called while the app is
+    /// foregrounded; the caller is responsible for having shown consent.
+    func start(
+        selection: AmbientModelSelection,
+        retention: AmbientRetentionPolicy,
+        context: AmbientCaptureContext,
+        conditions: AmbientDeviceConditions
+    ) async {
+        guard phase == .idle || phase == .stopped || phase == .failed else {
+            logger.warning("Ambient session already active — ignoring duplicate start")
+            return
+        }
+        guard UIApplication.shared.applicationState == .active else {
+            fail("Open RunAnywhere and try again — recording can only start while the app is on screen.")
+            return
+        }
+        guard !FlowSessionManager.shared.holdsAudioSession else {
+            fail("Voice Keyboard dictation is using the microphone. End that session first.")
+            return
+        }
+        // A phone/FaceTime call owns the mic exclusively — setActive fails with
+        // a generic "Session activation failed" otherwise, which looks like a bug.
+        if Self.isInPhoneCall {
+            fail("End the phone call first — the green call indicator in the status bar means the mic is busy.")
+            return
+        }
+        guard selection.canStartCapture else {
+            fail("Pick and download a speech detector and a transcription model before recording.")
+            return
+        }
+        guard !conditions.shouldStopCapture else {
+            fail("The device is too hot to start an ambient session. Let it cool down first.")
+            return
+        }
+
+        reset()
+        self.selection = selection
+        self.retentionPolicy = retention
+        transition(to: .preparing)
+        statusMessage = "Loading \(selection.asrModelID)…"
+
+        guard await requestMicrophone() else { return }
+
+        let sessionID = UUID().uuidString
+        var configuration = RAAmbientConfiguration.defaults(sttModelID: selection.asrModelID)
+        configuration.vadModelID = selection.vadModelID
+        // The note keeps its own continuous recording, so the pipeline does not
+        // need to hand back per-segment audio as well.
+        configuration.retainSegmentAudio = false
+
+        let started: RAAmbientSession
+        do {
+            started = try await RunAnywhere.ambient.start(configuration, sessionID: sessionID)
+        } catch {
+            fail("Could not prepare the models: \(error.localizedDescription)")
+            return
+        }
+        session = started
+
+        // Do not touch disk until the mic is actually open. Saving first left
+        // empty date-only notes whenever session activation failed (phone call,
+        // Bluetooth, etc.) — the list then showed a growing duration forever.
+        guard await startAudioEngine(feeding: started) else {
+            await started.cancel(reason: "Microphone unavailable")
+            session = nil
+            return
+        }
+
+        let deviceInfo = DeviceInfoService.shared.deviceInfo
+        var record = AmbientSessionRecord(
+            id: sessionID,
+            startedAt: Date(),
+            profileID: selection.profileID,
+            vadModelID: selection.vadModelID,
+            sttModelID: selection.asrModelID,
+            digestModelID: selection.digestModelID,
+            retentionPolicy: retention,
+            context: context,
+            deviceModel: deviceInfo?.modelName ?? "Unknown",
+            osVersion: deviceInfo?.osVersion ?? ""
+        )
+        if retention.retainsAudio, await hasStorageHeadroom(for: Self.recordingHeadroomBytes) {
+            record.audioRelativePath = await store.beginRecording(
+                sessionID: sessionID,
+                sampleRate: Self.captureSampleRate
+            )
+            isWritingAudio = record.audioRelativePath != nil
+        }
+        sessionRecord = record
+        await store.save(record)
+
+        consumeEvents(from: started)
+        benchmarkRecorder.begin(sessionID: sessionID, conditions: conditions)
+        if #available(iOS 16.1, *) { startLiveActivity(sessionID: sessionID) }
+        startElapsedTimer()
+
+        transition(to: .listening)
+        statusMessage = "Listening. Lock the screen if you like — recording stays visible."
+        logger.info("Ambient session \(sessionID, privacy: .public) started")
+    }
+
+    // MARK: - Stop / Pause
+
+    /// Stop capture, finish in-flight transcription, summarize, and save.
+    func stop(reason: String? = nil) async {
+        guard phase != .idle, phase != .stopped else { return }
+        logger.info("Ambient session stopping (\(reason ?? "user", privacy: .public))")
+
+        elapsedTask?.cancel()
+        elapsedTask = nil
+        audioCapture.stopRecording(deactivateSession: true)
+        isWritingAudio = false
+        await closeRecording()
+        transition(to: .processing)
+        statusMessage = "Finishing transcription…"
+
+        await session?.finish()
+        session = nil
+        await eventTask?.value
+        eventTask = nil
+        await digestTask?.value
+        digestTask = nil
+
+        sessionRecord?.endedAt = Date()
+        sessionRecord?.stopReason = reason
+
+        statusMessage = "Writing the summary…"
+        await summarizeNote()
+
+        if let record = sessionRecord {
+            await store.save(record)
+            await benchmarkRecorder.finish(record: record, store: store)
+        }
+
+        if #available(iOS 16.1, *) { await endLiveActivity() }
+        audioLevel = 0
+        transition(to: .stopped)
+        statusMessage = reason.map { "Stopped: \($0)" } ?? "Note saved."
+    }
+
+    func pause() async {
+        guard phase.isRecording else { return }
+        await session?.pause()
+        transition(to: .paused)
+        statusMessage = "Paused. The microphone stays open but nothing is captured."
+    }
+
+    func resume() async {
+        guard phase == .paused else { return }
+        await session?.resume()
+        transition(to: .listening)
+        statusMessage = "Listening."
+    }
+
+
+    // MARK: - Event Consumption
+
+    private func consumeEvents(from session: RAAmbientSession) {
+        eventTask = Task { [weak self] in
+            for await event in session.events {
+                guard let self else { return }
+                await self.handle(event)
+            }
+        }
+    }
+
+    private func handle(_ event: RAAmbientEvent) async {
+        switch event {
+        case .state(let state):
+            applyPipelineState(state)
+
+        case .speechStarted:
+            benchmarkRecorder.markSpeechStarted()
+
+        case .speechEnded(_, let durationMs):
+            benchmarkRecorder.markSpeechEnded(durationMs: durationMs)
+
+        case .segmentOpened:
+            if phase == .listening { transition(to: .capturingSpeech) }
+
+        case .segmentFinalized(let segment):
+            await persist(segment)
+
+        case .transcript(let transcript):
+            await persist(transcript)
+
+        case .resourceGate(let gate):
+            apply(gate)
+
+        case .failure(let failure):
+            await handle(failure)
+        }
+    }
+
+    private func applyPipelineState(_ state: RAAmbientState) {
+        switch state {
+        case .listening where phase.isRecording:
+            transition(to: .listening)
+        case .speechSegment where phase.isRecording:
+            transition(to: .capturingSpeech)
+        case .processing where phase.isRecording:
+            transition(to: .transcribing)
+        default:
+            break
+        }
+    }
+
+    private func persist(_ segment: RAAmbientSegment) async {
+        guard var record = sessionRecord else { return }
+        record.upsert(AmbientSegmentRecord(from: segment))
+        sessionRecord = record
+        benchmarkRecorder.markSegment()
+        await store.save(record)
+        updateLiveActivityIfNeeded()
+    }
+
+    private func persist(_ transcript: RAAmbientTranscript) async {
+        guard var record = sessionRecord else { return }
+
+        // Transcription can finish before the segmentFinalized event is
+        // handled on this actor; create a stub segment so the text is never
+        // dropped.
+        var segment = record.segments.first(where: { $0.id == transcript.segmentID })
+            ?? AmbientSegmentRecord(
+                id: transcript.segmentID,
+                sessionID: transcript.sessionID,
+                index: transcript.segmentIndex,
+                startedAt: transcript.startedAt,
+                endedAt: transcript.endedAt,
+                durationMs: transcript.audioDurationMs,
+                sampleRate: Self.captureSampleRate,
+                peakConfidence: transcript.confidence
+            )
+
+        segment.apply(transcript)
+        record.upsert(segment)
+        sessionRecord = record
+        liveTranscript = transcript.text
+        benchmarkRecorder.markTranscript(transcript)
+        await store.save(record)
+
+        accumulate(transcript.text)
+    }
+
+    private func apply(_ gate: RAAmbientResourceGate) {
+        if gate.isActive {
+            activeGates[gate.reason] = gate.detail
+        } else {
+            activeGates.removeValue(forKey: gate.reason)
+        }
+        benchmarkRecorder.markGate(gate)
+        logger.info("Ambient gate \(gate.reason.rawValue, privacy: .public) active=\(gate.isActive)")
+    }
+
+    private func handle(_ failure: RAAmbientFailure) async {
+        let detail = "[\(failure.stage.rawValue)] \(failure.message)"
+        logger.error("Ambient failure \(detail, privacy: .public)")
+        lastError = failure.message
+        guard failure.isFatal else { return }
+        await stop(reason: failure.message)
+        transition(to: .failed)
+    }
+
+    // MARK: - Summarization
+
+    /// Roughly one page of transcript. Small enough that a 0.6B model still has
+    /// room for its answer, large enough that the summary has real context.
+    private static let chunkCharacterLimit = 2_000
+
+    /// Buffer finalized transcript and digest it a chunk at a time, so a
+    /// two-hour note is summarized as it happens rather than in one impossible
+    /// pass at the end.
+    private func accumulate(_ text: String) {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        pendingChunk += pendingChunk.isEmpty ? trimmed : " " + trimmed
+        guard pendingChunk.count >= Self.chunkCharacterLimit else { return }
+        scheduleChunkDigest()
+    }
+
+    /// Digests are chained onto a single task so LLM work stays serialized
+    /// behind transcription and never runs two generations at once.
+    private func scheduleChunkDigest() {
+        guard selection?.digestModelID != nil, !pendingChunk.isEmpty else { return }
+        guard activeGates[.thermal] == nil, activeGates[.memory] == nil else {
+            logger.info("Holding the chunk digest while a resource gate is active")
+            return
+        }
+        // A Metal model cannot run while the screen is locked, and the whole
+        // point of the feature is that capture survives locking. The text is
+        // kept in the buffer and digested on return to the foreground.
+        guard canRunDigestNow else {
+            logger.info("Deferring chunk digest until the app is foregrounded")
+            return
+        }
+
+        let chunk = pendingChunk
+        pendingChunk = ""
+        let previous = digestTask
+        digestTask = Task { [weak self] in
+            await previous?.value
+            guard let self else { return }
+            // Re-check inside the task: the phone may have locked between
+            // schedule and run, and Metal work from background always fails.
+            await self.digestChunk(chunk)
+        }
+    }
+
+    private func digestChunk(_ chunk: String) async {
+        let modelID = selection?.digestModelID ?? sessionRecord?.digestModelID
+        guard let modelID else { return }
+        guard canRunDigestNow else {
+            // Restore the text and wait for foreground — never touch Metal here.
+            pendingChunk = chunk + (pendingChunk.isEmpty ? "" : " " + pendingChunk)
+            if var record = sessionRecord {
+                record.summaryPending = true
+                sessionRecord = record
+                await store.save(record)
+            }
+            logger.info("Chunk digest deferred — app is not in the foreground")
+            return
+        }
+        do {
+            try await ensureLoaded(modelID: modelID, category: .language)
+            // Screen can lock during model load; refuse generate if it did.
+            guard canRunDigestNow else {
+                pendingChunk = chunk + (pendingChunk.isEmpty ? "" : " " + pendingChunk)
+                logger.info("Chunk digest aborted after load — app left the foreground")
+                return
+            }
+            let digest = try await RunAnywhere.ambient.digest(text: chunk, mode: .chunk)
+            guard var record = sessionRecord else { return }
+            record.partialSummaries.append(digest.summary)
+            record.mergeActionItems(digest.actionItems)
+            // Until the merge runs, the joined partials are the best summary
+            // the note has, so a crash mid-recording still leaves it readable.
+            if record.summary.isEmpty || record.summaryPending {
+                record.summary = record.partialSummaries.joined(separator: "\n\n")
+            }
+            record.summaryPending = false
+            sessionRecord = record
+            benchmarkRecorder.markDigest(digest)
+            await store.save(record)
+            updateLiveActivityIfNeeded()
+        } catch {
+            // Put the text back so the next attempt still covers it.
+            pendingChunk = chunk + (pendingChunk.isEmpty ? "" : " " + pendingChunk)
+            let detail = error.localizedDescription
+            logger.warning("Chunk digest failed: \(detail, privacy: .public)")
+            if var record = sessionRecord {
+                record.summaryPending = true
+                sessionRecord = record
+                await store.save(record)
+            }
+        }
+    }
+
+    /// Digest the tail of the transcript, then fold every partial summary into
+    /// the one summary and action list the note keeps.
+    private func summarizeNote() async {
+        guard var record = sessionRecord else { return }
+        let modelID = selection?.digestModelID ?? record.digestModelID
+        guard let modelID else {
+            logger.info("No digest model on the note — skipping summary")
+            return
+        }
+
+        guard canRunDigestNow else {
+            // Stop can arrive from the Live Activity or a Shortcut while the
+            // app is backgrounded. Segments are already on disk, so the next
+            // foreground can digest `fullTranscript` even with no partials yet.
+            record.summaryPending = true
+            if record.summary.isEmpty {
+                record.summary = record.partialSummaries.joined(separator: "\n\n")
+            }
+            sessionRecord = record
+            await store.save(record)
+            logger.info("Merge deferred to the foreground for note \(record.id, privacy: .public)")
+            return
+        }
+
+        if !pendingChunk.isEmpty {
+            let tail = pendingChunk
+            pendingChunk = ""
+            await digestChunk(tail)
+        }
+
+        guard var current = sessionRecord else { return }
+        // Short notes never hit the mid-session chunk threshold. If the live
+        // buffer digest failed (or was empty), summarize from the persisted
+        // transcript so a working STT note is never left summary-less.
+        if current.partialSummaries.isEmpty {
+            let source = current.fullTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !source.isEmpty {
+                pendingChunk = ""
+                await digestChunk(source)
+                current = sessionRecord ?? current
+            }
+        }
+
+        let finished = await merged(current, modelID: modelID)
+        if finished.summary.isEmpty, !finished.fullTranscript.isEmpty {
+            var pending = finished
+            pending.summaryPending = true
+            sessionRecord = pending
+            await store.save(pending)
+            statusMessage = "Note saved. Summary still pending — open the note and tap Retry."
+            logger.warning(
+                "Summarization produced no summary for note \(pending.id, privacy: .public)"
+            )
+        } else {
+            sessionRecord = finished
+        }
+    }
+
+    /// Re-run summarization for a saved note that has a transcript but no
+    /// summary (failed digest, deferred GPU work, etc.).
+    func retrySummary(for noteID: String) async {
+        guard !phase.holdsAudioSession else {
+            lastError = "Stop the current recording before retrying a summary."
+            return
+        }
+        guard var note = await store.loadSession(id: noteID) else { return }
+        guard let modelID = note.digestModelID ?? selection?.digestModelID else {
+            lastError = "Pick a summarizing model on Notes, then retry."
+            return
+        }
+        guard canRunDigestNow else {
+            lastError = "Bring the app to the foreground to finish the summary."
+            return
+        }
+
+        statusMessage = "Writing the summary…"
+        note.summaryPending = true
+        note.digestModelID = modelID
+        await store.save(note)
+
+        if note.partialSummaries.isEmpty {
+            let source = note.fullTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !source.isEmpty else {
+                note.summaryPending = false
+                await store.save(note)
+                statusMessage = "Nothing to summarize — this note has no transcript."
+                return
+            }
+            do {
+                try await ensureLoaded(modelID: modelID, category: .language)
+                guard canRunDigestNow else {
+                    note.summaryPending = true
+                    await store.save(note)
+                    lastError = "Bring the app to the foreground to finish the summary."
+                    statusMessage = lastError ?? ""
+                    return
+                }
+                let digest = try await RunAnywhere.ambient.digest(text: source, mode: .chunk)
+                note.partialSummaries = [digest.summary]
+                note.mergeActionItems(digest.actionItems)
+                note.summary = digest.summary
+                benchmarkRecorder.markDigest(digest)
+            } catch {
+                note.summaryPending = true
+                await store.save(note)
+                lastError = "Summarization failed: \(error.localizedDescription)"
+                statusMessage = lastError ?? ""
+                return
+            }
+        }
+
+        let finished = await merged(note, modelID: modelID)
+        if sessionRecord?.id == finished.id { sessionRecord = finished }
+        didFinishDeferredMerge.send(finished.id)
+        statusMessage = finished.summary.isEmpty
+            ? "Summary still empty — try a different summarizing model."
+            : "Summary updated."
+    }
+
+    /// The reduce half of the map-reduce: one pass over the partial summaries.
+    /// Returns the updated note, saved, so it can also finish a note that is no
+    /// longer the active one.
+    private func merged(_ note: AmbientSessionRecord, modelID: String) async -> AmbientSessionRecord {
+        var record = note
+        guard canRunDigestNow else {
+            record.summaryPending = true
+            await store.save(record)
+            logger.info("Merge deferred — app is not in the foreground")
+            return record
+        }
+        if record.partialSummaries.isEmpty {
+            let source = record.fullTranscript.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !source.isEmpty {
+                do {
+                    try await ensureLoaded(modelID: modelID, category: .language)
+                    guard canRunDigestNow else {
+                        record.summaryPending = true
+                        await store.save(record)
+                        return record
+                    }
+                    let digest = try await RunAnywhere.ambient.digest(text: source, mode: .chunk)
+                    record.partialSummaries = [digest.summary]
+                    record.mergeActionItems(digest.actionItems)
+                    record.summary = digest.summary
+                    benchmarkRecorder.markDigest(digest)
+                } catch {
+                    let detail = error.localizedDescription
+                    logger.warning("Transcript digest failed: \(detail, privacy: .public)")
+                    record.summaryPending = true
+                    await store.save(record)
+                    return record
+                }
+            } else {
+                record.summaryPending = false
+                await store.save(record)
+                return record
+            }
+        }
+
+        // A single partial is already one summary of one chunk; running the
+        // merge over it would only paraphrase it and risk losing detail.
+        guard record.partialSummaries.count > 1 else {
+            record.summary = record.partialSummaries[0]
+            record.summaryPending = false
+            await store.save(record)
+            return record
+        }
+
+        do {
+            try await ensureLoaded(modelID: modelID, category: .language)
+            guard canRunDigestNow else {
+                record.summaryPending = true
+                await store.save(record)
+                return record
+            }
+            let joined = record.partialSummaries.enumerated()
+                .map { "Part \($0.offset + 1): \($0.element)" }
+                .joined(separator: "\n\n")
+            let digest = try await RunAnywhere.ambient.digest(text: joined, mode: .merge)
+            record.summary = digest.summary
+            record.replaceMachineActionItems(with: digest.actionItems)
+            benchmarkRecorder.markDigest(digest)
+        } catch {
+            record.summary = record.partialSummaries.joined(separator: "\n\n")
+            let detail = error.localizedDescription
+            logger.warning("Merge failed, keeping the partial summaries: \(detail, privacy: .public)")
+        }
+        record.summaryPending = false
+        await store.save(record)
+        return record
+    }
+
+    /// Summarization always needs the foreground. Stop-from-Lock-Screen leaves
+    /// the process backgrounded, and both MLX and llama.cpp-on-Metal refuse
+    /// GPU work there (`kIOGPUCommandBufferCallbackErrorBackgroundExecutionNotPermitted`).
+    /// Capture/ASR keep running; the note is marked `summaryPending` instead.
+    private var canRunDigestNow: Bool {
+        UIApplication.shared.applicationState == .active
+    }
+
+    /// Finish anything that had to wait for the GPU to become usable again:
+    /// the current note's buffered chunks, and any note that stopped while
+    /// backgrounded and never got its merge.
+    private func runDeferredDigests() async {
+        if phase.holdsAudioSession {
+            if !pendingChunk.isEmpty { scheduleChunkDigest() }
+            return
+        }
+
+        for note in await store.loadSessions() where note.summaryPending {
+            guard let modelID = note.digestModelID else { continue }
+            let finished = await merged(note, modelID: modelID)
+            if sessionRecord?.id == finished.id { sessionRecord = finished }
+            didFinishDeferredMerge.send(finished.id)
+        }
+    }
+
+    private func ensureLoaded(modelID: String, category: RAModelCategory) async throws {
+        var request = RACurrentModelRequest()
+        request.category = category
+        // Always reload. A prior stop-from-Lock-Screen attempt can leave the
+        // Metal/llama.cpp backend wedged (`backend is in error state`), and
+        // skipping load then makes every foreground retry fail too.
+        if RunAnywhere.currentModel(request).modelID == modelID {
+            var unload = RAModelUnloadRequest()
+            unload.modelID = modelID
+            unload.category = category
+            _ = await RunAnywhere.unloadModel(unload)
+        }
+
+        var load = RAModelLoadRequest()
+        load.modelID = modelID
+        load.category = category
+        let result = await RunAnywhere.loadModel(load)
+        guard result.success else {
+            throw NSError(
+                domain: "AmbientMemory",
+                code: 1,
+                userInfo: [NSLocalizedDescriptionKey: result.errorMessage]
+            )
+        }
+    }
+
+    // MARK: - Audio Engine
+
+    private func requestMicrophone() async -> Bool {
+        guard await audioCapture.requestPermission() else {
+            fail("Microphone access is required to record a note.")
+            return false
+        }
+        return true
+    }
+
+    /// True while a cellular / FaceTime / VoIP call still owns the audio route.
+    private static var isInPhoneCall: Bool {
+        CXCallObserver().calls.contains { !$0.hasEnded }
+    }
+
+    private func startAudioEngine(feeding session: RAAmbientSession) async -> Bool {
+        if Self.isInPhoneCall {
+            fail("End the phone call first — the green call indicator in the status bar means the mic is busy.")
+            return false
+        }
+        do {
+            // Warm the session before the engine so a stale category left by
+            // TTS / model-picker playback does not fail the first attempt.
+            // The engine start then skips reconfiguration to avoid a second
+            // deactivate/activate race against mediaserverd.
+            try await audioCapture.activateAudioSession()
+            try await AudioCapturePump.startRecording(
+                with: audioCapture,
+                configureSession: false
+            ) { [weak self] data in
+                guard let self else { return }
+                self.audioLevel = self.audioCapture.audioLevel
+                guard self.phase.isRecording else { return }
+                session.ingest(pcm16: data)
+                // Every buffer goes to the recording, not just the speech the
+                // detector kept, so playback is the room as it sounded rather
+                // than a cut of detected utterances.
+                if self.isWritingAudio { self.appendToRecording(data) }
+            }
+            return true
+        } catch {
+            if Self.isInPhoneCall {
+                fail("End the phone call first — the green call indicator in the status bar means the mic is busy.")
+            } else {
+                let detail = error.localizedDescription
+                fail(
+                    "Could not start the microphone: \(detail). "
+                        + "End any call, close other apps using the mic, then try Record again."
+                )
+            }
+            return false
+        }
+    }
+
+    /// Writes are chained rather than fired off independently: separate tasks
+    /// entering the store actor have no ordering guarantee, and a WAV whose
+    /// buffers land out of order is a scrambled recording.
+    private func appendToRecording(_ data: Data) {
+        let previous = audioWriteTask
+        audioWriteTask = Task { [store] in
+            await previous?.value
+            await store.appendRecording(data)
+        }
+    }
+
+    /// Drain queued writes before closing, so the last seconds of a note are in
+    /// the file when its header is stamped with the final length.
+    private func closeRecording() async {
+        await audioWriteTask?.value
+        audioWriteTask = nil
+        await store.finishRecording()
+    }
+
+    // MARK: - Interruptions and External Stop
+
+    private func observeInterruptions() {
+        let center = NotificationCenter.default
+        interruptionObservers.append(center.addObserver(
+            forName: AVAudioSession.interruptionNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] notification in
+            Task { @MainActor in self?.handleAudioInterruption(notification) }
+        })
+
+        interruptionObservers.append(center.addObserver(
+            forName: AVAudioSession.mediaServicesWereResetNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in await self?.stop(reason: "Audio services were reset") }
+        })
+
+        interruptionObservers.append(center.addObserver(
+            forName: ProcessInfo.thermalStateDidChangeNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in await self?.handleThermalChange() }
+        })
+    }
+
+    /// GPU summarization can only run on screen, so returning to the
+    /// foreground is the trigger for anything that had to wait.
+    private func observeForeground() {
+        interruptionObservers.append(NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            Task { @MainActor in
+                // Give iOS a beat after unlock before Metal work; immediate
+                // generate right on didBecomeActive still races the GPU gate.
+                try? await Task.sleep(nanoseconds: 400_000_000)
+                guard UIApplication.shared.applicationState == .active else { return }
+                await self?.runDeferredDigests()
+            }
+        })
+    }
+
+    /// The Live Activity's Stop button and the App Intent both signal through
+    /// the shared Darwin channel, so a stop from outside the app is honored.
+    private func observeStopRequests() {
+        DarwinNotificationCenter.shared.addObserver(
+            name: SharedConstants.DarwinNotifications.ambientStopRequested
+        ) { [weak self] in
+            Task { @MainActor in await self?.stop(reason: "Stopped from the Lock Screen") }
+        }
+    }
+
+    private func handleAudioInterruption(_ notification: Notification) {
+        guard let raw = notification.userInfo?[AVAudioSessionInterruptionTypeKey] as? UInt,
+              let type = AVAudioSession.InterruptionType(rawValue: raw) else { return }
+        guard phase.isRecording || phase == .paused else { return }
+
+        switch type {
+        case .began:
+            benchmarkRecorder.markInterruption()
+            Task { await stop(reason: "Interrupted by a call or another app") }
+        case .ended:
+            // iOS will not let a backgrounded app restart the engine, so the
+            // session stays stopped and the user restarts it explicitly.
+            statusMessage = "Interruption ended. Start a new session when you are ready."
+        @unknown default:
+            break
+        }
+    }
+
+    private func handleThermalChange() async {
+        let conditions = AmbientModelProfileResolver().currentConditions(
+            deviceInfo: DeviceInfoService.shared.deviceInfo
+        )
+        guard phase.isRecording else { return }
+
+        if conditions.shouldStopCapture {
+            await stop(reason: "Device reached a critical thermal state")
+            return
+        }
+        await session?.report(gate: RAAmbientResourceGate(
+            reason: .thermal,
+            isActive: conditions.shouldSuspendDerivedWork,
+            detail: "Thermal state: \(conditions.thermalDescription)"
+        ))
+    }
+
+    private func hasStorageHeadroom(for bytes: Int) async -> Bool {
+        let available = await store.availableCapacityBytes()
+        return available == 0 || available > Int64(bytes) + Self.storageFloorBytes
+    }
+
+    /// A long note can fill the disk. Recording stops on its own when space
+    /// runs low; transcription keeps going, because the text is what matters.
+    private func stopRecordingAudioIfStorageIsLow() async {
+        guard isWritingAudio,
+              await !hasStorageHeadroom(for: Self.recordingHeadroomBytes) else { return }
+        isWritingAudio = false
+        await closeRecording()
+        apply(RAAmbientResourceGate(
+            reason: .storage,
+            isActive: true,
+            detail: "Low storage — the recording stopped, transcription continues"
+        ))
+    }
+
+    // MARK: - Live Activity
+
+    @available(iOS 16.1, *)
+    private func startLiveActivity(sessionID: String) {
+        guard ActivityAuthorizationInfo().areActivitiesEnabled else {
+            logger.info("Live Activities disabled — ambient session runs without one")
+            return
+        }
+        do {
+            liveActivity = try Activity.request(
+                attributes: AmbientActivityAttributes(sessionId: sessionID),
+                content: .init(state: currentActivityState(), staleDate: nil),
+                pushType: nil
+            )
+        } catch {
+            logger.warning("Ambient Live Activity start failed: \(error.localizedDescription, privacy: .public)")
+        }
+    }
+
+    private func updateLiveActivityIfNeeded() {
+        guard #available(iOS 16.1, *), let activity = liveActivity else { return }
+        let state = currentActivityState()
+        Task { await activity.update(.init(state: state, staleDate: nil)) }
+    }
+
+    @available(iOS 16.1, *)
+    private func endLiveActivity() async {
+        guard let activity = liveActivity else { return }
+        var state = currentActivityState()
+        state.isStopped = true
+        await activity.end(.init(state: state, staleDate: nil), dismissalPolicy: .after(.now + 4))
+        liveActivity = nil
+    }
+
+    @available(iOS 16.1, *)
+    private func currentActivityState() -> AmbientActivityAttributes.ContentState {
+        AmbientActivityAttributes.ContentState(
+            phase: phase.liveActivityPhase,
+            elapsedSeconds: elapsedSeconds,
+            segmentCount: sessionRecord?.segments.count ?? 0,
+            actionItemCount: sessionRecord?.actionItems.count ?? 0,
+            isStopped: !phase.isRecording && phase != .paused
+        )
+    }
+
+    // MARK: - Timer
+
+    private func startElapsedTimer() {
+        elapsedTask = Task { [weak self] in
+            while !Task.isCancelled {
+                try? await Task.sleep(nanoseconds: 1_000_000_000)
+                guard let self, self.phase.isRecording || self.phase == .paused else { break }
+                self.elapsedSeconds += 1
+                if self.elapsedSeconds % 5 == 0 {
+                    self.updateLiveActivityIfNeeded()
+                }
+                if self.elapsedSeconds % 30 == 0 {
+                    await self.stopRecordingAudioIfStorageIsLow()
+                }
+            }
+        }
+    }
+
+    // MARK: - Helpers
+
+    private static let storageFloorBytes: Int64 = 500_000_000
+    /// Roughly ten minutes of 16 kHz mono PCM, the headroom a note needs before
+    /// it is worth opening a recording at all.
+    private static let recordingHeadroomBytes = 20_000_000
+    private static let captureSampleRate = 16_000
+
+    private func reset() {
+        elapsedSeconds = 0
+        liveTranscript = ""
+        activeGates.removeAll()
+        lastError = nil
+        statusMessage = ""
+        sessionRecord = nil
+        pendingChunk = ""
+        isWritingAudio = false
+    }
+
+    private func transition(to next: AmbientSessionPhase) {
+        guard phase != next else { return }
+        phase = next
+        logger.debug("Ambient phase → \(next.rawValue, privacy: .public)")
+    }
+
+    private func fail(_ message: String) {
+        lastError = message
+        statusMessage = message
+        transition(to: .failed)
+        logger.error("Ambient session failed to start: \(message, privacy: .public)")
+    }
+}
+
+// MARK: - Phase
+
+/// UI-facing session phase. Distinct from the SDK's pipeline state because it
+/// also covers permission/model preparation and terminal app-side outcomes.
+enum AmbientSessionPhase: String, Sendable {
+    case idle
+    case preparing
+    case listening
+    case capturingSpeech
+    case transcribing
+    case processing
+    case paused
+    case stopped
+    case failed
+
+    var isRecording: Bool {
+        switch self {
+        case .listening, .capturingSpeech, .transcribing:
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// A paused session keeps the engine running so it can resume instantly,
+    /// and `preparing`/`processing` bracket the same resources, so all of them
+    /// count as holding the microphone.
+    var holdsAudioSession: Bool {
+        switch self {
+        case .idle, .stopped, .failed:
+            return false
+        default:
+            return true
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .idle: return "Not recording"
+        case .preparing: return "Preparing models"
+        case .listening: return "Listening"
+        case .capturingSpeech: return "Capturing speech"
+        case .transcribing: return "Transcribing"
+        case .processing: return "Finishing up"
+        case .paused: return "Paused"
+        case .stopped: return "Stopped"
+        case .failed: return "Stopped on an error"
+        }
+    }
+
+    var liveActivityPhase: String {
+        switch self {
+        case .capturingSpeech: return "speech"
+        case .transcribing, .processing: return "processing"
+        case .paused: return "paused"
+        case .preparing: return "preparing"
+        default: return "listening"
+        }
+    }
+}
+#endif

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Services/WAVFileWriter.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Services/WAVFileWriter.swift
@@ -1,0 +1,92 @@
+//
+//  WAVFileWriter.swift
+//  RunAnywhereAI
+//
+//  Streams 16-bit PCM into a WAV file as it arrives.
+//
+//  A note can run for hours, so the samples cannot be buffered in memory and
+//  written once at the end: the header is written up front with zeroed sizes
+//  and patched with the real lengths when the file is closed.
+//
+
+import Foundation
+
+/// Appends PCM16 samples to a growing WAV file.
+///
+/// Not thread-safe by itself; `AmbientMemoryStore` owns the only instance and
+/// serializes access to it.
+final class WAVFileWriter {
+
+    private let handle: FileHandle
+    private var dataBytes: UInt32 = 0
+    private var isClosed = false
+
+    private static let headerSize = 44
+    private static let bitsPerSample: UInt16 = 16
+    private static let channelCount: UInt16 = 1
+
+    init(url: URL, sampleRate: Int) throws {
+        try FileManager.default.createDirectory(
+            at: url.deletingLastPathComponent(),
+            withIntermediateDirectories: true
+        )
+        // Until-first-unlock stays writable after the screen locks — required
+        // for Voice Memos-style background capture. Complete protection
+        // refuses every append the moment the phone locks.
+        try Self.header(sampleRate: sampleRate, dataBytes: 0)
+            .write(to: url, options: [.atomic, .completeFileProtectionUntilFirstUserAuthentication])
+        handle = try FileHandle(forWritingTo: url)
+        try handle.seekToEnd()
+    }
+
+    func append(_ pcm16: Data) throws {
+        guard !isClosed, !pcm16.isEmpty else { return }
+        try handle.write(contentsOf: pcm16)
+        dataBytes += UInt32(pcm16.count)
+    }
+
+    /// Patch the RIFF and data chunk sizes, then close. A file that is never
+    /// closed (a crash mid-note) still plays in most players, just with a
+    /// zero-length header, which is why the samples are on disk regardless.
+    func close() throws {
+        guard !isClosed else { return }
+        isClosed = true
+        defer { try? handle.close() }
+
+        try handle.seek(toOffset: 4)
+        try handle.write(contentsOf: Self.littleEndian(UInt32(Self.headerSize - 8) + dataBytes))
+        try handle.seek(toOffset: 40)
+        try handle.write(contentsOf: Self.littleEndian(dataBytes))
+    }
+
+    // MARK: - Header
+
+    private static func header(sampleRate: Int, dataBytes: UInt32) -> Data {
+        let byteRate = UInt32(sampleRate) * UInt32(channelCount) * UInt32(bitsPerSample / 8)
+        let blockAlign = channelCount * (bitsPerSample / 8)
+
+        var data = Data(capacity: headerSize)
+        data.append(contentsOf: Array("RIFF".utf8))
+        data.append(littleEndian(UInt32(headerSize - 8) + dataBytes))
+        data.append(contentsOf: Array("WAVE".utf8))
+        data.append(contentsOf: Array("fmt ".utf8))
+        data.append(littleEndian(UInt32(16)))
+        data.append(littleEndian(UInt16(1)))
+        data.append(littleEndian(channelCount))
+        data.append(littleEndian(UInt32(sampleRate)))
+        data.append(littleEndian(byteRate))
+        data.append(littleEndian(blockAlign))
+        data.append(littleEndian(bitsPerSample))
+        data.append(contentsOf: Array("data".utf8))
+        data.append(littleEndian(dataBytes))
+        return data
+    }
+
+    private static func littleEndian(_ value: UInt32) -> Data {
+        withUnsafeBytes(of: value.littleEndian) { Data($0) }
+    }
+
+    private static func littleEndian(_ value: UInt16) -> Data {
+        withUnsafeBytes(of: value.littleEndian) { Data($0) }
+    }
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/ViewModels/AmbientMemoryViewModel.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/ViewModels/AmbientMemoryViewModel.swift
@@ -1,0 +1,416 @@
+//
+//  AmbientMemoryViewModel.swift
+//  RunAnywhereAI
+//
+//  State for the offline notes screens: the notes list, global text search,
+//  note editing, free model picks, storage accounting, and deletion.
+//
+//  Capture itself belongs to `AmbientSessionManager`; this view model reads
+//  that manager and owns everything around a recording.
+//
+//  Nothing here touches the app's RAG index. That index is single-tenant and
+//  belongs to Chat's document Q&A: indexing notes into it would let a question
+//  about an attached PDF retrieve private recordings, and attaching a document
+//  would wipe whatever notes had put there. Search is plain text instead.
+//
+
+#if os(iOS)
+import Combine
+import Foundation
+import RunAnywhere
+import os
+
+@MainActor
+final class AmbientMemoryViewModel: ObservableObject {
+
+    // MARK: - Setup
+
+    @Published var selectedProfileID: String = AmbientModelProfile.quality.id
+    /// Explicit user picks only — never auto-filled from a profile on appear.
+    @Published var selection: AmbientModelSelection = AmbientModelSelection(
+        profileID: AmbientModelProfile.quality.id,
+        vadModelID: "",
+        asrModelID: ""
+    )
+    @Published var retentionPolicy: AmbientRetentionPolicy = .default
+    @Published var audioExpiry: AmbientRetentionWindow = .default
+    @Published var context = AmbientCaptureContext.empty
+    @Published private(set) var conditions: AmbientDeviceConditions?
+    @Published private(set) var recommendedProfileID: String?
+
+    /// One-time consent, shown as a first-run sheet so recording afterwards is
+    /// a single tap.
+    @Published private(set) var hasRecordingConsent = false
+
+    // MARK: - Library
+
+    @Published private(set) var sessions: [AmbientSessionRecord] = []
+    @Published var searchText = ""
+    @Published private(set) var searchHits: [AmbientSearchHit] = []
+    @Published private(set) var storageBytes: Int64 = 0
+    @Published private(set) var retainedAudioBytes: Int64 = 0
+
+    @Published private(set) var errorMessage: String?
+
+    // MARK: - Collaborators
+
+    private let logger = Logger(subsystem: "com.runanywhere", category: "AmbientNotes")
+    private let store = AmbientMemoryStore.shared
+    private let resolver = AmbientModelProfileResolver()
+    private let defaults = UserDefaults.standard
+    private var cancellables = Set<AnyCancellable>()
+    private var hasLoaded = false
+
+    let sessionManager = AmbientSessionManager.shared
+
+    var profile: AmbientModelProfile {
+        AmbientModelProfile.profile(id: selectedProfileID) ?? .quality
+    }
+
+    /// True when VAD and ASR have been picked and their files are on disk.
+    var isCaptureStackReady: Bool {
+        isDownloaded(selection.vadModelID) && isDownloaded(selection.asrModelID)
+    }
+
+    /// Recording is one tap once consent has been given and the capture stack
+    /// is on disk — any framework the user chose, including GPU ASR.
+    var canStartSession: Bool {
+        hasRecordingConsent && isCaptureStackReady && !sessionManager.isCapturing
+    }
+
+    /// Shown when Record cannot start because a required model is unset or not
+    /// downloaded yet. Never points the user at the Models tab.
+    var missingModelMessage: String? {
+        guard !isCaptureStackReady else { return nil }
+        if selection.vadModelID.isEmpty || selection.asrModelID.isEmpty {
+            return "Pick and download a speech detector and a transcription model below."
+        }
+        return "Download the speech detector and transcription model below to start recording."
+    }
+
+    /// Soft warning when a GPU ASR was chosen, or when summarizing will wait
+    /// for the foreground after a Lock Screen stop — Record stays enabled.
+    var backgroundRiskMessage: String? {
+        var parts: [String] = []
+        if !selection.asrModelID.isEmpty, !selection.isASRBackgroundSafe {
+            parts.append(
+                "This transcription model uses the GPU, so lock-screen transcription may stall."
+            )
+        }
+        if selection.digestModelID != nil {
+            parts.append(
+                "Summarizing finishes when the app is open — stopping from the Lock Screen saves the note and summarizes on return."
+            )
+        }
+        guard !parts.isEmpty else { return nil }
+        return parts.joined(separator: " ")
+    }
+
+    func modelInfo(for modelID: String) -> RAModelInfo? {
+        guard !modelID.isEmpty else { return nil }
+        return ModelListViewModel.shared.availableModels.first { $0.id == modelID }
+    }
+
+    func displayName(for modelID: String) -> String {
+        guard !modelID.isEmpty else { return "None" }
+        if let model = modelInfo(for: modelID) {
+            return model.consumerDisplayName
+        }
+        return modelID
+    }
+
+    func isDownloaded(_ modelID: String) -> Bool {
+        guard !modelID.isEmpty, let model = modelInfo(for: modelID) else { return false }
+        return model.isBuiltIn || model.localPathURL != nil
+    }
+
+    /// Notes matching the current query, or every note when the field is empty.
+    var visibleSessions: [AmbientSessionRecord] {
+        guard !searchText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return sessions }
+        let order = Dictionary(uniqueKeysWithValues: searchHits.enumerated().map { ($0.element.sessionID, $0.offset) })
+        return sessions
+            .filter { order[$0.id] != nil }
+            .sorted { (order[$0.id] ?? 0) < (order[$1.id] ?? 0) }
+    }
+
+    func searchHit(for sessionID: String) -> AmbientSearchHit? {
+        searchHits.first { $0.sessionID == sessionID }
+    }
+
+    var totalActionItemCount: Int {
+        sessions.reduce(0) { $0 + $1.actionItems.count }
+    }
+
+    var totalSegmentCount: Int {
+        sessions.reduce(0) { $0 + $1.segments.count }
+    }
+
+    // MARK: - Lifecycle
+
+    func onAppear() async {
+        if ModelListViewModel.shared.availableModels.isEmpty {
+            await ModelListViewModel.shared.loadModelsFromRegistry()
+        }
+        refreshConditions()
+        guard !hasLoaded else {
+            refreshBackgroundFlags()
+            await refreshLibrary()
+            return
+        }
+        hasLoaded = true
+        restoreSettings()
+        observeSearch()
+        observeDeferredMerges()
+        await store.expireAudio(olderThan: audioExpiry)
+        await refreshLibrary()
+    }
+
+    func refreshConditions() {
+        let current = resolver.currentConditions(deviceInfo: DeviceInfoService.shared.deviceInfo)
+        conditions = current
+        recommendedProfileID = resolver.recommendedProfile(
+            for: current,
+            available: ModelListViewModel.shared.availableModels
+        ).id
+    }
+
+    /// Explicit Developer action: copy this profile's preferred catalog IDs
+    /// into the three slots. Does not download anything.
+    func applyProfile(_ profileID: String) {
+        selectedProfileID = profileID
+        let resolved = resolver.resolve(
+            profile: AmbientModelProfile.profile(id: profileID) ?? .quality,
+            available: ModelListViewModel.shared.availableModels
+        )
+        selection = resolved
+        persistSettings()
+    }
+
+    func select(vad model: RAModelInfo) {
+        selection.vadModelID = model.id
+        persistSettings()
+    }
+
+    func select(asr model: RAModelInfo) {
+        selection.asrModelID = model.id
+        selection.isASRBackgroundSafe = model.isBackgroundSafe
+        persistSettings()
+    }
+
+    func select(digest model: RAModelInfo?) {
+        selection.digestModelID = model?.id
+        selection.isDigestBackgroundSafe = model?.isBackgroundSafe ?? true
+        persistSettings()
+    }
+
+    func clearDigest() {
+        select(digest: nil)
+    }
+
+    func grantRecordingConsent() {
+        hasRecordingConsent = true
+        persistSettings()
+    }
+
+    func setRetention(_ policy: AmbientRetentionPolicy) {
+        retentionPolicy = policy
+        persistSettings()
+    }
+
+    /// Change how long recordings are kept. Note text is never affected.
+    func setAudioExpiry(_ window: AmbientRetentionWindow) {
+        audioExpiry = window
+        persistSettings()
+        Task {
+            await store.expireAudio(olderThan: window)
+            await refreshLibrary()
+        }
+    }
+
+    // MARK: - Capture
+
+    func startSession() async {
+        guard canStartSession else { return }
+        refreshConditions()
+        guard let conditions else { return }
+        await sessionManager.start(
+            selection: selection,
+            retention: retentionPolicy,
+            context: context,
+            conditions: conditions
+        )
+    }
+
+    func stopSession() async {
+        await sessionManager.stop()
+        await refreshLibrary()
+    }
+
+    /// Re-run summarization for a note that has a transcript but no summary.
+    func retrySummary(sessionID: String) async {
+        await sessionManager.retrySummary(for: sessionID)
+        await refreshLibrary()
+    }
+
+    func togglePause() async {
+        if sessionManager.phase == .paused {
+            await sessionManager.resume()
+        } else {
+            await sessionManager.pause()
+        }
+    }
+
+    // MARK: - Library
+
+    func refreshLibrary() async {
+        sessions = await store.loadSessions()
+        storageBytes = await store.totalBytes()
+        retainedAudioBytes = await store.retainedAudioBytes()
+        updateSearchResults()
+    }
+
+    func note(id: String) -> AmbientSessionRecord? {
+        sessions.first { $0.id == id }
+    }
+
+    func delete(sessionID: String) async {
+        await store.delete(sessionID: sessionID)
+        await refreshLibrary()
+    }
+
+    /// Remove every note, recording, and benchmark sample. Deliberately leaves
+    /// the shared RAG index alone: it holds Chat's attached document, not
+    /// anything this feature wrote.
+    func purgeEverything() async {
+        await store.purgeEverything()
+        await refreshLibrary()
+    }
+
+    /// Absolute location of a note's recording, or `nil` once the audio has
+    /// expired or been purged.
+    func audioURL(for relativePath: String) async -> URL? {
+        let url = await store.audioURL(for: relativePath)
+        return FileManager.default.fileExists(atPath: url.path) ? url : nil
+    }
+
+    // MARK: - Note Editing
+
+    func rename(sessionID: String, to title: String) async {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        await update(sessionID: sessionID) { note in
+            note.customTitle = trimmed.isEmpty ? nil : trimmed
+        }
+    }
+
+    func toggleActionItem(_ itemID: String, in sessionID: String) async {
+        await update(sessionID: sessionID) { note in
+            guard let index = note.actionItems.firstIndex(where: { $0.id == itemID }) else { return }
+            note.actionItems[index].isDone.toggle()
+        }
+    }
+
+    func addActionItem(_ text: String, to sessionID: String) async {
+        let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        await update(sessionID: sessionID) { note in
+            note.actionItems.append(AmbientActionItem(text: trimmed, isManual: true))
+        }
+    }
+
+    func deleteActionItem(_ itemID: String, from sessionID: String) async {
+        await update(sessionID: sessionID) { note in
+            note.actionItems.removeAll { $0.id == itemID }
+        }
+    }
+
+    private func update(sessionID: String, _ mutate: (inout AmbientSessionRecord) -> Void) async {
+        guard var note = sessions.first(where: { $0.id == sessionID }) else { return }
+        mutate(&note)
+        await store.save(note)
+        if let index = sessions.firstIndex(where: { $0.id == sessionID }) {
+            sessions[index] = note
+        }
+    }
+
+    // MARK: - Search
+
+    private func observeSearch() {
+        $searchText
+            .debounce(for: .milliseconds(200), scheduler: RunLoop.main)
+            .sink { [weak self] _ in
+                self?.updateSearchResults()
+            }
+            .store(in: &cancellables)
+    }
+
+    /// A note whose merge was deferred to the foreground has just gained its
+    /// summary, so the list has to reload to stop showing "Summary pending".
+    private func observeDeferredMerges() {
+        sessionManager.didFinishDeferredMerge
+            .receive(on: RunLoop.main)
+            .sink { [weak self] _ in
+                Task { await self?.refreshLibrary() }
+            }
+            .store(in: &cancellables)
+    }
+
+    private func updateSearchResults() {
+        searchHits = store.search(searchText, in: sessions)
+    }
+
+    // MARK: - Settings Persistence
+
+    private enum SettingsKey {
+        static let profile = "ambient.profileID"
+        static let vad = "ambient.vadModelID"
+        static let asr = "ambient.asrModelID"
+        static let digest = "ambient.digestModelID"
+        static let retention = "ambient.retentionPolicy"
+        static let window = "ambient.audioExpiryWindow"
+        static let consent = "ambient.recordingConsent"
+    }
+
+    /// Restore saved picks only — never fill empty slots from a profile.
+    private func restoreSettings() {
+        selectedProfileID = defaults.string(forKey: SettingsKey.profile) ?? AmbientModelProfile.quality.id
+        retentionPolicy = defaults.string(forKey: SettingsKey.retention)
+            .flatMap(AmbientRetentionPolicy.init(rawValue:)) ?? .default
+        if defaults.object(forKey: SettingsKey.window) != nil {
+            audioExpiry = AmbientRetentionWindow(rawValue: defaults.integer(forKey: SettingsKey.window))
+                ?? .default
+        }
+        hasRecordingConsent = defaults.bool(forKey: SettingsKey.consent)
+
+        selection = AmbientModelSelection(
+            profileID: selectedProfileID,
+            vadModelID: defaults.string(forKey: SettingsKey.vad) ?? "",
+            asrModelID: defaults.string(forKey: SettingsKey.asr) ?? "",
+            digestModelID: defaults.string(forKey: SettingsKey.digest)
+        )
+        refreshBackgroundFlags()
+    }
+
+    private func refreshBackgroundFlags() {
+        if let asr = modelInfo(for: selection.asrModelID) {
+            selection.isASRBackgroundSafe = asr.isBackgroundSafe
+        } else if selection.asrModelID.isEmpty {
+            selection.isASRBackgroundSafe = true
+        }
+        if let digestID = selection.digestModelID, let digest = modelInfo(for: digestID) {
+            selection.isDigestBackgroundSafe = digest.isBackgroundSafe
+        } else {
+            selection.isDigestBackgroundSafe = true
+        }
+    }
+
+    private func persistSettings() {
+        defaults.set(selectedProfileID, forKey: SettingsKey.profile)
+        defaults.set(selection.vadModelID, forKey: SettingsKey.vad)
+        defaults.set(selection.asrModelID, forKey: SettingsKey.asr)
+        defaults.set(selection.digestModelID, forKey: SettingsKey.digest)
+        defaults.set(retentionPolicy.rawValue, forKey: SettingsKey.retention)
+        defaults.set(audioExpiry.rawValue, forKey: SettingsKey.window)
+        defaults.set(hasRecordingConsent, forKey: SettingsKey.consent)
+    }
+}
+#endif

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Views/AmbientBenchmarkSheet.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Views/AmbientBenchmarkSheet.swift
@@ -1,0 +1,276 @@
+//
+//  AmbientBenchmarkSheet.swift
+//  RunAnywhereAI
+//
+//  Ambient run history and export. Kept separate from the synthetic STT
+//  benchmark dashboard so a multi-hour, environment-dependent ambient run
+//  never gets averaged into deterministic scenario numbers.
+//
+
+#if os(iOS)
+import SwiftUI
+import UIKit
+
+struct AmbientBenchmarkSheet: View {
+    @StateObject private var viewModel = AmbientBenchmarkViewModel()
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var exportDocument: AmbientExportDocument?
+    @State private var showClearConfirmation = false
+
+    var body: some View {
+        NavigationStack {
+            Group {
+                if viewModel.samples.isEmpty {
+                    VStack(spacing: AppSpacing.smallMedium) {
+                        Text("No ambient runs recorded yet.")
+                            .font(AppTypography.subheadlineMedium)
+                        Text(
+                            "Every session you stop writes one sample here: real-time factor, "
+                            + "latency, memory, battery drain per hour, thermals, and "
+                            + "useful-memory rate."
+                        )
+                            .font(AppTypography.caption)
+                            .foregroundColor(AppColors.textSecondary)
+                            .multilineTextAlignment(.center)
+                    }
+                    .padding(AppSpacing.large)
+                } else {
+                    List {
+                        Section("Across \(viewModel.samples.count) runs") {
+                            LabeledContent(
+                                "Median RTF",
+                                value: String(format: "%.2f", viewModel.medianRealTimeFactor)
+                            )
+                            LabeledContent(
+                                "Median battery/hour",
+                                value: String(format: "%.1f%%", viewModel.medianBatteryPerHour)
+                            )
+                            LabeledContent("Total listening", value: viewModel.totalListeningDescription)
+                            LabeledContent(
+                                "Action items done",
+                                value: String(format: "%.0f%%", viewModel.completedActionItemRate * 100)
+                            )
+                        }
+
+                        ForEach(Array(viewModel.samples.reversed())) { sample in
+                            AmbientBenchmarkRow(sample: sample)
+                        }
+                    }
+                }
+            }
+            .navigationTitle("Ambient Benchmarks")
+            .navigationBarTitleDisplayModeCompat(.inline)
+            .toolbar {
+                ToolbarItem(placement: .navigationBarLeading) {
+                    Button("Done") { dismiss() }
+                }
+                ToolbarItem(placement: .navigationBarTrailing) {
+                    Menu {
+                        Button("Export CSV") { exportDocument = viewModel.csvDocument() }
+                        Button("Export JSON") { exportDocument = viewModel.jsonDocument() }
+                        Divider()
+                        Button("Clear samples", role: .destructive) { showClearConfirmation = true }
+                    } label: {
+                        Image(systemName: "square.and.arrow.up")
+                    }
+                    .disabled(viewModel.samples.isEmpty)
+                }
+            }
+            .adaptiveSheet(isPresented: Binding(
+                get: { exportDocument != nil },
+                set: { if !$0 { exportDocument = nil } }
+            )) {
+                if let exportDocument {
+                    ActivityShareSheet(items: [exportDocument.url])
+                }
+            }
+            .confirmationDialog(
+                "Clear benchmark samples?",
+                isPresented: $showClearConfirmation,
+                titleVisibility: .visible
+            ) {
+                Button("Clear", role: .destructive) {
+                    Task { await viewModel.clear() }
+                }
+                Button("Cancel", role: .cancel) {}
+            }
+            .task { await viewModel.load() }
+        }
+    }
+}
+
+// MARK: - Row
+
+struct AmbientBenchmarkRow: View {
+    let sample: AmbientBenchmarkSample
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text("\(sample.profileID.capitalized) · \(Self.formatter.string(from: sample.recordedAt))")
+                .font(AppTypography.subheadlineMedium)
+            Text(detailLine)
+                .font(AppTypography.caption2)
+                .foregroundColor(AppColors.textSecondary)
+            Text(environmentLine)
+                .font(AppTypography.caption2)
+                .foregroundColor(AppColors.textSecondary)
+        }
+        .padding(.vertical, 2)
+    }
+
+    private var detailLine: String {
+        String(
+            format: "%@ · RTF %.2f · first transcript %.0f ms · peak %@",
+            AmbientMemoryView.duration(Int(sample.sessionSeconds)),
+            sample.medianRealTimeFactor,
+            sample.firstTranscriptLatencyMs,
+            sample.peakMemoryBytes.formattedFileSize
+        )
+    }
+
+    private var environmentLine: String {
+        var parts = ["\(sample.segmentCount) segments", "\(sample.actionItemCount) action items"]
+        if sample.droppedSegmentCount > 0 { parts.append("\(sample.droppedSegmentCount) dropped") }
+        if sample.interruptionCount > 0 { parts.append("\(sample.interruptionCount) interruptions") }
+        parts.append("thermals \(sample.thermalState)")
+        if !sample.environment.isEmpty { parts.append(sample.environment) }
+        if !sample.placement.isEmpty { parts.append(sample.placement) }
+        return parts.joined(separator: " · ")
+    }
+
+    private static let formatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .short
+        formatter.timeStyle = .short
+        return formatter
+    }()
+}
+
+// MARK: - View Model
+
+@MainActor
+final class AmbientBenchmarkViewModel: ObservableObject {
+    @Published private(set) var samples: [AmbientBenchmarkSample] = []
+
+    private let store = AmbientMemoryStore.shared
+
+    func load() async {
+        samples = await store.loadBenchmarkSamples()
+    }
+
+    func clear() async {
+        await store.clearBenchmarkSamples()
+        samples = []
+    }
+
+    var medianRealTimeFactor: Double {
+        AmbientBenchmarkRecorder.median(samples.map(\.medianRealTimeFactor))
+    }
+
+    var medianBatteryPerHour: Double {
+        AmbientBenchmarkRecorder.median(samples.map(\.batteryDeltaPerHour))
+    }
+
+    var totalListeningDescription: String {
+        AmbientMemoryView.duration(Int(samples.reduce(0) { $0 + $1.sessionSeconds }))
+    }
+
+    var completedActionItemRate: Double {
+        let total = samples.reduce(0) { $0 + $1.actionItemCount }
+        guard total > 0 else { return 0 }
+        let done = samples.reduce(0) { $0 + $1.completedActionItemCount }
+        return Double(done) / Double(total)
+    }
+
+    // MARK: Export
+
+    func csvDocument() -> AmbientExportDocument? {
+        let header = [
+            "recordedAt", "sessionId", "profile", "device", "chip", "os", "audioRoute",
+            "environment", "placement", "sessionSeconds", "speechSeconds", "speechRatio",
+            "segments", "transcribed", "dropped", "actionItems", "completedActionItems",
+            "medianTranscriptionMs", "medianRTF", "medianDigestMs", "firstTranscriptMs",
+            "peakMemoryBytes", "batteryPerHour", "thermalState", "interruptions", "retainedAudioBytes",
+        ].joined(separator: ",")
+
+        let rows = samples.map { sample in
+            [
+                ISO8601DateFormatter().string(from: sample.recordedAt),
+                sample.sessionID,
+                sample.profileID,
+                sample.deviceModel,
+                sample.chipName,
+                sample.osVersion,
+                sample.audioRoute,
+                sample.environment,
+                sample.placement,
+                String(format: "%.1f", sample.sessionSeconds),
+                String(format: "%.1f", sample.speechSeconds),
+                String(format: "%.3f", sample.speechRatio),
+                String(sample.segmentCount),
+                String(sample.transcribedSegmentCount),
+                String(sample.droppedSegmentCount),
+                String(sample.actionItemCount),
+                String(sample.completedActionItemCount),
+                String(format: "%.1f", sample.medianTranscriptionMs),
+                String(format: "%.3f", sample.medianRealTimeFactor),
+                String(format: "%.1f", sample.medianExtractionMs),
+                String(format: "%.1f", sample.firstTranscriptLatencyMs),
+                String(sample.peakMemoryBytes),
+                String(format: "%.2f", sample.batteryDeltaPerHour),
+                sample.thermalState,
+                String(sample.interruptionCount),
+                String(sample.retainedAudioBytes),
+            ]
+            .map(Self.escapeCSV)
+            .joined(separator: ",")
+        }
+
+        return write(([header] + rows).joined(separator: "\n"), extension: "csv")
+    }
+
+    func jsonDocument() -> AmbientExportDocument? {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
+        guard let data = try? encoder.encode(samples),
+              let text = String(data: data, encoding: .utf8) else { return nil }
+        return write(text, extension: "json")
+    }
+
+    private func write(_ contents: String, extension pathExtension: String) -> AmbientExportDocument? {
+        let name = "ambient-benchmarks-\(Int(Date().timeIntervalSince1970)).\(pathExtension)"
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(name)
+        do {
+            try contents.write(to: url, atomically: true, encoding: .utf8)
+            return AmbientExportDocument(url: url)
+        } catch {
+            return nil
+        }
+    }
+
+    private static func escapeCSV(_ value: String) -> String {
+        guard value.contains(",") || value.contains("\"") || value.contains("\n") else { return value }
+        return "\"\(value.replacingOccurrences(of: "\"", with: "\"\""))\""
+    }
+}
+
+/// Identifiable wrapper so a freshly written export file can drive a sheet.
+struct AmbientExportDocument: Identifiable {
+    let url: URL
+    var id: String { url.path }
+}
+
+// MARK: - Share Sheet
+
+struct ActivityShareSheet: UIViewControllerRepresentable {
+    let items: [Any]
+
+    func makeUIViewController(context: Context) -> UIActivityViewController {
+        UIActivityViewController(activityItems: items, applicationActivities: nil)
+    }
+
+    func updateUIViewController(_ controller: UIActivityViewController, context: Context) {}
+}
+#endif

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Views/AmbientDeveloperView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Views/AmbientDeveloperView.swift
@@ -1,0 +1,270 @@
+//
+//  AmbientDeveloperView.swift
+//  RunAnywhereAI
+//
+//  Everything a tester needs and a user does not: optional profile presets,
+//  the same free model pickers as the Notes screen, audio expiry, capture
+//  labels, device conditions, storage, and the benchmark export.
+//
+
+#if os(iOS)
+import RunAnywhere
+import SwiftUI
+
+struct AmbientDeveloperView: View {
+    @ObservedObject var viewModel: AmbientMemoryViewModel
+    @ObservedObject private var modelList = ModelListViewModel.shared
+    @Environment(\.dismiss) private var dismiss
+
+    @State private var showBenchmarks = false
+    @State private var showVADPicker = false
+    @State private var showASRPicker = false
+    @State private var showDigestPicker = false
+
+    var body: some View {
+        NavigationStack {
+            Form {
+                profileSection
+                modelSection
+                audioSection
+                contextSection
+                deviceSection
+                benchmarkSection
+            }
+            .navigationTitle("Developer")
+            .navigationBarTitleDisplayModeCompat(.inline)
+            .toolbar {
+                ToolbarItem(placement: .confirmationAction) {
+                    Button("Done") { dismiss() }
+                }
+            }
+            .adaptiveSheet(isPresented: $showBenchmarks) {
+                AmbientBenchmarkSheet()
+            }
+            .adaptiveSheet(isPresented: $showVADPicker) {
+                ModelSelectionSheet(context: .vad) { model in
+                    viewModel.select(vad: model)
+                }
+            }
+            .adaptiveSheet(isPresented: $showASRPicker) {
+                ModelSelectionSheet(context: .stt) { model in
+                    viewModel.select(asr: model)
+                }
+            }
+            .adaptiveSheet(isPresented: $showDigestPicker) {
+                ModelSelectionSheet(context: .llm) { model in
+                    viewModel.select(digest: model)
+                }
+            }
+            .task {
+                if modelList.availableModels.isEmpty {
+                    await modelList.loadModelsFromRegistry()
+                }
+            }
+        }
+    }
+
+    // MARK: - Profile
+
+    private var profileSection: some View {
+        Section {
+            Picker("Profile", selection: profileBinding) {
+                ForEach(AmbientModelProfile.allProfiles) { profile in
+                    Text(profile.displayName).tag(profile.id)
+                }
+            }
+            .pickerStyle(.segmented)
+
+            Text(viewModel.profile.summary)
+                .font(AppTypography.caption)
+                .foregroundColor(AppColors.textSecondary)
+
+            if let recommended = viewModel.recommendedProfileID,
+               recommended != viewModel.selectedProfileID,
+               let profile = AmbientModelProfile.profile(id: recommended) {
+                Button("Apply recommended \(profile.displayName) IDs") {
+                    viewModel.applyProfile(recommended)
+                }
+                .font(AppTypography.caption)
+            }
+        } header: {
+            Text("Lab profile preset")
+        } footer: {
+            Text(
+                "Applying a profile only copies candidate model IDs into the slots below. "
+                + "Nothing downloads automatically — use Change → Get → Use for each role."
+            )
+        }
+    }
+
+    private var profileBinding: Binding<String> {
+        Binding(
+            get: { viewModel.selectedProfileID },
+            set: { viewModel.applyProfile($0) }
+        )
+    }
+
+    // MARK: - Models
+
+    private var modelSection: some View {
+        Section {
+            modelButtonRow(
+                title: "Speech detector",
+                modelID: viewModel.selection.vadModelID
+            ) { showVADPicker = true }
+
+            modelButtonRow(
+                title: "Transcription",
+                modelID: viewModel.selection.asrModelID
+            ) { showASRPicker = true }
+
+            modelButtonRow(
+                title: "Summarizing",
+                modelID: viewModel.selection.digestModelID ?? ""
+            ) { showDigestPicker = true }
+
+            if viewModel.selection.digestModelID != nil {
+                Button("Clear summarizer", role: .destructive) {
+                    viewModel.clearDigest()
+                }
+                .font(AppTypography.caption)
+            }
+
+            if let risk = viewModel.backgroundRiskMessage {
+                Text(risk)
+                    .font(AppTypography.caption2)
+                    .foregroundColor(AppColors.statusOrange)
+            }
+        } header: {
+            Text("Models")
+        } footer: {
+            Text(
+                "Any catalog model is allowed, including GPU backends, so you can stress-test limits. "
+                + "A soft warning appears when lock-screen transcription or background summarizing may stall."
+            )
+        }
+    }
+
+    private func modelButtonRow(
+        title: String,
+        modelID: String,
+        onChange: @escaping () -> Void
+    ) -> some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(AppTypography.caption)
+                    .foregroundColor(AppColors.textSecondary)
+                Text(viewModel.displayName(for: modelID))
+                    .font(AppTypography.body)
+                    .lineLimit(1)
+                Text(viewModel.isDownloaded(modelID) ? "Ready" : (modelID.isEmpty ? "Not set" : "Needs download"))
+                    .font(AppTypography.caption2)
+                    .foregroundColor(
+                        viewModel.isDownloaded(modelID)
+                            ? AppColors.statusGreen
+                            : AppColors.statusOrange
+                    )
+            }
+            Spacer()
+            Button("Change", action: onChange)
+                .font(AppTypography.caption)
+        }
+    }
+
+    // MARK: - Audio
+
+    private var audioSection: some View {
+        Section {
+            Picker("Keep", selection: retentionBinding) {
+                ForEach(AmbientRetentionPolicy.allCases) { policy in
+                    Text(policy.displayName).tag(policy)
+                }
+            }
+
+            Picker("Delete recordings", selection: expiryBinding) {
+                ForEach(AmbientRetentionWindow.allCases) { window in
+                    Text(window.displayName).tag(window)
+                }
+            }
+
+            LabeledContent("Recordings") {
+                Text(viewModel.retainedAudioBytes.formattedFileSize)
+                    .font(AppTypography.caption)
+                    .foregroundColor(AppColors.textSecondary)
+            }
+            LabeledContent("Everything") {
+                Text(viewModel.storageBytes.formattedFileSize)
+                    .font(AppTypography.caption)
+                    .foregroundColor(AppColors.textSecondary)
+            }
+        } header: {
+            Text("Recordings and storage")
+        } footer: {
+            Text(
+                "Expiry deletes recordings only — a note's summary, action items, and transcript are kept "
+                + "until you delete the note. Audio costs roughly 115 MB per hour."
+            )
+        }
+    }
+
+    private var retentionBinding: Binding<AmbientRetentionPolicy> {
+        Binding(
+            get: { viewModel.retentionPolicy },
+            set: { viewModel.setRetention($0) }
+        )
+    }
+
+    private var expiryBinding: Binding<AmbientRetentionWindow> {
+        Binding(
+            get: { viewModel.audioExpiry },
+            set: { viewModel.setAudioExpiry($0) }
+        )
+    }
+
+    // MARK: - Context
+
+    private var contextSection: some View {
+        Section {
+            TextField("Environment (quiet, office, café, car…)", text: $viewModel.context.environment)
+            TextField("Placement (desk, pocket, face down…)", text: $viewModel.context.placement)
+            TextField("Note", text: $viewModel.context.note)
+        } header: {
+            Text("Capture labels")
+        } footer: {
+            Text(
+                "Labels are stored with the note and its benchmark sample so multi-hour runs "
+                + "stay comparable across environments."
+            )
+        }
+    }
+
+    // MARK: - Device
+
+    @ViewBuilder
+    private var deviceSection: some View {
+        if let conditions = viewModel.conditions {
+            Section("This device") {
+                LabeledContent("Tier", value: conditions.tier.displayName)
+                LabeledContent("Available memory", value: conditions.availableMemoryBytes.formattedFileSize)
+                LabeledContent("Thermal state", value: conditions.thermalDescription)
+                LabeledContent("Low Power Mode", value: conditions.isLowPowerModeEnabled ? "On" : "Off")
+                if conditions.batteryLevel >= 0 {
+                    LabeledContent("Battery", value: "\(Int(conditions.batteryLevel * 100))%")
+                }
+            }
+        }
+    }
+
+    private var benchmarkSection: some View {
+        Section {
+            Button("Benchmark samples") { showBenchmarks = true }
+            LabeledContent("Notes", value: "\(viewModel.sessions.count)")
+            LabeledContent("Segments", value: "\(viewModel.totalSegmentCount)")
+            LabeledContent("Action items", value: "\(viewModel.totalActionItemCount)")
+        } header: {
+            Text("Instrumentation")
+        }
+    }
+}
+#endif

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Views/AmbientMemoryView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Views/AmbientMemoryView.swift
@@ -1,0 +1,483 @@
+//
+//  AmbientMemoryView.swift
+//  RunAnywhereAI
+//
+//  The notes screen: one Record button, a live row while recording, global
+//  search, and the notes list. Pure SwiftUI — capture and inference live in
+//  `AmbientSessionManager` and the SDK's ambient solution.
+//
+
+#if os(iOS)
+import RunAnywhere
+import SwiftUI
+
+struct AmbientMemoryView: View {
+    @StateObject private var viewModel = AmbientMemoryViewModel()
+    @ObservedObject private var session = AmbientSessionManager.shared
+    /// Observed so Ready / Needs download labels refresh after Get in a sheet.
+    @ObservedObject private var modelList = ModelListViewModel.shared
+
+    @State private var showDeveloper = false
+    @State private var showPurgeConfirmation = false
+    @State private var showConsent = false
+    @State private var showVADPicker = false
+    @State private var showASRPicker = false
+    @State private var showDigestPicker = false
+
+    /// Set by the App Shortcut / Action Button deep link so recording starts as
+    /// soon as the screen is up and consent is already in place.
+    var autoStartRequested: Bool = false
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: AppSpacing.mediumLarge) {
+                modelsSection
+                recordControl
+                if isCapturing { liveRow }
+                if let warning = warningMessage { warningLine(warning) }
+                if let error = session.lastError ?? viewModel.errorMessage { errorBanner(error) }
+                searchField
+                notesList
+            }
+            .padding(AppSpacing.mediumLarge)
+        }
+        .navigationTitle("Notes")
+        .navigationBarTitleDisplayModeCompat(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Menu {
+                    Button("Developer") { showDeveloper = true }
+                    Divider()
+                    Button("Delete everything", role: .destructive) { showPurgeConfirmation = true }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+            }
+        }
+        .adaptiveSheet(isPresented: $showDeveloper) {
+            AmbientDeveloperView(viewModel: viewModel)
+        }
+        .adaptiveSheet(isPresented: $showConsent) {
+            AmbientConsentSheet {
+                viewModel.grantRecordingConsent()
+                showConsent = false
+                Task { await viewModel.startSession() }
+            }
+        }
+        .adaptiveSheet(isPresented: $showVADPicker) {
+            ModelSelectionSheet(context: .vad) { model in
+                viewModel.select(vad: model)
+            }
+        }
+        .adaptiveSheet(isPresented: $showASRPicker) {
+            ModelSelectionSheet(context: .stt) { model in
+                viewModel.select(asr: model)
+            }
+        }
+        .adaptiveSheet(isPresented: $showDigestPicker) {
+            ModelSelectionSheet(context: .llm) { model in
+                viewModel.select(digest: model)
+            }
+        }
+        .confirmationDialog(
+            "Delete every note?",
+            isPresented: $showPurgeConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete all notes and recordings", role: .destructive) {
+                Task { await viewModel.purgeEverything() }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("This removes every transcript, summary, action item, recording, and benchmark sample.")
+        }
+        .task {
+            await viewModel.onAppear()
+            if autoStartRequested, viewModel.canStartSession, !session.isRecording {
+                await viewModel.startSession()
+            }
+        }
+    }
+
+    private var isCapturing: Bool {
+        session.isRecording || session.phase == .paused || session.phase == .preparing
+    }
+
+    // MARK: - Models
+
+    /// Free picks for each role — any catalog model, Get/Use in the sheet.
+    private var modelsSection: some View {
+        // Touch the list so downloads in a sheet invalidate Ready labels.
+        let _ = modelList.availableModels.count
+        return AmbientCard {
+            Text("Models")
+                .font(AppTypography.subheadlineMedium)
+                .foregroundColor(AppColors.textPrimary)
+
+            modelRow(
+                title: "Speech detector",
+                modelID: viewModel.selection.vadModelID,
+                required: true
+            ) { showVADPicker = true }
+
+            modelRow(
+                title: "Transcription",
+                modelID: viewModel.selection.asrModelID,
+                required: true
+            ) { showASRPicker = true }
+
+            modelRow(
+                title: "Summarizing",
+                modelID: viewModel.selection.digestModelID ?? "",
+                required: false
+            ) { showDigestPicker = true }
+
+            if let risk = viewModel.backgroundRiskMessage {
+                Text(risk)
+                    .font(AppTypography.caption2)
+                    .foregroundColor(AppColors.statusOrange)
+            }
+        }
+    }
+
+    private func modelRow(
+        title: String,
+        modelID: String,
+        required: Bool,
+        onChange: @escaping () -> Void
+    ) -> some View {
+        HStack(alignment: .center, spacing: AppSpacing.smallMedium) {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(title)
+                    .font(AppTypography.caption)
+                    .foregroundColor(AppColors.textSecondary)
+                Text(viewModel.displayName(for: modelID))
+                    .font(AppTypography.subheadline)
+                    .foregroundColor(AppColors.textPrimary)
+                    .lineLimit(1)
+                Text(statusLabel(for: modelID, required: required))
+                    .font(AppTypography.caption2)
+                    .foregroundColor(statusColor(for: modelID, required: required))
+            }
+            Spacer(minLength: AppSpacing.small)
+            Button("Change", action: onChange)
+                .font(AppTypography.caption)
+                .buttonStyle(.bordered)
+                .disabled(isCapturing)
+        }
+    }
+
+    private func statusLabel(for modelID: String, required: Bool) -> String {
+        if modelID.isEmpty {
+            return required ? "Required" : "Optional"
+        }
+        return viewModel.isDownloaded(modelID) ? "Ready" : "Download in picker"
+    }
+
+    private func statusColor(for modelID: String, required: Bool) -> Color {
+        if modelID.isEmpty {
+            return required ? AppColors.statusOrange : AppColors.textSecondary
+        }
+        return viewModel.isDownloaded(modelID) ? AppColors.statusGreen : AppColors.statusOrange
+    }
+
+    // MARK: - Record
+
+    private var recordControl: some View {
+        VStack(spacing: AppSpacing.smallMedium) {
+            Button {
+                Task { await toggleRecording() }
+            } label: {
+                Label(
+                    isCapturing ? "Stop" : "Record",
+                    systemImage: isCapturing ? "stop.fill" : "mic.fill"
+                )
+                .font(AppTypography.headline)
+                .frame(maxWidth: .infinity)
+                .padding(.vertical, AppSpacing.small)
+            }
+            .buttonStyle(.borderedProminent)
+            .tint(isCapturing ? AppColors.statusRed : AppColors.primaryAccent)
+            .disabled(!isCapturing && viewModel.missingModelMessage != nil)
+
+            // Avoid duplicating the red error banner — fail() sets both.
+            if !session.statusMessage.isEmpty, session.statusMessage != session.lastError {
+                Text(session.statusMessage)
+                    .font(AppTypography.caption)
+                    .foregroundColor(AppColors.textSecondary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+    }
+
+    private func toggleRecording() async {
+        if isCapturing {
+            await viewModel.stopSession()
+            return
+        }
+        guard viewModel.isCaptureStackReady else { return }
+        guard viewModel.hasRecordingConsent else {
+            // First run: take consent once, then record on one tap forever after.
+            showConsent = true
+            return
+        }
+        await viewModel.startSession()
+    }
+
+    private var liveRow: some View {
+        AmbientCard {
+            HStack {
+                Label(session.phase.displayName, systemImage: "waveform")
+                    .font(AppTypography.subheadlineMedium)
+                    .foregroundColor(AppColors.statusRed)
+                Spacer()
+                Text(Self.duration(session.elapsedSeconds))
+                    .font(AppTypography.caption.monospacedDigit())
+                    .foregroundColor(AppColors.textSecondary)
+                Button(session.phase == .paused ? "Resume" : "Pause") {
+                    Task { await viewModel.togglePause() }
+                }
+                .font(AppTypography.caption)
+                .buttonStyle(.bordered)
+            }
+
+            AmbientLevelMeter(level: session.audioLevel)
+
+            if !session.liveTranscript.isEmpty {
+                Text(session.liveTranscript)
+                    .font(AppTypography.caption)
+                    .foregroundColor(AppColors.textSecondary)
+                    .lineLimit(2)
+            }
+        }
+    }
+
+    /// Missing-model copy, then any active resource gate — background-risk
+    /// soft-warn lives under the Models section so Record stays available.
+    private var warningMessage: String? {
+        if let missing = viewModel.missingModelMessage, !isCapturing { return missing }
+        return session.activeGates.values.sorted().first
+    }
+
+    // MARK: - Notes
+
+    private var searchField: some View {
+        HStack(spacing: AppSpacing.small) {
+            Image(systemName: "magnifyingglass")
+                .foregroundColor(AppColors.textSecondary)
+            TextField("Search all notes", text: $viewModel.searchText)
+                .textFieldStyle(.plain)
+                .autocorrectionDisabled()
+            if !viewModel.searchText.isEmpty {
+                Button {
+                    viewModel.searchText = ""
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundColor(AppColors.textSecondary)
+                }
+                .buttonStyle(.plain)
+            }
+        }
+        .padding(AppSpacing.smallMedium)
+        .background(
+            Color(.secondarySystemBackground),
+            in: RoundedRectangle(cornerRadius: AppSpacing.cornerRadiusRegular)
+        )
+    }
+
+    @ViewBuilder
+    private var notesList: some View {
+        let notes = viewModel.visibleSessions
+        if notes.isEmpty {
+            Text(
+                viewModel.searchText.isEmpty
+                    ? "No notes yet. Tap Record to make your first one."
+                    : "No notes match that search."
+            )
+            .font(AppTypography.caption)
+            .foregroundColor(AppColors.textSecondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        } else {
+            LazyVStack(spacing: AppSpacing.small) {
+                ForEach(notes) { record in
+                    NavigationLink {
+                        AmbientSessionDetailView(sessionID: record.id, viewModel: viewModel)
+                    } label: {
+                        AmbientCard {
+                            AmbientSessionRow(record: record, hit: viewModel.searchHit(for: record.id))
+                        }
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+        }
+    }
+
+    // MARK: - Building Blocks
+
+    private func warningLine(_ message: String) -> some View {
+        Label(message, systemImage: "exclamationmark.triangle")
+            .font(AppTypography.caption)
+            .foregroundColor(AppColors.statusOrange)
+            .frame(maxWidth: .infinity, alignment: .leading)
+    }
+
+    private func errorBanner(_ message: String) -> some View {
+        Text(message)
+            .font(AppTypography.caption)
+            .foregroundColor(AppColors.statusRed)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(AppSpacing.small)
+            .background(
+                AppColors.statusRed.opacity(0.1),
+                in: RoundedRectangle(cornerRadius: AppSpacing.cornerRadiusRegular)
+            )
+    }
+
+    static func duration(_ seconds: Int) -> String {
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
+        let secs = seconds % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, secs)
+        }
+        return String(format: "%d:%02d", minutes, secs)
+    }
+}
+
+// MARK: - Consent
+
+/// Shown once, before the first recording. Consent is a property of the
+/// feature rather than of each session, so recording afterwards is one tap.
+struct AmbientConsentSheet: View {
+    let onAccept: () -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    var body: some View {
+        NavigationStack {
+            VStack(alignment: .leading, spacing: AppSpacing.mediumLarge) {
+                Text("Recording a note")
+                    .font(AppTypography.title3)
+                    .foregroundColor(AppColors.textPrimary)
+
+                Text(
+                    "A note records this room until you press Stop, and stays visible in a Live Activity "
+                    + "the whole time. Speech detection, transcription, and summarizing all run on this "
+                    + "device; nothing is uploaded."
+                )
+                .font(AppTypography.body)
+                .foregroundColor(AppColors.textSecondary)
+
+                Text(
+                    "The recording is kept alongside the transcript so you can hear what the model heard. "
+                    + "Delete a note to remove both, or set an audio expiry under Developer."
+                )
+                .font(AppTypography.caption)
+                .foregroundColor(AppColors.textSecondary)
+
+                Spacer()
+
+                Button("Start recording") { onAccept() }
+                    .buttonStyle(.borderedProminent)
+                    .frame(maxWidth: .infinity)
+            }
+            .padding(AppSpacing.mediumLarge)
+            .navigationBarTitleDisplayModeCompat(.inline)
+            .toolbar {
+                ToolbarItem(placement: .cancellationAction) {
+                    Button("Cancel") { dismiss() }
+                }
+            }
+        }
+    }
+}
+
+// MARK: - Shared Components
+
+struct AmbientCard<Content: View>: View {
+    @ViewBuilder let content: Content
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.smallMedium) {
+            content
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding(AppSpacing.mediumLarge)
+        .background(
+            Color(.secondarySystemBackground),
+            in: RoundedRectangle(cornerRadius: AppSpacing.cornerRadiusRegular)
+        )
+    }
+}
+
+struct AmbientLevelMeter: View {
+    let level: Float
+
+    var body: some View {
+        GeometryReader { geometry in
+            ZStack(alignment: .leading) {
+                Capsule().fill(Color(.tertiarySystemFill))
+                Capsule()
+                    .fill(AppColors.statusGreen)
+                    .frame(width: geometry.size.width * CGFloat(min(max(level, 0), 1)))
+            }
+        }
+        .frame(height: 6)
+    }
+}
+
+struct AmbientSessionRow: View {
+    let record: AmbientSessionRecord
+    /// Present while searching, so the row can show the text that matched
+    /// instead of the summary the note usually leads with.
+    var hit: AmbientSearchHit?
+
+    var body: some View {
+        HStack {
+            VStack(alignment: .leading, spacing: 2) {
+                Text(record.title)
+                    .font(AppTypography.subheadlineMedium)
+                    .foregroundColor(AppColors.textPrimary)
+                    .lineLimit(2)
+
+                if let hit {
+                    Text(hit.snippet)
+                        .font(AppTypography.caption)
+                        .foregroundColor(AppColors.textSecondary)
+                        .lineLimit(2)
+                    Text(hit.kind.label)
+                        .font(AppTypography.caption2)
+                        .foregroundColor(AppColors.textSecondary)
+                } else {
+                    Text(subtitle)
+                        .font(AppTypography.caption)
+                        .foregroundColor(AppColors.textSecondary)
+                }
+
+                if record.summaryPending {
+                    Text("Summary pending")
+                        .font(AppTypography.caption2)
+                        .foregroundColor(AppColors.statusOrange)
+                } else if let reason = record.stopReason {
+                    Text(reason)
+                        .font(AppTypography.caption2)
+                        .foregroundColor(AppColors.statusOrange)
+                }
+            }
+            Spacer()
+            Image(systemName: "chevron.right")
+                .font(AppTypography.caption)
+                .foregroundColor(AppColors.textSecondary)
+        }
+        .padding(.vertical, AppSpacing.xSmall)
+    }
+
+    private var subtitle: String {
+        var parts = [AmbientMemoryView.duration(Int(record.duration))]
+        let open = record.actionItems.filter { !$0.isDone }.count
+        if open > 0 { parts.append("\(open) to do") }
+        if record.hasAudio { parts.append("Recording") }
+        return parts.joined(separator: " · ")
+    }
+}
+#endif

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Views/AmbientSessionDetailView.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/AmbientMemory/Views/AmbientSessionDetailView.swift
@@ -1,0 +1,458 @@
+//
+//  AmbientSessionDetailView.swift
+//  RunAnywhereAI
+//
+//  One note: its summary, action items, the continuous transcript, and
+//  playback of the recording.
+//
+
+#if os(iOS)
+import AVFoundation
+import SwiftUI
+
+struct AmbientSessionDetailView: View {
+    let sessionID: String
+    @ObservedObject var viewModel: AmbientMemoryViewModel
+
+    @Environment(\.dismiss) private var dismiss
+    @State private var showDeleteConfirmation = false
+    @State private var isRenaming = false
+    @State private var draftTitle = ""
+    @State private var draftItem = ""
+    @StateObject private var player = AmbientNotePlayer()
+
+    private var record: AmbientSessionRecord? {
+        viewModel.note(id: sessionID)
+    }
+
+    var body: some View {
+        Group {
+            if let record {
+                content(for: record)
+            } else {
+                Text("This note is no longer on the device.")
+                    .font(AppTypography.caption)
+                    .foregroundColor(AppColors.textSecondary)
+            }
+        }
+        .navigationTitle(record?.title ?? "Note")
+        .navigationBarTitleDisplayModeCompat(.inline)
+        .toolbar {
+            ToolbarItem(placement: .navigationBarTrailing) {
+                Menu {
+                    Button("Rename") {
+                        draftTitle = record?.customTitle ?? record?.title ?? ""
+                        isRenaming = true
+                    }
+                    Divider()
+                    Button("Delete note", role: .destructive) { showDeleteConfirmation = true }
+                } label: {
+                    Image(systemName: "ellipsis.circle")
+                }
+                .disabled(record == nil)
+            }
+        }
+        .alert("Rename note", isPresented: $isRenaming) {
+            TextField("Title", text: $draftTitle)
+            Button("Save") {
+                Task { await viewModel.rename(sessionID: sessionID, to: draftTitle) }
+            }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("Leave it empty to go back to the summary-derived title.")
+        }
+        .confirmationDialog(
+            "Delete this note?",
+            isPresented: $showDeleteConfirmation,
+            titleVisibility: .visible
+        ) {
+            Button("Delete summary, transcript, and recording", role: .destructive) {
+                Task {
+                    player.stop()
+                    await viewModel.delete(sessionID: sessionID)
+                    dismiss()
+                }
+            }
+            Button("Cancel", role: .cancel) {}
+        }
+        .onDisappear { player.stop() }
+    }
+
+    private func content(for record: AmbientSessionRecord) -> some View {
+        List {
+            summarySection(record)
+            actionItemsSection(record)
+            transcriptSection(record)
+            recordingSection(record)
+        }
+    }
+
+    // MARK: - Summary
+
+    @ViewBuilder
+    private func summarySection(_ record: AmbientSessionRecord) -> some View {
+        Section("Summary") {
+            if record.summaryPending {
+                Label(
+                    "Waiting to summarize. This finishes the next time the app is open, or tap Retry.",
+                    systemImage: "clock"
+                )
+                .font(AppTypography.caption)
+                .foregroundColor(AppColors.statusOrange)
+            }
+            if record.summary.isEmpty {
+                Text(emptySummaryMessage(for: record))
+                    .font(AppTypography.caption)
+                    .foregroundColor(AppColors.textSecondary)
+            } else {
+                Text(record.summary)
+                    .font(AppTypography.body)
+                    .foregroundColor(AppColors.textPrimary)
+            }
+            if record.summary.isEmpty, !record.fullTranscript.isEmpty, record.digestModelID != nil {
+                Button("Retry summary") {
+                    Task { await viewModel.retrySummary(sessionID: sessionID) }
+                }
+                .font(AppTypography.caption)
+            }
+            Text("\(Self.dateFormatter.string(from: record.startedAt)) · "
+                + AmbientMemoryView.duration(Int(record.duration)))
+                .font(AppTypography.caption2)
+                .foregroundColor(AppColors.textSecondary)
+        }
+    }
+
+    private func emptySummaryMessage(for record: AmbientSessionRecord) -> String {
+        if record.summaryPending { return "No summary yet." }
+        if record.digestModelID == nil {
+            return "No summarizing model was selected for this note."
+        }
+        if !record.fullTranscript.isEmpty {
+            return "Summarization did not finish. Tap Retry, or pick a different summarizing model."
+        }
+        return "Nothing was said worth summarizing."
+    }
+
+    // MARK: - Action Items
+
+    @ViewBuilder
+    private func actionItemsSection(_ record: AmbientSessionRecord) -> some View {
+        Section("Action items") {
+            ForEach(record.actionItems) { item in
+                Button {
+                    Task { await viewModel.toggleActionItem(item.id, in: sessionID) }
+                } label: {
+                    HStack(alignment: .top, spacing: AppSpacing.smallMedium) {
+                        Image(systemName: item.isDone ? "checkmark.circle.fill" : "circle")
+                            .foregroundColor(item.isDone ? AppColors.statusGreen : AppColors.textSecondary)
+                        Text(item.text)
+                            .font(AppTypography.callout)
+                            .foregroundColor(item.isDone ? AppColors.textSecondary : AppColors.textPrimary)
+                            .strikethrough(item.isDone)
+                    }
+                }
+                .buttonStyle(.plain)
+                .swipeActions {
+                    Button("Delete", role: .destructive) {
+                        Task { await viewModel.deleteActionItem(item.id, from: sessionID) }
+                    }
+                }
+            }
+
+            HStack {
+                TextField("Add item", text: $draftItem)
+                    .font(AppTypography.callout)
+                    .onSubmit { addItem() }
+                Button("Add") { addItem() }
+                    .font(AppTypography.caption)
+                    .disabled(draftItem.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+            }
+        }
+    }
+
+    private func addItem() {
+        let text = draftItem
+        draftItem = ""
+        Task { await viewModel.addActionItem(text, to: sessionID) }
+    }
+
+    // MARK: - Transcript and Recording
+
+    @ViewBuilder
+    private func transcriptSection(_ record: AmbientSessionRecord) -> some View {
+        Section("Transcript") {
+            if record.fullTranscript.isEmpty {
+                Text("No speech was captured.")
+                    .font(AppTypography.caption)
+                    .foregroundColor(AppColors.textSecondary)
+            } else {
+                Text(record.fullTranscript)
+                    .font(AppTypography.callout)
+                    .foregroundColor(AppColors.textPrimary)
+                    .textSelection(.enabled)
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func recordingSection(_ record: AmbientSessionRecord) -> some View {
+        Section("Recording") {
+            if let path = record.audioRelativePath {
+                AmbientRecordingPlayerView(relativePath: path, player: player) {
+                    await viewModel.audioURL(for: path)
+                }
+            } else {
+                Text("Recording removed to save space.")
+                    .font(AppTypography.caption)
+                    .foregroundColor(AppColors.textSecondary)
+            }
+        }
+    }
+
+    private static let dateFormatter: DateFormatter = {
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        return formatter
+    }()
+}
+
+// MARK: - Playback
+
+/// Voice Memos-style transport: play/pause, scrubber, and elapsed/remaining.
+struct AmbientRecordingPlayerView: View {
+    let relativePath: String
+    @ObservedObject var player: AmbientNotePlayer
+    let resolveURL: () async -> URL?
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: AppSpacing.smallMedium) {
+            HStack(spacing: AppSpacing.mediumLarge) {
+                Button {
+                    Task { await toggle() }
+                } label: {
+                    Image(systemName: player.isPlaying(relativePath) ? "pause.fill" : "play.fill")
+                        .font(.system(size: 22, weight: .semibold))
+                        .foregroundColor(AppColors.primaryAccent)
+                        .frame(width: 36, height: 36)
+                }
+                .buttonStyle(.plain)
+
+                VStack(alignment: .leading, spacing: 4) {
+                    Slider(
+                        value: Binding(
+                            get: { player.displayProgress(for: relativePath) },
+                            set: { player.seek(to: $0, key: relativePath) }
+                        ),
+                        in: 0...max(player.duration(for: relativePath), 0.01)
+                    )
+                    .tint(AppColors.primaryAccent)
+
+                    HStack {
+                        Text(Self.format(player.displayProgress(for: relativePath)))
+                        Spacer()
+                        Text(Self.format(player.duration(for: relativePath)))
+                    }
+                    .font(AppTypography.caption2.monospacedDigit())
+                    .foregroundColor(AppColors.textSecondary)
+                }
+            }
+
+            if let error = player.lastError {
+                Text(error)
+                    .font(AppTypography.caption2)
+                    .foregroundColor(AppColors.statusRed)
+            }
+        }
+        .task {
+            // Load duration even before the first play so the scrubber isn't empty.
+            if let url = await resolveURL() {
+                player.prepare(url: url, key: relativePath)
+            }
+        }
+    }
+
+    private func toggle() async {
+        if player.isPlaying(relativePath) {
+            player.pause()
+            return
+        }
+        if player.isLoaded(relativePath) {
+            player.resume()
+            return
+        }
+        guard let url = await resolveURL() else {
+            player.reportMissingFile()
+            return
+        }
+        player.play(url: url, key: relativePath)
+    }
+
+    private static func format(_ seconds: TimeInterval) -> String {
+        guard seconds.isFinite, seconds >= 0 else { return "0:00" }
+        let total = Int(seconds.rounded(.down))
+        let hours = total / 3600
+        let minutes = (total % 3600) / 60
+        let secs = total % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, secs)
+        }
+        return String(format: "%d:%02d", minutes, secs)
+    }
+}
+
+/// Plays a note's recording with seek support.
+///
+/// `AVAudioPlayer` streams the WAV from disk, which matters because a note can
+/// run for hours and decoding one into memory would not fit.
+@MainActor
+final class AmbientNotePlayer: NSObject, ObservableObject {
+    @Published private(set) var playingKey: String?
+    @Published private(set) var currentTime: TimeInterval = 0
+    @Published private(set) var duration: TimeInterval = 0
+    @Published private(set) var lastError: String?
+
+    private var player: AVAudioPlayer?
+    private var loadedKey: String?
+    private var tick: Timer?
+    /// True while the user is dragging the scrubber so the timer doesn't fight them.
+    private var isScrubbing = false
+
+    func isPlaying(_ key: String) -> Bool {
+        playingKey == key && (player?.isPlaying ?? false)
+    }
+
+    func isLoaded(_ key: String) -> Bool { loadedKey == key && player != nil }
+
+    func duration(for key: String) -> TimeInterval {
+        loadedKey == key ? duration : 0
+    }
+
+    func displayProgress(for key: String) -> TimeInterval {
+        loadedKey == key ? currentTime : 0
+    }
+
+    /// Open the file to learn its duration without starting playback.
+    func prepare(url: URL, key: String) {
+        guard loadedKey != key else { return }
+        do {
+            try configureSession()
+            let prepared = try AVAudioPlayer(contentsOf: url)
+            prepared.prepareToPlay()
+            player = prepared
+            loadedKey = key
+            playingKey = nil
+            duration = prepared.duration
+            currentTime = 0
+            lastError = nil
+        } catch {
+            lastError = "Could not open the recording: \(error.localizedDescription)"
+            clearEngine()
+        }
+    }
+
+    func play(url: URL, key: String) {
+        if loadedKey != key || player == nil {
+            prepare(url: url, key: key)
+        }
+        guard let player else { return }
+        do {
+            try configureSession()
+            player.delegate = self
+            player.play()
+            playingKey = key
+            lastError = nil
+            startTicking()
+        } catch {
+            lastError = "Could not play the recording: \(error.localizedDescription)"
+            clearEngine()
+        }
+    }
+
+    func pause() {
+        player?.pause()
+        playingKey = nil
+        stopTicking()
+        currentTime = player?.currentTime ?? currentTime
+    }
+
+    func resume() {
+        guard let player, loadedKey != nil else { return }
+        do {
+            try configureSession()
+            player.play()
+            playingKey = loadedKey
+            lastError = nil
+            startTicking()
+        } catch {
+            lastError = "Could not resume playback: \(error.localizedDescription)"
+        }
+    }
+
+    func seek(to time: TimeInterval, key: String) {
+        guard loadedKey == key, let player else { return }
+        isScrubbing = true
+        let clamped = min(max(0, time), max(player.duration, 0))
+        player.currentTime = clamped
+        currentTime = clamped
+        isScrubbing = false
+    }
+
+    func stop() {
+        stopTicking()
+        player?.stop()
+        clearEngine()
+        try? AVAudioSession.sharedInstance().setActive(false, options: [.notifyOthersOnDeactivation])
+    }
+
+    func reportMissingFile() {
+        lastError = "Recording file is missing or was never finished."
+    }
+
+    private func configureSession() throws {
+        try AVAudioSession.sharedInstance().setCategory(.playback, mode: .spokenAudio)
+        try AVAudioSession.sharedInstance().setActive(true)
+    }
+
+    private func startTicking() {
+        stopTicking()
+        tick = Timer.scheduledTimer(withTimeInterval: 0.25, repeats: true) { [weak self] _ in
+            Task { @MainActor in self?.tickProgress() }
+        }
+    }
+
+    private func stopTicking() {
+        tick?.invalidate()
+        tick = nil
+    }
+
+    private func tickProgress() {
+        guard !isScrubbing, let player else { return }
+        currentTime = player.currentTime
+        duration = player.duration
+        if !player.isPlaying, playingKey != nil {
+            // Ended or interrupted without the delegate firing.
+            playingKey = nil
+            stopTicking()
+        }
+    }
+
+    private func clearEngine() {
+        player = nil
+        loadedKey = nil
+        playingKey = nil
+        currentTime = 0
+        duration = 0
+    }
+}
+
+extension AmbientNotePlayer: AVAudioPlayerDelegate {
+    nonisolated func audioPlayerDidFinishPlaying(_ player: AVAudioPlayer, successfully flag: Bool) {
+        Task { @MainActor in
+            self.currentTime = self.duration
+            self.playingKey = nil
+            self.stopTicking()
+        }
+    }
+}
+#endif

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/AudioCapturePump.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/Voice/AudioCapturePump.swift
@@ -14,9 +14,10 @@ enum AudioCapturePump {
     /// MainActor hop so STT, VAD, and keyboard dictation do not repeat it.
     static func startRecording(
         with audioCapture: AudioCaptureManager,
+        configureSession: Bool = true,
         onChunk: @escaping @MainActor @Sendable (Data) -> Void
     ) async throws {
-        try await audioCapture.startRecording { audioData in
+        try await audioCapture.startRecording(configureSession: configureSession) { audioData in
             MainActor.assumeIsolated {
                 onChunk(audioData)
             }

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/VoiceKeyboard/FlowSessionManager.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Features/VoiceKeyboard/FlowSessionManager.swift
@@ -50,6 +50,10 @@ final class FlowSessionManager: ObservableObject {
     @Published var sessionPhase: FlowSessionPhase = .idle
     @Published var lastError: String?
 
+    /// Every phase from acquiring the microphone through teardown. Broader than
+    /// `isActive`, which only covers the phases the keyboard UI reacts to.
+    var holdsAudioSession: Bool { sessionPhase != .idle }
+
     // MARK: - Private State
 
     private var audioBuffer = Data()
@@ -104,6 +108,13 @@ final class FlowSessionManager: ObservableObject {
     func handleStartFlow() async {
         guard sessionPhase == .idle else {
             logger.warning("Flow session already active — ignoring duplicate start")
+            return
+        }
+        // One microphone and one Live Activity at a time: the Ambient Memory
+        // Lab holds both while it is capturing.
+        guard !AmbientSessionManager.shared.isCapturing else {
+            lastError = "A note is recording and using the microphone. Stop it first."
+            logger.warning("Ambient capture active — refusing to start dictation")
             return
         }
         await activateSession()

--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Shared/SharedConstants.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Shared/SharedConstants.swift
@@ -16,6 +16,12 @@ enum SharedConstants {
     static let urlScheme = "runanywhere"
     static let startFlowURLString = "runanywhere://startFlow"
 
+    // Deep links for the Ambient Memory Lab. `startAmbient` is what the App
+    // Shortcut (and therefore the Action Button) opens; `ambient` just routes
+    // to the Lab without starting a session.
+    static let ambientURLString = "runanywhere://ambient"
+    static let startAmbientURLString = "runanywhere://startAmbient"
+
     // App Group UserDefaults keys
     enum Keys {
         static let sessionState = "sessionState"                // FlowSessionPhase raw value
@@ -42,6 +48,8 @@ enum SharedConstants {
         static let stopListening = "com.runanywhere.keyboard.stopListening"
         static let cancelListening = "com.runanywhere.keyboard.cancelListening"
         static let endSession = "com.runanywhere.session.end"
+        // Live Activity / App Intent → app: stop the ambient memory session.
+        static let ambientStopRequested = "com.runanywhere.ambient.stopRequested"
     }
 
     // Curated map of host app bundle IDs → URL schemes for bounce-back (WisprFlow approach).

--- a/examples/ios/RunAnywhereAI/RunAnywhereAIUnitTests/AmbientModelProfileTests.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAIUnitTests/AmbientModelProfileTests.swift
@@ -1,0 +1,208 @@
+//
+//  AmbientModelProfileTests.swift
+//  RunAnywhereAIUnitTests
+//
+//  Device-aware profile routing. The resolver is pure, so these cover the
+//  decisions that would otherwise only show up on a hot phone: degrading to a
+//  smaller stack, refusing a profile the catalog cannot satisfy, and never
+//  proposing a stack that cannot actually start capture.
+//
+
+import Foundation
+import RunAnywhere
+import XCTest
+@testable import RunAnywhereAI
+
+final class AmbientModelProfileTests: XCTestCase {
+
+    private let resolver = AmbientModelProfileResolver()
+
+    // MARK: - Resolution
+
+    func testResolveKeepsTheFirstCandidatePresentInTheCatalog() {
+        let selection = resolver.resolve(
+            profile: .quality,
+            available: Self.models([
+                "silero-vad",
+                "sherpa-onnx-whisper-tiny.en",
+                "sherpa-nemo-parakeet-tdt-0.6b-v3-int8",
+                "qwen3-1.7b-q4_k_m",
+            ])
+        )
+
+        XCTAssertEqual(selection.asrModelID, "sherpa-nemo-parakeet-tdt-0.6b-v3-int8")
+        XCTAssertEqual(selection.digestModelID, "qwen3-1.7b-q4_k_m")
+        XCTAssertTrue(selection.canStartCapture)
+        XCTAssertTrue(selection.isDigestBackgroundSafe)
+    }
+
+    func testResolveFallsBackWhenThePreferredASRIsMissing() {
+        let selection = resolver.resolve(
+            profile: .quality,
+            available: Self.models(["silero-vad", "sherpa-onnx-whisper-tiny.en"])
+        )
+
+        XCTAssertEqual(selection.asrModelID, "sherpa-onnx-whisper-tiny.en")
+        XCTAssertNil(selection.digestModelID)
+        XCTAssertTrue(selection.canStartCapture, "Capture only needs a detector and a transcriber")
+        XCTAssertFalse(selection.supportsDigest)
+    }
+
+    func testCaptureIsBlockedWithoutADetector() {
+        let selection = resolver.resolve(
+            profile: .quality,
+            available: Self.models(["sherpa-onnx-whisper-tiny.en"])
+        )
+
+        XCTAssertTrue(selection.vadModelID.isEmpty)
+        XCTAssertFalse(selection.canStartCapture)
+    }
+
+    // MARK: - Background Safety
+
+    /// Dogfooding allows GPU ASR so limits can be tested. The resolver still
+    /// flags `isASRBackgroundSafe` so the UI can soft-warn without blocking.
+    func testAnMLXASRIsAcceptedButFlaggedAsNotBackgroundSafe() {
+        let selection = resolver.resolve(
+            profile: .quality,
+            available: Self.models(["silero-vad"])
+                + Self.models(
+                    ["sherpa-nemo-parakeet-tdt-0.6b-v3-int8", "sherpa-onnx-whisper-tiny.en"],
+                    framework: .mlx
+                )
+        )
+
+        XCTAssertEqual(selection.asrModelID, "sherpa-nemo-parakeet-tdt-0.6b-v3-int8")
+        XCTAssertFalse(selection.isASRBackgroundSafe)
+        XCTAssertTrue(selection.canStartCapture)
+    }
+
+    /// Summarizing is not always-on, so a GPU model is allowed — it is just
+    /// flagged so its work gets deferred to the foreground.
+    func testAGPUDigestModelIsAllowedButFlaggedForDeferral() {
+        let selection = resolver.resolve(
+            profile: .compatibility,
+            available: Self.models(["silero-vad", "sherpa-onnx-whisper-tiny.en"])
+                + Self.models(["qwen3-0.6b-q4_k_m", "mlx-qwen3-0.6b-4bit"], framework: .mlx)
+        )
+
+        XCTAssertEqual(selection.digestModelID, "qwen3-0.6b-q4_k_m")
+        XCTAssertFalse(selection.isDigestBackgroundSafe)
+        XCTAssertTrue(selection.canStartCapture, "A GPU summarizer must not block recording")
+    }
+
+    func testIsBackgroundSafeIsFalseForMetalBackendsAndTrueForSherpa() {
+        XCTAssertFalse(RAInferenceFramework.mlx.isBackgroundSafe)
+        XCTAssertFalse(RAInferenceFramework.llamaCpp.isBackgroundSafe, "llama.cpp uses ggml-metal here")
+        XCTAssertTrue(RAInferenceFramework.sherpa.isBackgroundSafe)
+    }
+
+    // MARK: - Recommendation
+
+    func testAHealthyHighEndDeviceGetsTheBestViableProfile() {
+        let profile = resolver.recommendedProfile(
+            for: Self.conditions(tier: .highEnd, availableMemoryBytes: 6_000_000_000),
+            available: Self.fullCatalog
+        )
+
+        XCTAssertEqual(profile.id, AmbientModelProfile.highEnd.id)
+    }
+
+    func testThermalPressureStepsDownToTheLightestViableProfile() {
+        let profile = resolver.recommendedProfile(
+            for: Self.conditions(
+                tier: .highEnd,
+                availableMemoryBytes: 6_000_000_000,
+                thermalState: .serious
+            ),
+            available: Self.fullCatalog
+        )
+
+        XCTAssertEqual(profile.id, AmbientModelProfile.compatibility.id)
+    }
+
+    func testLowPowerModeAlsoStepsDown() {
+        let profile = resolver.recommendedProfile(
+            for: Self.conditions(
+                tier: .highEnd,
+                availableMemoryBytes: 6_000_000_000,
+                isLowPowerModeEnabled: true
+            ),
+            available: Self.fullCatalog
+        )
+
+        XCTAssertEqual(profile.id, AmbientModelProfile.compatibility.id)
+    }
+
+    func testAProfileIsRejectedWhenItCannotFitInAvailableMemory() {
+        let profile = resolver.recommendedProfile(
+            for: Self.conditions(tier: .highEnd, availableMemoryBytes: 1_500_000_000),
+            available: Self.fullCatalog
+        )
+
+        XCTAssertEqual(profile.id, AmbientModelProfile.compatibility.id)
+    }
+
+    func testAnEmptyCatalogStillReturnsAProfileRatherThanFailing() {
+        let profile = resolver.recommendedProfile(
+            for: Self.conditions(tier: .highEnd, availableMemoryBytes: 6_000_000_000),
+            available: []
+        )
+
+        XCTAssertEqual(profile.id, AmbientModelProfile.compatibility.id)
+        XCTAssertFalse(
+            resolver.resolve(profile: profile, available: []).canStartCapture,
+            "The UI must still be told capture is impossible"
+        )
+    }
+
+    // MARK: - Conditions
+
+    func testSummarizingIsSuspendedUnderPressureButCaptureContinues() {
+        let hot = Self.conditions(tier: .highEnd, availableMemoryBytes: 0, thermalState: .serious)
+        XCTAssertTrue(hot.shouldSuspendDerivedWork)
+        XCTAssertFalse(hot.shouldStopCapture)
+
+        let critical = Self.conditions(tier: .highEnd, availableMemoryBytes: 0, thermalState: .critical)
+        XCTAssertTrue(critical.shouldStopCapture)
+    }
+
+    // MARK: - Fixtures
+
+    private static let fullCatalog: [RAModelInfo] = models([
+        "silero-vad",
+        "sherpa-onnx-whisper-tiny.en",
+        "sherpa-nemo-parakeet-tdt-0.6b-v3-int8",
+        "qwen3-0.6b-q4_k_m",
+        "qwen3-1.7b-q4_k_m",
+        "qwen3-4b-q4_k_m",
+    ])
+
+    private static func models(
+        _ ids: [String],
+        framework: RAInferenceFramework = .sherpa
+    ) -> [RAModelInfo] {
+        ids.map { id in
+            var model = RAModelInfo()
+            model.id = id
+            model.name = id
+            model.framework = framework
+            return model
+        }
+    }
+
+    private static func conditions(
+        tier: HardwareTier,
+        availableMemoryBytes: Int64,
+        thermalState: ProcessInfo.ThermalState = .nominal,
+        isLowPowerModeEnabled: Bool = false
+    ) -> AmbientDeviceConditions {
+        AmbientDeviceConditions(
+            tier: tier,
+            availableMemoryBytes: availableMemoryBytes,
+            thermalState: thermalState,
+            isLowPowerModeEnabled: isLowPowerModeEnabled,
+            batteryLevel: 0.8
+        )
+    }
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereAIUnitTests/AmbientRecordTests.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAIUnitTests/AmbientRecordTests.swift
@@ -1,0 +1,397 @@
+//
+//  AmbientRecordTests.swift
+//  RunAnywhereAIUnitTests
+//
+//  Persistence semantics the notes feature depends on: idempotent upserts,
+//  action-item merging, audio-only expiry, and the derived values shown in the
+//  UI.
+//
+
+import Foundation
+import RunAnywhere
+import XCTest
+@testable import RunAnywhereAI
+
+final class AmbientRecordTests: XCTestCase {
+
+    // MARK: - Idempotent Persistence
+
+    func testUpsertingTheSameSegmentReplacesRatherThanAppends() {
+        var session = Self.session()
+        let segment = Self.segment(index: 0)
+
+        session.upsert(segment)
+        session.upsert(segment)
+
+        XCTAssertEqual(session.segments.count, 1, "A replayed segment event must not duplicate the record")
+    }
+
+    func testUpsertingATranscribedSegmentUpdatesInPlace() {
+        var session = Self.session()
+        var segment = Self.segment(index: 0)
+        session.upsert(segment)
+
+        segment.apply(Self.transcript(segmentID: segment.id, text: "hello there"))
+        session.upsert(segment)
+
+        XCTAssertEqual(session.segments.count, 1)
+        XCTAssertEqual(session.segments[0].transcript, "hello there")
+        XCTAssertEqual(session.transcribedSegments.count, 1)
+    }
+
+    func testUntranscribedSegmentsAreExcludedFromTheTranscribedSet() {
+        var session = Self.session()
+        session.upsert(Self.segment(index: 0))
+
+        XCTAssertTrue(session.transcribedSegments.isEmpty)
+    }
+
+    func testFullTranscriptJoinsEverySegmentIntoOneBody() {
+        var session = Self.session()
+        session.upsert(Self.transcribedSegment(index: 0, text: "Ship the beta."))
+        session.upsert(Self.transcribedSegment(index: 1, text: "  "))
+        session.upsert(Self.transcribedSegment(index: 2, text: "Then tell Ana."))
+
+        XCTAssertEqual(session.fullTranscript, "Ship the beta. Then tell Ana.")
+    }
+
+    // MARK: - Action Items
+
+    func testMergingActionItemsDropsRepeatsAcrossChunks() {
+        var session = Self.session()
+
+        session.mergeActionItems(["Call the vet", "Book the flight"])
+        session.mergeActionItems(["call the vet  ", "Pack a bag"])
+
+        XCTAssertEqual(session.actionItems.map(\.text), ["Call the vet", "Book the flight", "Pack a bag"])
+    }
+
+    func testAManualItemSurvivesAReDigest() {
+        var session = Self.session()
+        session.mergeActionItems(["Call the vet"])
+        session.actionItems.append(AmbientActionItem(text: "Water the plants", isManual: true))
+
+        session.replaceMachineActionItems(with: ["Call the vet", "Book the flight"])
+
+        XCTAssertEqual(
+            session.actionItems.map(\.text).sorted(),
+            ["Book the flight", "Call the vet", "Water the plants"],
+            "The merge pass must never erase something the tester typed"
+        )
+        XCTAssertTrue(try XCTUnwrap(session.actionItems.first { $0.text == "Water the plants" }).isManual)
+    }
+
+    func testReDigestKeepsWhatTheTesterAlreadyTickedOff() {
+        var session = Self.session()
+        session.mergeActionItems(["Call the vet"])
+        session.actionItems[0].isDone = true
+
+        session.replaceMachineActionItems(with: ["Call the vet", "Book the flight"])
+
+        XCTAssertTrue(try XCTUnwrap(session.actionItems.first { $0.text == "Call the vet" }).isDone)
+        XCTAssertFalse(try XCTUnwrap(session.actionItems.first { $0.text == "Book the flight" }).isDone)
+    }
+
+    // MARK: - Derived Values
+
+    func testRealTimeFactorIsNilUntilTheSegmentIsTranscribed() {
+        var segment = Self.segment(index: 0, durationMs: 2_000)
+        XCTAssertNil(segment.realTimeFactor)
+
+        segment.apply(Self.transcript(segmentID: segment.id, text: "hi", transcriptionMs: 500))
+        XCTAssertEqual(try XCTUnwrap(segment.realTimeFactor), 0.25, accuracy: 0.0001)
+    }
+
+    func testASegmentWithNaNConfidenceStillJSONEncodes() throws {
+        var session = Self.session()
+        var segment = AmbientSegmentRecord(
+            id: "seg",
+            sessionID: session.id,
+            index: 0,
+            startedAt: Date(timeIntervalSince1970: 0),
+            endedAt: Date(timeIntervalSince1970: 1),
+            durationMs: 1_000,
+            sampleRate: 16_000,
+            peakConfidence: Float.nan
+        )
+        segment.apply(RAAmbientTranscript(
+            id: "seg",
+            sessionID: session.id,
+            segmentID: "seg",
+            segmentIndex: 0,
+            text: "hello",
+            confidence: Float.infinity,
+            languageCode: "en",
+            startedAt: Date(timeIntervalSince1970: 0),
+            endedAt: Date(timeIntervalSince1970: 1),
+            audioDurationMs: 1_000,
+            transcriptionMs: 50,
+            modelID: "parakeet"
+        ))
+        session.upsert(segment)
+
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        XCTAssertNoThrow(try encoder.encode(session))
+        XCTAssertEqual(session.segments[0].peakConfidence, 0)
+        XCTAssertNil(session.segments[0].transcriptConfidence)
+    }
+
+    func testIncompleteNotesReportZeroDuration() {
+        var note = Self.session()
+        note.endedAt = nil
+        XCTAssertEqual(note.duration, 0)
+        note.endedAt = note.startedAt.addingTimeInterval(125)
+        XCTAssertEqual(note.duration, 125, accuracy: 0.001)
+    }
+
+    func testEmptyOrphanIsDetectedOnlyWhenNothingWasCaptured() {
+        var orphan = Self.session()
+        orphan.endedAt = nil
+        XCTAssertTrue(orphan.isEmptyOrphan)
+
+        orphan.summary = "Said something"
+        XCTAssertFalse(orphan.isEmptyOrphan)
+    }
+
+    func testTitleFallsBackFromCustomToSummaryToDate() {
+        var session = Self.session()
+        XCTAssertFalse(session.title.isEmpty, "A note with nothing in it still needs a row title")
+
+        session.summary = "Planned the release. Ana takes the beta."
+        XCTAssertEqual(session.title, "Planned the release")
+
+        session.customTitle = "Release sync"
+        XCTAssertEqual(session.title, "Release sync", "A renamed note must keep its name")
+    }
+
+    // MARK: - Audio Expiry
+
+    func testExpiryWindowsProduceTheExpectedCutoff() {
+        let now = Date(timeIntervalSince1970: 1_000_000)
+
+        XCTAssertEqual(
+            try XCTUnwrap(AmbientRetentionWindow.oneDay.expiryCutoff(from: now)),
+            now.addingTimeInterval(-86_400)
+        )
+        XCTAssertEqual(
+            try XCTUnwrap(AmbientRetentionWindow.thirtyDays.expiryCutoff(from: now)),
+            now.addingTimeInterval(-30 * 86_400)
+        )
+    }
+
+    func testRecordingsNeverExpireByDefault() {
+        XCTAssertEqual(AmbientRetentionWindow.default, .keepUntilDeleted)
+        XCTAssertNil(AmbientRetentionWindow.keepUntilDeleted.expiryCutoff(from: Date()))
+    }
+
+    /// The behavior that was silently wrong before: expiry used to delete whole
+    /// notes, so a week-old note lost its text along with its audio.
+    func testExpiringAudioKeepsEverythingElseAboutTheNote() async throws {
+        let store = AmbientMemoryStore.shared
+        var note = Self.session(id: "expiry-\(UUID().uuidString)")
+        note.endedAt = Date(timeIntervalSince1970: 0)
+        note.summary = "Planned the release."
+        note.mergeActionItems(["Ship the beta"])
+        note.upsert(Self.transcribedSegment(index: 0, text: "We should ship the beta."))
+        note.audioRelativePath = "Audio/\(note.id).wav"
+        await store.save(note)
+
+        let expired = await store.expireAudio(olderThan: .oneDay, now: Date())
+
+        XCTAssertTrue(expired.contains(note.id))
+        let saved = await store.loadSession(id: note.id)
+        let reloaded = try XCTUnwrap(saved, "Expiry must never delete the note")
+        XCTAssertNil(reloaded.audioRelativePath)
+        XCTAssertEqual(reloaded.summary, "Planned the release.")
+        XCTAssertEqual(reloaded.actionItems.map(\.text), ["Ship the beta"])
+        XCTAssertEqual(reloaded.fullTranscript, "We should ship the beta.")
+
+        await store.delete(sessionID: note.id)
+    }
+
+    func testAudioIsKeptByDefaultForDogfooding() {
+        XCTAssertEqual(AmbientRetentionPolicy.default, .retainAudio)
+        XCTAssertTrue(AmbientRetentionPolicy.retainAudio.retainsAudio)
+        XCTAssertFalse(AmbientRetentionPolicy.transcriptsOnly.retainsAudio)
+    }
+
+    // MARK: - Decoding Older Notes
+
+    /// Notes written before summaries existed must still open. Losing a
+    /// tester's history to a schema change is worse than a summary-less note.
+    func testANoteWrittenBeforeSummariesStillDecodes() throws {
+        let legacy = """
+        {"id":"old","startedAt":"1970-01-01T00:00:00Z","profileID":"quality",\
+        "vadModelID":"silero-vad","sttModelID":"parakeet","retentionPolicy":"retainAudio",\
+        "context":{"environment":"","placement":"","note":""},"deviceModel":"iPhone",\
+        "osVersion":"18.0","segments":[]}
+        """
+
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        let note = try decoder.decode(AmbientSessionRecord.self, from: Data(legacy.utf8))
+
+        XCTAssertEqual(note.id, "old")
+        XCTAssertEqual(note.summary, "")
+        XCTAssertTrue(note.actionItems.isEmpty)
+        XCTAssertTrue(note.partialSummaries.isEmpty)
+        XCTAssertFalse(note.summaryPending)
+        XCTAssertNil(note.audioRelativePath)
+    }
+
+    // MARK: - Search
+
+    func testSearchMatchesSummaryActionItemsAndTranscript() {
+        var summarized = Self.session(id: "a")
+        summarized.summary = "Planned the vet appointment."
+        var withItem = Self.session(id: "b")
+        withItem.mergeActionItems(["Book the flight"])
+        var spoken = Self.session(id: "c")
+        spoken.upsert(Self.transcribedSegment(index: 0, text: "Remember to buy oat milk on the way home."))
+
+        let store = AmbientMemoryStore.shared
+        let notes = [summarized, withItem, spoken]
+
+        XCTAssertEqual(store.search("vet", in: notes).map(\.sessionID), ["a"])
+        XCTAssertEqual(store.search("flight", in: notes).first?.kind, .actionItem)
+        XCTAssertEqual(store.search("oat milk", in: notes).first?.kind, .transcript)
+        XCTAssertTrue(store.search("   ", in: notes).isEmpty, "An empty query must not match everything")
+    }
+
+    // MARK: - Benchmark Sample
+
+    func testSpeechRatioAndActionItemRateHandleEmptyRuns() {
+        let empty = Self.benchmarkSample(sessionSeconds: 0, speechSeconds: 0, items: 0, completed: 0)
+        XCTAssertEqual(empty.speechRatio, 0)
+        XCTAssertEqual(empty.completedActionItemRate, 0)
+
+        let real = Self.benchmarkSample(sessionSeconds: 600, speechSeconds: 150, items: 4, completed: 3)
+        XCTAssertEqual(real.speechRatio, 0.25, accuracy: 0.0001)
+        XCTAssertEqual(real.completedActionItemRate, 0.75, accuracy: 0.0001)
+    }
+
+    // MARK: - Session Phase
+
+    func testOnlyLiveCapturePhasesCountAsRecording() {
+        XCTAssertTrue(AmbientSessionPhase.listening.isRecording)
+        XCTAssertTrue(AmbientSessionPhase.capturingSpeech.isRecording)
+        XCTAssertTrue(AmbientSessionPhase.transcribing.isRecording)
+
+        XCTAssertFalse(AmbientSessionPhase.preparing.isRecording)
+        XCTAssertFalse(AmbientSessionPhase.paused.isRecording)
+        XCTAssertFalse(AmbientSessionPhase.idle.isRecording)
+    }
+
+    /// The microphone is still ours while preparing, paused, or finishing, so
+    /// dictation must not be able to slip in during those phases.
+    func testPausedAndPreparingStillHoldTheMicrophone() {
+        for phase in [
+            AmbientSessionPhase.preparing,
+            .listening,
+            .capturingSpeech,
+            .transcribing,
+            .processing,
+            .paused
+        ] {
+            XCTAssertTrue(phase.holdsAudioSession, "\(phase.rawValue) must block a second audio session")
+        }
+
+        for phase in [AmbientSessionPhase.idle, .stopped, .failed] {
+            XCTAssertFalse(phase.holdsAudioSession, "\(phase.rawValue) must release the microphone")
+        }
+    }
+
+    // MARK: - Fixtures
+
+    private static func session(id: String = "session") -> AmbientSessionRecord {
+        AmbientSessionRecord(
+            id: id,
+            startedAt: Date(timeIntervalSince1970: 0),
+            profileID: "quality",
+            vadModelID: "silero-vad",
+            sttModelID: "parakeet",
+            retentionPolicy: .retainAudio,
+            context: .empty,
+            deviceModel: "iPhone",
+            osVersion: "26.0"
+        )
+    }
+
+    private static func segment(index: Int, durationMs: Int = 1_000) -> AmbientSegmentRecord {
+        AmbientSegmentRecord(from: RAAmbientSegment(
+            id: "segment-\(index)",
+            sessionID: "session",
+            index: index,
+            startedAt: Date(timeIntervalSince1970: 0),
+            endedAt: Date(timeIntervalSince1970: Double(durationMs) / 1000),
+            durationMs: durationMs,
+            sampleRate: 16_000,
+            peakConfidence: 0.9,
+            pcm16: nil
+        ))
+    }
+
+    private static func transcribedSegment(index: Int, text: String) -> AmbientSegmentRecord {
+        var stored = segment(index: index)
+        stored.apply(transcript(segmentID: stored.id, text: text))
+        return stored
+    }
+
+    private static func transcript(
+        segmentID: String,
+        text: String,
+        transcriptionMs: Int = 100
+    ) -> RAAmbientTranscript {
+        RAAmbientTranscript(
+            id: segmentID,
+            sessionID: "session",
+            segmentID: segmentID,
+            segmentIndex: 0,
+            text: text,
+            confidence: 0.8,
+            languageCode: "en",
+            startedAt: Date(timeIntervalSince1970: 0),
+            endedAt: Date(timeIntervalSince1970: 1),
+            audioDurationMs: 2_000,
+            transcriptionMs: transcriptionMs,
+            modelID: "parakeet"
+        )
+    }
+
+    private static func benchmarkSample(
+        sessionSeconds: Double,
+        speechSeconds: Double,
+        items: Int,
+        completed: Int
+    ) -> AmbientBenchmarkSample {
+        AmbientBenchmarkSample(
+            id: UUID(),
+            recordedAt: Date(),
+            sessionID: "session",
+            profileID: "quality",
+            deviceModel: "iPhone",
+            chipName: "Apple Silicon",
+            osVersion: "26.0",
+            audioRoute: "MicrophoneBuiltIn",
+            environment: "office",
+            placement: "desk",
+            sessionSeconds: sessionSeconds,
+            speechSeconds: speechSeconds,
+            segmentCount: 10,
+            transcribedSegmentCount: 10,
+            droppedSegmentCount: 0,
+            actionItemCount: items,
+            completedActionItemCount: completed,
+            medianTranscriptionMs: 200,
+            medianRealTimeFactor: 0.2,
+            medianExtractionMs: 900,
+            firstTranscriptLatencyMs: 1_500,
+            peakMemoryBytes: 1_000,
+            batteryDeltaPerHour: 12,
+            thermalState: "nominal",
+            interruptionCount: 0,
+            retainedAudioBytes: 0
+        )
+    }
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereActivityExtension/AmbientLiveActivity.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereActivityExtension/AmbientLiveActivity.swift
@@ -1,0 +1,154 @@
+//
+//  AmbientLiveActivity.swift
+//  RunAnywhereActivityExtension
+//
+//  Live Activity for the Ambient Memory Lab.
+//
+//  The Lock Screen is visible to anyone holding the phone, so this surface
+//  never renders transcript, summary, speaker, or memory text — only that a
+//  session is recording, for how long, and how much it has captured.
+//
+
+import ActivityKit
+import AppIntents
+import SwiftUI
+import WidgetKit
+
+private enum AmbientBrand {
+    static let accent      = Color(.sRGB, red: 1.0, green: 0.412, blue: 0.0)     // #FF6900
+    static let red         = Color(.sRGB, red: 0.937, green: 0.267, blue: 0.267) // #EF4444
+    static let darkBg      = Color(.sRGB, red: 0.059, green: 0.090, blue: 0.165) // #0F172A
+    static let darkSurface = Color(.sRGB, red: 0.102, green: 0.122, blue: 0.180) // #1A1F2E
+}
+
+struct AmbientLiveActivityWidget: Widget {
+    var body: some WidgetConfiguration {
+        ActivityConfiguration(for: AmbientActivityAttributes.self) { context in
+            AmbientLockScreenView(state: context.state)
+        } dynamicIsland: { context in
+            DynamicIsland {
+                DynamicIslandExpandedRegion(.leading) {
+                    Image(systemName: "brain.head.profile")
+                        .font(.title3)
+                        .foregroundStyle(AmbientBrand.accent)
+                        .padding(.leading, 4)
+                }
+                DynamicIslandExpandedRegion(.center) {
+                    Text(AmbientPhase.title(context.state.phase, isStopped: context.state.isStopped))
+                        .font(.headline)
+                }
+                DynamicIslandExpandedRegion(.trailing) {
+                    VStack(alignment: .trailing, spacing: 2) {
+                        Text(AmbientPhase.duration(context.state.elapsedSeconds))
+                            .font(.subheadline.monospacedDigit())
+                            .foregroundStyle(.secondary)
+                        Text("\(context.state.segmentCount) captured")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    .padding(.trailing, 4)
+                }
+                DynamicIslandExpandedRegion(.bottom) {
+                    if !context.state.isStopped {
+                        Button(intent: StopAmbientMemoryIntent()) {
+                            Label("Stop", systemImage: "stop.fill")
+                                .frame(maxWidth: .infinity)
+                        }
+                        .tint(AmbientBrand.red)
+                        .padding(.horizontal, 8)
+                    }
+                }
+            } compactLeading: {
+                Image(systemName: "brain.head.profile")
+                    .font(.caption)
+                    .foregroundStyle(AmbientBrand.accent)
+            } compactTrailing: {
+                Text(AmbientPhase.duration(context.state.elapsedSeconds))
+                    .font(.caption2.monospacedDigit())
+                    .foregroundStyle(.secondary)
+            } minimal: {
+                Image(systemName: "brain.head.profile")
+                    .font(.caption)
+                    .foregroundStyle(AmbientBrand.accent)
+            }
+            .keylineTint(AmbientBrand.accent)
+        }
+    }
+}
+
+// MARK: - Lock Screen
+
+private struct AmbientLockScreenView: View {
+    let state: AmbientActivityAttributes.ContentState
+
+    var body: some View {
+        HStack(spacing: 14) {
+            Image(systemName: "brain.head.profile")
+                .font(.title)
+                .foregroundStyle(AmbientBrand.accent)
+                .frame(width: 44, height: 44)
+
+            VStack(alignment: .leading, spacing: 2) {
+                Text(AmbientPhase.title(state.phase, isStopped: state.isStopped))
+                    .font(.headline)
+                    .foregroundStyle(.white)
+                Text(subtitle)
+                    .font(.caption.monospacedDigit())
+                    .foregroundStyle(.white.opacity(0.6))
+            }
+
+            Spacer()
+
+            if !state.isStopped {
+                Button(intent: StopAmbientMemoryIntent()) {
+                    Image(systemName: "stop.fill")
+                        .font(.headline)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(AmbientBrand.red)
+            }
+        }
+        .padding(16)
+        .background(
+            LinearGradient(
+                colors: [AmbientBrand.darkBg, AmbientBrand.darkSurface],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+            )
+        )
+        .activityBackgroundTint(AmbientBrand.darkBg)
+        .activitySystemActionForegroundColor(.white)
+    }
+
+    private var subtitle: String {
+        var parts = [AmbientPhase.duration(state.elapsedSeconds)]
+        parts.append("\(state.segmentCount) captured")
+        if state.actionItemCount > 0 { parts.append("\(state.actionItemCount) to do") }
+        return parts.joined(separator: " · ")
+    }
+}
+
+// MARK: - Presentation Helpers
+
+private enum AmbientPhase {
+    static func title(_ phase: String, isStopped: Bool) -> String {
+        if isStopped { return "Note stopped" }
+        switch phase {
+        case "preparing":  return "Preparing note"
+        case "speech":     return "Note hearing speech"
+        case "processing": return "Note transcribing"
+        case "paused":     return "Note paused"
+        default:           return "Note recording"
+        }
+    }
+
+    static func duration(_ seconds: Int) -> String {
+        let hours = seconds / 3600
+        let minutes = (seconds % 3600) / 60
+        let secs = seconds % 60
+        if hours > 0 {
+            return String(format: "%d:%02d:%02d", hours, minutes, secs)
+        }
+        return String(format: "%d:%02d", minutes, secs)
+    }
+}

--- a/examples/ios/RunAnywhereAI/RunAnywhereActivityExtension/RunAnywhereActivityExtensionBundle.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereActivityExtension/RunAnywhereActivityExtensionBundle.swift
@@ -10,5 +10,6 @@ import SwiftUI
 struct RunAnywhereActivityExtensionBundle: WidgetBundle {
     var body: some Widget {
         DictationLiveActivityWidget()
+        AmbientLiveActivityWidget()
     }
 }

--- a/examples/ios/RunAnywhereAI/scripts/ambient-device-checklist.sh
+++ b/examples/ios/RunAnywhereAI/scripts/ambient-device-checklist.sh
@@ -1,0 +1,204 @@
+#!/usr/bin/env bash
+# Notes — physical-device validation harness.
+#
+# The risky behavior is all things a simulator cannot reproduce: a locked
+# screen, a real phone call, a Bluetooth route change, thermal throttling, and
+# multi-hour battery drain. This script does the parts a machine can do
+# (install, launch, log capture, per-run artifacts) and prints the manual steps
+# in order so a run is reproducible and comparable to the last one.
+#
+# Usage:
+#   scripts/ambient-device-checklist.sh list
+#   scripts/ambient-device-checklist.sh install <device-udid>
+#   scripts/ambient-device-checklist.sh logs <device-udid> [minutes]
+#   scripts/ambient-device-checklist.sh checklist
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+APP_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+BUNDLE_ID="${AMBIENT_BUNDLE_ID:-com.runanywhere.RunAnywhere}"
+RESULTS_DIR="${APP_ROOT}/.ambient-runs"
+
+log() {
+    printf '\n==> %s\n' "$*"
+}
+
+require_command() {
+    if ! command -v "$1" >/dev/null 2>&1; then
+        echo "error: required command not found: $1" >&2
+        exit 1
+    fi
+}
+
+cmd_list() {
+    require_command xcrun
+    log "Connected devices"
+    xcrun devicectl list devices
+}
+
+cmd_install() {
+    local udid="${1:?usage: install <device-udid>}"
+    require_command xcodebuild
+    require_command xcrun
+
+    log "Building for the device"
+    xcodebuild \
+        -project "${APP_ROOT}/RunAnywhereAI.xcodeproj" \
+        -scheme RunAnywhereAI \
+        -configuration Debug \
+        -destination "id=${udid}" \
+        -skipPackagePluginValidation \
+        -derivedDataPath "${APP_ROOT}/.build-device" \
+        build
+
+    local app_path
+    app_path="$(find "${APP_ROOT}/.build-device/Build/Products" -maxdepth 3 -name 'RunAnywhereAI.app' | head -1)"
+    if [ -z "${app_path}" ]; then
+        echo "error: could not locate the built RunAnywhereAI.app" >&2
+        exit 1
+    fi
+
+    log "Installing ${app_path}"
+    xcrun devicectl device install app --device "${udid}" "${app_path}"
+
+    cat <<'NOTE'
+
+Installed. Before the first run, on the device:
+  1. Open Advanced > Notes. Under Models, Change each role, Get, then Use —
+     pick any catalog models (including MLX) to stress-test. No defaults are
+     pre-selected. Developer profiles only copy candidate IDs if you apply one.
+  2. Grant microphone access and allow Live Activities for RunAnywhere.
+  3. Settings > Action Button > Shortcut > "Start Memory Lab" (iPhone 15 Pro and later).
+NOTE
+}
+
+cmd_logs() {
+    local udid="${1:?usage: logs <device-udid> [minutes]}"
+    local minutes="${2:-60}"
+    require_command xcrun
+    mkdir -p "${RESULTS_DIR}"
+
+    local out="${RESULTS_DIR}/ambient-$(date +%Y%m%d-%H%M%S).log"
+    log "Streaming AmbientSession / AmbientMemory logs for ${minutes} minutes to ${out}"
+    xcrun devicectl device console \
+        --device "${udid}" \
+        > "${out}" 2>&1 &
+    local pid=$!
+    trap 'kill "${pid}" 2>/dev/null || true' EXIT
+    sleep $(( minutes * 60 ))
+    kill "${pid}" 2>/dev/null || true
+    trap - EXIT
+
+    log "Saved ${out}"
+    echo "Export the in-app benchmark CSV (Notes > Developer > Benchmark samples > Export CSV) into the same folder."
+}
+
+cmd_checklist() {
+    cat <<'CHECKLIST'
+
+Notes — manual device checklist
+==============================
+Record the result of every line. A run is only comparable to another run when
+the environment and placement labels were set under Developer before starting.
+
+Models (from Notes, without visiting the Models tab)
+  [ ] Slots start empty (None). Record is disabled until VAD + ASR are Ready.
+  [ ] Change Speech detector → Get → Use any VAD; row shows Ready.
+  [ ] Change Transcription → Get → Use any STT (try an MLX ASR once): soft
+      warning appears for GPU ASR but Record is still allowed once Ready.
+  [ ] Change Summarizing → Get → Use any LLM (optional); GPU digest soft-warns
+      and defers merge when stopped from background.
+  [ ] Developer → Apply a profile: IDs fill the slots; still need Get/Use for
+      anything not already downloaded.
+
+Lifecycle
+  [ ] Tap Record, lock the screen, confirm the Live Activity shows elapsed time
+      and never shows transcript text.
+  [ ] Background the app for 10 minutes, return, confirm capture continued and
+      the transcript grew (CPU ASR). With GPU ASR, note whether it stalled —
+      that is expected limit-test data, not a hard failure.
+  [ ] Record with the screen locked for 30 minutes on a CPU ASR, then read the
+      console log: segments must keep transcribing the whole time.
+  [ ] Stop from the Live Activity's Stop button; confirm the note saves.
+  [ ] Stop from Shortcuts while the app is backgrounded. With a GPU summarizer
+      selected, the note shows "Summary pending" and finishes on next launch.
+
+Activation
+  [ ] Action Button after a cold launch: app opens, shows preparation, then
+      records. It must never capture without the recording state visible.
+  [ ] Action Button with models not yet picked/downloaded: a clear missing-
+      model state on Notes, not a silent failure.
+  [ ] Action Button while already listening: no second session, no second
+      Live Activity.
+  [ ] Action Button right after an interruption ended.
+
+Interruptions
+  [ ] Incoming phone call: session stops, in-flight segment is saved.
+  [ ] Siri invocation mid-session.
+  [ ] Music/podcast playback starts mid-session.
+  [ ] Bluetooth headset connect and disconnect mid-session (route change).
+  [ ] Start Voice Keyboard dictation while a note is recording: one of the two
+      must refuse — never two live microphones.
+
+Resource pressure
+  [ ] Low Power Mode on: capture continues, derived work is gated, and the gate
+      is visible in the UI.
+  [ ] Drive the device to a serious thermal state: summarizing pauses.
+  [ ] Drive it to critical: capture stops and the reason is recorded on the
+      note.
+  [ ] Fill storage close to the floor mid-note: the recording stops and reports
+      the storage gate; transcription keeps landing.
+
+Permissions and teardown
+  [ ] Revoke microphone access in Settings mid-session.
+  [ ] Force quit mid-note; relaunch and confirm the note is saved up to its
+      last finalized segment and no Live Activity is orphaned.
+
+Search
+  [ ] Search a word that appears only in a summary, only in an action item, and
+      only deep in a transcript: each returns its note with the matching
+      snippet.
+  [ ] Search with the field cleared: every note is listed, newest first.
+
+Notes isolation from Chat
+  [ ] Attach a document in Chat and ask about it: no note content appears in
+      the answer.
+  [ ] Record a note, then ask Chat about the attached document again: the
+      document answer still works, so nothing wiped Chat's index.
+
+Privacy
+  [ ] Enable Airplane Mode for a full note; every stage must still work.
+  [ ] Delete one note; confirm its recording and transcript both go.
+  [ ] Delete everything; confirm storage returns to near zero and Chat's
+      attached document still answers.
+  [ ] Set an audio expiry, wait past it, and confirm the note keeps its
+      summary, action items, and transcript while the recording is gone.
+
+Timed runs (repeat each three times, then a multi-hour dogfood run)
+  [ ] 5 minutes locked
+  [ ] 30 minutes locked
+  [ ] 60 minutes locked
+  [ ] Multi-hour dogfood session
+
+Environments (label each under Developer before starting)
+  [ ] quiet room   [ ] office      [ ] restaurant  [ ] vehicle
+  [ ] wind         [ ] TV/podcast  [ ] in pocket   [ ] on a desk
+  [ ] phone face down
+
+Hardware spread
+  [ ] iPhone 14   [ ] iPhone 15   [ ] iPhone 16   [ ] iPhone 17
+
+After each run, export the benchmark CSV and keep it with the console log.
+CHECKLIST
+}
+
+case "${1:-checklist}" in
+    list)      cmd_list ;;
+    install)   shift; cmd_install "$@" ;;
+    logs)      shift; cmd_logs "$@" ;;
+    checklist) cmd_checklist ;;
+    *)
+        echo "usage: $(basename "$0") {list|install <udid>|logs <udid> [minutes]|checklist}" >&2
+        exit 1
+        ;;
+esac

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Features/AmbientMemory/Services/AmbientMemoryPipeline.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Features/AmbientMemory/Services/AmbientMemoryPipeline.swift
@@ -1,0 +1,497 @@
+//
+//  AmbientMemoryPipeline.swift
+//  RunAnywhere SDK
+//
+//  The composed ambient-memory pipeline: VAD debounce, pre/post-roll,
+//  segment finalization, and serially-scheduled transcription.
+//
+//  Hosts never see this type. They start a session through
+//  `RunAnywhere.ambient.start(...)`, push microphone PCM into the returned
+//  handle, and consume `RAAmbientEvent`s. Keeping the loop here — rather than
+//  in each app — is what makes the ambient feature one SDK entry point
+//  instead of a multi-stage orchestration every consumer reimplements.
+//
+
+import Foundation
+
+/// Serialised owner of one ambient session's audio state machine.
+///
+/// Reentrancy is deliberate: `transcribe` suspends the actor so incoming audio
+/// keeps being framed and segmented while a previous segment is still being
+/// transcribed. Transcription itself stays serial because only the single
+/// drain task pulls from `pendingTranscriptions`.
+actor AmbientMemoryPipeline {
+
+    // MARK: - Segment Accumulation
+
+    private struct OpenSegment {
+        let index: Int
+        let startedAt: Date
+        var samples: [Int16]
+        var peakConfidence: Float
+        /// Audio appended since the last speech frame, used to trim the tail
+        /// back to the configured post-roll when the segment closes.
+        var trailingSilenceSamples: Int
+    }
+
+    private struct PendingTranscription {
+        let segment: RAAmbientSegment
+        let samples: [Int16]
+    }
+
+    // MARK: - Stored State
+
+    private let sessionID: String
+    private let configuration: RAAmbientConfiguration
+    private let continuation: AsyncStream<RAAmbientEvent>.Continuation
+    private let logger = SDKLogger(category: "AmbientMemory")
+
+    private let frameSampleCount: Int
+    private let frameDurationMs: Int
+    private let preRollCapacity: Int
+    private let postRollSampleCount: Int
+    private let maxSegmentSampleCount: Int
+
+    private var state: RAAmbientState = .idle
+    private var isPaused = false
+    private var isFinished = false
+
+    /// Samples received but not yet aligned into a whole detector frame.
+    private var frameRemainder: [Int16] = []
+    /// Rolling window kept while no segment is open, so an opened segment can
+    /// reach back across the debounce window plus the configured pre-roll.
+    private var preRoll: [Int16] = []
+
+    private var openSegment: OpenSegment?
+    private var speechRunMs = 0
+    private var silenceRunMs = 0
+    private var nextSegmentIndex = 0
+
+    private var pendingTranscriptions: [PendingTranscription] = []
+    private var drainTask: Task<Void, Never>?
+    private var isBackpressureActive = false
+
+    // MARK: - Init
+
+    init(
+        sessionID: String,
+        configuration: RAAmbientConfiguration,
+        continuation: AsyncStream<RAAmbientEvent>.Continuation
+    ) {
+        self.sessionID = sessionID
+        self.configuration = configuration
+        self.continuation = continuation
+
+        let frameSamples = configuration.vadFrameSampleCount
+        self.frameSampleCount = frameSamples
+        self.frameDurationMs = max(1, frameSamples * 1000 / max(1, configuration.sampleRate))
+        self.preRollCapacity = Self.sampleCount(
+            forMs: configuration.preRollMs + configuration.speechDebounceMs,
+            sampleRate: configuration.sampleRate
+        )
+        self.postRollSampleCount = Self.sampleCount(
+            forMs: configuration.postRollMs,
+            sampleRate: configuration.sampleRate
+        )
+        self.maxSegmentSampleCount = Self.sampleCount(
+            forMs: configuration.maxSegmentMs,
+            sampleRate: configuration.sampleRate
+        )
+    }
+
+    // MARK: - Lifecycle
+
+    /// Load the configured VAD and STT models, then arm the detector.
+    /// Throws only when a model the session cannot run without fails to load.
+    func prepare() async throws {
+        transition(to: .preparing)
+
+        try await loadModel(
+            id: configuration.vadModelID,
+            category: .voiceActivityDetection,
+            label: "VAD"
+        )
+        try await loadModel(
+            id: configuration.sttModelID,
+            category: .speechRecognition,
+            label: "STT"
+        )
+
+        try? await RunAnywhere.resetVAD()
+        transition(to: .listening)
+    }
+
+    /// Consume host audio until the stream closes, then flush and stop.
+    func run(audio: AsyncStream<Data>) async {
+        for await chunk in audio {
+            guard !isFinished else { break }
+            await ingest(chunk)
+        }
+        await finish()
+    }
+
+    func pause() {
+        guard !isFinished, !isPaused else { return }
+        isPaused = true
+        transition(to: .paused)
+    }
+
+    func resume() {
+        guard !isFinished, isPaused else { return }
+        isPaused = false
+        transition(to: openSegment == nil ? .listening : .speechSegment)
+    }
+
+    /// Forward a host-observed condition (thermal, memory, storage) onto the
+    /// same event stream so consumers have one ordered source of truth.
+    func report(gate: RAAmbientResourceGate) {
+        guard !isFinished else { return }
+        continuation.yield(.resourceGate(gate))
+    }
+
+    /// Close any open segment, drain queued transcriptions, and end the stream.
+    func finish() async {
+        guard !isFinished else { return }
+        isFinished = true
+
+        if openSegment != nil {
+            closeSegment(reason: .sessionEnd, at: Date())
+        }
+        await drainTask?.value
+
+        transition(to: .stopped)
+        continuation.finish()
+    }
+
+    /// End the session immediately, discarding queued work. Used when the host
+    /// loses the microphone or hits a fatal error.
+    func abort(_ failure: RAAmbientFailure) {
+        guard !isFinished else { return }
+        isFinished = true
+
+        drainTask?.cancel()
+        drainTask = nil
+        pendingTranscriptions.removeAll()
+        openSegment = nil
+
+        continuation.yield(.failure(failure))
+        transition(to: .failed)
+        continuation.finish()
+    }
+
+    // MARK: - Ingestion
+
+    private func ingest(_ chunk: Data) async {
+        guard !isPaused, !isFinished else { return }
+
+        frameRemainder.append(contentsOf: Self.int16Samples(from: chunk))
+        while frameRemainder.count >= frameSampleCount, !isFinished {
+            let frame = Array(frameRemainder.prefix(frameSampleCount))
+            frameRemainder.removeFirst(frameSampleCount)
+            await processFrame(frame)
+        }
+    }
+
+    private func processFrame(_ frame: [Int16]) async {
+        let float32 = Self.float32Data(from: frame)
+        let result: RAVADResult
+        do {
+            result = try await RunAnywhere.detectVoiceActivity(
+                float32,
+                options: configuration.vadOptions
+            )
+        } catch {
+            continuation.yield(.failure(RAAmbientFailure(
+                stage: .vad,
+                message: "Voice activity detection failed: \(error.localizedDescription)",
+                isFatal: false
+            )))
+            return
+        }
+
+        guard result.errorMessage.isEmpty else {
+            continuation.yield(.failure(RAAmbientFailure(
+                stage: .vad,
+                message: result.errorMessage,
+                isFatal: false
+            )))
+            return
+        }
+
+        if openSegment == nil {
+            advanceWhileIdle(frame: frame, result: result)
+        } else {
+            advanceWhileSpeaking(frame: frame, result: result)
+        }
+    }
+
+    /// No segment open: keep a rolling pre-roll window and wait for enough
+    /// continuous speech to clear the debounce threshold.
+    private func advanceWhileIdle(frame: [Int16], result: RAVADResult) {
+        preRoll.append(contentsOf: frame)
+        if preRoll.count > preRollCapacity {
+            preRoll.removeFirst(preRoll.count - preRollCapacity)
+        }
+
+        guard result.isSpeech else {
+            speechRunMs = 0
+            return
+        }
+
+        speechRunMs += frameDurationMs
+        guard speechRunMs >= configuration.speechDebounceMs else { return }
+
+        let startedAt = Date()
+        let index = nextSegmentIndex
+        nextSegmentIndex += 1
+        openSegment = OpenSegment(
+            index: index,
+            startedAt: startedAt,
+            samples: preRoll,
+            peakConfidence: result.confidence,
+            trailingSilenceSamples: 0
+        )
+        preRoll.removeAll(keepingCapacity: true)
+        speechRunMs = 0
+        silenceRunMs = 0
+
+        continuation.yield(.speechStarted(at: startedAt))
+        continuation.yield(.segmentOpened(
+            id: Self.segmentID(sessionID: sessionID, index: index),
+            index: index,
+            startedAt: startedAt
+        ))
+        transition(to: .speechSegment)
+    }
+
+    /// Segment open: accumulate audio, then close on sustained silence or when
+    /// the segment hits its length cap.
+    private func advanceWhileSpeaking(frame: [Int16], result: RAVADResult) {
+        guard var segment = openSegment else { return }
+
+        segment.samples.append(contentsOf: frame)
+        if result.isSpeech {
+            segment.peakConfidence = max(segment.peakConfidence, result.confidence)
+            segment.trailingSilenceSamples = 0
+            silenceRunMs = 0
+        } else {
+            segment.trailingSilenceSamples += frame.count
+            silenceRunMs += frameDurationMs
+        }
+        openSegment = segment
+
+        if silenceRunMs >= configuration.silenceHangoverMs {
+            closeSegment(reason: .silence, at: Date())
+        } else if segment.samples.count >= maxSegmentSampleCount {
+            closeSegment(reason: .lengthCap, at: Date())
+        }
+    }
+
+    // MARK: - Segment Finalization
+
+    private enum CloseReason {
+        case silence
+        case lengthCap
+        case sessionEnd
+    }
+
+    private func closeSegment(reason: CloseReason, at endedAt: Date) {
+        guard let segment = openSegment else { return }
+        openSegment = nil
+        silenceRunMs = 0
+        speechRunMs = 0
+
+        var samples = segment.samples
+        // Only a silence-triggered close has a measured silent tail to trim;
+        // the length cap and session end stop mid-speech.
+        if reason == .silence, segment.trailingSilenceSamples > postRollSampleCount {
+            samples.removeLast(segment.trailingSilenceSamples - postRollSampleCount)
+        }
+
+        let durationMs = Self.durationMs(sampleCount: samples.count, sampleRate: configuration.sampleRate)
+        continuation.yield(.speechEnded(at: endedAt, durationMs: durationMs))
+
+        guard durationMs >= configuration.minSegmentMs else {
+            logger.debug(
+                "Dropping \(durationMs)ms ambient segment below the "
+                + "\(self.configuration.minSegmentMs)ms floor"
+            )
+            transition(to: pendingTranscriptions.isEmpty && drainTask == nil ? .listening : .processing)
+            return
+        }
+
+        let record = RAAmbientSegment(
+            id: Self.segmentID(sessionID: sessionID, index: segment.index),
+            sessionID: sessionID,
+            index: segment.index,
+            startedAt: segment.startedAt,
+            endedAt: endedAt,
+            durationMs: durationMs,
+            sampleRate: configuration.sampleRate,
+            peakConfidence: segment.peakConfidence,
+            pcm16: configuration.retainSegmentAudio ? Self.pcm16Data(from: samples) : nil
+        )
+        continuation.yield(.segmentFinalized(record))
+        enqueue(PendingTranscription(segment: record, samples: samples))
+    }
+
+    // MARK: - Serial Transcription
+
+    private func enqueue(_ job: PendingTranscription) {
+        pendingTranscriptions.append(job)
+
+        while pendingTranscriptions.count > configuration.maxQueuedSegments {
+            let dropped = pendingTranscriptions.removeFirst()
+            isBackpressureActive = true
+            continuation.yield(.resourceGate(RAAmbientResourceGate(
+                reason: .backpressure,
+                isActive: true,
+                detail: "Dropped segment \(dropped.segment.index): transcription is behind capture"
+            )))
+        }
+
+        transition(to: .processing)
+        startDrainingIfNeeded()
+    }
+
+    private func startDrainingIfNeeded() {
+        guard drainTask == nil else { return }
+        drainTask = Task { [weak self] in
+            await self?.drain()
+        }
+    }
+
+    private func drain() async {
+        while !pendingTranscriptions.isEmpty, !Task.isCancelled {
+            let job = pendingTranscriptions.removeFirst()
+            await transcribe(job)
+        }
+        drainTask = nil
+
+        if isBackpressureActive {
+            isBackpressureActive = false
+            continuation.yield(.resourceGate(RAAmbientResourceGate(
+                reason: .backpressure,
+                isActive: false,
+                detail: "Transcription caught up with capture"
+            )))
+        }
+
+        guard !isFinished else { return }
+        transition(to: openSegment == nil ? .listening : .speechSegment)
+    }
+
+    private func transcribe(_ job: PendingTranscription) async {
+        let startedAt = Date()
+        do {
+            let output = try await RunAnywhere.transcribe(
+                audio: Self.pcm16Data(from: job.samples),
+                options: configuration.sttOptions
+            )
+            guard output.errorMessage.isEmpty else {
+                yieldTranscriptionFailure(output.errorMessage, segmentID: job.segment.id)
+                return
+            }
+
+            let text = output.text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else {
+                logger.debug("Ambient segment \(job.segment.index) transcribed to empty text; skipping")
+                return
+            }
+
+            continuation.yield(.transcript(RAAmbientTranscript(
+                id: job.segment.id,
+                sessionID: sessionID,
+                segmentID: job.segment.id,
+                segmentIndex: job.segment.index,
+                text: text,
+                confidence: output.confidence,
+                languageCode: output.hasLanguageCode ? output.languageCode : "",
+                startedAt: job.segment.startedAt,
+                endedAt: job.segment.endedAt,
+                audioDurationMs: job.segment.durationMs,
+                transcriptionMs: Int(Date().timeIntervalSince(startedAt) * 1000),
+                modelID: configuration.sttModelID
+            )))
+        } catch {
+            yieldTranscriptionFailure(error.localizedDescription, segmentID: job.segment.id)
+        }
+    }
+
+    private func yieldTranscriptionFailure(_ message: String, segmentID: String) {
+        continuation.yield(.failure(RAAmbientFailure(
+            stage: .transcription,
+            message: message,
+            isFatal: false,
+            segmentID: segmentID
+        )))
+    }
+
+    // MARK: - Helpers
+
+    private func loadModel(id: String, category: RAModelCategory, label: String) async throws {
+        guard !id.isEmpty else {
+            throw SDKException(
+                code: .invalidArgument,
+                message: "Ambient memory requires a \(label) model id",
+                category: .validation
+            )
+        }
+
+        let snapshot = RunAnywhere.loadedModelSnapshot(category: category)
+        if snapshot.found, snapshot.modelID == id { return }
+
+        var request = RAModelLoadRequest()
+        request.modelID = id
+        request.category = category
+        let result = await RunAnywhere.loadModel(request)
+        guard result.success else {
+            let failure = RAAmbientFailure(
+                stage: .modelLoad,
+                message: "\(label) model '\(id)' failed to load: \(result.errorMessage)",
+                isFatal: true
+            )
+            continuation.yield(.failure(failure))
+            throw SDKException(code: .modelLoadFailed, message: failure.message, category: .component)
+        }
+    }
+
+    private func transition(to next: RAAmbientState) {
+        guard state != next else { return }
+        state = next
+        continuation.yield(.state(next))
+    }
+
+    private static func segmentID(sessionID: String, index: Int) -> String {
+        "\(sessionID)-seg-\(String(format: "%06d", index))"
+    }
+
+    private static func sampleCount(forMs milliseconds: Int, sampleRate: Int) -> Int {
+        max(0, milliseconds * sampleRate / 1000)
+    }
+
+    private static func durationMs(sampleCount: Int, sampleRate: Int) -> Int {
+        guard sampleRate > 0 else { return 0 }
+        return sampleCount * 1000 / sampleRate
+    }
+
+    private static func int16Samples(from data: Data) -> [Int16] {
+        let count = data.count / MemoryLayout<Int16>.size
+        guard count > 0 else { return [] }
+        return data.withUnsafeBytes { raw in
+            Array(UnsafeBufferPointer(
+                start: raw.baseAddress?.assumingMemoryBound(to: Int16.self),
+                count: count
+            ))
+        }
+    }
+
+    private static func pcm16Data(from samples: [Int16]) -> Data {
+        samples.withUnsafeBufferPointer { Data(buffer: $0) }
+    }
+
+    private static func float32Data(from samples: [Int16]) -> Data {
+        let floats = samples.map { Float($0) / 32_768.0 }
+        return floats.withUnsafeBufferPointer { Data(buffer: $0) }
+    }
+}

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Features/STT/Services/AudioCaptureManager.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Features/STT/Services/AudioCaptureManager.swift
@@ -126,9 +126,7 @@ public class AudioCaptureManager: ObservableObject, @unchecked Sendable {
             try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
                 DispatchQueue.global(qos: .userInitiated).async {
                     do {
-                        let audioSession = AVAudioSession.sharedInstance()
-                        try audioSession.setCategory(.record, mode: .measurement)
-                        try audioSession.setActive(true)
+                        try Self.activateRecordingSession()
                         continuation.resume()
                     } catch {
                         continuation.resume(throwing: error)
@@ -211,9 +209,7 @@ public class AudioCaptureManager: ObservableObject, @unchecked Sendable {
         try await withCheckedThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in
             DispatchQueue.global(qos: .userInitiated).async {
                 do {
-                    let audioSession = AVAudioSession.sharedInstance()
-                    try audioSession.setCategory(.record, mode: .measurement)
-                    try audioSession.setActive(true)
+                    try Self.activateRecordingSession()
                     continuation.resume()
                 } catch {
                     continuation.resume(throwing: error)
@@ -223,6 +219,35 @@ public class AudioCaptureManager: ObservableObject, @unchecked Sendable {
         logger.info("Audio session activated (keepalive)")
         #endif
     }
+
+    /// Configure `.record` / `.measurement` and activate, recovering from the
+    /// common "Session activation failed" case where the shared session was
+    /// left active under a different category (TTS, playback, a prior start).
+    #if os(iOS) || os(tvOS)
+    private static func activateRecordingSession() throws {
+        let audioSession = AVAudioSession.sharedInstance()
+        // Drop any leftover activation first — changing category while still
+        // active is a frequent cause of activation failures on device.
+        try? audioSession.setActive(false, options: .notifyOthersOnDeactivation)
+        try audioSession.setCategory(
+            .record,
+            mode: .measurement,
+            options: [.allowBluetoothHFP]
+        )
+        do {
+            try audioSession.setActive(true)
+        } catch {
+            // mediaserverd sometimes needs a beat after deactivation.
+            Thread.sleep(forTimeInterval: 0.2)
+            try audioSession.setCategory(
+                .record,
+                mode: .measurement,
+                options: [.allowBluetoothHFP]
+            )
+            try audioSession.setActive(true)
+        }
+    }
+    #endif
 
     /// Deactivates the AVAudioSession. Call this when the session is fully ended.
     public func deactivateAudioSession() {

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/AmbientMemory/AmbientMemoryTypes.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/AmbientMemory/AmbientMemoryTypes.swift
@@ -1,0 +1,316 @@
+//
+//  AmbientMemoryTypes.swift
+//  RunAnywhere SDK
+//
+//  Public value types for the ambient-memory solution: the configuration a
+//  host supplies when starting a session, the typed lifecycle events the
+//  session emits, and the structured records the pipeline produces.
+//
+//  The host owns microphone acquisition and every storage / UI policy
+//  decision; the SDK owns VAD debounce, segment boundaries, transcription
+//  scheduling, and the event contract described here.
+//
+
+import Foundation
+
+// MARK: - Session State
+
+/// Coarse lifecycle state of an ambient-memory session. Hosts render this
+/// directly; every transition is published as `RAAmbientEvent.state`.
+public enum RAAmbientState: String, Sendable, CaseIterable {
+    /// No session has been started.
+    case idle
+    /// Models are being resolved / loaded.
+    case preparing
+    /// Audio is flowing and VAD is armed, but no speech segment is open.
+    case listening
+    /// A speech segment is currently open and accumulating audio.
+    case speechSegment
+    /// At least one finalized segment is queued for or undergoing transcription.
+    case processing
+    /// The host paused ingestion; the session keeps its buffers.
+    case paused
+    /// The session finished normally and released its resources.
+    case stopped
+    /// The session ended on an unrecoverable failure.
+    case failed
+}
+
+// MARK: - Configuration
+
+/// Tuning for one ambient-memory session.
+///
+/// Durations are milliseconds of audio, not wall clock, so they stay stable
+/// when ingestion runs faster or slower than real time (offline replay,
+/// tests, or a backlogged host).
+public struct RAAmbientConfiguration: Sendable {
+    /// VAD model id loaded into `.voiceActivityDetection` before listening.
+    public var vadModelID: String
+    /// STT model id loaded into `.speechRecognition` before listening.
+    public var sttModelID: String
+    /// Sample rate of the Int16 PCM the host feeds in.
+    public var sampleRate: Int
+    /// Audio retained ahead of a speech-start transition so segments do not
+    /// clip the first phoneme.
+    public var preRollMs: Int
+    /// Audio retained past a speech-end transition before the segment closes.
+    public var postRollMs: Int
+    /// Continuous speech required before a segment opens. Suppresses segments
+    /// from door slams, keyboard clicks, and other single-frame transients.
+    public var speechDebounceMs: Int
+    /// Continuous silence required before an open segment closes.
+    public var silenceHangoverMs: Int
+    /// Segments shorter than this are discarded instead of transcribed.
+    public var minSegmentMs: Int
+    /// An open segment is force-closed at this length so a long monologue
+    /// still produces incremental transcripts.
+    public var maxSegmentMs: Int
+    /// Emit the segment's PCM on `segmentFinalized`. Hosts that persist raw
+    /// audio for dogfooding set this; production defaults leave it off.
+    public var retainSegmentAudio: Bool
+    /// Finalized segments allowed to queue for transcription before the
+    /// pipeline sheds load and reports a backpressure gate.
+    public var maxQueuedSegments: Int
+    /// Transcription options forwarded to `RunAnywhere.transcribe`.
+    public var sttOptions: RASTTOptions
+    /// Detector overrides forwarded to `RunAnywhere.detectVoiceActivity`.
+    public var vadOptions: RAVADOptions?
+
+    public init(
+        vadModelID: String,
+        sttModelID: String,
+        sampleRate: Int = 16_000,
+        preRollMs: Int = 320,
+        postRollMs: Int = 240,
+        speechDebounceMs: Int = 128,
+        silenceHangoverMs: Int = 700,
+        minSegmentMs: Int = 400,
+        maxSegmentMs: Int = 25_000,
+        retainSegmentAudio: Bool = false,
+        maxQueuedSegments: Int = 4,
+        sttOptions: RASTTOptions = .defaults(),
+        vadOptions: RAVADOptions? = nil
+    ) {
+        self.vadModelID = vadModelID
+        self.sttModelID = sttModelID
+        self.sampleRate = sampleRate
+        self.preRollMs = preRollMs
+        self.postRollMs = postRollMs
+        self.speechDebounceMs = speechDebounceMs
+        self.silenceHangoverMs = silenceHangoverMs
+        self.minSegmentMs = minSegmentMs
+        self.maxSegmentMs = maxSegmentMs
+        self.retainSegmentAudio = retainSegmentAudio
+        self.maxQueuedSegments = maxQueuedSegments
+        self.sttOptions = sttOptions
+        self.vadOptions = vadOptions
+    }
+
+    /// Defaults tuned for continuous ambient capture with the catalogued
+    /// Silero VAD. Callers must still choose an STT model.
+    public static func defaults(sttModelID: String) -> RAAmbientConfiguration {
+        RAAmbientConfiguration(
+            vadModelID: RunAnywhere.defaultVADModelID,
+            sttModelID: sttModelID
+        )
+    }
+
+    /// Frame size the pipeline feeds the detector, in samples. Silero expects
+    /// 32 ms frames at 16 kHz; the value scales with `sampleRate`.
+    public var vadFrameSampleCount: Int {
+        max(160, sampleRate * 32 / 1000)
+    }
+}
+
+// MARK: - Segments and Transcripts
+
+/// One finalized run of speech, bounded by VAD transitions plus roll padding.
+public struct RAAmbientSegment: Sendable, Identifiable {
+    /// Stable id derived from the session id and segment index, so a host
+    /// retrying persistence writes the same record instead of a duplicate.
+    public let id: String
+    public let sessionID: String
+    public let index: Int
+    public let startedAt: Date
+    public let endedAt: Date
+    public let durationMs: Int
+    public let sampleRate: Int
+    /// Peak VAD confidence observed inside the segment.
+    public let peakConfidence: Float
+    /// Int16 PCM for the segment, present only when the configuration asked
+    /// for retained audio.
+    public let pcm16: Data?
+
+    public init(
+        id: String,
+        sessionID: String,
+        index: Int,
+        startedAt: Date,
+        endedAt: Date,
+        durationMs: Int,
+        sampleRate: Int,
+        peakConfidence: Float,
+        pcm16: Data?
+    ) {
+        self.id = id
+        self.sessionID = sessionID
+        self.index = index
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.durationMs = durationMs
+        self.sampleRate = sampleRate
+        self.peakConfidence = peakConfidence
+        self.pcm16 = pcm16
+    }
+}
+
+/// A completed transcription for one segment.
+public struct RAAmbientTranscript: Sendable, Identifiable {
+    public let id: String
+    public let sessionID: String
+    public let segmentID: String
+    public let segmentIndex: Int
+    public let text: String
+    public let confidence: Float
+    public let languageCode: String
+    public let startedAt: Date
+    public let endedAt: Date
+    public let audioDurationMs: Int
+    public let transcriptionMs: Int
+    public let modelID: String
+
+    /// Transcription time over audio duration. Below 1.0 means the pipeline
+    /// keeps up with real-time capture.
+    public var realTimeFactor: Double {
+        guard audioDurationMs > 0 else { return 0 }
+        return Double(transcriptionMs) / Double(audioDurationMs)
+    }
+
+    public init(
+        id: String,
+        sessionID: String,
+        segmentID: String,
+        segmentIndex: Int,
+        text: String,
+        confidence: Float,
+        languageCode: String,
+        startedAt: Date,
+        endedAt: Date,
+        audioDurationMs: Int,
+        transcriptionMs: Int,
+        modelID: String
+    ) {
+        self.id = id
+        self.sessionID = sessionID
+        self.segmentID = segmentID
+        self.segmentIndex = segmentIndex
+        self.text = text
+        self.confidence = confidence
+        self.languageCode = languageCode
+        self.startedAt = startedAt
+        self.endedAt = endedAt
+        self.audioDurationMs = audioDurationMs
+        self.transcriptionMs = transcriptionMs
+        self.modelID = modelID
+    }
+}
+
+// MARK: - Gates and Failures
+
+/// A non-fatal condition that made the pipeline shed or defer work.
+public struct RAAmbientResourceGate: Sendable {
+    public enum Reason: String, Sendable {
+        /// Transcription fell behind ingestion and queued segments were dropped.
+        case backpressure
+        /// The host reported a thermal state that suspends derived work.
+        case thermal
+        /// The host reported memory pressure.
+        case memory
+        /// The host reported insufficient storage for retained audio.
+        case storage
+    }
+
+    public let reason: Reason
+    /// `true` when the gate engaged, `false` when it cleared.
+    public let isActive: Bool
+    public let detail: String
+
+    public init(reason: Reason, isActive: Bool, detail: String) {
+        self.reason = reason
+        self.isActive = isActive
+        self.detail = detail
+    }
+}
+
+/// A pipeline error, scoped to the stage that produced it.
+public struct RAAmbientFailure: Sendable {
+    public enum Stage: String, Sendable {
+        case modelLoad
+        case vad
+        case transcription
+        case ingestion
+    }
+
+    public let stage: Stage
+    public let message: String
+    /// Fatal failures end the session; non-fatal ones skip a single segment.
+    public let isFatal: Bool
+    public let segmentID: String?
+
+    public init(stage: Stage, message: String, isFatal: Bool, segmentID: String? = nil) {
+        self.stage = stage
+        self.message = message
+        self.isFatal = isFatal
+        self.segmentID = segmentID
+    }
+}
+
+// MARK: - Events
+
+/// Everything an ambient session tells its host. The host owns UI and storage
+/// policy and reacts to these; it never drives the pipeline's internal stages.
+public enum RAAmbientEvent: Sendable {
+    case state(RAAmbientState)
+    case speechStarted(at: Date)
+    case speechEnded(at: Date, durationMs: Int)
+    case segmentOpened(id: String, index: Int, startedAt: Date)
+    case segmentFinalized(RAAmbientSegment)
+    case transcript(RAAmbientTranscript)
+    case resourceGate(RAAmbientResourceGate)
+    case failure(RAAmbientFailure)
+}
+
+// MARK: - Note Digest
+
+/// Which pass of the map-reduce summarization a digest call is performing.
+///
+/// A whole note rarely fits in a small local model's context, so transcripts
+/// are digested in chunks while capture runs (`chunk`) and those partial
+/// summaries are folded into one final answer at the end (`merge`).
+public enum RAAmbientDigestMode: String, Sendable, CaseIterable {
+    case chunk
+    case merge
+}
+
+/// One summary plus the action items that came with it.
+///
+/// This is the only structured output the ambient solution produces. A note
+/// gets many of these during capture and exactly one after the merge.
+public struct RAAmbientNoteDigest: Sendable, Equatable {
+    public let summary: String
+    public let actionItems: [String]
+    public let extractionMs: Int
+    public let modelID: String
+
+    public init(
+        summary: String,
+        actionItems: [String],
+        extractionMs: Int,
+        modelID: String
+    ) {
+        self.summary = summary
+        self.actionItems = actionItems
+        self.extractionMs = extractionMs
+        self.modelID = modelID
+    }
+}

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/AmbientMemory/RunAnywhere+AmbientMemory.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/AmbientMemory/RunAnywhere+AmbientMemory.swift
@@ -1,0 +1,377 @@
+//
+//  RunAnywhere+AmbientMemory.swift
+//  RunAnywhere SDK
+//
+//  Public API for the ambient-memory solution — one entry point that composes
+//  VAD, segmentation, transcription, structured memory extraction, and RAG
+//  recall for long-running "listen and remember" experiences.
+//
+//  Division of responsibility:
+//    - Host: microphone acquisition, foreground/background policy, consent UI,
+//      storage, retention, and everything the platform gates.
+//    - SDK: model loading, VAD debounce, pre/post-roll, segment boundaries,
+//      serial transcription scheduling, extraction prompts, and RAG plumbing.
+//
+//  Hosts start a session, push Int16 PCM into the handle, and consume the
+//  handle's `events` stream. They never drive the individual stages.
+//
+
+import Foundation
+
+// MARK: - Session Handle
+
+/// Live handle to one ambient-memory session.
+///
+/// The handle is the host's only interface to a running pipeline: feed it
+/// audio, read its events, and end it. It is safe to use from any isolation
+/// domain.
+public final class RAAmbientSession: Sendable {
+
+    /// Identifier shared by every segment, transcript, and memory this session
+    /// produces. Hosts persist it to group a recording.
+    public let id: String
+
+    /// Ordered lifecycle events. Finishes after `finish()` / `cancel()` or a
+    /// fatal pipeline failure.
+    public let events: AsyncStream<RAAmbientEvent>
+
+    private let configuration: RAAmbientConfiguration
+    private let pipeline: AmbientMemoryPipeline
+    private let audio: AsyncStream<Data>.Continuation
+    private let runTask: Task<Void, Never>
+
+    private init(
+        id: String,
+        configuration: RAAmbientConfiguration,
+        events: AsyncStream<RAAmbientEvent>,
+        pipeline: AmbientMemoryPipeline,
+        audio: AsyncStream<Data>.Continuation,
+        runTask: Task<Void, Never>
+    ) {
+        self.id = id
+        self.configuration = configuration
+        self.events = events
+        self.pipeline = pipeline
+        self.audio = audio
+        self.runTask = runTask
+    }
+
+    /// Push one microphone chunk of Int16 PCM at the configured sample rate.
+    ///
+    /// Non-blocking. The pipeline buffers a bounded number of chunks; if the
+    /// host outruns detection, the oldest chunks are dropped rather than
+    /// growing memory without limit.
+    public func ingest(pcm16: Data) {
+        guard !pcm16.isEmpty else { return }
+        audio.yield(pcm16)
+    }
+
+    /// Stop consuming audio while keeping segment and queue state.
+    public func pause() async {
+        await pipeline.pause()
+    }
+
+    public func resume() async {
+        await pipeline.resume()
+    }
+
+    /// Surface a host-detected condition (thermal, memory, storage) on the
+    /// session's event stream so consumers see one ordered timeline.
+    public func report(gate: RAAmbientResourceGate) async {
+        await pipeline.report(gate: gate)
+    }
+
+    /// Close the open segment, transcribe everything queued, then end the
+    /// session. Returns once the event stream has finished.
+    public func finish() async {
+        audio.finish()
+        await runTask.value
+    }
+
+    /// End immediately and discard queued transcription work. Use when the
+    /// microphone is lost or the host must release resources now.
+    public func cancel(reason: String) async {
+        audio.finish()
+        await pipeline.abort(RAAmbientFailure(
+            stage: .ingestion,
+            message: reason,
+            isFatal: true
+        ))
+        runTask.cancel()
+    }
+
+    // MARK: Factory
+
+    static func start(
+        id: String,
+        configuration: RAAmbientConfiguration
+    ) async throws -> RAAmbientSession {
+        let (events, eventContinuation) = AsyncStream.makeStream(of: RAAmbientEvent.self)
+        let pipeline = AmbientMemoryPipeline(
+            sessionID: id,
+            configuration: configuration,
+            continuation: eventContinuation
+        )
+
+        do {
+            try await pipeline.prepare()
+        } catch {
+            eventContinuation.finish()
+            throw error
+        }
+
+        // Bounded so a host feeding faster than the detector can drain sheds
+        // the oldest audio instead of accumulating unbounded PCM.
+        let (audio, audioContinuation) = AsyncStream.makeStream(
+            of: Data.self,
+            bufferingPolicy: .bufferingNewest(configuration.maxQueuedAudioChunks)
+        )
+        let runTask = Task { await pipeline.run(audio: audio) }
+
+        return RAAmbientSession(
+            id: id,
+            configuration: configuration,
+            events: events,
+            pipeline: pipeline,
+            audio: audioContinuation,
+            runTask: runTask
+        )
+    }
+}
+
+// MARK: - Ambient Capability
+
+public extension RunAnywhere {
+
+    /// Capability accessor for the ambient-memory solution.
+    /// Mirrors the shape of `RunAnywhere.solutions` / `RunAnywhere.lora`.
+    static var ambient: AmbientMemory { AmbientMemory() }
+
+    /// Stateless namespace for ambient-memory APIs. Each session owns its own
+    /// pipeline, so this type holds no mutable state.
+    struct AmbientMemory: Sendable {
+
+        /// Internal so the namespace is only reachable through
+        /// `RunAnywhere.ambient` rather than constructed by callers.
+        init() {}
+
+        /// Load the configured VAD/STT models and open an ambient session.
+        ///
+        /// - Parameters:
+        ///   - configuration: Segmentation and model tuning for this session.
+        ///   - sessionID: Stable id for the recording. Supply your own when
+        ///     the host already minted one for persistence.
+        /// - Returns: A started session ready to receive audio.
+        /// - Throws: `SDKException` when the SDK is not initialized or a
+        ///   required model cannot be loaded.
+        public func start(
+            _ configuration: RAAmbientConfiguration,
+            sessionID: String = UUID().uuidString
+        ) async throws -> RAAmbientSession {
+            guard RunAnywhere.isInitialized else {
+                throw SDKException(code: .notInitialized, message: "SDK not initialized", category: .internal)
+            }
+            try await RunAnywhere.ensureServicesReady()
+
+            return try await RAAmbientSession.start(id: sessionID, configuration: configuration)
+        }
+
+        /// Summarize text into one summary plus action items using the
+        /// currently loaded language model.
+        ///
+        /// Call with `.chunk` while capture runs to digest each block of
+        /// transcript, then once with `.merge` over the joined partial
+        /// summaries to produce the note's final summary and a deduplicated
+        /// action list. The prompt, JSON contract, and response repair all
+        /// live here so hosts never post-process model output themselves.
+        public func digest(
+            text: String,
+            mode: RAAmbientDigestMode = .chunk,
+            maxActionItems: Int = 8
+        ) async throws -> RAAmbientNoteDigest {
+            guard RunAnywhere.isInitialized else {
+                throw SDKException(code: .notInitialized, message: "SDK not initialized", category: .internal)
+            }
+            let snapshot = RunAnywhere.loadedModelSnapshot(category: .language)
+            guard snapshot.found else {
+                throw SDKException(
+                    code: .modelNotLoaded,
+                    message: "Ambient note summarization requires a loaded language model",
+                    category: .component
+                )
+            }
+
+            let startedAt = Date()
+            var options = RALLMGenerationOptions.defaults()
+            options.temperature = 0.1
+            options.maxTokens = 512
+            options.systemPrompt = AmbientDigestPrompt.system(mode: mode, maxActionItems: maxActionItems)
+            let result = try await RunAnywhere.generate(
+                prompt: AmbientDigestPrompt.user(text: text, mode: mode),
+                options: options
+            )
+
+            let parsed = AmbientDigestPrompt.parse(result.text, fallbackText: text)
+            return RAAmbientNoteDigest(
+                summary: parsed.summary,
+                actionItems: Array(parsed.actionItems.prefix(maxActionItems)),
+                extractionMs: Int(Date().timeIntervalSince(startedAt) * 1000),
+                modelID: snapshot.modelID
+            )
+        }
+
+        /// Ingest a finalized transcript into the RAG index with ambient
+        /// provenance attached, so recall results can be traced back to the
+        /// session, segment, and capture time they came from.
+        ///
+        /// The RAG pipeline must already be created via
+        /// `RunAnywhere.ragCreatePipeline(...)`.
+        @discardableResult
+        public func index(
+            transcript: RAAmbientTranscript,
+            extraMetadata: [String: String] = [:]
+        ) async throws -> RARAGStatistics {
+            var document = RARAGDocument()
+            document.id = transcript.segmentID
+            document.text = transcript.text
+            document.mediaType = "text/plain"
+            document.metadata = extraMetadata.merging([
+                "source": "ambient-memory",
+                "sessionId": transcript.sessionID,
+                "segmentId": transcript.segmentID,
+                "segmentIndex": String(transcript.segmentIndex),
+                "capturedAt": ISO8601DateFormatter().string(from: transcript.startedAt),
+                "sttModelId": transcript.modelID,
+            ]) { provided, _ in provided }
+
+            return try await RunAnywhere.ragIngest(document)
+        }
+
+        /// Answer a recall question over previously indexed ambient
+        /// transcripts. Retrieval and LLM synthesis both happen on-device.
+        public func recall(
+            question: String,
+            options: RARAGQueryOptions? = nil
+        ) async throws -> RARAGResult {
+            try await RunAnywhere.ragQuery(question: question, options: options)
+        }
+    }
+}
+
+// MARK: - Configuration Derivations
+
+extension RAAmbientConfiguration {
+    /// Audio chunks the ingestion stream buffers before shedding the oldest.
+    /// Scaled off the segment queue depth so both backpressure limits move
+    /// together when a host tunes for a slower device.
+    var maxQueuedAudioChunks: Int {
+        max(16, maxQueuedSegments * 16)
+    }
+}
+
+// MARK: - Digest Prompt
+
+/// Prompt construction and response parsing for note summarization.
+/// Lives in the SDK so every consumer gets the same contract and the same
+/// tolerance for models that wrap JSON in prose or code fences.
+enum AmbientDigestPrompt {
+
+    struct Parsed {
+        let summary: String
+        let actionItems: [String]
+    }
+
+    static func system(mode: RAAmbientDigestMode, maxActionItems: Int) -> String {
+        let task: String
+        switch mode {
+        case .chunk:
+            task = """
+            You summarize one part of a longer voice note. Cover only what this part says; \
+            do not invent context from before or after it.
+            """
+        case .merge:
+            task = """
+            You merge the partial summaries of one voice note into a single note summary. \
+            Combine overlapping points and drop duplicate action items, keeping the clearest wording of each.
+            """
+        }
+
+        return """
+        \(task)
+        Reply with JSON only, no prose and no code fences, in exactly this shape:
+        {"summary":"a few sentences","actionItems":["..."]}
+        The summary is plain prose. Each action item is one short imperative sentence \
+        describing something a person still has to do.
+        Include at most \(maxActionItems) action items, and only ones actually stated.
+        If nothing needs doing, return an empty actionItems array.
+        """
+    }
+
+    static func user(text: String, mode: RAAmbientDigestMode) -> String {
+        let heading = mode == .merge ? "Partial summaries:" : "Transcript:"
+        return """
+        \(heading)
+        \(text)
+
+        JSON:
+        """
+    }
+
+    /// Parse a model response into a summary and action items. Models
+    /// frequently wrap JSON in fences or leading commentary, so the payload is
+    /// located by brace span rather than assuming a clean document. A response
+    /// that yields nothing usable degrades to a truncation of the input, which
+    /// keeps a note readable even when the model misbehaves.
+    static func parse(_ response: String, fallbackText: String) -> Parsed {
+        let fallbackSummary = String(fallbackText.prefix(200))
+        guard let payload = jsonObject(in: response) else {
+            return Parsed(summary: fallbackSummary, actionItems: [])
+        }
+
+        let summary = (payload["summary"] as? String)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+        // JSONSerialization is the only reader tolerant of the shapes a small
+        // local model emits, so untyped values stop here.
+        let rawItems = payload["actionItems"] as? [Any] ?? [] // swiftlint:disable:this avoid_any_type
+        var seen = Set<String>()
+        let actionItems: [String] = rawItems.compactMap { entry in
+            guard let text = itemText(entry) else { return nil }
+            // Merge passes routinely restate the same task, so identical items
+            // collapse here rather than reaching the note as duplicates.
+            guard seen.insert(text.lowercased()).inserted else { return nil }
+            return text
+        }
+
+        return Parsed(
+            summary: summary.isEmpty ? fallbackSummary : summary,
+            actionItems: actionItems
+        )
+    }
+
+    /// Action items arrive either as bare strings or, from chattier models, as
+    /// objects carrying the sentence under a `text`-like key.
+    private static func itemText(_ entry: Any) -> String? { // swiftlint:disable:this avoid_any_type
+        let candidate: String?
+        if let string = entry as? String {
+            candidate = string
+        } else if let object = entry as? [String: Any] { // swiftlint:disable:this avoid_any_type
+            candidate = (object["text"] ?? object["item"] ?? object["action"]) as? String
+        } else {
+            candidate = nil
+        }
+        guard let text = candidate?.trimmingCharacters(in: .whitespacesAndNewlines), !text.isEmpty else {
+            return nil
+        }
+        return text
+    }
+
+    private static func jsonObject(in response: String) -> [String: Any]? { // swiftlint:disable:this prefer_concrete_types avoid_any_type
+        guard let start = response.firstIndex(of: "{"),
+              let end = response.lastIndex(of: "}"),
+              start < end else { return nil }
+        let slice = String(response[start...end])
+        guard let data = slice.data(using: .utf8),
+              let raw = try? JSONSerialization.jsonObject(with: data) else { return nil }
+        // swiftlint:disable:next avoid_any_type
+        return raw as? [String: Any]
+    }
+}

--- a/sdk/runanywhere-swift/Tests/RunAnywhereTests/AmbientMemorySurfaceTests.swift
+++ b/sdk/runanywhere-swift/Tests/RunAnywhereTests/AmbientMemorySurfaceTests.swift
@@ -1,0 +1,156 @@
+//
+//  AmbientMemorySurfaceTests.swift
+//  RunAnywhereTests
+//
+//  Covers the parts of the ambient-memory solution that are pure: the
+//  configuration derivations that set segment boundaries, and the extraction
+//  response parser, which has to survive whatever shape a small local model
+//  decides to emit.
+//
+
+import XCTest
+@testable import RunAnywhere
+
+final class AmbientMemorySurfaceTests: XCTestCase {
+
+    // MARK: - Configuration
+
+    func testDefaultsUseCataloguedVADAndSuppliedSTT() {
+        let config = RAAmbientConfiguration.defaults(sttModelID: "parakeet")
+
+        XCTAssertEqual(config.sttModelID, "parakeet")
+        XCTAssertEqual(config.vadModelID, RunAnywhere.defaultVADModelID)
+        XCTAssertEqual(config.sampleRate, 16_000)
+        XCTAssertFalse(config.retainSegmentAudio, "Retaining raw audio must be opt-in")
+    }
+
+    func testVADFrameIs32MillisecondsAtTheConfiguredRate() {
+        var config = RAAmbientConfiguration.defaults(sttModelID: "stt")
+        XCTAssertEqual(config.vadFrameSampleCount, 512)
+
+        config.sampleRate = 8_000
+        XCTAssertEqual(config.vadFrameSampleCount, 256)
+    }
+
+    func testVADFrameNeverDropsBelowTheDetectorFloor() {
+        var config = RAAmbientConfiguration.defaults(sttModelID: "stt")
+        config.sampleRate = 1_000
+
+        XCTAssertEqual(config.vadFrameSampleCount, 160, "A tiny rate must still produce a usable frame")
+    }
+
+    func testAudioBufferDepthScalesWithSegmentQueueDepth() {
+        var config = RAAmbientConfiguration.defaults(sttModelID: "stt")
+        config.maxQueuedSegments = 1
+        XCTAssertEqual(config.maxQueuedAudioChunks, 16, "A shallow segment queue keeps a usable audio floor")
+
+        config.maxQueuedSegments = 8
+        XCTAssertEqual(config.maxQueuedAudioChunks, 128)
+    }
+
+    // MARK: - Transcript
+
+    func testRealTimeFactorComparesTranscriptionAgainstAudioLength() {
+        let transcript = Self.transcript(audioDurationMs: 4_000, transcriptionMs: 1_000)
+        XCTAssertEqual(transcript.realTimeFactor, 0.25, accuracy: 0.0001)
+    }
+
+    func testRealTimeFactorIsZeroForEmptyAudio() {
+        let transcript = Self.transcript(audioDurationMs: 0, transcriptionMs: 900)
+        XCTAssertEqual(transcript.realTimeFactor, 0)
+    }
+
+    // MARK: - Digest Parsing
+
+    func testParsesCleanJSONResponse() {
+        let response = """
+        {"summary":"Planned the release","actionItems":[
+          "Ship the beta on Friday",
+          "Switch the build to the quality profile"
+        ]}
+        """
+
+        let parsed = AmbientDigestPrompt.parse(response, fallbackText: "transcript")
+
+        XCTAssertEqual(parsed.summary, "Planned the release")
+        XCTAssertEqual(parsed.actionItems, ["Ship the beta on Friday", "Switch the build to the quality profile"])
+    }
+
+    func testParsesJSONWrappedInFencesAndCommentary() {
+        let response = """
+        Sure! Here is the JSON you asked for:
+        ```json
+        {"summary":"Grocery list","actionItems":["Buy oat milk"]}
+        ```
+        Let me know if you need anything else.
+        """
+
+        let parsed = AmbientDigestPrompt.parse(response, fallbackText: "transcript")
+
+        XCTAssertEqual(parsed.summary, "Grocery list")
+        XCTAssertEqual(parsed.actionItems, ["Buy oat milk"])
+    }
+
+    func testActionItemObjectsAreUnwrappedToText() {
+        let response = #"{"summary":"s","actionItems":[{"text":"Water the plants"},{"action":"Call Ana"}]}"#
+
+        let parsed = AmbientDigestPrompt.parse(response, fallbackText: "transcript")
+
+        XCTAssertEqual(parsed.actionItems, ["Water the plants", "Call Ana"])
+    }
+
+    func testBlankAndDuplicateActionItemsAreDropped() {
+        let response = #"{"summary":"s","actionItems":["  ","Call Ana","call ana",{"note":"x"}]}"#
+
+        let parsed = AmbientDigestPrompt.parse(response, fallbackText: "transcript")
+
+        XCTAssertEqual(parsed.actionItems, ["Call Ana"], "A merge pass must not restate the same task twice")
+    }
+
+    func testNonJSONResponseDegradesToTheTranscriptSummary() {
+        let parsed = AmbientDigestPrompt.parse(
+            "I could not find anything worth summarizing.",
+            fallbackText: "We talked about the roadmap."
+        )
+
+        XCTAssertTrue(parsed.actionItems.isEmpty)
+        XCTAssertEqual(parsed.summary, "We talked about the roadmap.")
+    }
+
+    func testEmptySummaryFallsBackToTheTranscript() {
+        let parsed = AmbientDigestPrompt.parse(
+            #"{"summary":"  ","actionItems":[]}"#,
+            fallbackText: "Standup notes."
+        )
+
+        XCTAssertEqual(parsed.summary, "Standup notes.")
+    }
+
+    func testMergePromptAsksForDeduplication() {
+        let system = AmbientDigestPrompt.system(mode: .merge, maxActionItems: 8)
+
+        XCTAssertTrue(system.contains("merge"))
+        XCTAssertTrue(system.contains("duplicate"))
+        XCTAssertTrue(AmbientDigestPrompt.user(text: "a", mode: .merge).contains("Partial summaries:"))
+        XCTAssertTrue(AmbientDigestPrompt.user(text: "a", mode: .chunk).contains("Transcript:"))
+    }
+
+    // MARK: - Helpers
+
+    private static func transcript(audioDurationMs: Int, transcriptionMs: Int) -> RAAmbientTranscript {
+        RAAmbientTranscript(
+            id: "segment",
+            sessionID: "session",
+            segmentID: "segment",
+            segmentIndex: 0,
+            text: "hello",
+            confidence: 0.9,
+            languageCode: "en",
+            startedAt: Date(),
+            endedAt: Date(),
+            audioDurationMs: audioDurationMs,
+            transcriptionMs: transcriptionMs,
+            modelID: "stt"
+        )
+    }
+}


### PR DESCRIPTION
## Summary
- Add offline Notes (Ambient Memory) to the iOS example: one-tap record, VAD+ASR transcript, local LLM summary/action items, continuous WAV, Live Activity, and App Intents.
- Harden capture for lock-screen dogfood (mic session recovery, file protection until first unlock) and defer Metal/llama.cpp summarization until the app is foregrounded so Chat/LLM backends are not wedged.
- Expose free VAD/ASR/digest model picks in Notes, plus SDK `RunAnywhere.ambient` digest helpers and unit/device checklist coverage.

## Test plan
- [ ] Build/run RunAnywhereAI on device from `feat/offline-notes`
- [ ] Pick Silero VAD + Sherpa Parakeet ASR (+ optional LFM2 digest); verify Record requires downloaded VAD+ASR
- [ ] Record a note, lock the phone, speak, stop from Lock Screen / Live Activity — transcript+audio save; summary completes after opening the app (or Retry summary)
- [ ] Confirm no `kIOGPUCommandBufferCallbackErrorBackgroundExecutionNotPermitted` during locked capture; Chat still works after Notes stop
- [ ] Open note detail: play/pause WAV, search notes, retry summary if pending
- [ ] Run `scripts/ambient-device-checklist.sh checklist` for the manual matrix


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Ambient Memory for on-device recording, transcription, summaries, action items, searchable notes, and audio playback.
  * Added pause/resume controls, retention settings, data deletion, and session detail views.
  * Added Lock Screen and Dynamic Island Live Activity status with stop controls.
  * Added Siri, Shortcuts, deep links, and optional automatic session start.
  * Added adaptive model selection based on device conditions, battery, memory, and thermal state.
* **Bug Fixes**
  * Improved audio-session activation and prevented recording conflicts with other voice features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->