### PR TITLE
fix(python): stop the async stream dropping its terminal sentinel

### DIFF
--- a/sdk/runanywhere-python/runanywhere/_streaming.py
+++ b/sdk/runanywhere-python/runanywhere/_streaming.py
@@ -208,11 +208,28 @@ class _AsyncBridge(_Bridge):
             return
         fut.set_result(None)
 
+    def _enqueue_sentinel(self, sentinel: object) -> None:
+        """Run on the loop thread: push a terminal sentinel, rescheduling while the queue
+        is full so it is never dropped.
+
+        A bare ``put_nowait`` raises :class:`asyncio.QueueFull` inside the loop callback,
+        where it is swallowed by the exception handler and the consumer waits on ``get()``
+        forever. ``_enqueue`` already reschedules tokens for the same reason, and the sync
+        bridge gets this for free from its blocking ``put``. Stop means the consumer is
+        gone, so there is nobody left to hand the sentinel to.
+        """
+        if self._stop.is_set():
+            return
+        try:
+            self._q.put_nowait(sentinel)
+        except asyncio.QueueFull:
+            self._loop.call_soon(self._enqueue_sentinel, sentinel)
+
     def _on_done(self) -> None:
-        self._loop.call_soon_threadsafe(self._q.put_nowait, _DONE)
+        self._loop.call_soon_threadsafe(self._enqueue_sentinel, _DONE)
 
     def _on_error(self) -> None:
-        self._loop.call_soon_threadsafe(self._q.put_nowait, _ERROR)
+        self._loop.call_soon_threadsafe(self._enqueue_sentinel, _ERROR)
 
     async def get(self) -> object:
         return await self._q.get()

--- a/sdk/runanywhere-python/tests/test_streaming.py
+++ b/sdk/runanywhere-python/tests/test_streaming.py
@@ -8,7 +8,7 @@ from typing import Callable, List
 
 import pytest
 
-from runanywhere._streaming import aiter_tokens, iter_tokens
+from runanywhere._streaming import _DONE, _AsyncBridge, aiter_tokens, iter_tokens
 
 OnToken = Callable[[str], "bool | None"]
 
@@ -140,3 +140,29 @@ def test_aiter_tokens_reraises_worker_exception() -> None:
 
     with pytest.raises(RuntimeError, match="boom"):
         asyncio.run(run())
+
+
+def test_async_bridge_sentinel_survives_a_full_queue() -> None:
+    """The terminal sentinel must not be lost when the queue is saturated.
+
+    `_on_done` runs on the loop thread via `call_soon_threadsafe`. A bare `put_nowait`
+    there raises `QueueFull`, which the loop's exception handler swallows, so the
+    sentinel disappears and `aiter_tokens` waits on `get()` forever. `_enqueue` already
+    reschedules tokens for this reason and the sync bridge blocks in `put`, so the async
+    terminal path was the only one that could drop its message.
+    """
+
+    async def run() -> object:
+        loop = asyncio.get_running_loop()
+        bridge = _AsyncBridge(lambda cb: None, maxsize=1, loop=loop)
+        bridge._q.put_nowait("filler")  # saturate: maxsize is 1
+
+        bridge._on_done()  # schedules the sentinel while the queue is full
+        await asyncio.sleep(0)  # let that callback run and hit QueueFull
+
+        assert bridge._q.get_nowait() == "filler"  # drain, making room
+        for _ in range(10):  # give a rescheduled sentinel a chance to land
+            await asyncio.sleep(0)
+        return bridge._q.get_nowait()
+
+    assert asyncio.run(run()) is _DONE


### PR DESCRIPTION
## What

`_AsyncBridge` signals both completion and failure with a bare `put_nowait` posted to the loop thread:

```python
def _on_done(self) -> None:
    self._loop.call_soon_threadsafe(self._q.put_nowait, _DONE)

def _on_error(self) -> None:
    self._loop.call_soon_threadsafe(self._q.put_nowait, _ERROR)
```

The queue is bounded (`maxsize` defaults to 64). When it is saturated at that moment, `put_nowait` raises `asyncio.QueueFull` **inside the loop callback**, where the event loop's exception handler logs it and moves on. The sentinel is simply gone, and nothing else will post one.

`aiter_tokens` is then parked on `await bridge.get()` forever, so the caller's `async for` never ends and the worker thread is never joined.

## Why this is an oversight rather than a choice

Every sibling path in the same file already handles it:

- **Tokens, same class:** `_enqueue` catches `QueueFull` and reschedules itself until the consumer drains. That is the file's own backpressure mechanism, so the author knew the queue fills.
- **Sync bridge:** `_on_done` / `_on_error` use a blocking `self._q.put(...)`, which waits for space and cannot lose the sentinel.

The async terminal path was the only one that could drop its message. This routes both sentinels through the same reschedule, bailing out when `_stop` is set, since by then the consumer has gone and there is nobody to hand it to.

The trigger is ordinary: a consumer slower than the producer, which is the normal case for a local model feeding UI or I/O work per token.

## Testing

From `sdk/runanywhere-python` (Python 3.9, pytest 8.4.2):

- Full suite: **374 passed, 21 skipped**, plus one pre-existing failure, `test_package_import.py::test_version_string`, which raises `PackageNotFoundError: runanywhere` because the package is not pip-installed in my environment. It fails identically with my change stashed, so it is unrelated.
- Added one regression test, checked both ways. With the fix, 8 passed. With the source change reverted it fails, and the captured log shows the exact mechanism:

```
ERROR asyncio: Exception in callback Queue.put_nowait(<object ...>)
asyncio.queues.QueueFull
```

I first wrote this test at the `aiter_tokens` level and it passed without the fix, because a promptly draining consumer frees a slot before the sentinel lands. It only reproduces deterministically by saturating the queue and driving `_on_done` directly, so that is what the committed test does.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asynchronous streaming reliability when the queue is full.
  * Ensured completion and error signals are delivered without leaving consumers waiting indefinitely.
  * Prevented terminal signals from being sent after streaming has stopped.

* **Tests**
  * Added regression coverage for completion delivery under queue pressure.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->