### PR TITLE
fix(kotlin): measure fallback tokens/sec over decode time, not the whole span

### DIFF
--- a/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/LLM/RunAnywhereTextGeneration.kt
+++ b/sdk/runanywhere-kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/LLM/RunAnywhereTextGeneration.kt
@@ -306,6 +306,13 @@ internal suspend fun aggregateLLMStream(
 
     val totalLatencyMs = (nowMillis() - startTimeMs).toDouble()
     val ttftMs = firstTokenTimeMs?.let { (it - startTimeMs) }
+    // Decode-only denominator, matching commons' llm_module.cpp: prefill (TTFT) in
+    // the denominator systematically understates the rate, and the field this feeds
+    // is decode_tokens_per_second. Falls back to the full span when TTFT is unknown
+    // or not strictly inside it.
+    val decodeMs =
+        ttftMs?.toDouble()?.takeIf { it > 0 && it < totalLatencyMs }?.let { totalLatencyMs - it }
+            ?: totalLatencyMs
     val modelIdentity = resolveModelIdentity()
 
     // Prefer the backend's terminal aggregate result (text + metrics) when the
@@ -316,7 +323,7 @@ internal suspend fun aggregateLLMStream(
     val tokensGenerated = final?.usage?.output_tokens ?: tokenCount
     val decodeTokensPerSecond =
         final?.usage?.decode_tokens_per_second
-            ?: if (totalLatencyMs > 0) tokenCount / (totalLatencyMs / 1000.0) else 0.0
+            ?: if (decodeMs > 0) tokenCount / (decodeMs / 1000.0) else 0.0
     val ttftFromFinal = final?.usage?.ttft_ms?.takeIf { it > 0L }
     return RALLMGenerationResult(
         text = final?.text ?: answerResponse.toString(),


### PR DESCRIPTION
## What is wrong

`aggregateStream` computes the decode rate when the backend does not supply one, and divides by the full request span:

```kotlin
val decodeTokensPerSecond =
    final?.usage?.decode_tokens_per_second
        ?: if (totalLatencyMs > 0) tokenCount / (totalLatencyMs / 1000.0) else 0.0
```

`totalLatencyMs` starts at the request, so it includes prefill. The value feeds `TokenUsage.decode_tokens_per_second`.

## Why that is wrong

commons deliberately excludes prefill from this metric, and says so in `llm_module.cpp`:

```cpp
// Tokens/sec over decode time only — including prefill (TTFT) in the
// denominator systematically understates generation speed.
const double decode_ms = (ttft_ms > 0.0 && ttft_ms < total_time_ms)
                             ? total_time_ms - ttft_ms
                             : total_time_ms;
```

Python (`_generation.py`) and Electron (`stream.ts`) already measure it that way, both as `end - firstAt`. So the same run reports a different number depending on which path produced it: 100 tokens with 1s prefill in a 5s span is 25 tok/s from commons and 20 tok/s here. It is silent, because both write the same field, and the gap grows with prompt length.

The field name makes it unambiguous. After #605 this value is assigned to `decode_tokens_per_second`, so a denominator that includes prefill is measuring something the name rules out.

## What this does

Divides by decode time instead. `ttftMs` is already computed a few lines above, so nothing new is measured. The guard mirrors commons: subtract only when TTFT is known and strictly inside the span, otherwise fall back to the full span, which leaves the no-TTFT case byte-identical to today.

## Rebased onto #605, and the diff changed shape

This PR was opened before #605 landed and has been rebased onto it. #605 moved these metrics into `TokenUsage` and dropped the `tokens_per_second` and `ttft_ms` constructor arguments this PR previously set, so the earlier revision no longer applied. The fix is now a one-line denominator change on `decodeTokensPerSecond` plus the `decodeMs` it needs. The defect itself survived the refactor unchanged.

## Testing

From `sdk/runanywhere-kotlin` with JDK 17, using `--rerun-tasks` because Gradle reports the compile up-to-date and `touch` does not invalidate a content-hashed input:

```
./gradlew :compileDebugKotlin --rerun-tasks \
  -x :buildLocalJniLibs -x :downloadJniLibs -x :syncAndroidRuntimeLibs
BUILD SUCCESSFUL in 9s
```

The three excluded tasks stage native artifacts and cannot run on this machine: `downloadJniLibs` fetches `RABackendONNX-android-arm64-v8a-v0.20.12.zip`, which is not published yet, and the NDK pinned at `27.3.13750724` is not installed here. None of them affect Kotlin compilation of the changed file. CI covers the full path.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming performance metrics by separating initial response time from text decoding time.
  * Updated fallback token-generation speed calculations to use the more accurate decoding duration.
  * Added safeguards for unavailable or invalid timing data.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->