### PR TITLE
fix(web): abort the OPFS writable stream when the createWritable path fails

### DIFF
--- a/sdk/runanywhere-web/packages/core/src/Infrastructure/OPFSBridge.ts
+++ b/sdk/runanywhere-web/packages/core/src/Infrastructure/OPFSBridge.ts
@@ -239,12 +239,25 @@ async function writeBytesToOPFSFile(
   // require a sync-access handle (i.e. no main-thread restrictions on
   // Chrome / Firefox).
   if (typeof (handle as { createWritable?: unknown }).createWritable === 'function') {
+    let writable: Awaited<ReturnType<FileSystemFileHandle['createWritable']>> | undefined;
     try {
-      const writable = await handle.createWritable({ keepExistingData: false });
+      writable = await handle.createWritable({ keepExistingData: false });
       await writable.write(toOwnedArrayBuffer(bytes));
       await writable.close();
       return;
     } catch (err) {
+      // An open writable stream holds an exclusive lock on the file, so it has
+      // to be released before the fallback below asks the same handle for a
+      // sync-access handle — otherwise the fallback fails too and the write is
+      // lost. abort() itself throws when close() already ran, hence the
+      // nested catch.
+      if (writable !== undefined) {
+        try {
+          await writable.abort();
+        } catch {
+          // Stream was already closed or errored; the lock is gone either way.
+        }
+      }
       logger.debug(
         `OPFS createWritable failed, falling back to sync-access handle: ${
           err instanceof Error ? err.message : String(err)

--- a/sdk/runanywhere-web/packages/core/tests/unit/Infrastructure/OPFSBridge.test.ts
+++ b/sdk/runanywhere-web/packages/core/tests/unit/Infrastructure/OPFSBridge.test.ts
@@ -109,6 +109,47 @@ describe('OPFSBridge multi-module hydration', () => {
       BUNDLE_PATH,
     )).rejects.toThrow('forced MEMFS write failure');
   });
+
+  it('releases the writable lock before falling back to the sync-access handle', async () => {
+    const writable = {
+      write: vi.fn().mockRejectedValue(new DOMException('over quota', 'QuotaExceededError')),
+      close: vi.fn().mockResolvedValue(undefined),
+      abort: vi.fn().mockResolvedValue(undefined),
+    };
+    const sync = {
+      truncate: vi.fn(),
+      write: vi.fn().mockReturnValue(0),
+      flush: vi.fn(),
+      close: vi.fn(),
+    };
+    const fileHandle = {
+      kind: 'file',
+      name: 'model.gguf',
+      createWritable: vi.fn().mockResolvedValue(writable),
+      createSyncAccessHandle: vi.fn().mockResolvedValue(sync),
+    } as unknown as FileSystemFileHandle;
+    const directory = {
+      kind: 'directory',
+      name: 'Models',
+      getFileHandle: vi.fn().mockResolvedValue(fileHandle),
+      getDirectoryHandle: vi.fn().mockRejectedValue(
+        new DOMException('not a directory', 'NotFoundError'),
+      ),
+    } as unknown as FileSystemDirectoryHandle;
+    const root = {
+      kind: 'directory',
+      name: 'root',
+      getDirectoryHandle: vi.fn().mockResolvedValue(directory),
+    } as unknown as FileSystemDirectoryHandle;
+    OPFSBridge.setPersistentRoot(root);
+
+    await OPFSBridge.writeFileToOPFS(['Models', 'model.gguf'], new Uint8Array([1, 2, 3]));
+
+    // An open writable holds an exclusive lock on the file, so it has to be
+    // aborted or the sync-access fallback cannot acquire the file either.
+    expect(writable.abort).toHaveBeenCalledOnce();
+    expect(sync.write).toHaveBeenCalledOnce();
+  });
 });
 
 function installPersistentFile(bytes: Uint8Array): ReturnType<typeof vi.fn> {


### PR DESCRIPTION
## What

`writeBytesToOPFSFile` tries `createWritable` first and falls back to a sync-access handle when that path throws. If `createWritable()` itself succeeded but `write()` or `close()` threw, the stream was left open: the catch block only logged and fell through to the fallback.

## Why it matters

An open writable stream holds an **exclusive lock** on the OPFS file. So the fallback's `createSyncAccessHandle()` call, on that same handle, then fails as well and the write is lost. The leak defeats the exact recovery the fallback exists to provide, turning a recoverable `write()` failure (quota exceeded, transient storage error) into a failed persist.

The sync-access path directly below already guards its own `close()` with `try/finally`, so this is the one branch missing the release.

Fix is to abort the stream before falling through. `abort()` itself throws if `close()` already ran, so that call is guarded in turn rather than trading one unhandled rejection for another.

## Testing

From `sdk/runanywhere-web`:
- `npm run typecheck -w packages/core` — passes.
- Full unit suite from `packages/core`: **54 files, 233 tests, all passing.**
- `npx eslint` on both changed files — clean.

I added one regression test and checked it both ways: with the source fix reverted it fails with `expected "spy" to be called once, but got 0 times`, and it passes with the fix applied. It drives the real public entry point (`OPFSBridge.writeFileToOPFS`) through an injected persistent root, with a fake handle whose `write()` rejects, and asserts both that the writable is aborted and that the sync-access fallback then succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file writing reliability when browser storage limits are reached.
  * Ensured writes can fall back successfully after a streaming write fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->