### PR TITLE
fix(commons): require archive extensions to match the URL path suffix

### DIFF
--- a/sdk/runanywhere-commons/src/infrastructure/model_management/model_types.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/model_management/model_types.cpp
@@ -21,6 +21,16 @@
 #include "rac/core/rac_logger.h"
 #include "rac/infrastructure/model_management/rac_model_types.h"
 
+namespace {
+
+bool ends_with(const std::string& value, const char* suffix) {
+    const size_t suffix_length = std::strlen(suffix);
+    return value.size() >= suffix_length &&
+           value.compare(value.size() - suffix_length, suffix_length, suffix) == 0;
+}
+
+}  // namespace
+
 // =============================================================================
 // ARCHIVE TYPE FUNCTIONS
 // =============================================================================
@@ -45,24 +55,30 @@ rac_bool_t rac_archive_type_from_path(const char* url_path, rac_archive_type_t* 
         return RAC_FALSE;
     }
 
-    // Convert to lowercase for comparison
     std::string path(url_path);
-    std::ranges::transform(path, path.begin(), ::tolower);
+    const size_t suffix_noise = path.find_first_of("?#");
+    if (suffix_noise != std::string::npos) {
+        path.erase(suffix_noise);
+    }
+    std::ranges::transform(path, path.begin(),
+                           [](unsigned char character) {
+                               return static_cast<char>(std::tolower(character));
+                           });
 
     // Check suffixes (mirrors Swift's ArchiveType.from(url:))
