### PR TITLE
fix(commons): report a failed local_path copy from get_model_metrics

### DIFF
--- a/sdk/runanywhere-commons/include/rac/infrastructure/storage/rac_storage_analyzer.h
+++ b/sdk/runanywhere-commons/include/rac/infrastructure/storage/rac_storage_analyzer.h
@@ -268,7 +268,10 @@ RAC_API rac_result_t rac_storage_analyzer_analyze(rac_storage_analyzer_handle_t 
  * @param model_id Model identifier
  * @param framework Inference framework
  * @param out_metrics Output: Model metrics
- * @return RAC_SUCCESS or RAC_ERROR_NOT_FOUND
+ * @return RAC_SUCCESS, RAC_ERROR_INVALID_ARGUMENT on a null argument,
+ *         RAC_ERROR_NOT_FOUND if the model is not in the registry, or
+ *         RAC_ERROR_OUT_OF_MEMORY if a string copy into out_metrics fails
+ *         (out_metrics is left zeroed in that case)
  */
 RAC_API rac_result_t rac_storage_analyzer_get_model_metrics(
     rac_storage_analyzer_handle_t handle, rac_model_registry_handle_t registry_handle,

--- a/sdk/runanywhere-commons/src/infrastructure/storage/storage_analyzer.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/storage/storage_analyzer.cpp
@@ -669,6 +669,16 @@ rac_result_t rac_storage_analyzer_analyze(rac_storage_analyzer_handle_t handle,
                 metrics->local_path = strdup(path_buffer);
             }
         }
+        // Same contract the id/name copies above enforce: a failed duplication drops
+        // the row instead of publishing it with a null field. `path_to_use` is
+        // non-null exactly when a duplication was attempted, so this only fires on
+        // an allocation failure and never on the legitimate no-path case.
+        if (path_to_use && !metrics->local_path) {
+            free(const_cast<char*>(metrics->model_id));
+            free(const_cast<char*>(metrics->model_name));
+            memset(metrics, 0, sizeof(rac_model_storage_metrics_t));
+            continue;
+        }
 
         // Calculate size via callback
         if (path_to_use) {

--- a/sdk/runanywhere-commons/src/infrastructure/storage/storage_analyzer.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/storage/storage_analyzer.cpp
@@ -737,6 +737,17 @@ rac_result_t rac_storage_analyzer_get_model_metrics(rac_storage_analyzer_handle_
             out_metrics->local_path = strdup(path_buffer);
         }
     }
+    // Same contract the id/name copies above enforce: a failed duplication is
+    // reported, not silently returned as success with a null field. `path_to_use`
+    // is non-null exactly when a duplication was attempted, so this only fires on
+    // an allocation failure and never on the legitimate no-path case.
+    if (path_to_use && !out_metrics->local_path) {
+        free(const_cast<char*>(out_metrics->model_id));
+        free(const_cast<char*>(out_metrics->model_name));
+        memset(out_metrics, 0, sizeof(rac_model_storage_metrics_t));
+        rac_model_info_free(model);
+        return RAC_ERROR_OUT_OF_MEMORY;
+    }
 
     // Calculate size
     if (path_to_use) {

--- a/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_storage_analyzer.h
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/CRACommons/include/rac_storage_analyzer.h
@@ -243,7 +243,10 @@ RAC_API rac_result_t rac_storage_analyzer_analyze(rac_storage_analyzer_handle_t 
  * @param model_id Model identifier
  * @param framework Inference framework
  * @param out_metrics Output: Model metrics
- * @return RAC_SUCCESS or RAC_ERROR_NOT_FOUND
+ * @return RAC_SUCCESS, RAC_ERROR_INVALID_ARGUMENT on a null argument,
+ *         RAC_ERROR_NOT_FOUND if the model is not in the registry, or
+ *         RAC_ERROR_OUT_OF_MEMORY if a string copy into out_metrics fails
+ *         (out_metrics is left zeroed in that case)
  */
 RAC_API rac_result_t rac_storage_analyzer_get_model_metrics(
     rac_storage_analyzer_handle_t handle, rac_model_registry_handle_t registry_handle,


### PR DESCRIPTION
## What

`rac_storage_analyzer_get_model_metrics` duplicates three strings into the out struct. Two of them are checked:

```c
out_metrics->model_id = model->id ? strdup(model->id) : nullptr;
out_metrics->model_name = model->name ? strdup(model->name) : nullptr;
if ((model->id && !out_metrics->model_id) || (model->name && !out_metrics->model_name)) {
    free(...); memset(...); rac_model_info_free(model);
    return RAC_ERROR_OUT_OF_MEMORY;
}
```

The third is not, at either of its two sites:

```c
out_metrics->local_path = strdup(model->local_path);
...
out_metrics->local_path = strdup(path_buffer);
```

So a failed duplication left the function returning `RAC_SUCCESS` with `local_path` null.

## Why it matters

`local_path` being null is also the legitimate shape of a genuine success, for a model with no resolvable path on disk. A caller therefore cannot tell the two apart: it sees success either way, and the only signal that a copy failed is the absent field it is about to read.

This applies the contract the function already sets for the other two fields. The guard keys off `path_to_use`, which is non-null exactly when a duplication was attempted, so it fires only on an allocation failure and never on the no-path case. The cleanup mirrors the existing block above it.

Scope note, to be straight about it: this is an error-path correctness fix rather than something users hit in normal operation, since `strdup` failure means the process is already out of memory. I am raising it because the function itself already treats that case as worth reporting for `model_id` and `model_name`, and the asymmetry looks like an oversight rather than a decision.

## Testing

Configured with the `macos-debug` preset and built with Ninja:

- `test_storage_analyzer_proto` — 0 test(s) failed
- `test_storage_service_proto_abi` — 18 checks, 0 failures
- `test_core --run-all` — 18 passed, 0 failed

No new test: exercising it needs an allocator failure injected between two `strdup` calls inside one function, which the existing analyzer fixtures have no hook for. Happy to add one if you would like the path covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of storage analysis failures when model path information cannot be duplicated.
  * Prevented incomplete model metrics from being returned after an allocation failure.
  * Added clearer out-of-memory error reporting for this scenario.
  * Ensured output metrics remain cleared when retrieving model information fails.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
