### PR TITLE
fix: deep-copy model artifact descriptors

### DIFF
--- a/sdk/runanywhere-commons/src/infrastructure/model_management/model_registry_convert.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/model_management/model_registry_convert.cpp
@@ -9,6 +9,7 @@
  */
 
 #include "model_registry_internal.h"
+#include "model_types_internal.h"
 
 #include <cstdlib>
 #include <cstring>
@@ -23,67 +24,6 @@
 // Note: rac_strdup is declared in rac_types.h and implemented in rac_memory.cpp
 
 namespace rac::infra::model_registry::detail {
-
-namespace {
-
-// Deep copy of the expected-files manifest. Returns nullptr on null input or
-// allocation failure (callers treat a missing manifest as "no declared
-// expectations", which is the pre-existing behavior for null).
-rac_expected_model_files_t* deep_copy_expected_files(const rac_expected_model_files_t* src) {
-    if (!src) {
-        return nullptr;
-    }
-    rac_expected_model_files_t* copy = rac_expected_model_files_alloc();
-    if (!copy) {
-        return nullptr;
-    }
-    if (src->required_patterns && src->required_pattern_count > 0) {
-        copy->required_patterns =
-            static_cast<const char**>(calloc(src->required_pattern_count, sizeof(char*)));
-        if (copy->required_patterns) {
-            copy->required_pattern_count = src->required_pattern_count;
-            for (size_t i = 0; i < src->required_pattern_count; ++i) {
-                copy->required_patterns[i] = rac_strdup(src->required_patterns[i]);
-            }
-        }
-    }
-    if (src->optional_patterns && src->optional_pattern_count > 0) {
-        copy->optional_patterns =
-            static_cast<const char**>(calloc(src->optional_pattern_count, sizeof(char*)));
-        if (copy->optional_patterns) {
-            copy->optional_pattern_count = src->optional_pattern_count;
-            for (size_t i = 0; i < src->optional_pattern_count; ++i) {
-                copy->optional_patterns[i] = rac_strdup(src->optional_patterns[i]);
-            }
-        }
-    }
-    copy->description = rac_strdup(src->description);
-    return copy;
-}
-
-// Deep copy of the multi-file descriptor array.
-rac_model_file_descriptor_t* deep_copy_file_descriptors(const rac_model_file_descriptor_t* src,
-                                                        size_t count) {
-    if (!src || count == 0) {
-        return nullptr;
-    }
-    rac_model_file_descriptor_t* copy = rac_model_file_descriptors_alloc(count);
-    if (!copy) {
-        return nullptr;
-    }
-    for (size_t i = 0; i < count; ++i) {
-        copy[i].relative_path = rac_strdup(src[i].relative_path);
-        copy[i].destination_path = rac_strdup(src[i].destination_path);
-        copy[i].url = rac_strdup(src[i].url);
-        copy[i].is_required = src[i].is_required;
-        copy[i].role = src[i].role;
-        copy[i].size_bytes = src[i].size_bytes;
-        copy[i].checksum_sha256 = rac_strdup(src[i].checksum_sha256);
-    }
-    return copy;
-}
-
-}  // namespace
 
 rac_model_info_t* deep_copy_model(const rac_model_info_t* src) {
     if (!src)
@@ -103,17 +43,10 @@ rac_model_info_t* deep_copy_model(const rac_model_info_t* src) {
     // Copy artifact info struct. Expected-files and descriptor arrays MUST be
     // deep-copied: every registry save/get round-trips through this function,
     // and dropping them silently downgrades artifact completeness validation
-    // to filename heuristics everywhere downstream.
-    copy->artifact_info.kind = src->artifact_info.kind;
-    copy->artifact_info.archive_type = src->artifact_info.archive_type;
-    copy->artifact_info.archive_structure = src->artifact_info.archive_structure;
-    copy->artifact_info.expected_files =
-        deep_copy_expected_files(src->artifact_info.expected_files);
-    copy->artifact_info.file_descriptors = deep_copy_file_descriptors(
-        src->artifact_info.file_descriptors, src->artifact_info.file_descriptor_count);
-    copy->artifact_info.file_descriptor_count =
-        copy->artifact_info.file_descriptors ? src->artifact_info.file_descriptor_count : 0;
-    copy->artifact_info.strategy_id = rac_strdup(src->artifact_info.strategy_id);
+    // to filename heuristics everywhere downstream. Shared with
+    // rac_model_info_copy() so both duplicators keep identical ownership and
+    // pointer/count invariants (see model_types_internal.h).
+    rac::infra::model_types::artifact_info_copy(&src->artifact_info, &copy->artifact_info);
     copy->download_size = src->download_size;
     copy->memory_required = src->memory_required;
     copy->context_length = src->context_length;

--- a/sdk/runanywhere-commons/src/infrastructure/model_management/model_types.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/model_management/model_types.cpp
@@ -1255,34 +1255,61 @@ rac_model_info_t* rac_model_info_copy(const rac_model_info_t* model) {
     copy->artifact_info.file_descriptor_count = 0;
     copy->artifact_info.strategy_id = nullptr;
 
+    const auto duplicate_artifact_string = [](const char* source, const char** destination) {
+        if (!source) {
+            *destination = nullptr;
+            return true;
+        }
+        *destination = rac_strdup(source);
+        return *destination != nullptr;
+    };
+
     // expected_files (required_patterns + optional_patterns + description)
     if (model->artifact_info.expected_files) {
         copy->artifact_info.expected_files = rac_expected_model_files_alloc();
-        if (copy->artifact_info.expected_files) {
-            const auto* src_ef = model->artifact_info.expected_files;
-            auto* dst_ef = copy->artifact_info.expected_files;
+        if (!copy->artifact_info.expected_files) {
+            rac_model_info_free(copy);
+            return nullptr;
+        }
 
-            if (src_ef->required_patterns && src_ef->required_pattern_count > 0) {
-                dst_ef->required_patterns =
-                    static_cast<const char**>(calloc(src_ef->required_pattern_count, sizeof(char*)));
-                if (dst_ef->required_patterns) {
-                    dst_ef->required_pattern_count = src_ef->required_pattern_count;
-                    for (size_t i = 0; i < src_ef->required_pattern_count; ++i) {
-                        dst_ef->required_patterns[i] = rac_strdup(src_ef->required_patterns[i]);
-                    }
+        const auto* src_ef = model->artifact_info.expected_files;
+        auto* dst_ef = copy->artifact_info.expected_files;
+
+        if (src_ef->required_patterns && src_ef->required_pattern_count > 0) {
+            dst_ef->required_patterns =
+                static_cast<const char**>(calloc(src_ef->required_pattern_count, sizeof(char*)));
+            if (!dst_ef->required_patterns) {
+                rac_model_info_free(copy);
+                return nullptr;
+            }
+            dst_ef->required_pattern_count = src_ef->required_pattern_count;
+            for (size_t i = 0; i < src_ef->required_pattern_count; ++i) {
+                if (!duplicate_artifact_string(src_ef->required_patterns[i],
+                                               &dst_ef->required_patterns[i])) {
+                    rac_model_info_free(copy);
+                    return nullptr;
                 }
             }
-            if (src_ef->optional_patterns && src_ef->optional_pattern_count > 0) {
-                dst_ef->optional_patterns =
-                    static_cast<const char**>(calloc(src_ef->optional_pattern_count, sizeof(char*)));
-                if (dst_ef->optional_patterns) {
-                    dst_ef->optional_pattern_count = src_ef->optional_pattern_count;
-                    for (size_t i = 0; i < src_ef->optional_pattern_count; ++i) {
-                        dst_ef->optional_patterns[i] = rac_strdup(src_ef->optional_patterns[i]);
-                    }
+        }
+        if (src_ef->optional_patterns && src_ef->optional_pattern_count > 0) {
+            dst_ef->optional_patterns =
+                static_cast<const char**>(calloc(src_ef->optional_pattern_count, sizeof(char*)));
+            if (!dst_ef->optional_patterns) {
+                rac_model_info_free(copy);
+                return nullptr;
+            }
+            dst_ef->optional_pattern_count = src_ef->optional_pattern_count;
+            for (size_t i = 0; i < src_ef->optional_pattern_count; ++i) {
+                if (!duplicate_artifact_string(src_ef->optional_patterns[i],
+                                               &dst_ef->optional_patterns[i])) {
+                    rac_model_info_free(copy);
+                    return nullptr;
                 }
             }
-            dst_ef->description = rac_strdup(src_ef->description);
+        }
+        if (!duplicate_artifact_string(src_ef->description, &dst_ef->description)) {
+            rac_model_info_free(copy);
+            return nullptr;
         }
     }
 
@@ -1291,27 +1318,32 @@ rac_model_info_t* rac_model_info_copy(const rac_model_info_t* model) {
     if (model->artifact_info.file_descriptors && model->artifact_info.file_descriptor_count > 0) {
         copy->artifact_info.file_descriptors =
             rac_model_file_descriptors_alloc(model->artifact_info.file_descriptor_count);
-        if (copy->artifact_info.file_descriptors) {
-            copy->artifact_info.file_descriptor_count = model->artifact_info.file_descriptor_count;
-            for (size_t i = 0; i < model->artifact_info.file_descriptor_count; ++i) {
-                const auto& src_fd = model->artifact_info.file_descriptors[i];
-                auto& dst_fd = copy->artifact_info.file_descriptors[i];
-                dst_fd.relative_path = rac_strdup(src_fd.relative_path);
-                dst_fd.destination_path = rac_strdup(src_fd.destination_path);
-                dst_fd.url = rac_strdup(src_fd.url);
-                dst_fd.checksum_sha256 = rac_strdup(src_fd.checksum_sha256);
-                dst_fd.is_required = src_fd.is_required;
-                dst_fd.role = src_fd.role;
-                dst_fd.size_bytes = src_fd.size_bytes;
-            }
-        } else {
-            copy->artifact_info.file_descriptor_count = 0;
+        if (!copy->artifact_info.file_descriptors) {
+            rac_model_info_free(copy);
+            return nullptr;
         }
-    } else {
-        copy->artifact_info.file_descriptor_count = 0;
+        copy->artifact_info.file_descriptor_count = model->artifact_info.file_descriptor_count;
+        for (size_t i = 0; i < model->artifact_info.file_descriptor_count; ++i) {
+            const auto& src_fd = model->artifact_info.file_descriptors[i];
+            auto& dst_fd = copy->artifact_info.file_descriptors[i];
+            if (!duplicate_artifact_string(src_fd.relative_path, &dst_fd.relative_path) ||
+                !duplicate_artifact_string(src_fd.destination_path, &dst_fd.destination_path) ||
+                !duplicate_artifact_string(src_fd.url, &dst_fd.url) ||
+                !duplicate_artifact_string(src_fd.checksum_sha256, &dst_fd.checksum_sha256)) {
+                rac_model_info_free(copy);
+                return nullptr;
+            }
+            dst_fd.is_required = src_fd.is_required;
+            dst_fd.role = src_fd.role;
+            dst_fd.size_bytes = src_fd.size_bytes;
+        }
     }
 
-    copy->artifact_info.strategy_id = rac_strdup(model->artifact_info.strategy_id);
+    if (!duplicate_artifact_string(model->artifact_info.strategy_id,
+                                   &copy->artifact_info.strategy_id)) {
+        rac_model_info_free(copy);
+        return nullptr;
+    }
 
     // Copy tags
     if (model->tags && model->tag_count > 0) {

--- a/sdk/runanywhere-commons/src/infrastructure/model_management/model_types.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/model_management/model_types.cpp
@@ -1244,10 +1244,73 @@ rac_model_info_t* rac_model_info_copy(const rac_model_info_t* model) {
     copy->local_path = rac_strdup(model->local_path);
     copy->description = rac_strdup(model->description);
 
-    // Copy artifact info (shallow for now - TODO: deep copy if needed)
+    // Deep-copy artifact info: the struct assignment copies scalars (kind,
+    // archive_type, archive_structure), then each owned pointer must be
+    // deep-copied so the copy owns its data independently of the source.
+    // Omitting this silently drops multi-file artifact metadata on every
+    // model-assignment round-trip through rac_model_info_copy.
     copy->artifact_info = model->artifact_info;
     copy->artifact_info.expected_files = nullptr;
     copy->artifact_info.file_descriptors = nullptr;
+    copy->artifact_info.file_descriptor_count = 0;
+    copy->artifact_info.strategy_id = nullptr;
+
+    // expected_files (required_patterns + optional_patterns + description)
+    if (model->artifact_info.expected_files) {
+        copy->artifact_info.expected_files = rac_expected_model_files_alloc();
+        if (copy->artifact_info.expected_files) {
+            const auto* src_ef = model->artifact_info.expected_files;
+            auto* dst_ef = copy->artifact_info.expected_files;
+
+            if (src_ef->required_patterns && src_ef->required_pattern_count > 0) {
+                dst_ef->required_patterns =
+                    static_cast<const char**>(calloc(src_ef->required_pattern_count, sizeof(char*)));
+                if (dst_ef->required_patterns) {
+                    dst_ef->required_pattern_count = src_ef->required_pattern_count;
+                    for (size_t i = 0; i < src_ef->required_pattern_count; ++i) {
+                        dst_ef->required_patterns[i] = rac_strdup(src_ef->required_patterns[i]);
+                    }
+                }
+            }
+            if (src_ef->optional_patterns && src_ef->optional_pattern_count > 0) {
+                dst_ef->optional_patterns =
+                    static_cast<const char**>(calloc(src_ef->optional_pattern_count, sizeof(char*)));
+                if (dst_ef->optional_patterns) {
+                    dst_ef->optional_pattern_count = src_ef->optional_pattern_count;
+                    for (size_t i = 0; i < src_ef->optional_pattern_count; ++i) {
+                        dst_ef->optional_patterns[i] = rac_strdup(src_ef->optional_patterns[i]);
+                    }
+                }
+            }
+            dst_ef->description = rac_strdup(src_ef->description);
+        }
+    }
+
+    // file_descriptors (per-file metadata: relative_path, destination_path, url,
+    // checksum_sha256, and scalars)
+    if (model->artifact_info.file_descriptors && model->artifact_info.file_descriptor_count > 0) {
+        copy->artifact_info.file_descriptors =
+            rac_model_file_descriptors_alloc(model->artifact_info.file_descriptor_count);
+        if (copy->artifact_info.file_descriptors) {
+            copy->artifact_info.file_descriptor_count = model->artifact_info.file_descriptor_count;
+            for (size_t i = 0; i < model->artifact_info.file_descriptor_count; ++i) {
+                const auto& src_fd = model->artifact_info.file_descriptors[i];
+                auto& dst_fd = copy->artifact_info.file_descriptors[i];
+                dst_fd.relative_path = rac_strdup(src_fd.relative_path);
+                dst_fd.destination_path = rac_strdup(src_fd.destination_path);
+                dst_fd.url = rac_strdup(src_fd.url);
+                dst_fd.checksum_sha256 = rac_strdup(src_fd.checksum_sha256);
+                dst_fd.is_required = src_fd.is_required;
+                dst_fd.role = src_fd.role;
+                dst_fd.size_bytes = src_fd.size_bytes;
+            }
+        } else {
+            copy->artifact_info.file_descriptor_count = 0;
+        }
+    } else {
+        copy->artifact_info.file_descriptor_count = 0;
+    }
+
     copy->artifact_info.strategy_id = rac_strdup(model->artifact_info.strategy_id);
 
     // Copy tags

--- a/sdk/runanywhere-commons/src/infrastructure/model_management/model_types.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/model_management/model_types.cpp
@@ -10,6 +10,8 @@
  * Do NOT add features not present in the Swift code.
  */
 
+#include "model_types_internal.h"
+
 #include <algorithm>
 #include <cctype>
 #include <cstdlib>
@@ -20,6 +22,10 @@
 
 #include "rac/core/rac_logger.h"
 #include "rac/infrastructure/model_management/rac_model_types.h"
+
+namespace {
+constexpr const char* LOG_CAT = "ModelTypes";
+}  // namespace
 
 // =============================================================================
 // ARCHIVE TYPE FUNCTIONS
@@ -1215,6 +1221,148 @@ void rac_model_info_array_free(rac_model_info_t** models, size_t count) {
     free(static_cast<void*>(models));
 }
 
+// =============================================================================
+// ARTIFACT INFO DEEP COPY
+//
+// One copy authority for the three heap blocks owned by
+// rac_model_artifact_info_t. Both duplicators of rac_model_info_t call this:
+// rac_model_info_copy() below and deep_copy_model() in
+// model_registry_convert.cpp. See model_types_internal.h for the contract.
+// =============================================================================
+
+namespace {
+
+// Duplicates a nullable C string. Returns false only when a non-null source
+// could not be duplicated, so callers can distinguish "absent" from "OOM".
+bool dup_optional_string(const char* src, const char** out) {
+    if (!src) {
+        *out = nullptr;
+        return true;
+    }
+    *out = rac_strdup(src);
+    return *out != nullptr;
+}
+
+// Duplicates a pattern array. All-or-nothing: on failure nothing is written to
+// *out_patterns / *out_count and the partial array is released, so the caller
+// never sees a counted array with NULL entries.
+bool dup_pattern_array(const char* const* src, size_t count, const char*** out_patterns,
+                       size_t* out_count) {
+    if (!src || count == 0) {
+        return true;  // nothing to copy; caller's fields stay NULL/0
+    }
+    auto** patterns = static_cast<const char**>(calloc(count, sizeof(char*)));
+    if (!patterns) {
+        return false;
+    }
+    for (size_t i = 0; i < count; ++i) {
+        if (!dup_optional_string(src[i], &patterns[i])) {
+            for (size_t j = 0; j < i; ++j) {
+                free((void*)patterns[j]);
+            }
+            free(static_cast<void*>(patterns));
+            return false;
+        }
+    }
+    *out_patterns = patterns;
+    *out_count = count;
+    return true;
+}
+
+// Deep copy of the expected-files manifest. Returns nullptr on null input or on
+// any allocation failure (the partial copy is released first).
+rac_expected_model_files_t* copy_expected_files(const rac_expected_model_files_t* src) {
+    if (!src) {
+        return nullptr;
+    }
+    rac_expected_model_files_t* copy = rac_expected_model_files_alloc();
+    if (!copy) {
+        return nullptr;
+    }
+    if (!dup_pattern_array(src->required_patterns, src->required_pattern_count,
+                           &copy->required_patterns, &copy->required_pattern_count) ||
+        !dup_pattern_array(src->optional_patterns, src->optional_pattern_count,
+                           &copy->optional_patterns, &copy->optional_pattern_count) ||
+        !dup_optional_string(src->description, &copy->description)) {
+        rac_expected_model_files_free(copy);
+        return nullptr;
+    }
+    return copy;
+}
+
+// Deep copy of the multi-file descriptor array. Returns nullptr on empty input
+// or on any allocation failure (the partial array is released first).
+rac_model_file_descriptor_t* copy_file_descriptors(const rac_model_file_descriptor_t* src,
+                                                   size_t count) {
+    if (!src || count == 0) {
+        return nullptr;
+    }
+    rac_model_file_descriptor_t* copy = rac_model_file_descriptors_alloc(count);
+    if (!copy) {
+        return nullptr;
+    }
+    for (size_t i = 0; i < count; ++i) {
+        if (!dup_optional_string(src[i].relative_path, &copy[i].relative_path) ||
+            !dup_optional_string(src[i].destination_path, &copy[i].destination_path) ||
+            !dup_optional_string(src[i].url, &copy[i].url) ||
+            !dup_optional_string(src[i].checksum_sha256, &copy[i].checksum_sha256)) {
+            // rac_model_file_descriptors_alloc() zeroes the array, so freeing
+            // all `count` entries is safe even though only `i` are populated.
+            rac_model_file_descriptors_free(copy, count);
+            return nullptr;
+        }
+        copy[i].is_required = src[i].is_required;
+        copy[i].role = src[i].role;
+        copy[i].size_bytes = src[i].size_bytes;
+    }
+    return copy;
+}
+
+}  // namespace
+
+namespace rac::infra::model_types {
+
+rac_result_t artifact_info_copy(const rac_model_artifact_info_t* src,
+                                rac_model_artifact_info_t* dst) {
+    if (!src || !dst) {
+        return RAC_ERROR_NULL_POINTER;
+    }
+
+    // Scalars first, then every owned pointer explicitly -- never a struct
+    // assignment, which would alias src's heap blocks into dst.
+    dst->kind = src->kind;
+    dst->archive_type = src->archive_type;
+    dst->archive_structure = src->archive_structure;
+    dst->expected_files = nullptr;
+    dst->file_descriptors = nullptr;
+    dst->file_descriptor_count = 0;
+    dst->strategy_id = nullptr;
+
+    bool ok = true;
+
+    dst->expected_files = copy_expected_files(src->expected_files);
+    if (src->expected_files && !dst->expected_files) {
+        ok = false;
+    }
+
+    dst->file_descriptors =
+        copy_file_descriptors(src->file_descriptors, src->file_descriptor_count);
+    // The invariant consumers rely on: a non-zero count always implies a
+    // non-NULL array. Derive the count from the pointer, never from the source.
+    dst->file_descriptor_count = dst->file_descriptors ? src->file_descriptor_count : 0;
+    if (src->file_descriptors && src->file_descriptor_count > 0 && !dst->file_descriptors) {
+        ok = false;
+    }
+
+    if (!dup_optional_string(src->strategy_id, &dst->strategy_id)) {
+        ok = false;
+    }
+
+    return ok ? RAC_SUCCESS : RAC_ERROR_OUT_OF_MEMORY;
+}
+
+}  // namespace rac::infra::model_types
+
 rac_model_info_t* rac_model_info_copy(const rac_model_info_t* model) {
     if (!model)
         return nullptr;
@@ -1244,105 +1392,21 @@ rac_model_info_t* rac_model_info_copy(const rac_model_info_t* model) {
     copy->local_path = rac_strdup(model->local_path);
     copy->description = rac_strdup(model->description);
 
-    // Deep-copy artifact info: the struct assignment copies scalars (kind,
-    // archive_type, archive_structure), then each owned pointer must be
-    // deep-copied so the copy owns its data independently of the source.
-    // Omitting this silently drops multi-file artifact metadata on every
-    // model-assignment round-trip through rac_model_info_copy.
-    copy->artifact_info = model->artifact_info;
-    copy->artifact_info.expected_files = nullptr;
-    copy->artifact_info.file_descriptors = nullptr;
-    copy->artifact_info.file_descriptor_count = 0;
-    copy->artifact_info.strategy_id = nullptr;
-
-    const auto duplicate_artifact_string = [](const char* source, const char** destination) {
-        if (!source) {
-            *destination = nullptr;
-            return true;
-        }
-        *destination = rac_strdup(source);
-        return *destination != nullptr;
-    };
-
-    // expected_files (required_patterns + optional_patterns + description)
-    if (model->artifact_info.expected_files) {
-        copy->artifact_info.expected_files = rac_expected_model_files_alloc();
-        if (!copy->artifact_info.expected_files) {
-            rac_model_info_free(copy);
-            return nullptr;
-        }
-
-        const auto* src_ef = model->artifact_info.expected_files;
-        auto* dst_ef = copy->artifact_info.expected_files;
-
-        if (src_ef->required_patterns && src_ef->required_pattern_count > 0) {
-            dst_ef->required_patterns =
-                static_cast<const char**>(calloc(src_ef->required_pattern_count, sizeof(char*)));
-            if (!dst_ef->required_patterns) {
-                rac_model_info_free(copy);
-                return nullptr;
-            }
-            dst_ef->required_pattern_count = src_ef->required_pattern_count;
-            for (size_t i = 0; i < src_ef->required_pattern_count; ++i) {
-                if (!duplicate_artifact_string(src_ef->required_patterns[i],
-                                               &dst_ef->required_patterns[i])) {
-                    rac_model_info_free(copy);
-                    return nullptr;
-                }
-            }
-        }
-        if (src_ef->optional_patterns && src_ef->optional_pattern_count > 0) {
-            dst_ef->optional_patterns =
-                static_cast<const char**>(calloc(src_ef->optional_pattern_count, sizeof(char*)));
-            if (!dst_ef->optional_patterns) {
-                rac_model_info_free(copy);
-                return nullptr;
-            }
-            dst_ef->optional_pattern_count = src_ef->optional_pattern_count;
-            for (size_t i = 0; i < src_ef->optional_pattern_count; ++i) {
-                if (!duplicate_artifact_string(src_ef->optional_patterns[i],
-                                               &dst_ef->optional_patterns[i])) {
-                    rac_model_info_free(copy);
-                    return nullptr;
-                }
-            }
-        }
-        if (!duplicate_artifact_string(src_ef->description, &dst_ef->description)) {
-            rac_model_info_free(copy);
-            return nullptr;
-        }
-    }
-
-    // file_descriptors (per-file metadata: relative_path, destination_path, url,
-    // checksum_sha256, and scalars)
-    if (model->artifact_info.file_descriptors && model->artifact_info.file_descriptor_count > 0) {
-        copy->artifact_info.file_descriptors =
-            rac_model_file_descriptors_alloc(model->artifact_info.file_descriptor_count);
-        if (!copy->artifact_info.file_descriptors) {
-            rac_model_info_free(copy);
-            return nullptr;
-        }
-        copy->artifact_info.file_descriptor_count = model->artifact_info.file_descriptor_count;
-        for (size_t i = 0; i < model->artifact_info.file_descriptor_count; ++i) {
-            const auto& src_fd = model->artifact_info.file_descriptors[i];
-            auto& dst_fd = copy->artifact_info.file_descriptors[i];
-            if (!duplicate_artifact_string(src_fd.relative_path, &dst_fd.relative_path) ||
-                !duplicate_artifact_string(src_fd.destination_path, &dst_fd.destination_path) ||
-                !duplicate_artifact_string(src_fd.url, &dst_fd.url) ||
-                !duplicate_artifact_string(src_fd.checksum_sha256, &dst_fd.checksum_sha256)) {
-                rac_model_info_free(copy);
-                return nullptr;
-            }
-            dst_fd.is_required = src_fd.is_required;
-            dst_fd.role = src_fd.role;
-            dst_fd.size_bytes = src_fd.size_bytes;
-        }
-    }
-
-    if (!duplicate_artifact_string(model->artifact_info.strategy_id,
-                                   &copy->artifact_info.strategy_id)) {
-        rac_model_info_free(copy);
-        return nullptr;
+    // Deep-copy the artifact block through the one shared helper (see
+    // model_types_internal.h). A shallow struct assignment aliases the source's
+    // expected-files manifest and descriptor array into the copy -- a double
+    // free -- and nulling only the pointers while keeping
+    // file_descriptor_count leaves consumers iterating a NULL array.
+    //
+    // Best-effort on OOM by design: rac_model_info_copy() has always returned a
+    // (possibly lossy) copy rather than NULL once allocation started, and
+    // rac_model_assignment_* pushes the result straight into its cache without
+    // a NULL check. Turning artifact OOM into a NULL return would move the
+    // crash there instead of fixing it.
+    if (rac::infra::model_types::artifact_info_copy(&model->artifact_info, &copy->artifact_info) ==
+        RAC_ERROR_OUT_OF_MEMORY) {
+        RAC_LOG_WARNING(LOG_CAT, "Out of memory copying artifact info for model '%s'",
+                        model->id ? model->id : "?");
     }
 
     // Copy tags

--- a/sdk/runanywhere-commons/src/infrastructure/model_management/model_types_internal.h
+++ b/sdk/runanywhere-commons/src/infrastructure/model_management/model_types_internal.h
@@ -1,0 +1,52 @@
+/**
+ * @file model_types_internal.h
+ * @brief Private model-type ownership helpers shared by commons TUs.
+ *
+ * NOT part of the public C ABI; only files under
+ * `src/infrastructure/model_management/` may include this header.
+ *
+ * `rac_model_artifact_info_t` owns three heap blocks (the expected-files
+ * manifest, the file-descriptor array, and the strategy id). Every place that
+ * duplicates a `rac_model_info_t` has to duplicate them too, and the copy has
+ * to keep `file_descriptors` and `file_descriptor_count` in lockstep --
+ * consumers such as `model_folder_is_complete_struct()` iterate
+ * `file_descriptors[i]` bounded only by `file_descriptor_count`, so a non-zero
+ * count paired with a NULL pointer is a null dereference. This header is the
+ * single declaration of that copy so no TU has to hand-roll it again.
+ */
+
+#ifndef RAC_INFRA_MODEL_MANAGEMENT_MODEL_TYPES_INTERNAL_H
+#define RAC_INFRA_MODEL_MANAGEMENT_MODEL_TYPES_INTERNAL_H
+
+#include "rac/core/rac_error.h"
+#include "rac/infrastructure/model_management/rac_model_types.h"
+
+namespace rac::infra::model_types {
+
+/**
+ * @brief Deep-copy an artifact descriptor block into @p dst.
+ *
+ * @p dst is overwritten wholesale: scalars are assigned and every owned pointer
+ * is duplicated, so the result shares no memory with @p src and can be released
+ * through the normal `rac_model_info_free()` / `rac_expected_model_files_free()`
+ * + `rac_model_file_descriptors_free()` path. @p dst must not already own
+ * artifact memory (callers pass a freshly zeroed struct); its previous contents
+ * are not freed.
+ *
+ * Failure contract -- @p dst is left in a consistent, freeable state on every
+ * path:
+ *   - each owned block is all-or-nothing (a partially duplicated expected-files
+ *     manifest or descriptor array is released and the field left NULL rather
+ *     than handed back with counted NULL entries), and
+ *   - `file_descriptors == NULL` if and only if `file_descriptor_count == 0`.
+ *
+ * @return RAC_ERROR_NULL_POINTER if either argument is NULL,
+ *         RAC_ERROR_OUT_OF_MEMORY if any block could not be duplicated (@p dst
+ *         then holds the blocks that did succeed), RAC_SUCCESS otherwise.
+ */
+rac_result_t artifact_info_copy(const rac_model_artifact_info_t* src,
+                                rac_model_artifact_info_t* dst);
+
+}  // namespace rac::infra::model_types
+
+#endif  // RAC_INFRA_MODEL_MANAGEMENT_MODEL_TYPES_INTERNAL_H

--- a/sdk/runanywhere-commons/tests/CMakeLists.txt
+++ b/sdk/runanywhere-commons/tests/CMakeLists.txt
@@ -893,6 +893,23 @@ rac_link_archive_deps(test_model_string_accessors)
 target_compile_features(test_model_string_accessors PRIVATE cxx_std_17)
 add_test(NAME model_string_accessors_tests COMMAND test_model_string_accessors)
 
+# --- Artifact-descriptor deep-copy round-trip tests --------------------------
+# Guards the one shared artifact copy (rac::infra::model_types::artifact_info_copy)
+# used by both rac_model_info_copy() and the registry's deep_copy_model():
+# multi-file metadata survives a copy and a registry save/get, the copy owns its
+# own memory, and file_descriptors/file_descriptor_count never disagree (a
+# non-zero count over a NULL array is a null deref in
+# model_folder_is_complete_struct). Pure C ABI test, no protobuf required.
+add_executable(test_model_artifact_copy test_model_artifact_copy.cpp)
+target_include_directories(test_model_artifact_copy PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/include
+)
+target_link_libraries(test_model_artifact_copy PRIVATE rac_commons)
+rac_link_archive_deps(test_model_artifact_copy)
+target_compile_features(test_model_artifact_copy PRIVATE cxx_std_17)
+add_test(NAME model_artifact_copy_tests COMMAND test_model_artifact_copy)
+
 # --- Proto enum ↔ C enum mapper parity tests --------------------------
 # Exercises rac_inference_framework_from/to_proto, rac_model_category_*,
 # rac_model_format_*, rac_model_source_* and rac_archive_type_*. Pure C ABI,

--- a/sdk/runanywhere-commons/tests/test_model_artifact_copy.cpp
+++ b/sdk/runanywhere-commons/tests/test_model_artifact_copy.cpp
@@ -1,0 +1,310 @@
+/**
+ * @file test_model_artifact_copy.cpp
+ * @brief Round-trip tests for artifact-descriptor deep copy.
+ *
+ * `rac_model_artifact_info_t` owns three heap blocks: the expected-files
+ * manifest, the multi-file descriptor array, and the strategy id. Both
+ * duplicators of a `rac_model_info_t` -- the public `rac_model_info_copy()` and
+ * the registry's internal `deep_copy_model()` (reached here through
+ * save + get) -- must duplicate all three, and must keep `file_descriptors`
+ * and `file_descriptor_count` in lockstep.
+ *
+ * The two regressions under test:
+ *
+ *   1. Shallow copy loses data. `rac_model_info_copy()` used to assign the
+ *      artifact struct and then null the two pointers, so every model-assignment
+ *      cache round-trip silently dropped multi-file metadata and downgraded
+ *      completeness validation to filename heuristics.
+ *
+ *   2. Shallow copy breaks the pointer/count invariant. Nulling
+ *      `file_descriptors` while retaining `file_descriptor_count` hands
+ *      consumers a non-zero count over a NULL array;
+ *      `model_folder_is_complete_struct()` in model_registry_manifest.cpp
+ *      indexes `file_descriptors[i]` bounded only by that count, so the copy
+ *      dereferences NULL.
+ *
+ * The tests also assert the copy owns its own memory (no pointer aliasing) and
+ * survives the source being freed, which is what makes it safe for both callers
+ * to `rac_model_info_free()` independently.
+ */
+
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+
+#include "rac/core/rac_error.h"
+#include "rac/infrastructure/model_management/rac_model_registry.h"
+#include "rac/infrastructure/model_management/rac_model_types.h"
+
+namespace {
+
+#define EXPECT_TRUE(_cond)                                                          \
+    do {                                                                            \
+        if (!(_cond)) {                                                             \
+            std::fprintf(stderr, "FAIL @ %s:%d: %s\n", __FILE__, __LINE__, #_cond); \
+            return 1;                                                               \
+        }                                                                           \
+    } while (0)
+
+#define EXPECT_STREQ(_a, _b)                                                             \
+    do {                                                                                 \
+        if (!(_a) || !(_b) || std::strcmp((_a), (_b)) != 0) {                            \
+            std::fprintf(stderr, "FAIL @ %s:%d: \"%s\" != \"%s\"\n", __FILE__, __LINE__, \
+                         (_a) ? (_a) : "(null)", (_b) ? (_b) : "(null)");                \
+            return 1;                                                                    \
+        }                                                                                \
+    } while (0)
+
+const char* kRequiredPatterns[] = {"*.onnx", "tokens.txt"};
+const char* kOptionalPatterns[] = {"README.md"};
+
+// A model carrying every artifact field a real multi-file model uses: an
+// expected-files manifest (required + optional patterns + description), two
+// descriptors (one with url/checksum, one deliberately without, to cover the
+// nullable-string path), and a custom strategy id.
+rac_model_info_t* build_multi_file_model() {
+    rac_model_info_t* model = rac_model_info_alloc();
+    if (!model) {
+        return nullptr;
+    }
+    model->id = rac_strdup("test-multi-file");
+    model->name = rac_strdup("Test Multi File");
+    model->category = RAC_MODEL_CATEGORY_SPEECH_RECOGNITION;
+    model->format = RAC_MODEL_FORMAT_ONNX;
+    model->framework = RAC_FRAMEWORK_SHERPA;
+    model->download_url = rac_strdup("https://example.test/multi");
+    model->description = rac_strdup("multi-file test model");
+
+    model->artifact_info.kind = RAC_ARTIFACT_KIND_MULTI_FILE;
+    model->artifact_info.archive_type = RAC_ARCHIVE_TYPE_ZIP;
+    model->artifact_info.archive_structure = RAC_ARCHIVE_STRUCTURE_DIRECTORY_BASED;
+    model->artifact_info.strategy_id = rac_strdup("sherpa-multi");
+
+    rac_expected_model_files_t* files = rac_expected_model_files_alloc();
+    files->required_patterns = static_cast<const char**>(calloc(2, sizeof(char*)));
+    files->required_patterns[0] = rac_strdup(kRequiredPatterns[0]);
+    files->required_patterns[1] = rac_strdup(kRequiredPatterns[1]);
+    files->required_pattern_count = 2;
+    files->optional_patterns = static_cast<const char**>(calloc(1, sizeof(char*)));
+    files->optional_patterns[0] = rac_strdup(kOptionalPatterns[0]);
+    files->optional_pattern_count = 1;
+    files->description = rac_strdup("encoder + tokens");
+    model->artifact_info.expected_files = files;
+
+    rac_model_file_descriptor_t* descriptors = rac_model_file_descriptors_alloc(2);
+    descriptors[0].relative_path = rac_strdup("encoder.onnx");
+    descriptors[0].destination_path = rac_strdup("encoder.onnx");
+    descriptors[0].url = rac_strdup("https://example.test/multi/encoder.onnx");
+    descriptors[0].checksum_sha256 = rac_strdup("abc123");
+    descriptors[0].is_required = RAC_TRUE;
+    descriptors[0].role = RAC_MODEL_FILE_ROLE_PRIMARY_MODEL;
+    descriptors[0].size_bytes = 4096;
+    // Second descriptor leaves url and checksum NULL on purpose.
+    descriptors[1].relative_path = rac_strdup("tokens.txt");
+    descriptors[1].destination_path = rac_strdup("tokens.txt");
+    descriptors[1].is_required = RAC_FALSE;
+    descriptors[1].role = RAC_MODEL_FILE_ROLE_TOKENIZER;
+    descriptors[1].size_bytes = 128;
+    model->artifact_info.file_descriptors = descriptors;
+    model->artifact_info.file_descriptor_count = 2;
+
+    return model;
+}
+
+// Field-by-field check of a copy against the values build_multi_file_model()
+// wrote. Takes values rather than the source pointer so it can run after the
+// source has been freed.
+int verify_multi_file_artifact(const rac_model_artifact_info_t& artifact) {
+    EXPECT_TRUE(artifact.kind == RAC_ARTIFACT_KIND_MULTI_FILE);
+    EXPECT_TRUE(artifact.archive_type == RAC_ARCHIVE_TYPE_ZIP);
+    EXPECT_TRUE(artifact.archive_structure == RAC_ARCHIVE_STRUCTURE_DIRECTORY_BASED);
+    EXPECT_STREQ(artifact.strategy_id, "sherpa-multi");
+
+    EXPECT_TRUE(artifact.expected_files != nullptr);
+    EXPECT_TRUE(artifact.expected_files->required_pattern_count == 2);
+    EXPECT_TRUE(artifact.expected_files->required_patterns != nullptr);
+    EXPECT_STREQ(artifact.expected_files->required_patterns[0], kRequiredPatterns[0]);
+    EXPECT_STREQ(artifact.expected_files->required_patterns[1], kRequiredPatterns[1]);
+    EXPECT_TRUE(artifact.expected_files->optional_pattern_count == 1);
+    EXPECT_TRUE(artifact.expected_files->optional_patterns != nullptr);
+    EXPECT_STREQ(artifact.expected_files->optional_patterns[0], kOptionalPatterns[0]);
+    EXPECT_STREQ(artifact.expected_files->description, "encoder + tokens");
+
+    EXPECT_TRUE(artifact.file_descriptor_count == 2);
+    EXPECT_TRUE(artifact.file_descriptors != nullptr);
+    EXPECT_STREQ(artifact.file_descriptors[0].relative_path, "encoder.onnx");
+    EXPECT_STREQ(artifact.file_descriptors[0].destination_path, "encoder.onnx");
+    EXPECT_STREQ(artifact.file_descriptors[0].url, "https://example.test/multi/encoder.onnx");
+    EXPECT_STREQ(artifact.file_descriptors[0].checksum_sha256, "abc123");
+    EXPECT_TRUE(artifact.file_descriptors[0].is_required == RAC_TRUE);
+    EXPECT_TRUE(artifact.file_descriptors[0].role == RAC_MODEL_FILE_ROLE_PRIMARY_MODEL);
+    EXPECT_TRUE(artifact.file_descriptors[0].size_bytes == 4096);
+    EXPECT_STREQ(artifact.file_descriptors[1].relative_path, "tokens.txt");
+    EXPECT_STREQ(artifact.file_descriptors[1].destination_path, "tokens.txt");
+    EXPECT_TRUE(artifact.file_descriptors[1].url == nullptr);
+    EXPECT_TRUE(artifact.file_descriptors[1].checksum_sha256 == nullptr);
+    EXPECT_TRUE(artifact.file_descriptors[1].is_required == RAC_FALSE);
+    EXPECT_TRUE(artifact.file_descriptors[1].role == RAC_MODEL_FILE_ROLE_TOKENIZER);
+    EXPECT_TRUE(artifact.file_descriptors[1].size_bytes == 128);
+    return 0;
+}
+
+// The invariant every consumer that iterates file_descriptors[i] relies on.
+int verify_descriptor_invariant(const rac_model_artifact_info_t& artifact) {
+    EXPECT_TRUE((artifact.file_descriptors != nullptr) == (artifact.file_descriptor_count > 0));
+    return 0;
+}
+
+// ---------------------------------------------------------------------------
+// rac_model_info_copy() preserves the whole artifact block.
+// ---------------------------------------------------------------------------
+int test_model_info_copy_preserves_artifact() {
+    rac_model_info_t* source = build_multi_file_model();
+    EXPECT_TRUE(source != nullptr);
+
+    rac_model_info_t* copy = rac_model_info_copy(source);
+    EXPECT_TRUE(copy != nullptr);
+
+    int rc = verify_descriptor_invariant(copy->artifact_info);
+    if (rc == 0) {
+        rc = verify_multi_file_artifact(copy->artifact_info);
+    }
+
+    rac_model_info_free(source);
+    rac_model_info_free(copy);
+    return rc;
+}
+
+// ---------------------------------------------------------------------------
+// The copy owns its memory: no pointer is shared with the source, and the copy
+// stays fully readable after the source is freed. Both callers free
+// independently, so any aliasing here is a double free in production.
+// ---------------------------------------------------------------------------
+int test_model_info_copy_is_independent() {
+    rac_model_info_t* source = build_multi_file_model();
+    EXPECT_TRUE(source != nullptr);
+
+    rac_model_info_t* copy = rac_model_info_copy(source);
+    EXPECT_TRUE(copy != nullptr);
+
+    EXPECT_TRUE(copy->artifact_info.expected_files != source->artifact_info.expected_files);
+    EXPECT_TRUE(copy->artifact_info.expected_files->required_patterns !=
+                source->artifact_info.expected_files->required_patterns);
+    EXPECT_TRUE(copy->artifact_info.expected_files->required_patterns[0] !=
+                source->artifact_info.expected_files->required_patterns[0]);
+    EXPECT_TRUE(copy->artifact_info.expected_files->optional_patterns !=
+                source->artifact_info.expected_files->optional_patterns);
+    EXPECT_TRUE(copy->artifact_info.expected_files->description !=
+                source->artifact_info.expected_files->description);
+    EXPECT_TRUE(copy->artifact_info.file_descriptors != source->artifact_info.file_descriptors);
+    EXPECT_TRUE(copy->artifact_info.file_descriptors[0].relative_path !=
+                source->artifact_info.file_descriptors[0].relative_path);
+    EXPECT_TRUE(copy->artifact_info.file_descriptors[0].url !=
+                source->artifact_info.file_descriptors[0].url);
+    EXPECT_TRUE(copy->artifact_info.file_descriptors[0].checksum_sha256 !=
+                source->artifact_info.file_descriptors[0].checksum_sha256);
+    EXPECT_TRUE(copy->artifact_info.strategy_id != source->artifact_info.strategy_id);
+
+    // Free the source first, then read the copy end to end.
+    rac_model_info_free(source);
+    const int rc = verify_multi_file_artifact(copy->artifact_info);
+    rac_model_info_free(copy);
+    return rc;
+}
+
+// ---------------------------------------------------------------------------
+// Regression: a source whose count disagrees with its (NULL) array must not
+// propagate the count. This is the shape the old shallow copy produced, and
+// model_folder_is_complete_struct() dereferences file_descriptors[i] using only
+// that count.
+// ---------------------------------------------------------------------------
+int test_copy_never_pairs_null_array_with_nonzero_count() {
+    rac_model_info_t* source = rac_model_info_alloc();
+    EXPECT_TRUE(source != nullptr);
+    source->id = rac_strdup("inconsistent");
+    source->artifact_info.kind = RAC_ARTIFACT_KIND_MULTI_FILE;
+    source->artifact_info.file_descriptors = nullptr;
+    source->artifact_info.file_descriptor_count = 3;  // lies about the array
+
+    rac_model_info_t* copy = rac_model_info_copy(source);
+    EXPECT_TRUE(copy != nullptr);
+    EXPECT_TRUE(copy->artifact_info.file_descriptors == nullptr);
+    EXPECT_TRUE(copy->artifact_info.file_descriptor_count == 0);
+    const int rc = verify_descriptor_invariant(copy->artifact_info);
+
+    rac_model_info_free(source);
+    rac_model_info_free(copy);
+    return rc;
+}
+
+// ---------------------------------------------------------------------------
+// An artifact with no manifest and no descriptors copies to the same empty
+// shape (and frees cleanly).
+// ---------------------------------------------------------------------------
+int test_copy_empty_artifact() {
+    rac_model_info_t* source = rac_model_info_alloc();
+    EXPECT_TRUE(source != nullptr);
+    source->id = rac_strdup("single-file");
+    source->artifact_info.kind = RAC_ARTIFACT_KIND_SINGLE_FILE;
+
+    rac_model_info_t* copy = rac_model_info_copy(source);
+    EXPECT_TRUE(copy != nullptr);
+    EXPECT_TRUE(copy->artifact_info.kind == RAC_ARTIFACT_KIND_SINGLE_FILE);
+    EXPECT_TRUE(copy->artifact_info.expected_files == nullptr);
+    EXPECT_TRUE(copy->artifact_info.file_descriptors == nullptr);
+    EXPECT_TRUE(copy->artifact_info.file_descriptor_count == 0);
+    EXPECT_TRUE(copy->artifact_info.strategy_id == nullptr);
+    const int rc = verify_descriptor_invariant(copy->artifact_info);
+
+    rac_model_info_free(source);
+    rac_model_info_free(copy);
+    return rc;
+}
+
+// ---------------------------------------------------------------------------
+// The registry's deep_copy_model() path (save + get) shares the same helper, so
+// a save/get round-trip must return the artifact block intact.
+// ---------------------------------------------------------------------------
+int test_registry_round_trip_preserves_artifact() {
+    rac_model_registry_handle_t registry = nullptr;
+    EXPECT_TRUE(rac_model_registry_create(&registry) == RAC_SUCCESS);
+    EXPECT_TRUE(registry != nullptr);
+
+    rac_model_info_t* source = build_multi_file_model();
+    EXPECT_TRUE(source != nullptr);
+    EXPECT_TRUE(rac_model_registry_save(registry, source) == RAC_SUCCESS);
+
+    // Free the source before reading back: the registry must hold its own copy.
+    rac_model_info_free(source);
+
+    rac_model_info_t* fetched = nullptr;
+    EXPECT_TRUE(rac_model_registry_get(registry, "test-multi-file", &fetched) == RAC_SUCCESS);
+    EXPECT_TRUE(fetched != nullptr);
+
+    int rc = verify_descriptor_invariant(fetched->artifact_info);
+    if (rc == 0) {
+        rc = verify_multi_file_artifact(fetched->artifact_info);
+    }
+
+    rac_model_info_free(fetched);
+    rac_model_registry_destroy(registry);
+    return rc;
+}
+
+}  // namespace
+
+int main(int /*argc*/, char** /*argv*/) {
+    int failures = 0;
+    failures += test_model_info_copy_preserves_artifact();
+    failures += test_model_info_copy_is_independent();
+    failures += test_copy_never_pairs_null_array_with_nonzero_count();
+    failures += test_copy_empty_artifact();
+    failures += test_registry_round_trip_preserves_artifact();
+
+    if (failures == 0) {
+        std::fprintf(stdout, "[PASS] test_model_artifact_copy\n");
+        return 0;
+    }
+    std::fprintf(stderr, "[FAIL] test_model_artifact_copy (%d failure(s))\n", failures);
+    return 1;
+}


### PR DESCRIPTION
## Summary

- deep-copy `expected_files` and every multi-file artifact descriptor in `rac_model_info_copy()`
- keep `file_descriptor_count` consistent with descriptor ownership
- normalize owned pointers before allocation so the copy never aliases the source

## Root cause

`rac_model_info_copy()` copied `artifact_info` as a struct, then cleared its descriptor pointer without clearing `file_descriptor_count`. Consumers iterate the array using that retained count, which could dereference a null pointer. A non-null descriptor pointer paired with a zero count could also remain aliased after the struct copy and be freed twice.

## Impact

Model assignment caching and other paths using `rac_model_info_copy()` now preserve multi-file artifact metadata with independent ownership. Because the fix is in shared C++ commons, it benefits all platform SDKs.

## Validation

- `git diff --check`
- reviewed allocation/free symmetry against `rac_expected_model_files_free()` and `rac_model_file_descriptors_free()`

C++ lint was not run because `clang-format` is unavailable in the local environment. The existing local CMake build directory was incomplete and could not be regenerated within the command window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model information copying to preserve artifact metadata, including file patterns, descriptions, and descriptors.
  * Ensured copied model details remain complete and consistent when metadata is missing or resources cannot be allocated.
  * Fixed model artifact copies so they remain independent from the original data.
  * Improved handling of empty or inconsistent artifact metadata during model save and retrieval.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->