### PR TITLE
fix(example/android): salvage the sentence from a default-form stray tool call

### DIFF
--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatToolResultNormalizer.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatToolResultNormalizer.kt
@@ -81,7 +81,10 @@ internal object ChatToolResultNormalizer {
         if (raw.isBlank() || !strayToolCall.containsMatchIn(raw)) return raw
         var salvaged: String? = null
         val withoutCalls = strayToolCall.replace(raw) { match ->
-            if (salvaged == null) salvaged = firstStringLiteral.find(match.groupValues[1])?.groupValues?.get(1)
+            // Group 1 carries the LFM2 form's body, group 2 the `<tool_call>` form's, and
+            // only one alternative matches per hit, so read whichever is populated.
+            val body = match.groupValues[1].ifEmpty { match.groupValues[2] }
+            if (salvaged == null) salvaged = firstStringLiteral.find(body)?.groupValues?.get(1)
             ""
         }
         val remaining = withoutCalls.trim()

--- a/examples/android/RunAnywhereAI/app/src/test/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatRequestPolicyTest.kt
+++ b/examples/android/RunAnywhereAI/app/src/test/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatRequestPolicyTest.kt
@@ -134,6 +134,19 @@ class ChatRequestPolicyTest {
     }
 
     @Test
+    fun `stray tool-call salvage also covers the default tool_call form`() {
+        // Same shape as the LFM2.5 case above, in the DEFAULT `<tool_call>` syntax that
+        // `strayToolCall` also matches. The call body lands in the regex's second group,
+        // so reading only the first left the bubble blank.
+        val raw = """<tool_call>[ask_user("What would you like to do today, Aman?")]</tool_call>"""
+
+        val visible = ChatToolResultNormalizer.stripStrayToolCall(raw)
+
+        assertFalse("tool markers must not survive", visible.contains("tool_call"))
+        assertEquals("What would you like to do today, Aman?", visible)
+    }
+
+    @Test
     fun `stray tool-call stripping keeps surrounding prose and leaves clean replies untouched`() {
         val mixed = "Sure, here you go.<|tool_call_start|>[noop()]<|tool_call_end|>"
         assertEquals("Sure, here you go.", ChatToolResultNormalizer.stripStrayToolCall(mixed))


### PR DESCRIPTION
## What

`ChatToolResultNormalizer.stripStrayToolCall` matches two syntaxes in one alternation:

```kotlin
"""<\|tool_call_start\|>(.*?)<\|tool_call_end\|>|<tool_call>(.*?)</tool_call>"""
```

Only one alternative matches per hit, so the LFM2 body lands in group 1 and the `<tool_call>` body in group 2. The salvage read group 1 only:

```kotlin
if (salvaged == null) salvaged = firstStringLiteral.find(match.groupValues[1])?.groupValues?.get(1)
```

For a default-form call that means searching an empty string, finding no literal, and returning nothing once the block is stripped.

## Why it matters

When such a call is the entire reply, the user gets a **blank chat bubble**. That is the exact outcome the existing LFM2 test is there to prevent:

> The call's string literal is the model's intended sentence — surface it rather than a blank bubble.

The guard just was not covering the second form. It runs on user-visible text at three `ChatViewModel` call sites (763, 805, 826), including the streaming accumulator.

Verified the group semantics on the same alternation before changing anything:

| Input | group 1 | group 2 | user sees today | with this fix |
|---|---|---|---|---|
| `<\|tool_call_start\|>[ask_user("What next?")]<\|tool_call_end\|>` | body | empty | `What next?` | `What next?` |
| `<tool_call>[ask_user("What next?")]</tool_call>` | empty | body | *(blank)* | `What next?` |

## Testing, and the gap I want to be upfront about

I added a regression test next to the existing LFM2 one, in the same style, covering the default form.

**I could not run the Android example's unit tests on this host.** The example consumes the SDK as staged local AARs, which needs `build-core-android.sh` and therefore an NDK, and this machine has none (`doctor.sh` reports Android NDK not found). `./gradlew :app:testDebugUnitTest` fails at `debugRuntimeClasspath` resolution before reaching any test. So rather than imply a gate I did not run:

- I proved the group behaviour mechanically against an equivalent alternation, which is where the bug lives; the table above is that output.
- The source change is two lines using `String.ifEmpty`, and `groupValues` elements are non-null, so it cannot change the function's type.
- My longest added line is 100 characters against 112 already present in the same file, so it is within the file's existing style. ktlint runs on the SDK, not this module.

CI's `kotlin-android` job stages the AARs and then runs `testDebugUnitTest lintDebug assembleDebug` in `examples/android/RunAnywhereAI`, so the new test does get executed there. That job is the authoritative check.

## One thing I deliberately did not touch

By the repo's own rule that post-processing model output belongs below the app, this normalizer arguably belongs in commons or the Kotlin SDK, so that every consumer gets it rather than each app reimplementing tag and tool-markup stripping. That is a design change on code you have just shipped, with a rationale in the comments, so I kept this PR to the group-index bug. Happy to open an issue if moving it down a layer is wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of stray tool-call text in chat responses.
  * Preserves the embedded user-facing message while removing tool-call markers.
  * Supports both standard and LFM2 tool-call formats.

* **Tests**
  * Added regression coverage for standard tool-call text cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->