### PR TITLE
fix(release): name the flags that actually exist in the payload guard

### DIFF
--- a/sdk/runanywhere-swift/scripts/release-swift-binaries.sh
+++ b/sdk/runanywhere-swift/scripts/release-swift-binaries.sh
@@ -67,7 +67,7 @@ export DRY_RUN RAC_BACKEND_ONNX RAC_BACKEND_SHERPA RAC_BACKEND_NEURT RAC_BACKEND
 
 if [ "${RAC_BACKEND_ONNX}" != "ON" ] || [ "${RAC_BACKEND_SHERPA}" != "ON" ] || \
    [ "${RAC_BACKEND_NEURT}" != "ON" ] || [ "${RAC_BACKEND_MLX}" != "ON" ]; then
-    echo "error: a Swift release requires every Apple binary/resource payload (ONNX, Sherpa, CoreML, and MLX must be ON)" >&2
+    echo "error: a Swift release requires every Apple binary/resource payload; RAC_BACKEND_ONNX, RAC_BACKEND_SHERPA, RAC_BACKEND_NEURT and RAC_BACKEND_MLX must all be ON" >&2
     exit 1
 fi
 


### PR DESCRIPTION
## What is wrong

`release-swift-binaries.sh` guards on `RAC_BACKEND_NEURT`, but the error it prints names `CoreML`:

```sh
if [ "${RAC_BACKEND_ONNX}" != "ON" ] || [ "${RAC_BACKEND_SHERPA}" != "ON" ] || \
   [ "${RAC_BACKEND_NEURT}" != "ON" ] || [ "${RAC_BACKEND_MLX}" != "ON" ]; then
    echo "error: a Swift release requires every Apple binary/resource payload (ONNX, Sherpa, CoreML, and MLX must be ON)" >&2
```

There is no `RAC_BACKEND_COREML` any more, so the one line a failed release prints points at a variable that does not exist.

## Why that is wrong

#619 renamed `RAC_BACKEND_COREML` to `RAC_BACKEND_NEURT` across this exact file and updated everything except the message. From that commit's diff of this file:

```
-RAC_BACKEND_COREML="${RAC_BACKEND_COREML:-ON}"
+RAC_BACKEND_NEURT="${RAC_BACKEND_NEURT:-ON}"
-export DRY_RUN RAC_BACKEND_ONNX RAC_BACKEND_SHERPA RAC_BACKEND_COREML RAC_BACKEND_MLX
+export DRY_RUN RAC_BACKEND_ONNX RAC_BACKEND_SHERPA RAC_BACKEND_NEURT RAC_BACKEND_MLX
-   [ "${RAC_BACKEND_COREML}" != "ON" ] || [ "${RAC_BACKEND_MLX}" != "ON" ]; then
+   [ "${RAC_BACKEND_NEURT}" != "ON" ] || [ "${RAC_BACKEND_MLX}" != "ON" ]; then
```

Comments, the variable, the export, the condition and the `zip_target` calls all moved; only the error text did not. So this is an oversight from the rename rather than a deliberate choice of wording.

The sibling guard one directory over already uses the form this change adopts, which is why I matched it rather than inventing one:

```sh
# build-core-xcframework.sh:55
echo "error: the Swift package unconditionally requires Sherpa and NeuRT binaries; RAC_BACKEND_SHERPA and RAC_BACKEND_NEURT must be ON" >&2
```

## What this does

Names all four variables the guard actually reads.

## Testing

Behaviour on current `main`, which sends you after a flag that no longer exists:

```
$ RAC_BACKEND_NEURT=OFF ./sdk/runanywhere-swift/scripts/release-swift-binaries.sh 0.20.12
error: a Swift release requires every Apple binary/resource payload (ONNX, Sherpa, CoreML, and MLX must be ON)
```

With this change:

```
$ RAC_BACKEND_NEURT=OFF ./sdk/runanywhere-swift/scripts/release-swift-binaries.sh 0.20.12
error: a Swift release requires every Apple binary/resource payload; RAC_BACKEND_ONNX, RAC_BACKEND_SHERPA, RAC_BACKEND_NEURT and RAC_BACKEND_MLX must all be ON
```

`bash -n` on the script is clean. I did not run shellcheck, which is not installed on this machine, and the change is inside a single existing `echo`, so control flow is untouched.

I left the `iOS CoreML XCFramework` label in `release.yml` alone: it carries a comment describing the CoreML Stable-Diffusion engine, so that wording reads as deliberate rather than a leftover.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved release validation errors by clearly identifying all required backend configuration flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->