### PR TITLE
LFM2.5-2.6B: v75/v81 NPU eligibility + llamacpp backend (release v30)

### DIFF
--- a/engines/qhexrt/qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/qhexrt_model_catalog.cpp
@@ -56,8 +56,9 @@ struct ModelPolicy {
 constexpr ModelPolicy kModelPolicies[] = {
     {"lfm2_5_230m", kAllSupportedArches, false},
     {"lfm2_5_350m", kAllSupportedArches, false},
-    // Only v79 context binaries are published for this one; the repo is public, so no HF auth gate.
-    {"lfm2_5_2_6b", kV79, false},
+    // v75/v79/v81 context binaries are published (public repo, no HF auth gate). v75 + v81 ship the 2-part
+    // hybrid decode split (each part < 2 GiB); v79 ships the monolithic decode.
+    {"lfm2_5_2_6b", kAllSupportedArches, false},
     {"qwen3_5_0_8b", kAllSupportedArches, false},
     {"qwen3_5_2b", kAllSupportedArches, false},
     {"qwen3_5_4b", kV79V81, false},

--- a/examples/android/RunAnywhereAI/app/build.gradle.kts
+++ b/examples/android/RunAnywhereAI/app/build.gradle.kts
@@ -102,8 +102,8 @@ android {
         applicationId = "com.runanywhere.runanywhereai"
         minSdk = 24
         targetSdk = 37
-        versionCode = 27
-        versionName = "0.1.16"
+        versionCode = 30
+        versionName = "0.1.17"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
 

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/data/ModelCatalog.kt
@@ -349,6 +349,24 @@ internal object ModelCatalog {
             LANGUAGE,
             1_400_000_000
         ),
+        SingleFileModel(
+            "lfm2.5-2.6b-q4_k_m",
+            "LiquidAI LFM2.5 2.6B Q4_K_M",
+            "https://huggingface.co/LiquidAI/LFM2.5-2.6B-GGUF/resolve/main/LFM2.5-2.6B-Q4_K_M.gguf",
+            LLAMA,
+            LANGUAGE,
+            1_674_000_000,
+            supportsThinking = true
+        ),
+        SingleFileModel(
+            "lfm2.5-2.6b-q8_0",
+            "LiquidAI LFM2.5 2.6B Q8_0",
+            "https://huggingface.co/LiquidAI/LFM2.5-2.6B-GGUF/resolve/main/LFM2.5-2.6B-Q8_0.gguf",
+            LLAMA,
+            LANGUAGE,
+            2_875_000_000,
+            supportsThinking = true
+        ),
     )
 
     private val vlm = listOf(


### PR DESCRIPTION
The merged v79 support (#624) only makes LFM2.5-2.6B eligible on **v79** and adds no llamacpp option. This brings the model to **v75 + v81** on the NPU and adds the **llamacpp** GGUF entries, matching the published HF bundles (`runanywhere/lfm2_5_2_6b_HNPU` now has `v75/`, `v79/`, `v81/`).

## Changes
- **`qhexrt_model_catalog.cpp`** — `lfm2_5_2_6b` eligibility `kV79` → `kAllSupportedArches` (v75/v79/v81). Without this the model is silently ineligible on v75/v81 devices (`not eligible on the detected QHexRT device`).
- **`ModelCatalog.kt`** — add LFM2.5-2.6B for the **llamacpp** backend (`lfm2.5-2.6b-q4_k_m`, `lfm2.5-2.6b-q8_0`) from `LiquidAI/LFM2.5-2.6B-GGUF`.
- **`app/build.gradle.kts`** — `versionCode 30` / `versionName 0.1.17` (supersedes the incomplete v29 build).

## Validation
- On-device Plane B (`NpuModelE2ETest`) SMOKE_PASS 14/14 on both **v75 (SM8650)** and **v81 (SM8850)** — full SDK lifecycle register→download→load→generate→delete.
- `ModelCatalogTest` passes with the new rows (unique IDs, framework/category).

> Requires the companion QHexRT PR (`op_lfm_split_generate` runtime) so the v75/v81 2-part split bundle actually runs.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Expanded model support to include additional architecture variants and new Android model options.
  * Added two new high-quality LLM model choices in the Android app, both with thinking support.
* **Bug Fixes**
  * Improved compatibility for the updated model policy across more supported architectures.
* **Chores**
  * Bumped the Android app version to 0.1.17.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->