### PR TITLE
fix(scripts): align the NDK fallback in setup.sh and doctor.sh with VERSIONS

### DIFF
--- a/scripts/setup/doctor.sh
+++ b/scripts/setup/doctor.sh
@@ -87,7 +87,9 @@ echo
 printf "${C_BOLD}Toolchains${C_RESET} ${C_DIM}(scanning…)${C_RESET}\n"
 
 NDK_VERSION=$(grep -E '^racNdkVersion=' "${REPO_ROOT}/sdk/runanywhere-kotlin/gradle.properties" 2>/dev/null | cut -d= -f2 | tr -d ' \r' || true)
-NDK_VERSION="${NDK_VERSION:-27.0.12077973}"
+# Keep this in step with NDK_VERSION in sdk/runanywhere-commons/VERSIONS
+# (currently r27d), which racNdkVersion above is read from.
+NDK_VERSION="${NDK_VERSION:-27.3.13750724}"
 
 ANDROID_SDK=""
 for candidate in \

--- a/scripts/setup/setup.sh
+++ b/scripts/setup/setup.sh
@@ -40,7 +40,9 @@ case "${OS}" in
 esac
 
 NDK_VERSION=$(grep -E '^racNdkVersion=' "${REPO_ROOT}/sdk/runanywhere-kotlin/gradle.properties" 2>/dev/null | cut -d= -f2 | tr -d ' \r' || true)
-NDK_VERSION="${NDK_VERSION:-27.0.12077973}"
+# Keep this in step with NDK_VERSION in sdk/runanywhere-commons/VERSIONS
+# (currently r27d), which racNdkVersion above is read from.
+NDK_VERSION="${NDK_VERSION:-27.3.13750724}"
 
 have() { command -v "$1" >/dev/null 2>&1; }
 


### PR DESCRIPTION
## What

`scripts/setup/setup.sh` and `scripts/setup/doctor.sh` both read `racNdkVersion` from the Kotlin SDK's `gradle.properties`, then fall back to a hardcoded literal if that read comes back empty:

```sh
NDK_VERSION=$(grep -E '^racNdkVersion=' "${REPO_ROOT}/sdk/runanywhere-kotlin/gradle.properties" 2>/dev/null | cut -d= -f2 | tr -d ' \r' || true)
NDK_VERSION="${NDK_VERSION:-27.0.12077973}"
```

That literal is stale. The canonical `NDK_VERSION` in `sdk/runanywhere-commons/VERSIONS` is `27.3.13750724`, and every other fallback in the tree already mirrors the canonical values:

| Site | Fallback |
|---|---|
| `sdk/runanywhere-kotlin/build.gradle.kts` (4 sites), backend modules (3 sites) | `27.3.13750724` |
| `examples/react-native/RunAnywhereAI/android/*` | `27.3.13750724` |
| `sdk/runanywhere-flutter/packages/*/android/build.gradle` | `28.2.13676358` (matches `FLUTTER_NDK_VERSION`) |
| **these two scripts** | **`27.0.12077973`** |

## Why

`VERSIONS` pins r27d deliberately, so a developer who lands on the fallback gets pointed at an NDK the project has moved off: `setup.sh` would install that version and `doctor.sh` reports it as the expected toolchain.

To be straight about the scope: the fallback is only reached when the `gradle.properties` read yields nothing, so this is a latent drift fix rather than something that misfires on a normal clone. `AGENTS.md` states the rule it violates, that the canonical version lives in `VERSIONS` and the fallback literals should mirror it whenever it is bumped.

## Testing

From the worktree:
- `bash -n` on both scripts: clean.
- Ran `doctor.sh` for real; it reports `Android NDK 27.3.13750724` as expected (correctly flagged not-found, since this host has no NDK installed).
- Exercised both branches of the resolution: with `gradle.properties` readable it resolves `27.3.13750724` as before, and with the path forced missing the fallback now also gives `27.3.13750724` instead of `27.0.12077973`.

## One thing I left alone

`sdk/runanywhere-commons/.github/workflows/build-commons.yml:97` and `release.yml:112` carry the same stale `27.0.12077973` under `${ANDROID_NDK_VERSION:-...}`, and `ANDROID_NDK_VERSION` is never set anywhere in the repo. GitHub only runs workflows from the root `.github/workflows/`, so that nested directory looks vestigial and I did not want to quietly update constants in dead config. Happy to include them here, or to remove that directory in a separate PR, whichever you prefer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated Android development setup scripts to use NDK version 27.3.13750724.
  * Synchronized the fallback NDK version across setup tools and project configuration.
  * Added maintenance notes to simplify future version updates and help reduce environment-related setup issues.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->