-    if (path.rfind(".tar.bz2") != std::string::npos || path.rfind(".tbz2") != std::string::npos) {
+    if (ends_with(path, ".tar.bz2") || ends_with(path, ".tbz2")) {
         *out_type = RAC_ARCHIVE_TYPE_TAR_BZ2;
         return RAC_TRUE;
     }
-    if (path.rfind(".tar.gz") != std::string::npos || path.rfind(".tgz") != std::string::npos) {
+    if (ends_with(path, ".tar.gz") || ends_with(path, ".tgz")) {
         *out_type = RAC_ARCHIVE_TYPE_TAR_GZ;
         return RAC_TRUE;
     }
-    if (path.rfind(".tar.xz") != std::string::npos || path.rfind(".txz") != std::string::npos) {
+    if (ends_with(path, ".tar.xz") || ends_with(path, ".txz")) {
         *out_type = RAC_ARCHIVE_TYPE_TAR_XZ;
         return RAC_TRUE;
     }
-    if (path.rfind(".zip") != std::string::npos) {
+    if (ends_with(path, ".zip")) {
         *out_type = RAC_ARCHIVE_TYPE_ZIP;
         return RAC_TRUE;
     }

--- a/sdk/runanywhere-commons/src/infrastructure/model_management/model_types.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/model_management/model_types.cpp
@@ -21,16 +21,6 @@
 #include "rac/core/rac_logger.h"
 #include "rac/infrastructure/model_management/rac_model_types.h"
 
-namespace {
-
-bool ends_with(const std::string& value, const char* suffix) {
-    const size_t suffix_length = std::strlen(suffix);
-    return value.size() >= suffix_length &&
-           value.compare(value.size() - suffix_length, suffix_length, suffix) == 0;
-}
-
-}  // namespace
-
 // =============================================================================
 // ARCHIVE TYPE FUNCTIONS
 // =============================================================================
@@ -60,25 +50,24 @@ rac_bool_t rac_archive_type_from_path(const char* url_path, rac_archive_type_t* 
     if (suffix_noise != std::string::npos) {
         path.erase(suffix_noise);
     }
-    std::ranges::transform(path, path.begin(),
-                           [](unsigned char character) {
-                               return static_cast<char>(std::tolower(character));
-                           });
+    std::ranges::transform(path, path.begin(), [](unsigned char character) {
+        return static_cast<char>(std::tolower(character));
+    });
 
     // Check suffixes (mirrors Swift's ArchiveType.from(url:))
-    if (ends_with(path, ".tar.bz2") || ends_with(path, ".tbz2")) {
+    if (path.ends_with(".tar.bz2") || path.ends_with(".tbz2")) {
         *out_type = RAC_ARCHIVE_TYPE_TAR_BZ2;
         return RAC_TRUE;
     }
-    if (ends_with(path, ".tar.gz") || ends_with(path, ".tgz")) {
+    if (path.ends_with(".tar.gz") || path.ends_with(".tgz")) {
         *out_type = RAC_ARCHIVE_TYPE_TAR_GZ;
         return RAC_TRUE;
     }
-    if (ends_with(path, ".tar.xz") || ends_with(path, ".txz")) {
+    if (path.ends_with(".tar.xz") || path.ends_with(".txz")) {
         *out_type = RAC_ARCHIVE_TYPE_TAR_XZ;
         return RAC_TRUE;
     }
-    if (ends_with(path, ".zip")) {
+    if (path.ends_with(".zip")) {
         *out_type = RAC_ARCHIVE_TYPE_ZIP;
         return RAC_TRUE;
     }

--- a/sdk/runanywhere-commons/tests/test_extraction.cpp
+++ b/sdk/runanywhere-commons/tests/test_extraction.cpp
@@ -1342,6 +1342,39 @@ static TestResult test_archive_type_from_path() {
     ASSERT_EQ(rac_archive_type_from_path("model.gguf", &type), RAC_FALSE,
               "Should not detect archive from .gguf");
 
+    struct ArchivePathCase {
+        const char* path;
+        rac_archive_type_t expected_type;
+    };
+    static const ArchivePathCase archive_paths[] = {
+        {"MODEL.ZIP?download=1#fragment", RAC_ARCHIVE_TYPE_ZIP},
+        {"model.tar.gz?download=1", RAC_ARCHIVE_TYPE_TAR_GZ},
+        {"model.tgz#fragment", RAC_ARCHIVE_TYPE_TAR_GZ},
+        {"model.tar.bz2", RAC_ARCHIVE_TYPE_TAR_BZ2},
+        {"model.tbz2", RAC_ARCHIVE_TYPE_TAR_BZ2},
+        {"model.tar.xz", RAC_ARCHIVE_TYPE_TAR_XZ},
+        {"model.txz", RAC_ARCHIVE_TYPE_TAR_XZ},
+    };
+    for (const auto& archive_path : archive_paths) {
+        ASSERT_EQ(rac_archive_type_from_path(archive_path.path, &type), RAC_TRUE,
+                  "Should detect an archive from a terminal extension");
+        ASSERT_EQ(type, archive_path.expected_type, "Should detect the expected archive type");
+    }
+
+    static const char* non_archive_paths[] = {
+        "model.zip.backup",
+        "weights.zip.sha256",
+        "https://host/archive.zip/metadata.json",
+        "model.tar.gz.backup",
+        "model.tgz.sha256",
+        "model.tar.xz/metadata.json",
+        "model.tbz2.backup",
+    };
+    for (const char* path : non_archive_paths) {
+        ASSERT_EQ(rac_archive_type_from_path(path, &type), RAC_FALSE,
+                  "Should reject an archive extension before the path suffix");
+    }
+
     return TEST_PASS();
 }
 


### PR DESCRIPTION
## Description

Corrects archive classification so supported extensions are recognized only at the end of a URL path.

Previously, an extension appearing in a backup filename, checksum filename, or parent path could incorrectly mark a normal file as an archive. That could route a valid download through extraction and produce a misleading failure. Query strings, fragments, and uppercase extensions remain supported.

This change keeps archive handling consistent for every SDK that relies on the shared native layer.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing

- [x] Added/updated tests for changes
- [x] Required CI checks pass

### Platform-Specific Testing

Not applicable. This is a shared native behavior change with no user-interface impact.

## Labels

- [ ] `core` - Maintainer permissions required

## Checklist

- [x] Project style guidelines followed
- [x] Self-review completed
- [x] Documentation updated or confirmed unnecessary

## Screenshots

Not applicable.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved archive file detection for paths containing query parameters and fragments.
  * Prevented false positives when archive extensions appear before the end of a path.
  * Added reliable handling for uppercase and alternate archive extensions.

* **Tests**
  * Expanded coverage for query strings, fragments, alternate archive formats, and invalid embedded extensions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->