### PR TITLE
fix(flutter): propagate tool-calling cancellation failures

### DIFF
--- a/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_tool_calling.dart
+++ b/sdk/runanywhere-flutter/packages/runanywhere/lib/native/dart_bridge_tool_calling.dart
@@ -18,6 +18,7 @@ import 'package:fixnum/fixnum.dart' show Int64;
 
 import 'package:runanywhere/core/native/rac_native.dart';
 import 'package:runanywhere/foundation/logging/sdk_logger.dart';
+import 'package:runanywhere/generated/ra_result_codes.dart';
 import 'package:runanywhere/generated/tool_calling.pb.dart'
     show
         ToolCallValidationRequest,
@@ -183,8 +184,7 @@ class DartBridgeToolCalling {
   bool cancelSession(int sessionHandle) {
     final fn = RacNative.bindings.rac_tool_calling_session_cancel_proto;
     try {
-      fn(sessionHandle);
-      return true;
+      return fn(sessionHandle) == RacResultCodes.success;
     } catch (e) {
       _logger.warning('session cancel failed: $e');
       return false;


### PR DESCRIPTION
## Description

### Problem

`DartBridgeToolCalling.cancelSession()` documents that it returns `false` when the native cancellation call fails. The implementation discarded the `rac_result_t` returned by `rac_tool_calling_session_cancel_proto` and returned `true` for every non-throwing FFI invocation. Ordinary native failures are returned as result codes rather than Dart exceptions, so callers could receive a successful cancellation result even when the native call reported failure.

### Root cause

The bridge treated the absence of an FFI exception as operational success instead of checking the structured native result code.

### Change

- Capture the cancellation return value.
- Return `true` only when it equals the generated `RacResultCodes.success` constant.
- Preserve the existing exception handling and warning log.

This is limited to the Flutter tool-calling bridge. It does not change the public API, native ABI, cancellation semantics, or behavior of other SDKs. No documentation or migration change is required because the implementation now matches the existing documented return contract.

### Expected and actual behavior

- Expected: `cancelSession()` returns `true` for `RAC_SUCCESS` and `false` for a non-success native result or an FFI exception.
- Before: every non-throwing native call returned `true`, regardless of its result code.
- After: the returned Boolean reflects the native result code.

### Related issue

No linked issue. This was found by comparing the bridge's documented return contract with its implementation. Searches for the native symbol and tool-calling cancellation found no open issue or overlapping pull request.

### Risk and reviewer guidance

Risk is low: the change is a direct comparison against the generated success constant already used throughout the Flutter bridge. Please verify the Boolean mapping at `cancelSession()` and the generated result-code import.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally — Flutter, Dart, Melos, and FVM are not installed on this host, so local Flutter analysis could not be run.
- [ ] Added/updated tests for changes — no unit test was added because repository guidance asks contributors not to add unit tests unless specifically requested; this is a focused bridge result-code correction.

Validation completed:

- `git diff --check origin/main...HEAD` — passed.
- Confirmed the Dart FFI binding returns an integer `rac_result_t`.
- Confirmed `RacResultCodes.success` is the generated success constant with value `0`.
- Reviewed the one-file diff for unrelated changes and prohibited attribution references — none found.

Recommended CI validation:

- Flutter analyzer and repository validation gates.

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device) — not applicable; no Swift or iOS sample files changed.
- [ ] Tested on iPad / Tablet — not applicable; no Swift or iOS sample files changed.
- [ ] Tested on Mac (macOS target) — not applicable; no Swift or macOS files changed.

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device) — not applicable; no Kotlin or Android sample files changed.
- [ ] Tested on Android Tablet — not applicable; no Kotlin or Android sample files changed.

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS — not run; no Flutter/iOS toolchain or device is available on this host.
- [ ] Tested on Android — not run; no Flutter/Android toolchain or device is available on this host.

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS — not applicable; no React Native files changed.
- [ ] Tested on Android — not applicable; no React Native files changed.

**Playground:**
- [ ] Tested on target platform — not applicable; no Playground files changed.
- [ ] Verified no regressions in existing Playground projects — not applicable; the change is isolated to the Flutter FFI bridge.
**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop) — not applicable; no Web files changed.
- [ ] Tested in Firefox — not applicable; no Web files changed.
- [ ] Tested in Safari — not applicable; no Web files changed.
- [ ] WASM backends load (LlamaCpp + ONNX) — not applicable; no WASM or Web backend files changed.
- [ ] OPFS storage persistence verified (survives page refresh) — not applicable; no OPFS code changed.
- [ ] Settings persistence verified (localStorage) — not applicable; no Web settings code changed.

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`sdk/runanywhere-kotlin`)
- [x] `Flutter SDK` - Changes to Flutter SDK (`sdk/runanywhere-flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`sdk/runanywhere-react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`sdk/runanywhere-web`)
- [ ] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

**Sample Apps:**
- [ ] `iOS Sample` - Changes to iOS example app (`examples/ios`)
- [ ] `Android Sample` - Changes to Android example app (`examples/android`)
- [ ] `Flutter Sample` - Changes to Flutter example app (`examples/flutter`)
- [ ] `React Native Sample` - Changes to React Native example app (`examples/react-native`)
- [ ] `Web Sample` - Changes to Web example app (`examples/web`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed) — no documentation update is needed because there is no public API or usage change and the existing method documentation already describes the corrected behavior.

## Screenshots
No screenshots are applicable. This change has no user-interface output and only corrects a Boolean result in the Flutter FFI bridge.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Session cancellation now reports success only when the native operation completes successfully.
  * Cancellation failures and exceptions are handled more accurately.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->