### PR TITLE
feat(npu): add LFM2.5-2.6B (HNPU) for Hexagon v79

### DIFF
--- a/README.md
+++ b/README.md
@@ -550,6 +550,7 @@ Prebuilt bundles published on [Hugging Face](https://huggingface.co/runanywhere/
 |---|---|---|---|
 | Llama-3.2-1B | LLM | 1.2 B | [llama3_2_1b_HNPU](https://huggingface.co/runanywhere/llama3_2_1b_HNPU) |
 | LFM2.5-230M / 350M | LLM | 0.23 / 0.35 B | [lfm2_5_230m_HNPU](https://huggingface.co/runanywhere/lfm2_5_230m_HNPU) · [lfm2_5_350m_HNPU](https://huggingface.co/runanywhere/lfm2_5_350m_HNPU) |
+| LFM2.5-2.6B | LLM | 2.6 B | [lfm2_5_2_6b_HNPU](https://huggingface.co/runanywhere/lfm2_5_2_6b_HNPU) |
 | Qwen3.5-0.8B / 2B / 4B | LLM | 0.8-4 B | [qwen3_5_0_8b_HNPU](https://huggingface.co/runanywhere/qwen3_5_0_8b_HNPU) · [2b](https://huggingface.co/runanywhere/qwen3_5_2b_HNPU) · [4b](https://huggingface.co/runanywhere/qwen3_5_4b_HNPU) |
 | Bonsai 1-bit family | LLM | 1.7 / 4 / 8 / 27 B | 1-bit and ternary builds; Bonsai-27B runs on Hexagon v81 |
 | Gemma-4-E2B / E4B | LLM + VLM | ~2 / 4 B | [gemma4_e2b_HNPU](https://huggingface.co/runanywhere/gemma4_e2b_HNPU) · [gemma4_e4b_HNPU](https://huggingface.co/runanywhere/gemma4_e4b_HNPU) |

--- a/engines/qhexrt/qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/qhexrt_model_catalog.cpp
@@ -44,9 +44,9 @@ struct ModelPolicy {
     // Fail-closed gate: when true, register_for_arch_proto() skips the row until an
     // HF token is configured, which is what drives the per-SDK "bring your own HF
     // token" preflight UX. Most RunAnywhere-hosted QHexRT repos are PUBLIC and set this
-    // false; the gated ones (kitten_nano_0_8_varlen, lfm2_5_2_6b) set it true. The exact
-    // set is pinned by test_qhexrt_model_catalog's private_ids, so publishing a model to a
-    // private repo means flipping this row AND that set — nothing else changes.
+    // false; only kitten_nano_0_8_varlen is gated today. The exact set is pinned by
+    // test_qhexrt_model_catalog's private_ids, so hosting a model behind a gated HF repo
+    // means flipping this row AND that set — nothing else changes.
     bool requires_hf_auth;
 };
 
@@ -56,10 +56,8 @@ struct ModelPolicy {
 constexpr ModelPolicy kModelPolicies[] = {
     {"lfm2_5_230m", kAllSupportedArches, false},
     {"lfm2_5_350m", kAllSupportedArches, false},
-    // Only v79 context binaries are published, and the repo is PRIVATE, so requires_hf_auth is set
-    // (as it is for kitten_nano_0_8_varlen): registration is skipped until a token is configured,
-    // driving the bring-your-own-token preflight instead of failing at download.
-    {"lfm2_5_2_6b", kV79, true},
+    // Only v79 context binaries are published for this one; the repo is public, so no HF auth gate.
+    {"lfm2_5_2_6b", kV79, false},
     {"qwen3_5_0_8b", kAllSupportedArches, false},
     {"qwen3_5_2b", kAllSupportedArches, false},
     {"qwen3_5_4b", kV79V81, false},

--- a/engines/qhexrt/qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/qhexrt_model_catalog.cpp
@@ -43,12 +43,10 @@ struct ModelPolicy {
     uint8_t arch_mask;
     // Fail-closed gate: when true, register_for_arch_proto() skips the row until an
     // HF token is configured, which is what drives the per-SDK "bring your own HF
-    // token" preflight UX. Every RunAnywhere-hosted QHexRT repo referenced below is
-    // currently PUBLIC, so all rows set this false. The field, its accessor
-    // (rac_qhexrt_catalog_model_requires_hf_auth), the gate at line ~345, and the
-    // downstream token-prompt UI are deliberately RETAINED for future gated models:
-    // flip a single row to true if/when a model is re-hosted behind a gated HF repo
-    // and the token preflight fires again with no other code change.
+    // token" preflight UX. Most RunAnywhere-hosted QHexRT repos are PUBLIC and set this
+    // false; the gated ones (kitten_nano_0_8_varlen, lfm2_5_2_6b) set it true. The exact
+    // set is pinned by test_qhexrt_model_catalog's private_ids, so publishing a model to a
+    // private repo means flipping this row AND that set — nothing else changes.
     bool requires_hf_auth;
 };
 
@@ -58,9 +56,9 @@ struct ModelPolicy {
 constexpr ModelPolicy kModelPolicies[] = {
     {"lfm2_5_230m", kAllSupportedArches, false},
     {"lfm2_5_350m", kAllSupportedArches, false},
-    // Only v79 context binaries are published, and the repo is PRIVATE — the first row to set
-    // requires_hf_auth, which is exactly what that gate exists for: registration is skipped until a
-    // token is configured, driving the bring-your-own-token preflight instead of failing at download.
+    // Only v79 context binaries are published, and the repo is PRIVATE, so requires_hf_auth is set
+    // (as it is for kitten_nano_0_8_varlen): registration is skipped until a token is configured,
+    // driving the bring-your-own-token preflight instead of failing at download.
     {"lfm2_5_2_6b", kV79, true},
     {"qwen3_5_0_8b", kAllSupportedArches, false},
     {"qwen3_5_2b", kAllSupportedArches, false},

--- a/engines/qhexrt/qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/qhexrt_model_catalog.cpp
@@ -58,6 +58,10 @@ struct ModelPolicy {
 constexpr ModelPolicy kModelPolicies[] = {
     {"lfm2_5_230m", kAllSupportedArches, false},
     {"lfm2_5_350m", kAllSupportedArches, false},
+    // Only v79 context binaries are published, and the repo is PRIVATE — the first row to set
+    // requires_hf_auth, which is exactly what that gate exists for: registration is skipped until a
+    // token is configured, driving the bring-your-own-token preflight instead of failing at download.
+    {"lfm2_5_2_6b", kV79, true},
     {"qwen3_5_0_8b", kAllSupportedArches, false},
     {"qwen3_5_2b", kAllSupportedArches, false},
     {"qwen3_5_4b", kV79V81, false},

--- a/engines/qhexrt/tests/test_qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/tests/test_qhexrt_model_catalog.cpp
@@ -80,6 +80,7 @@ int test_native_catalog_owns_arch_and_auth_policy() {
         "whisper_base",   "whisper_small", "moonshine_base",
         "moonshine_tiny", "melotts_en",    "embeddinggemma_300m",
         "siglip2_base",   "lama_dilated",
+        "lfm2_5_2_6b",
     };
     const std::unordered_set<std::string> v81 = {
         "qwen3_0_6b",

--- a/engines/qhexrt/tests/test_qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/tests/test_qhexrt_model_catalog.cpp
@@ -159,8 +159,9 @@ int test_native_catalog_owns_arch_and_auth_policy() {
                   v81.count(id) == 0 ? RAC_FALSE : RAC_TRUE);
     }
 
-    const std::unordered_set<std::string> private_ids = {"kitten_nano_0_8_varlen"};
-    ASSERT_EQ(private_ids.size(), static_cast<size_t>(1));
+    const std::unordered_set<std::string> private_ids = {"kitten_nano_0_8_varlen",
+                                                        "lfm2_5_2_6b"};
+    ASSERT_EQ(private_ids.size(), static_cast<size_t>(2));
     for (const std::string& id : all) {
         ASSERT_EQ(rac_qhexrt_catalog_model_requires_hf_auth(id.c_str()),
                   private_ids.count(id) == 0 ? RAC_FALSE : RAC_TRUE);

--- a/engines/qhexrt/tests/test_qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/tests/test_qhexrt_model_catalog.cpp
@@ -159,9 +159,8 @@ int test_native_catalog_owns_arch_and_auth_policy() {
                   v81.count(id) == 0 ? RAC_FALSE : RAC_TRUE);
     }
 
-    const std::unordered_set<std::string> private_ids = {"kitten_nano_0_8_varlen",
-                                                        "lfm2_5_2_6b"};
-    ASSERT_EQ(private_ids.size(), static_cast<size_t>(2));
+    const std::unordered_set<std::string> private_ids = {"kitten_nano_0_8_varlen"};
+    ASSERT_EQ(private_ids.size(), static_cast<size_t>(1));
     for (const std::string& id : all) {
         ASSERT_EQ(rac_qhexrt_catalog_model_requires_hf_auth(id.c_str()),
                   private_ids.count(id) == 0 ? RAC_FALSE : RAC_TRUE);

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -42,6 +42,11 @@ internal object ModelCatalog {
     val npuCatalog: List<SingleFileModel> = listOf(
         SingleFileModel("lfm2_5_230m", "LFM2.5 230M (HNPU)", "https://huggingface.co/runanywhere/lfm2_5_230m_HNPU/lfm2-5-230m.json", QHEXRT, LANGUAGE, 538_771_163L, contextLength = 512),
         SingleFileModel("lfm2_5_350m", "LFM2.5 350M (HNPU)", "https://huggingface.co/runanywhere/lfm2_5_350m_HNPU/lfm2-5-350m-2048.json", QHEXRT, LANGUAGE, 1_441_493_515L, contextLength = 2_048),
+        // contextLength MUST be 512: LFM2.5-2.6B has 32 query heads, and GQA-native attention is
+        // HTP-correct only at <=16, so the bundle ships materialized MHA capped at 512.
+        // supportsThinking: its chat template opens <think> unconditionally (no enable_thinking flag),
+        // so the manifest carries a no_think_prefill the runtime swaps in when thinking is turned off.
+        SingleFileModel("lfm2_5_2_6b", "LFM2.5 2.6B (HNPU)", "https://huggingface.co/runanywhere/lfm2_5_2_6b_HNPU/lfm2-5-2.6b.json", QHEXRT, LANGUAGE, 3_259_942_826L, contextLength = 512, supportsThinking = true),
         SingleFileModel("qwen3_5_0_8b", "Qwen3.5 0.8B (HNPU)", "https://huggingface.co/runanywhere/qwen3_5_0_8b_HNPU/qwen3.5-0.8b-1024.json", QHEXRT, LANGUAGE, 2_046_527_510L, contextLength = 1_024, supportsThinking = true),
         SingleFileModel("qwen3_5_2b", "Qwen3.5 2B (HNPU)", "https://huggingface.co/runanywhere/qwen3_5_2b_HNPU/qwen3.5-2b-1024.json", QHEXRT, LANGUAGE, 4_817_344_861L, contextLength = 1_024),
         SingleFileModel("qwen3_5_4b", "Qwen3.5 4B (HNPU)", "https://huggingface.co/runanywhere/qwen3_5_4b_HNPU/qwen3.5-4b-1024.json", QHEXRT, LANGUAGE, 6_177_585_629L, contextLength = 1_024),

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatRequestPolicy.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatRequestPolicy.kt
@@ -32,6 +32,9 @@ internal object ChatRequestPolicy {
      * ESTIMATED and deliberately over-counted (≈3 chars/token + per-message role markers) plus a context
      * margin — better to trim a turn early than to overflow and crash. Large-context models (Qwen3.5 =
      * 1024) keep their full history for normal conversations; only long chats on tiny models get trimmed.
+     *
+     * Kept turns are a CONTIGUOUS chronological block. Trailing turns that cannot fit are skipped rather
+     * than aborting the scan, so one oversized reply costs you that reply, not the entire conversation.
      */
     fun windowHistory(
         turn: ChatTurnSnapshot,
@@ -51,7 +54,17 @@ internal object ChatRequestPolicy {
         val kept = ArrayDeque<ProtoChatMessage>()
         for (message in turn.history.asReversed()) { // keep the most RECENT turns that fit
             val cost = est(message.content)
-            if (cost > available) break
+            if (cost > available) {
+                // A single oversized message must not erase the whole history. A plain `break` here made
+                // trimming ALL-OR-NOTHING: one long assistant reply (a reasoning model easily emits 150-250
+                // tokens) exceeds the entire history budget on a 512-token model, so every older turn was
+                // discarded too — including the SHORT user turn that carried the facts, which would have fit
+                // with room to spare. The model then answers "I don't have information about your name"
+                // immediately after being told it. Skip trailing messages that cannot fit; once something
+                // HAS been kept, stop, so the result stays a contiguous chronological block.
+                if (kept.isEmpty()) continue
+                break
+            }
             available -= cost
             kept.addFirst(message)
         }

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatToolResultNormalizer.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatToolResultNormalizer.kt
@@ -29,6 +29,13 @@ internal object ChatToolResultNormalizer {
     // The full-word alternation keeps the prior behavior of trimming an unclosed
     // `<think ...` that carries attributes. A lone trailing `<` stays untouched so
     // a legitimate less-than at the end of an answer is preserved.
+    // LFM2 `<|tool_call_start|>…<|tool_call_end|>` and the DEFAULT `<tool_call>…</tool_call>` form.
+    private val strayToolCall = Regex(
+        """<\|tool_call_start\|>(.*?)<\|tool_call_end\|>|<tool_call>(.*?)</tool_call>""",
+        RegexOption.DOT_MATCHES_ALL,
+    )
+    private val firstStringLiteral = Regex("\"([^\"]+)\"")
+
     private val incompleteThinkingTag = Regex(
         pattern = "<\\s*/?\\s*(?:(?:think|thinking)\\b[^>]*|t(?:h(?:i(?:n(?:k(?:i(?:n(?:g)?)?)?)?)?)?)?)$",
         options = setOf(RegexOption.IGNORE_CASE, RegexOption.DOT_MATCHES_ALL),
@@ -55,6 +62,30 @@ internal object ChatToolResultNormalizer {
             text = visibleOnly(text).ifBlank { "The model did not produce a visible answer." },
             thinking = thinking,
         )
+    }
+
+    /**
+     * Strip stray tool-call markup from a reply produced on the STANDARD (no-tools) route.
+     *
+     * Tool-trained models emit their call syntax unprompted even when no tools are registered — LFM2.5
+     * answers a plain "Hi my name is Aman" with
+     * `<|tool_call_start|>[ask_user("What would you like to do today, Aman?")]<|tool_call_end|>`.
+     * Commons parses that into LLMStreamEvent.tool_call regardless of whether tools were requested, but the
+     * raw text still carries the markers, so on the standard route the user sees the literal tags.
+     *
+     * The call's first string literal is the model's intended user-facing sentence (that is the whole point
+     * of an ask_user-style call), so surface it when the block is all there is; otherwise just remove the
+     * block and keep the surrounding prose.
+     */
+    fun stripStrayToolCall(raw: String): String {
+        if (raw.isBlank() || !strayToolCall.containsMatchIn(raw)) return raw
+        var salvaged: String? = null
+        val withoutCalls = strayToolCall.replace(raw) { match ->
+            if (salvaged == null) salvaged = firstStringLiteral.find(match.groupValues[1])?.groupValues?.get(1)
+            ""
+        }
+        val remaining = withoutCalls.trim()
+        return if (remaining.isNotEmpty()) remaining else salvaged?.trim().orEmpty()
     }
 
     internal fun splitThinking(raw: String): ThinkingSplit {

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatViewModel.kt
@@ -760,7 +760,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
             ?: if (totalMs > 0 && result.tokens_generated > 0) result.tokens_generated * 1000.0 / totalMs else 0.0
         updateReply(request, index) { reply ->
             reply.copy(
-                text = result.text,
+                text = ChatToolResultNormalizer.stripStrayToolCall(result.text),
                 thinking = result.thinking_content?.takeIf { it.isNotBlank() },
                 // Mirrors iOS buildMessageAnalytics: prefer the result's TTFT and
                 // fall back to the value recorded from the SDK's first-token event;
@@ -799,7 +799,11 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
                     updateReply(request, index) { it.copy(thinking = accumulated) }
                 },
                 onToken = { accumulated ->
-                    updateReply(request, index) { it.copy(text = accumulated) }
+                    // Tool-trained models emit call syntax unprompted even with no tools registered; on the
+                    // standard route those markers are noise, so never let them reach the bubble.
+                    updateReply(request, index) {
+                        it.copy(text = ChatToolResultNormalizer.stripStrayToolCall(accumulated))
+                    }
                 },
             )
 
@@ -819,7 +823,7 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
             ?: if (totalMs > 0 && tokens > 0) tokens * 1000.0 / totalMs else 0.0
         updateReply(request, index) { reply ->
             reply.copy(
-                text = result.text,
+                text = ChatToolResultNormalizer.stripStrayToolCall(result.text),
                 thinking = result.thinking_content?.takeIf { it.isNotBlank() },
                 stats = GenerationStats(
                     tokens = tokens,

--- a/examples/android/RunAnywhereAI/app/src/test/java/com/runanywhere/runanywhereai/ModelCatalogTest.kt
+++ b/examples/android/RunAnywhereAI/app/src/test/java/com/runanywhere/runanywhereai/ModelCatalogTest.kt
@@ -154,6 +154,7 @@ class ModelCatalogTest {
 
         assertEquals(512, byId.getValue("lfm2_5_230m").contextLength)
         assertEquals(2_048, byId.getValue("lfm2_5_350m").contextLength)
+        assertEquals(512, byId.getValue("lfm2_5_2_6b").contextLength)
         assertEquals(1_024, byId.getValue("qwen3_5_0_8b").contextLength)
         assertEquals(1_024, byId.getValue("qwen3_5_2b").contextLength)
         assertEquals(1_024, byId.getValue("qwen3_5_4b").contextLength)

--- a/examples/android/RunAnywhereAI/app/src/test/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatRequestPolicyTest.kt
+++ b/examples/android/RunAnywhereAI/app/src/test/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatRequestPolicyTest.kt
@@ -117,6 +117,32 @@ class ChatRequestPolicyTest {
     }
 
     @Test
+    fun `stray tool-call markup never reaches the chat bubble on the standard route`() {
+        // Verbatim from an LFM2.5-2.6B reply to a plain greeting, with no tools registered.
+        val raw = """<|tool_call_start|>[ask_user("What would you like to do today, Aman? """ +
+            """I'm here to help with any questions or tasks you have.")]<|tool_call_end|>"""
+
+        val visible = ChatToolResultNormalizer.stripStrayToolCall(raw)
+
+        assertFalse("tool markers must not survive", visible.contains("tool_call_start"))
+        assertFalse("tool markers must not survive", visible.contains("tool_call_end"))
+        // The call's string literal is the model's intended sentence — surface it rather than a blank bubble.
+        assertEquals(
+            "What would you like to do today, Aman? I'm here to help with any questions or tasks you have.",
+            visible,
+        )
+    }
+
+    @Test
+    fun `stray tool-call stripping keeps surrounding prose and leaves clean replies untouched`() {
+        val mixed = "Sure, here you go.<|tool_call_start|>[noop()]<|tool_call_end|>"
+        assertEquals("Sure, here you go.", ChatToolResultNormalizer.stripStrayToolCall(mixed))
+
+        val clean = "Your name is Aman. I have that from our conversation."
+        assertEquals(clean, ChatToolResultNormalizer.stripStrayToolCall(clean))
+    }
+
+    @Test
     fun `windowHistory keeps a short user turn even when the newest reply is too big to fit`() {
         // The LFM2.5-2.6B (512 ctx) failure: a reasoning model's reply alone exceeds the whole history
         // budget, so the old `break` discarded the short user turn behind it and the model answered

--- a/examples/android/RunAnywhereAI/app/src/test/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatRequestPolicyTest.kt
+++ b/examples/android/RunAnywhereAI/app/src/test/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatRequestPolicyTest.kt
@@ -117,6 +117,25 @@ class ChatRequestPolicyTest {
     }
 
     @Test
+    fun `windowHistory keeps a short user turn even when the newest reply is too big to fit`() {
+        // The LFM2.5-2.6B (512 ctx) failure: a reasoning model's reply alone exceeds the whole history
+        // budget, so the old `break` discarded the short user turn behind it and the model answered
+        // "I don't have information about your name" one turn after being told it.
+        val fact = ChatMessage("My name is Aman and I love pizza", isUser = true)
+        val hugeReply = ChatMessage("word ".repeat(200), isUser = false) // ~1000 chars, far over budget
+        val turn = ChatRequestPolicy.snapshot("what is my name and which food do i love?", listOf(fact, hugeReply))
+
+        val windowed = ChatRequestPolicy.windowHistory(
+            turn, contextTokens = 512, outputTokens = 256, systemPrompt = "You are a helpful assistant.",
+        )
+
+        // history is the proto shape, so compare on role+content: the fact survives, only the reply is dropped.
+        assertEquals(1, windowed.history.size)
+        assertEquals("My name is Aman and I love pizza", windowed.history.single().content)
+        assertEquals(MessageRole.MESSAGE_ROLE_USER, windowed.history.single().role)
+    }
+
+    @Test
     fun `windowHistory drops all history when the current prompt alone fills the context`() {
         val hugePrompt = "word ".repeat(400) // ~2000 chars -> far exceeds a 512-token window on its own
         val turn = ChatRequestPolicy.snapshot(

--- a/examples/flutter/RunAnywhereAI/lib/core/services/qhexrt_model_catalog.dart
+++ b/examples/flutter/RunAnywhereAI/lib/core/services/qhexrt_model_catalog.dart
@@ -116,6 +116,16 @@ abstract final class QHexRTModelCatalog {
       contextLength: 2048,
     ),
     QHexRTCatalogModel(
+      id: 'lfm2_5_2_6b',
+      name: 'LFM2.5 2.6B (HNPU)',
+      url:
+          'https://huggingface.co/runanywhere/lfm2_5_2_6b_HNPU/lfm2-5-2.6b.json',
+      category: _language,
+      memoryBytes: 3259942826,
+      contextLength: 512,
+      supportsThinking: true,
+    ),
+    QHexRTCatalogModel(
       id: 'qwen3_5_0_8b',
       name: 'Qwen3.5 0.8B (HNPU)',
       url:

--- a/examples/flutter/RunAnywhereAI/test/qhexrt_model_catalog_test.dart
+++ b/examples/flutter/RunAnywhereAI/test/qhexrt_model_catalog_test.dart
@@ -10,11 +10,11 @@ import 'package:runanywhere_ai/features/models/model_types.dart'
 void main() {
   tearDown(QHexRTModelCatalog.resetForTesting);
 
-  test('Flutter QHexRT catalog exactly matches the 52 Android rows', () {
+  test('Flutter QHexRT catalog exactly matches the 53 Android rows', () {
     final kotlinRows = _parseKotlinCatalog();
     const flutterRows = QHexRTModelCatalog.models;
 
-    expect(flutterRows, hasLength(52));
+    expect(flutterRows, hasLength(53));
     expect(
       flutterRows.map((model) => model.id).toList(),
       kotlinRows.map((model) => model.id).toList(),
@@ -99,9 +99,9 @@ void main() {
 
       expect(result.registered, 1);
       expect(result.failed, 0);
-      expect(result.skippedNative, 51);
+      expect(result.skippedNative, 52);
       expect(result.registeredModelIds, {'qwen3_5_0_8b_v81'});
-      expect(seenIds, hasLength(52));
+      expect(seenIds, hasLength(53));
       expect(seenIds, contains('kokoro_en'));
 
       final cpu = ModelInfo(
@@ -149,7 +149,7 @@ void main() {
 
     expect(registrarCalled, isFalse);
     expect(result.registeredModelIds, isEmpty);
-    expect(result.skippedNative, 52);
+    expect(result.skippedNative, 53);
     expect(QHexRTModelCatalog.registeredModelIds, isEmpty);
     expect(QHexRTModelCatalog.snapshots.value.revision, 2);
   });

--- a/examples/react-native/RunAnywhereAI/src/services/NpuModelCatalog.ts
+++ b/examples/react-native/RunAnywhereAI/src/services/NpuModelCatalog.ts
@@ -41,6 +41,15 @@ export const NPU_BUNDLES: readonly NpuBundle[] = [
     contextLength: 2_048,
   },
   {
+    id: 'lfm2_5_2_6b',
+    name: 'LFM2.5 2.6B (HNPU)',
+    url: 'https://huggingface.co/runanywhere/lfm2_5_2_6b_HNPU/lfm2-5-2.6b.json',
+    modality: ModelCategory.MODEL_CATEGORY_LANGUAGE,
+    estimatedSizeBytes: 3_259_942_826,
+    contextLength: 512,
+    supportsThinking: true,
+  },
+  {
     id: 'qwen3_5_0_8b',
     name: 'Qwen3.5 0.8B (HNPU)',
     url: 'https://huggingface.co/runanywhere/qwen3_5_0_8b_HNPU/qwen3.5-0.8b-1024.json',

--- a/examples/react-native/RunAnywhereAI/tests/unit/NpuModelCatalog.test.ts
+++ b/examples/react-native/RunAnywhereAI/tests/unit/NpuModelCatalog.test.ts
@@ -15,11 +15,11 @@ import {
 } from '../../src/services/NpuModelCatalog';
 
 describe('React Native QHexRT catalog', () => {
-  it('keeps 48 unique app-owned URL and presentation rows', () => {
-    expect(NPU_BUNDLES).toHaveLength(48);
+  it('keeps 49 unique app-owned URL and presentation rows', () => {
+    expect(NPU_BUNDLES).toHaveLength(49);
     expect(new Set(NPU_BUNDLES.map((bundle) => bundle.id))).toHaveProperty(
       'size',
-      48
+      49
     );
     expect(
       NPU_BUNDLES.every((bundle) => bundle.url.startsWith('https://'))
@@ -36,6 +36,7 @@ describe('React Native QHexRT catalog', () => {
     ).toEqual({
       lfm2_5_230m: 512,
       lfm2_5_350m: 2_048,
+      lfm2_5_2_6b: 512,
       qwen3_5_0_8b: 1_024,
       qwen3_5_2b: 1_024,
       qwen3_5_4b: 1_024,
@@ -50,6 +51,7 @@ describe('React Native QHexRT catalog', () => {
         (bundle) => bundle.id
       )
     ).toEqual([
+      'lfm2_5_2_6b',
       'qwen3_5_0_8b',
       'deepseek_r1_distill_qwen_1_5b',
       'deepseek_r1_distill_qwen_7b',


### PR DESCRIPTION
Adds **LFM2.5-2.6B** (LiquidAI, 2.6B hybrid conv+attention) to the QHexRT NPU catalog for **Hexagon v79**, plus two chat fixes this model exposed.

Bundle: [`runanywhere/lfm2_5_2_6b_HNPU`](https://huggingface.co/runanywhere/lfm2_5_2_6b_HNPU) — public, `v79/`, 3,259,944,912 B.

> ⚠️ **Cross-repo dependency.** The LLM device gate refuses to run without the acceptance suite
> `QHexRT/device_suites/suites/lfm2_5_2_6b_v79.json`, which lives in the private QHexRT repo and is mirrored
> into `androidTest/assets` by `sync_android_assets.sh`. That companion change is not in this PR.

> ⚠️ **Two commits here are NOT specific to this model** and could reasonably be split out — see
> "App fixes" below. Both change behaviour for every model.

## 1. Model integration (the titled change)

| area | change |
|---|---|
| native catalog | `{"lfm2_5_2_6b", kV79, false}` — v79-only (only v79 binaries are published), public repo so no auth gate |
| native test | id added to the v79 arch set |
| Android | catalog row + `contextLength` assertion |
| Flutter | catalog row + parity-test counts |
| React Native | catalog row + count / `contextLength` / `supportsThinking` assertions |
| README | NPU bundle table row |

Two row values are model-specific and deliberate:
- **`contextLength = 512`** — 32 query heads make GQA-native attention HTP-incorrect above 16, so the bundle
  ships materialized MHA capped at 512.
- **`supportsThinking = true`** — LFM2.5's chat template opens `<think>` unconditionally (no
  `enable_thinking` toggle).

### Validated on device (S25 / SM8750 / v79, QAIRT 2.48)

Real `registerModel → downloadModel → loadModel → generate` path via `NpuModelE2ETest`. **All nine gates pass:**

```
status=SMOKE_PASS  framework=INFERENCE_FRAMEWORK_QHEXRT  soc_model=SM8750
download_s=143   load_ms=1707   decode_toks=12.54   ttft_ms=1198   peak_rss_mb=2959
npu_supported ✓ arch_match ✓ repeated_load_stability ✓ framework_qhexrt ✓
canonical_suite ✓ llm_min_inputs ✓ llm_answer_suite ✓ llm_min_decode_toks ✓ delete_model ✓
```

6/6 suite cases correct at ~12.5 tok/s. Confirmed in the app UI too: appears under Liquid AI as
`LFM2.5 2.6B · 3.04 GB · NPU · Thinks`, downloads and answers, with no HF token configured.

**Scope caveat:** SMOKE bar, not ACCEPTANCE — the harness reports `acceptance_eligible=false`
("SDK HF registration resolves mutable remote state; no exact-hash local bundle was verified").

## 2. App fixes (general — not LFM-specific)

**`windowHistory` was all-or-nothing.** It iterated newest→oldest and `break`'d on the first message that
did not fit, so a single long assistant reply discarded the *entire* history — including the short user turn
behind it. On a 512-context model the history budget is ~118 tokens while one reasoning reply is 141–233, so
the model answered "I don't have information about your name" one turn after being told it. Trailing
oversized messages are now skipped rather than aborting the scan; once something has been kept the loop still
stops, so the result stays a contiguous chronological block (the existing suffix-contract test is unchanged
and still passes). Affects every small-context model, e.g. `llama3_2_1b` at 512.

**Stray tool-call markup reached the chat bubble.** Tool-trained models emit their call syntax unprompted
even with zero tools registered — LFM2.5 answers a plain greeting with
`<|tool_call_start|>[ask_user("…")]<|tool_call_end|>` (`ask_user` is not a registered tool; `preflight`
confirms the route was `STANDARD_GENERATION`). Commons parses that into `LLMStreamEvent.tool_call` regardless
of whether tools were requested, but the visible text keeps the markers. `stripStrayToolCall` now removes
them on the local generation paths (hosted untouched).
**Judgement call worth review:** when the block is the *entire* reply, stripping it outright leaves a blank
bubble, so the call's first string literal is surfaced instead — for an `ask_user`-style call that is exactly
the sentence the model meant for the user. Mixed replies keep surrounding prose; clean replies are untouched.
Arguably the deeper fix belongs in commons (it should not hand back text containing markup it just parsed).

3 new unit tests; `:app:testDebugUnitTest` green (ChatRequestPolicyTest 11 tests, 0 failures).

## Drive-by

`ModelPolicy`'s doc comment claimed every row sets `requires_hf_auth = false`; `kitten_nano_0_8_varlen` has
been `true` for a while. Corrected.

## Pre-existing issue found, NOT fixed here

`examples/flutter/.../test/qhexrt_model_catalog_test.dart` parses the Kotlin catalog and asserts both equal
length and equal id order, but on `main` the parser yields **59** Kotlin rows against Flutter's **52** — it
cannot pass as written. Seven rows exist in Kotlin and not Flutter: `nemotron_3_embed_1b`,
`cosmos3_edge_{text,vlm,diffusion}`, `parakeet_ctc_1_1b`, `canary_180m_flash`, `magpie_tts_357m`. This PR
preserves the delta (52→53, 59→60) rather than papering over it — those seven span diffusion/TTS/ASR and
adding them blind risks shipping catalog entries whose Flutter support is unverified. Worth a separate fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added the LFM2.5 2.6B language model for compatible Hexagon NPU devices across Android, Flutter, and React Native.
  * Added support for its 512-token context limit and thinking capabilities.

* **Bug Fixes**
  * Removed stray tool-call markup from visible chat responses.
  * Improved history handling when recent messages exceed the available context window.

* **Tests**
  * Added coverage for the new model and chat response and history-handling behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->