### PR TITLE
fix(rn): tear down stream after callback failure

### DIFF
--- a/sdk/runanywhere-react-native/packages/core/src/Adapters/HandleStreamAdapter.ts
+++ b/sdk/runanywhere-react-native/packages/core/src/Adapters/HandleStreamAdapter.ts
@@ -125,6 +125,10 @@ class HandleFanOut<Event> {
         this.subscribers.delete(s);
       }
     }
+    if (this.subscribers.size === 0) {
+      this.tearDown();
+      return;
+    }
     // Deterministic teardown on terminal events (Swift
     // LLMStreamAdapter.swift:63 finishes on `event.isFinal` instead of
     // waiting for the native onDone).


### PR DESCRIPTION
## What changed

- Tear down the shared Nitro subscription when callback failures remove the final stream subscriber.
- Return immediately after teardown so terminal-event handling does not run against an empty subscriber set.

## Why

`HandleFanOut.broadcast()` removes a subscriber when its `onMessage` callback throws. When the last or only subscriber threw, the set became empty without passing through the normal detach path. As a result, the native unsubscribe callback was never invoked and the per-handle fan-out remained cached indefinitely.

## Impact

React Native stream consumers no longer leave a native Nitro subscription and stale per-handle registry entry behind when the final subscriber callback throws. Normal fan-out and terminal-event behavior are unchanged.

## Validation

- `git diff --cached --check`
- `corepack yarn install --immutable`
- `corepack yarn workspace @runanywhere/core typecheck`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream subscription cleanup when no subscribers remain, helping prevent unnecessary ongoing processing after message handling ends.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->