### PR TITLE
fix(rcli): complete the FNV-1a digest behind local model ids

### DIFF
--- a/sdk/runanywhere-cli/src/catalog/model_ref.cpp
+++ b/sdk/runanywhere-cli/src/catalog/model_ref.cpp
@@ -98,14 +98,16 @@ std::string id_for_local_path(const std::string &path) {
 
   // The basename alone collides — every `.../model.mlpackage` sanitizes to the
   // same string — so pin the id to the whole path with an FNV-1a digest.
-  uint64_t hash = 1469598103934665603ULL;
+  uint64_t hash = 14695981039346656037ULL;  // FNV-1a 64-bit offset basis
   for (const unsigned char c : full) {
     hash ^= c;
     hash *= 1099511628211ULL;
   }
   static constexpr char kHex[] = "0123456789abcdef";
   std::string digest;
-  for (int shift = 28; shift >= 0; shift -= 4) {
+  // 16 nibbles: emit the whole 64-bit hash. Stopping at shift 28 kept only the
+  // low 32 bits, so paths differing above that bit shared an id.
+  for (int shift = 60; shift >= 0; shift -= 4) {
     digest.push_back(kHex[(hash >> shift) & 0xF]);
   }
   return "local-" + base + "-" + digest;


### PR DESCRIPTION
## What

`id_for_local_path` pins a local model's id to its full path, because the basename alone collides:

> The basename alone collides — every `.../model.mlpackage` sanitizes to the same string — so pin the id to the whole path with an FNV-1a digest.

Two things stopped it being that digest.

**1. The offset basis is a digit short.**

```cpp
uint64_t hash = 1469598103934665603ULL;
```

The FNV-1a 64-bit basis is `14695981039346656037` (`0xcbf29ce484222325`), 20 digits. The literal is that value with the trailing digit dropped, 19 digits. The prime on the next line is the correct `1099511628211`, so the intent is unambiguous.

**2. Half the hash never reaches the id.**

```cpp
for (int shift = 28; shift >= 0; shift -= 4) {
```

That emits 8 nibbles, so only bits 31-0 of a 64-bit hash are used. A 64-bit value needs shifts 60 down to 0.

## Why it matters

The digest exists so two bundles sharing a basename get distinct ids. Truncating to 32 bits shrinks that guarantee from 2^64 to 2^32, and paths differing solely above bit 31 collide outright. When they do, the second registration lands on the first one's id.

Concretely, for two different paths with the same basename:

```
/Users/me/models/model.mlpackage
  before: local-model.mlpackage-eb4d5469          (8 hex)
  after : local-model.mlpackage-f57ae22d33b5f963  (16 hex)

/var/lib/ra/model.mlpackage
  before: local-model.mlpackage-555bb248          (8 hex)
  after : local-model.mlpackage-3377f1976fc23a32  (16 hex)
```

## The one behavioural consequence, stated plainly

This changes the id computed for a given path, so a local model registered by an earlier build resolves under its old id. Ids are derived from the path on every run rather than stored as an input, so there is nothing to migrate; the effect is that a stale registry row from a previous build would no longer be matched. Given `rcli` is a developer CLI I judged that acceptable, but it is your call, and it is unavoidable for either half of the fix since both change the digest.

## Testing

Configured with `-DRAC_BUILD_CLI=ON -DRAC_BUILD_TESTS=ON -DRAC_DESKTOP_ADAPTER=ON` and built with Ninja:

- `test_rcli_unit --run-all` — **25 passed, 0 failed**

No existing test covers `id_for_local_path`, and I did not add one: asserting a specific digest string would pin the algorithm's output rather than its property, and the useful property (two paths sharing a basename get different ids) already held before this change. The constants above are checkable by eye against the FNV-1a spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved identifiers for locally stored models by using the complete hash value.
  * Reduced the risk of duplicate identifiers for models with similar or lengthy paths.
  * Standardized identifiers to a consistent 16-digit hexadecimal format for more reliable model references.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->