### PR TITLE
fix(commons): check the loaded state with the resolved model id

### DIFF
--- a/sdk/runanywhere-commons/src/infrastructure/storage/storage_analyzer.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/storage/storage_analyzer.cpp
@@ -342,7 +342,12 @@ void add_model_candidate_from_info(rac_storage_analyzer_handle_t handle,
     }
 
     bool is_loaded = false;
-    bool has_loaded_state = known_loaded_state(handle, current->id, &is_loaded);
+    // Use the resolved id, not the raw one: `id` already falls back to
+    // `requested_id` when `current->id` is null or empty, and every other use
+    // below reads `id`. Passing the raw pointer makes known_loaded_state()
+    // return false for exactly that case, which leaves `is_loaded` false and
+    // silently skips the loaded-model guard.
+    bool has_loaded_state = known_loaded_state(handle, id.c_str(), &is_loaded);
     if (!has_loaded_state) {
         add_warning_once(plan, seen_warnings, kLoadedStateUnavailableWarning);
     }


### PR DESCRIPTION
## What

`add_model_candidate_from_info` resolves the model id once, with a fallback for when the registry entry has no id of its own:

```cpp
const std::string id = current->id && current->id[0] != '\0' ? current->id : requested_id;
if (id.empty()) { ...return; }
```

Every later use reads that resolved `id` (the warnings, `row.model_id`, `row.storage_key`). The loaded-state probe was the one exception and passed the raw `current->id`:

```cpp
bool has_loaded_state = known_loaded_state(handle, current->id, &is_loaded);
```

## Why it matters

`known_loaded_state()` null-checks its `model_id` argument and returns false, leaving `is_loaded` untouched. So in exactly the case the fallback exists for, the probe reports no known state and `is_loaded` stays false, which means this guard never fires:

```cpp
if (is_loaded && !allow_loaded_models) {
    add_warning_once(plan, seen_warnings, "Model is loaded and cannot be safely deleted: " + id);
    return;
}
```

A model that is currently loaded then lands in the delete plan even though the caller asked not to touch loaded models. The "loaded state unavailable" warning is emitted, but it does not stop the deletion.

It is reachable through the requested-ids path (`rac_model_registry_get` then straight into this function), which does not check `current->id` first. The downloaded-models path is unaffected because it already skips entries with a null id.

Passing `id.c_str()` is safe: the early return above guarantees it is non-empty, so this only removes the null case rather than changing any behaviour that works today.

## Testing

Configured with the `macos-debug` preset and built with Ninja:
- `test_storage_analyzer_proto` — 0 test(s) failed
- `test_storage_service_proto_abi` — 18 checks, 0 failures
- `test_core --run-all` — 18 passed, 0 failed

No new test: the failure needs an `is_model_loaded` callback plus a registry entry with an empty id, which the existing analyzer fixtures do not model, and the change is a one-argument correction rather than new logic. Happy to add a fixture if you would prefer one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model detection when registry metadata is missing an ID.
  * Prevented incorrectly treating already loaded models as new candidates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->