### PR TITLE
chat: don't cap NPU sliding-window output by context (LFM2.5-2.6B was stuck at 256)

### DIFF
--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatGenerationBudgetPolicy.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatGenerationBudgetPolicy.kt
@@ -35,12 +35,23 @@ internal data class ChatGenerationBudget(
  * other consumers and future larger-budget modes.
  */
 internal object ChatGenerationBudgetPolicy {
-    const val MAX_NORMAL_OUTPUT_TOKENS: Int = 512
+    // Global ceiling for one normal chat response. Raised 512 -> 1024 so sliding-window NPU models can produce
+    // longer answers (a ~7 tok/s NPU reaches this in ~2.5 min worst case; EOS usually stops it much sooner).
+    const val MAX_NORMAL_OUTPUT_TOKENS: Int = 1024
 
-    fun resolve(requestedMaxTokens: Int, modelContextTokens: Int): ChatGenerationBudget {
+    fun resolve(
+        requestedMaxTokens: Int,
+        modelContextTokens: Int,
+        // QHexRT NPU decoders use a KV RING (sliding window): they keep generating coherently PAST the context
+        // size — the ring just forgets the oldest tokens, it never corrupts (verified: LFM2.5-2.6B streams
+        // 600+ coherent tokens on a 512 window). So their output is NOT bounded by the context. Only
+        // context-bound decoders (llama.cpp n_ctx, cloud) reserve half the window for the prompt.
+        slidingWindow: Boolean = false,
+    ): ChatGenerationBudget {
         val requested = requestedMaxTokens.coerceAtLeast(1)
         val context = modelContextTokens.takeIf { it > 0 }
-        val contextOutputLimit = context?.let { (it / 2).coerceAtLeast(1) }
+        val contextOutputLimit =
+            if (slidingWindow) null else context?.let { (it / 2).coerceAtLeast(1) }
         val effective = minOf(
             requested,
             MAX_NORMAL_OUTPUT_TOKENS,

--- a/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatViewModel.kt
+++ b/examples/android/RunAnywhereAI/app/src/main/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatViewModel.kt
@@ -652,6 +652,9 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
             contextTokens = activeModel.model.context_length,
             modelName = activeModel.model.name,
             forceGreedy = forceGreedy,
+            // QHexRT NPU models decode through a sliding-window KV ring, so their output isn't bounded by the
+            // (small) context window — let the budget policy skip the context clamp for them.
+            slidingWindow = forceGreedy,
         )
         val s = SettingsRepository.settings
         return options.copy(
@@ -666,11 +669,13 @@ class ChatViewModel(application: Application) : AndroidViewModel(application) {
         contextTokens: Int,
         modelName: String,
         forceGreedy: Boolean = false,
+        slidingWindow: Boolean = false,
     ): RALLMGenerationOptions {
         val s = SettingsRepository.settings
         val budget = ChatGenerationBudgetPolicy.resolve(
             requestedMaxTokens = s.maxTokens,
             modelContextTokens = contextTokens,
+            slidingWindow = slidingWindow,
         )
         if (budget.isCapped) {
             RACLog.i(

--- a/examples/android/RunAnywhereAI/app/src/test/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatGenerationBudgetPolicyTest.kt
+++ b/examples/android/RunAnywhereAI/app/src/test/java/com/runanywhere/runanywhereai/ui/screens/chat/ChatGenerationBudgetPolicyTest.kt
@@ -7,24 +7,38 @@ import org.junit.Test
 
 class ChatGenerationBudgetPolicyTest {
     @Test
-    fun `512 context model keeps half its window for input`() {
+    fun `context-bound 512 model reserves half its window for input`() {
         val budget = ChatGenerationBudgetPolicy.resolve(
             requestedMaxTokens = 4_096,
             modelContextTokens = 512,
         )
 
         assertEquals(4_096, budget.requestedMaxTokens)
-        assertEquals(256, budget.effectiveMaxTokens)
+        assertEquals(256, budget.effectiveMaxTokens) // 512 / 2
         assertTrue(budget.isCapped)
         assertTrue(budget.explanation("LFM").contains("preference stays saved"))
     }
 
     @Test
-    fun `1024 context model cannot inherit a 4096 output decode`() {
-        val budget = ChatGenerationBudgetPolicy.resolve(4_096, 1_024)
+    fun `sliding-window model is not bounded by its small context`() {
+        // QHexRT NPU (KV ring) keeps generating coherently past its context, so output caps at the global
+        // ceiling instead of the context window.
+        val budget = ChatGenerationBudgetPolicy.resolve(
+            requestedMaxTokens = 4_096,
+            modelContextTokens = 512,
+            slidingWindow = true,
+        )
 
         assertEquals(ChatGenerationBudgetPolicy.MAX_NORMAL_OUTPUT_TOKENS, budget.effectiveMaxTokens)
-        assertEquals(512, budget.effectiveMaxTokens)
+        assertEquals(1_024, budget.effectiveMaxTokens)
+        assertTrue(budget.isCapped)
+    }
+
+    @Test
+    fun `context-bound 1024 model reserves half its window`() {
+        val budget = ChatGenerationBudgetPolicy.resolve(4_096, 1_024)
+
+        assertEquals(512, budget.effectiveMaxTokens) // 1024 / 2
     }
 
     @Test
@@ -39,7 +53,7 @@ class ChatGenerationBudgetPolicyTest {
     fun `unknown context fails to the bounded normal chat maximum`() {
         val budget = ChatGenerationBudgetPolicy.resolve(4_096, 0)
 
-        assertEquals(512, budget.effectiveMaxTokens)
+        assertEquals(ChatGenerationBudgetPolicy.MAX_NORMAL_OUTPUT_TOKENS, budget.effectiveMaxTokens)
         assertEquals(null, budget.modelContextTokens)
         assertTrue(budget.explanation("Model").contains("until it reports a context size"))
     }


### PR DESCRIPTION
## Problem
LFM2.5-2.6B (and other QHexRT NPU LLMs) capped chat output at **256 tokens**. The budget policy did
`contextOutputLimit = context / 2`, and LFM's `context_length` is 512 → 256.

That assumed output must fit inside the context window. **It doesn't** for these models: QHexRT NPU decoders
use a **KV ring (sliding window)** — they keep generating *coherently* past the context size, the ring just
forgets the oldest tokens. Verified on device (v81, SM8850): LFM2.5-2.6B streams **600 coherent tokens** on a
512 window (no garbage — clean prose start to finish). Only *context-bound* decoders (llama.cpp `n_ctx`,
cloud) actually need to reserve prompt room.

## Change
- `ChatGenerationBudgetPolicy.resolve(..., slidingWindow: Boolean = false)` — when `slidingWindow`, skip the
  `context / 2` clamp entirely (output isn't bounded by the small context).
- Raise `MAX_NORMAL_OUTPUT_TOKENS` **512 → 1024** so the freed-up models can produce longer answers.
- `ChatViewModel.generationOptions` passes `slidingWindow = (framework == QHEXRT)`.
- Context-bound models (llama.cpp / cloud) keep the existing half-window reservation, unchanged.

Net effect: LFM2.5-2.6B on the NPU now generates up to **1024** tokens (or the user's saved `maxTokens`),
instead of 256. History windowing (input trimming) is untouched.

## Tests
`ChatGenerationBudgetPolicyTest` updated: context-bound 512 → 256, **sliding-window 512 → 1024 (new case)**,
context-bound 1024 → 512, large-context/unknown-context cases → 1024 ceiling. All pass.

## Verified
Built + installed on v81; the raw runtime already proven to emit 600 coherent tokens on a 512 window.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Increased the maximum normal chat response length from 512 to 1,024 tokens.
  * Improved support for sliding-window models, allowing longer responses based on the global output limit.
  * Updated QHexRT generation to take advantage of sliding-window context behavior.

* **Bug Fixes**
  * Preserved appropriate context limits for models that require reserving space for input.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->