### PR TITLE
fix(kotlin): gate synthesizeStream on ensureServicesReady before the voice lookup

### DIFF
--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/TTS/RunAnywhereTTS.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/TTS/RunAnywhereTTS.kt
@@ -94,6 +94,11 @@ fun RunAnywhere.synthesizeStream(
             close()
             return@callbackFlow
         }
+        // Phase 2 must have completed before the lifecycle query below, or a
+        // voice that is present is reported as missing. synthesize() and
+        // transcribeStream() already gate on this, as does Swift's
+        // synthesizeStream.
+        ensureServicesReady()
 
         // Mirror synthesize(): query ModelLifecycle (the canonical source of
         // truth) instead of CppBridgeTTS's own handle. Swift's


### PR DESCRIPTION
## What

`RunAnywhere.synthesizeStream(...)` checks `isInitialized` and then goes straight to the model lifecycle to find a loaded speech synthesis voice, without waiting for phase 2 initialisation.

If a caller starts streaming before phase 2 finishes, `currentModel(...)` reports `found = false` and the Flow closes without emitting a single output, so a voice that is actually loaded looks to the caller like no voice at all.

One line: call `ensureServicesReady()` before the lifecycle query.

## Why

Every sibling on this path already gates on it, so the streaming variant is the odd one out:

- `synthesize(...)` (same file) calls `ensureServicesReady()` immediately before the identical `currentModel(MODEL_CATEGORY_SPEECH_SYNTHESIS)` query.
- `transcribeStream(...)` in `RunAnywhereSTT.kt` calls it before its own lifecycle query.
- Swift's `synthesizeStream` awaits `ensureServicesReady()` before reading `loadedModelSnapshot(category: .speechSynthesis)`.

The call is left unwrapped to match `transcribeStream` in this SDK. I deliberately did not copy Swift's `do/catch` that finishes the stream silently on a phase 2 failure, since swallowing that error would leave the caller with an empty stream and no way to tell why.

## Testing

From `sdk/runanywhere-kotlin` (JDK 17):
- `./gradlew :compileDebugKotlin :ktlintMainSourceSetCheck -Prunanywhere.useLocalNatives=false` — BUILD SUCCESSFUL.

Scoped to the root module because `:modules:runanywhere-core-onnx:downloadJniLibs` cannot fetch native libs on this machine. No test added: this is a one-line ordering fix on a path whose behaviour is validated end to end through the example apps.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text-to-speech streaming reliability by ensuring required services are ready before voice selection and playback begin.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->