### PR TITLE
fix(react-native): categorise generation error codes as INTERNAL, matching Web

### DIFF
--- a/sdk/runanywhere-react-native/packages/core/src/Foundation/Errors/SDKException.ts
+++ b/sdk/runanywhere-react-native/packages/core/src/Foundation/Errors/SDKException.ts
@@ -444,7 +444,7 @@ function categoryForCode(code: ErrorCodeProto): ErrorCategoryProto {
     return ErrorCategoryProto.ERROR_CATEGORY_CONFIGURATION;
   if (code >= 110 && code <= 129) return ErrorCategoryProto.ERROR_CATEGORY_MODEL;
   if (code >= 130 && code <= 149)
-    return ErrorCategoryProto.ERROR_CATEGORY_COMPONENT;
+    return ErrorCategoryProto.ERROR_CATEGORY_INTERNAL;
   if (code >= 150 && code <= 179)
     return ErrorCategoryProto.ERROR_CATEGORY_NETWORK;
   if ((code >= 180 && code <= 219) || (code >= 280 && code <= 299)) {


### PR DESCRIPTION
## What

`categoryForCode` is hand-maintained in both the RN and Web SDKs, because neither can call the C++ helper synchronously at every throw site. Both copies carry the same instruction in their docstring:

> any change to the canonical mapping MUST be mirrored in this function (and in the RN/Web equivalent)

The two tables are the same 21 branches and agree on every range except one:

| Range | Web | React Native |
|---|---|---|
| 130-149 | `ERROR_CATEGORY_INTERNAL` | `ERROR_CATEGORY_COMPONENT` |

Web is the one that matches the core. `rac_result_to_proto_category` in `sdk/runanywhere-commons/src/foundation/rac_proto_adapters.cpp` has no explicit branch for 130-149, so those codes fall through to its documented `INTERNAL` fallback.

## Why it matters

That range is the generation failures, from `idl/errors.proto`:

```
ERROR_CODE_GENERATION_FAILED     = 130
ERROR_CODE_GENERATION_TIMEOUT    = 131
ERROR_CODE_CONTEXT_TOO_LONG      = 132
ERROR_CODE_TOKEN_LIMIT_EXCEEDED  = 133
ERROR_CODE_COST_LIMIT_EXCEEDED   = 134
ERROR_CODE_INFERENCE_FAILED      = 135
ERROR_CODE_GENERATION_CANCELLED  = 136
```

So a context-length overflow or a cancelled generation was reported under a different category on React Native than on Web, iOS, or the core itself. Anything that branches on category, whether error routing, retry policy, or telemetry grouping, got a different answer per platform for the same failure.

## Scope

One line. I deliberately did not touch anything else in the table, including the wider question of these 21-branch copies versus the consolidated 8-branch core function: the two SDK tables assign identical categories everywhere else, and reconciling them with the core's newer shape would change categorisation behaviour and is your call, not a drive-by.

After this change the RN and Web tables produce identical categories for all 21 branches (verified by diffing the extracted branch lists; the only remaining textual difference is the local variable name, since Web normalises a signed code via `Math.abs()` while RN receives a positive value by contract).

## Testing, and one gap I want to be upfront about

**I could not run `yarn typecheck` on this host.** The RN workspace pins `yarn@3.6.1` and this machine has no `yarn` or `corepack`, and `npx yarn@3.6.1` cannot resolve. Rather than imply a gate I did not run:

- `ErrorCategoryProto.ERROR_CATEGORY_INTERNAL` is already used at four other points in this same file, including the branch immediately below the changed one, so the identifier is valid in scope.
- The member exists in the generated proto (`sdk/shared/proto-ts/src/errors.ts`: `ERROR_CATEGORY_INTERNAL = 7`).
- The change swaps one member of `ErrorCategoryProto` for another inside an existing branch, so it cannot alter the function's type.

CI's `rn-typecheck` job is the authoritative check here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected error categorization for error codes 130–149, improving the accuracy of reported SDK errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->