### PR TITLE
fix(flutter): close the LLM stream controller when generation fails

### DIFF
--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/public/capabilities/runanywhere_llm.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/public/capabilities/runanywhere_llm.dart
@@ -292,6 +292,11 @@ class RunAnywhereLLM {
     // generation so a finished stream doesn't emit a spurious cancellation.
     var completed = false;
 
+    // `run()` is started detached from `onListen`, so anything it throws is an
+    // unhandled async error rather than something the caller can catch. The
+    // whole body therefore has to funnel failures into the controller and
+    // close it on every path, or a consumer awaiting the stream hangs forever.
+    // Mirrors the STT capability's try/catch/finally.
     Future<void> run() async {
       try {
         // Phase-2 readiness gate, mirroring Swift's `try await
@@ -300,20 +305,24 @@ class RunAnywhereLLM {
         // HTTP setup not-applicable, so the guard no longer re-attempts a
         // remote round-trip (the old ~4s DNS stall) on every send.
         await DartBridge.ensureServicesReady();
+        final upstream = DartBridgeLLM.shared.generateStreamProto(request);
+        await controller.addStream(upstream);
+        // Set before the `finally` closes: closing delivers `done`, which
+        // fires `onCancel`, and a finished generation must not be cancelled.
+        completed = true;
       } catch (e) {
+        // The generation is over either way — nothing left to cancel.
         completed = true;
         if (!controller.isClosed) {
           controller.addError(
             e is SDKException ? e : SDKException.generationFailed('$e'),
           );
+        }
+      } finally {
+        if (!controller.isClosed) {
           await controller.close();
         }
-        return;
       }
-      final upstream = DartBridgeLLM.shared.generateStreamProto(request);
-      await controller.addStream(upstream);
-      completed = true;
-      await controller.close();
     }
 
     // Start the worker only once a listener attaches (canonical lazy pattern),


### PR DESCRIPTION
## What

`RunAnywhereLLM._generateStreamProto` builds a `StreamController` and starts its worker detached, via `unawaited(run())` from `onListen`. Only the `ensureServicesReady()` call sat inside `try/catch`; the two lines after it did not:

```dart
final upstream = DartBridgeLLM.shared.generateStreamProto(request);
await controller.addStream(upstream);
await controller.close();
```

If `generateStreamProto()` throws, or `addStream()` completes with an error from the upstream bridge stream, `close()` is never reached.

## Why it matters

By that point the caller already holds `controller.stream` and is awaiting it. The controller is never closed and no error is ever delivered, so **the consumer waits forever** rather than seeing the failure. Because `run()` is detached, the exception surfaces as an unhandled async error somewhere else entirely, which makes it hard to trace back to the stalled generation.

The fix moves the whole body into the existing `try`, routes the failure through `controller.addError`, and closes in a `finally` so every path terminates the stream.

This is the pattern the STT capability already uses: its worker wraps the body in `try/catch/finally` and closes in the `finally` (`runanywhere_stt.dart`). LLM was the outlier.

## Testing

- `flutter analyze --no-pub` in `sdk/runanywhere-flutter/packages/runanywhere` (Flutter 3.44.6): `No issues found!`

No unit test added: the failure needs the native bridge stream to error, which the package validates end to end through the example apps per CONTRIBUTING, and the change is a control-flow guarantee rather than new logic.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming reliability by reporting readiness and generation failures through the stream.
  * Ensured streams close correctly after both successful and unsuccessful generation attempts.
  * Improved event delivery by starting generation before forwarding stream updates.
  * Prevented normal stream completion from being interrupted by cancellation, providing more consistent generation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->