### PR TITLE
fix(web): keep the modality default module when a lower-priority slot survives

### DIFF
--- a/sdk/runanywhere-web/packages/core/src/Adapters/ModalityProtoAdapter.ts
+++ b/sdk/runanywhere-web/packages/core/src/Adapters/ModalityProtoAdapter.ts
@@ -66,6 +66,39 @@ const MODALITY_CAPABILITIES: ReadonlySet<string> = new Set<ModalityCapabilityNam
   'voice-agent',
 ]);
 
+/**
+ * Slot preference used to pick the aggregate `defaultModule`. `llm` is the
+ * historical anchor; the rest are fallbacks so `tryDefault()` keeps returning
+ * a usable module while any modality slot is still occupied. Shared by
+ * register and unregister so the two cannot drift apart.
+ */
+const DEFAULT_MODULE_PRIORITY: readonly ModalityCapabilityName[] = [
+  'llm',
+  'vlm',
+  'stt',
+  'tts',
+  'vad',
+  'embedding',
+  'segmentation',
+  'rag',
+  'diffusion',
+  'structured-output',
+  'tool-calling',
+  'lora',
+  'voice-agent',
+];
+
+function recomputeDefaultModule(): void {
+  for (const slot of DEFAULT_MODULE_PRIORITY) {
+    const claimed = adapterState.modalitySlots[slot];
+    if (claimed) {
+      adapterState.defaultModule = claimed;
+      return;
+    }
+  }
+  adapterState.defaultModule = null;
+}
+
 export { DiarizationProtoAdapter } from './DiarizationProtoAdapter.js';
 export { RerankProtoAdapter } from './RerankProtoAdapter.js';
 export { DiffusionProtoAdapter } from './DiffusionProtoAdapter.js';
@@ -107,21 +140,7 @@ export class ModalityProtoAdapter {
     // Keep the aggregate `defaultModule` non-null so `tryDefault()` returns
     // something usable — prefer the LLM-owning module (the historical
     // anchor) then fall back to any non-null slot.
-    adapterState.defaultModule =
-      adapterState.modalitySlots.llm
-      ?? adapterState.modalitySlots.vlm
-      ?? adapterState.modalitySlots.stt
-      ?? adapterState.modalitySlots.tts
-      ?? adapterState.modalitySlots.vad
-      ?? adapterState.modalitySlots.embedding
-      ?? adapterState.modalitySlots.segmentation
-      ?? adapterState.modalitySlots.rag
-      ?? adapterState.modalitySlots.diffusion
-      ?? adapterState.modalitySlots['structured-output']
-      ?? adapterState.modalitySlots['tool-calling']
-      ?? adapterState.modalitySlots.lora
-      ?? adapterState.modalitySlots['voice-agent']
-      ?? null;
+    recomputeDefaultModule();
   }
 
   /**
@@ -151,14 +170,7 @@ export class ModalityProtoAdapter {
       }
     }
     if (adapterState.defaultModule === module) {
-      adapterState.defaultModule =
-        adapterState.modalitySlots.llm
-        ?? adapterState.modalitySlots.vlm
-        ?? adapterState.modalitySlots.stt
-        ?? adapterState.modalitySlots.tts
-        ?? adapterState.modalitySlots.vad
-        ?? adapterState.modalitySlots.segmentation
-        ?? null;
+      recomputeDefaultModule();
     }
   }
 

--- a/sdk/runanywhere-web/packages/core/tests/unit/runtime/EmscriptenModule.test.ts
+++ b/sdk/runanywhere-web/packages/core/tests/unit/runtime/EmscriptenModule.test.ts
@@ -2,6 +2,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest';
 import { SolutionConfig } from '@runanywhere/proto-ts/solutions';
 
 import { ModelRegistryAdapter } from '../../../src/Adapters/ModelRegistryAdapter';
+import { ModalityProtoAdapter } from '../../../src/Adapters/ModalityProtoAdapter';
 import { ModelLifecycleAdapter } from '../../../src/Adapters/ModelLifecycleAdapter';
 import { SolutionAdapter } from '../../../src/Adapters/SolutionAdapter';
 import {
@@ -202,6 +203,21 @@ describe('Emscripten module capability wiring', () => {
     expect(resetCommons).toHaveBeenCalledOnce();
     expect(resetA).toHaveBeenCalledOnce();
     expect(resetB).not.toHaveBeenCalled();
+  });
+
+  it('keeps a modality default when the survivor only owns a lower-priority slot', () => {
+    const llmBackend = fakeModule();
+    const ragBackend = fakeModule();
+
+    registerWasmModule(['llm'], llmBackend, ['llamacpp']);
+    registerWasmModule(['rag'], ragBackend, ['onnx']);
+    expect(ModalityProtoAdapter.tryDefault()).not.toBeNull();
+
+    unregisterWasmModule(llmBackend);
+
+    // `rag` is still claimed, so the aggregate default must fall back to it
+    // rather than going null.
+    expect(ModalityProtoAdapter.tryDefault()).not.toBeNull();
   });
 
   it.each([


### PR DESCRIPTION
## What

`registerModuleCapabilities` and `unregisterModuleCapabilities` in `ModalityProtoAdapter.ts` each carried their own copy of the `defaultModule` fallback chain. The register copy walks 13 slots; the unregister copy walked 6, missing `embedding`, `rag`, `diffusion`, `structured-output`, `tool-calling`, `lora` and `voice-agent`.

The result: unregistering the module that happened to own the default cleared `adapterState.defaultModule` even when another module still occupied one of the seven missing slots. `ModalityProtoAdapter.tryDefault()` then returns `null` and the SDK behaves as though no adapter is installed while a perfectly usable one is still registered.

Both copies are replaced with a single `recomputeDefaultModule()` helper driven by one ordered list, so the two paths cannot drift apart again. The register-side priority order is unchanged.

## Why this is reachable, not hypothetical

`registerWasmModule` documents that a module "may be registered against any subset of capabilities", and the existing unit tests already register single-capability modules that way, including `registerWasmModule(['rag'], ragModule, ['onnx'])`. Registering an `llm` module plus a `rag` module and then tearing down the `llm` one is enough to hit it.

## Testing

From `sdk/runanywhere-web`:
- `npm run typecheck -w packages/core` — passes.
- `npx vitest run tests/unit/runtime/EmscriptenModule.test.ts` (from `packages/core`) — 9 passed.

I added one regression case next to the existing teardown test and checked it both ways: with the source fix reverted it fails with `AssertionError: expected null not to be null`, and passes with the fix applied. I would rather it earn its place than just ride along.

Local note in case it helps anyone else: running the web unit tests needed `@bufbuild/protobuf` resolvable from `sdk/shared/proto-ts`, whose `dist` requires it but which has no `node_modules` of its own. A repo-root `npm install` currently fails on an unrelated peer-dependency conflict in the React Native example, so I worked around it locally rather than changing anything committed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default backend selection when modality-specific backends are registered or removed.
  * Preserved an available retrieval-augmented generation backend when the higher-priority language model backend is removed.
  * Ensured fallback behavior remains consistent across supported modality types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->