### PR TITLE
Add RunAnywhereANE (NeuRT) Swift package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -160,6 +160,15 @@ let package = Package(
         ),
 
         // =================================================================
+        // ANE Backend — Apple Neural Engine LLM + CoreML diffusion (NeuRT)
+        // =================================================================
+        .library(
+            name: "RunAnywhereANE",
+            type: .static,
+            targets: ["ANERuntime"]
+        ),
+
+        // =================================================================
         // macOS CLI host — registers real mlx-swift callbacks, then
         // delegates to the C++ rcli stack with llama.cpp + MLX both enabled.
         // =================================================================
@@ -259,6 +268,19 @@ let package = Package(
         ),
 
         // =================================================================
+        // C Bridge Module - ANE (NeuRT) Backend Headers
+        // =================================================================
+        .target(
+            name: "ANEBackend",
+            dependencies: [
+                "CRACommons",
+                "RABackendNeuRTBinary",
+            ],
+            path: "sdk/runanywhere-swift/Sources/ANERuntime/include",
+            publicHeadersPath: "."
+        ),
+
+        // =================================================================
         // C Bridge Module - MLX Backend Headers
         // =================================================================
         .target(
@@ -346,6 +368,30 @@ let package = Package(
                 .linkedFramework("CoreML"),
                 .linkedLibrary("archive"),
                 .linkedLibrary("bz2"),
+            ]
+        ),
+
+        // =================================================================
+        // ANE Runtime Backend — Apple Neural Engine LLM + CoreML diffusion
+        //
+        // Links RABackendNeuRTBinary and registers the `neurt` engine plugin
+        // via `ANE.register()`. NeuRT is also bundled into ONNXRuntime (so
+        // existing ONNX/diffusion consumers are unaffected); this standalone
+        // product lets consumers opt into ANE directly.
+        // =================================================================
+        .target(
+            name: "ANERuntime",
+            dependencies: [
+                "RunAnywhere",
+                "ANEBackend",
+                "RABackendNeuRTBinary",
+            ],
+            path: "sdk/runanywhere-swift/Sources/ANERuntime",
+            exclude: ["include"],
+            linkerSettings: [
+                .linkedLibrary("c++"),
+                .linkedFramework("Accelerate"),
+                .linkedFramework("CoreML"),
             ]
         ),
 
@@ -539,6 +585,14 @@ let package = Package(
             name: "RunAnywhereTests",
             dependencies: [
                 "RunAnywhere",
+                // Backend runtimes so BackendRegistrationTests can exercise the
+                // real plugin registry through each shipped XCFramework. MLX is
+                // omitted: its MLXBackend module re-exposes commons headers whose
+                // rac_vlm_result has drifted in the shipped RABackendMLX
+                // xcframework, which clangs against CRACommons in one module.
+                "LlamaCPPRuntime",
+                "ONNXRuntime",
+                "ANERuntime",
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
             ],
             path: "sdk/runanywhere-swift/Tests/RunAnywhereTests",

--- a/sdk/runanywhere-swift/Package.swift
+++ b/sdk/runanywhere-swift/Package.swift
@@ -68,6 +68,7 @@ let package = Package(
         .library(name: "RunAnywhereLlamaCPP", type: .static, targets: ["LlamaCPPRuntime"]),
         .library(name: "RunAnywhereONNX", type: .static, targets: ["ONNXRuntime"]),
         .library(name: "RunAnywhereMLX", type: .static, targets: ["MLXRuntime"]),
+        .library(name: "RunAnywhereANE", type: .static, targets: ["ANERuntime"]),
     ],
     dependencies: [
         // SPM deps use `.upToNextMinor` (not open-ended `from:`) so a
@@ -143,6 +144,19 @@ let package = Package(
                 "RABackendSherpaBinary",
             ],
             path: "Sources/ONNXRuntime/include",
+            publicHeadersPath: "."
+        ),
+
+        // -------------------------------------------------------------------
+        // C Bridge Module — ANE (NeuRT) Backend Headers
+        // -------------------------------------------------------------------
+        .target(
+            name: "ANEBackend",
+            dependencies: [
+                "CRACommons",
+                "RABackendNeuRTBinary",
+            ],
+            path: "Sources/ANERuntime/include",
             publicHeadersPath: "."
         ),
 
@@ -276,6 +290,31 @@ let package = Package(
         ),
 
         // -------------------------------------------------------------------
+        // ANE Runtime Backend — Apple Neural Engine LLM + CoreML diffusion
+        //
+        // Links RABackendNeuRTBinary and registers the `neurt` engine plugin
+        // via `ANE.register()`. NeuRT stays bundled in ONNXRuntime too, so
+        // existing ONNX/diffusion consumers are unaffected; this standalone
+        // product lets the example apps and external consumers opt into ANE
+        // directly.
+        // -------------------------------------------------------------------
+        .target(
+            name: "ANERuntime",
+            dependencies: [
+                "RunAnywhere",
+                "ANEBackend",
+                "RABackendNeuRTBinary",
+            ],
+            path: "Sources/ANERuntime",
+            exclude: ["include"],
+            linkerSettings: [
+                .linkedLibrary("c++"),
+                .linkedFramework("Accelerate"),
+                .linkedFramework("CoreML"),
+            ]
+        ),
+
+        // -------------------------------------------------------------------
         // MLX Runtime Backend
         // -------------------------------------------------------------------
         .target(
@@ -318,6 +357,14 @@ let package = Package(
             name: "RunAnywhereTests",
             dependencies: [
                 "RunAnywhere",
+                // Backend runtimes so BackendRegistrationTests can exercise the
+                // real plugin registry through each shipped XCFramework. MLX is
+                // omitted: its MLXBackend module re-exposes commons headers whose
+                // rac_vlm_result has drifted in the shipped RABackendMLX
+                // xcframework, which clangs against CRACommons in one module.
+                "LlamaCPPRuntime",
+                "ONNXRuntime",
+                "ANERuntime",
                 .product(name: "SwiftProtobuf", package: "swift-protobuf"),
             ],
             path: "Tests/RunAnywhereTests",

--- a/sdk/runanywhere-swift/Sources/ANERuntime/ANE.swift
+++ b/sdk/runanywhere-swift/Sources/ANERuntime/ANE.swift
@@ -9,8 +9,8 @@
 //  to `rac_plugin_register(...)` directly.
 //
 
-import CRACommons
 import ANEBackend
+import CRACommons
 import RunAnywhere
 
 // MARK: - ANE Module
@@ -69,10 +69,15 @@ public enum ANE {
             return rac_plugin_register(typedPointer)
         }
 
-        if registerResult == RAC_SUCCESS ||
-           registerResult == RAC_ERROR_MODULE_ALREADY_REGISTERED {
+        if registerResult == RAC_SUCCESS {
+            // This module registered the plugin, so it owns teardown.
             isRegistered = true
             logger.info("NeuRT engine plugin registered (ANE text generation + CoreML diffusion)")
+        } else if registerResult == RAC_ERROR_MODULE_ALREADY_REGISTERED {
+            // Already present (e.g. the commons static bootstrap registered it):
+            // available, but not owned here, so teardown is left to whoever
+            // registered it first. Deliberately do NOT set isRegistered.
+            logger.debug("NeuRT engine plugin already registered; leaving ownership with the existing registrant")
         } else {
             let errorMsg = String(cString: rac_error_message(registerResult))
             logger.error("NeuRT plugin registration failed: \(errorMsg)")
@@ -85,11 +90,19 @@ public enum ANE {
     /// domain as `register(priority:)` and the `autoRegister` Task hop.
     @MainActor
     public static func unregister() {
+        // Only tear down a registration this module owns; if NeuRT was already
+        // registered by the static bootstrap, leave it in place.
         guard isRegistered else { return }
 
-        _ = rac_plugin_unregister("neurt")
-        isRegistered = false
-        logger.info("NeuRT engine plugin unregistered")
+        let result = rac_plugin_unregister("neurt")
+        if result == RAC_SUCCESS {
+            isRegistered = false
+            logger.info("NeuRT engine plugin unregistered")
+        } else {
+            // Keep ownership so a later retry can still tear it down.
+            let errorMsg = String(cString: rac_error_message(result))
+            logger.error("NeuRT plugin unregistration failed: \(errorMsg)")
+        }
     }
 }
 

--- a/sdk/runanywhere-swift/Sources/ANERuntime/ANE.swift
+++ b/sdk/runanywhere-swift/Sources/ANERuntime/ANE.swift
@@ -1,0 +1,106 @@
+//
+//  ANE.swift
+//  ANERuntime Module
+//
+//  Thin wrapper that registers the Apple NeuRT engine (Apple Neural Engine LLM
+//  + CoreML diffusion) with the commons plugin registry. Mirrors ONNX.swift's
+//  Sherpa registration: the shipped RABackendNeuRT.xcframework exports only the
+//  `rac_plugin_entry_neurt` entry symbol, so we register by handing its vtable
+//  to `rac_plugin_register(...)` directly.
+//
+
+import CRACommons
+import ANEBackend
+import RunAnywhere
+
+// MARK: - ANE Module
+
+/// Apple Neural Engine (NeuRT) backend module.
+///
+/// Serves on-device text generation on the Apple Neural Engine and image
+/// generation (diffusion) over CoreML. Import this module and register it to
+/// route `framework == .neurt` model loads through the commons plugin router.
+///
+/// ## Registration
+///
+/// ```swift
+/// import ANERuntime
+///
+/// // Register the backend (also happens automatically via `autoRegister`).
+/// ANE.register()
+/// ```
+public enum ANE {
+    private static let logger = SDKLogger(category: "ANE")
+
+    // MARK: - Module Info
+
+    /// Current version of the ANE Runtime module.
+    public static let version = "1.0.0"
+
+    // MARK: - Registration State
+
+    @MainActor private static var isRegistered = false
+
+    // MARK: - Registration
+
+    /// Register the NeuRT engine plugin with the commons plugin registry.
+    ///
+    /// Safe to call multiple times — subsequent calls are no-ops, and a native
+    /// "already registered" result is treated as success.
+    ///
+    /// - Parameter priority: Ignored (C++ uses its own priority system).
+    @MainActor
+    public static func register(priority _: Int = 100) {
+        guard !isRegistered else {
+            logger.debug("ANE already registered, returning")
+            return
+        }
+
+        guard let vtable = rac_plugin_entry_neurt() else {
+            // warning level so this surfaces even under the production default
+            // (.warning) during early-boot backend registration.
+            logger.warning("NeuRT plugin entry returned null — ANE LLM/diffusion will not route")
+            return
+        }
+
+        let registerResult = vtable.withMemoryRebound(
+            to: rac_engine_vtable_t.self, capacity: 1
+        ) { typedPointer -> rac_result_t in
+            return rac_plugin_register(typedPointer)
+        }
+
+        if registerResult == RAC_SUCCESS ||
+           registerResult == RAC_ERROR_MODULE_ALREADY_REGISTERED {
+            isRegistered = true
+            logger.info("NeuRT engine plugin registered (ANE text generation + CoreML diffusion)")
+        } else {
+            let errorMsg = String(cString: rac_error_message(registerResult))
+            logger.error("NeuRT plugin registration failed: \(errorMsg)")
+        }
+    }
+
+    /// Unregister the NeuRT engine plugin from the commons registry.
+    ///
+    /// `@MainActor` so the `isRegistered` flag stays in the same isolation
+    /// domain as `register(priority:)` and the `autoRegister` Task hop.
+    @MainActor
+    public static func unregister() {
+        guard isRegistered else { return }
+
+        _ = rac_plugin_unregister("neurt")
+        isRegistered = false
+        logger.info("NeuRT engine plugin unregistered")
+    }
+}
+
+// MARK: - Auto-Registration
+
+extension ANE {
+    /// Enable auto-registration for this module.
+    /// Access this property to trigger backend registration.
+    public static let autoRegister: Void = {
+        Task { @MainActor in
+            ANE.register()
+        }
+    }()
+}

--- a/sdk/runanywhere-swift/Sources/ANERuntime/include/ANEBackend.h
+++ b/sdk/runanywhere-swift/Sources/ANERuntime/include/ANEBackend.h
@@ -1,0 +1,13 @@
+/**
+ * @file ANEBackend.h
+ * @brief Umbrella header for the ANEBackend C-bridge module.
+ *
+ * Exposes the NeuRT (Apple Neural Engine) engine plugin entry symbol to Swift
+ * so ANERuntime can register it with the commons plugin registry.
+ */
+#ifndef ANE_BACKEND_H
+#define ANE_BACKEND_H
+
+#include "rac_plugin_entry_neurt.h"
+
+#endif /* ANE_BACKEND_H */

--- a/sdk/runanywhere-swift/Sources/ANERuntime/include/module.modulemap
+++ b/sdk/runanywhere-swift/Sources/ANERuntime/include/module.modulemap
@@ -1,0 +1,9 @@
+module ANEBackend {
+    umbrella header "ANEBackend.h"
+
+    export *
+    module * { export * }
+
+    link framework "Accelerate"
+    link framework "CoreML"
+}

--- a/sdk/runanywhere-swift/Sources/ANERuntime/include/rac_plugin_entry_neurt.h
+++ b/sdk/runanywhere-swift/Sources/ANERuntime/include/rac_plugin_entry_neurt.h
@@ -1,0 +1,42 @@
+/**
+ * @file rac_plugin_entry_neurt.h
+ * @brief NeuRT (Apple Neural Engine) engine plugin entry declaration
+ *        (Swift bridge copy).
+ *
+ * Mirrors sdk/runanywhere-commons/include/rac/plugin/rac_plugin_entry_neurt.h
+ * so the Swift SDK can register the neurt engine's unified-ABI vtable with the
+ * plugin registry without pulling the commons private plugin headers into the
+ * CRACommons module map.
+ *
+ * The shipped RABackendNeuRT.xcframework exports only `rac_plugin_entry_neurt`
+ * (the `rac_backend_neurt_register` wrapper is not re-exported), so
+ * `ANE.register()` calls `rac_plugin_register(rac_plugin_entry_neurt())`
+ * directly — the same pattern ONNXRuntime uses for Sherpa.
+ */
+#ifndef RAC_PLUGIN_ENTRY_NEURT_H
+#define RAC_PLUGIN_ENTRY_NEURT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* Forward-declare the engine vtable struct. Swift treats this as an opaque
+ * pointer inside the ANEBackend module and casts to
+ * `UnsafePointer<rac_engine_vtable_t>` (imported from CRACommons) via
+ * `withMemoryRebound` before handing it to `rac_plugin_register()`. A plain
+ * forward declaration (rather than #include'ing the commons plugin header)
+ * avoids pulling internal plugin types into the Swift module map twice. */
+struct rac_engine_vtable;
+
+/**
+ * @brief Returns the engine vtable for the neurt engine (ANE LLM + CoreML
+ *        diffusion). Linked from RABackendNeuRT.xcframework. Safe to call
+ *        multiple times; returns the same static pointer.
+ */
+const struct rac_engine_vtable* rac_plugin_entry_neurt(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RAC_PLUGIN_ENTRY_NEURT_H */

--- a/sdk/runanywhere-swift/Sources/ANERuntime/include/shim.c
+++ b/sdk/runanywhere-swift/Sources/ANERuntime/include/shim.c
@@ -1,0 +1,1 @@
+// SPM requires at least one compilable source file per C target.

--- a/sdk/runanywhere-swift/Tests/RunAnywhereTests/BackendRegistrationTests.swift
+++ b/sdk/runanywhere-swift/Tests/RunAnywhereTests/BackendRegistrationTests.swift
@@ -41,10 +41,12 @@ import ONNXRuntime
 @MainActor
 final class BackendRegistrationTests: XCTestCase {
 
-    /// True when the commons plugin router can resolve a backend for `primitive`
-    /// (i.e. some routable plugin serving it is registered).
-    private func canRoute(_ primitive: rac_primitive_t) -> Bool {
-        rac_plugin_find(primitive) != nil
+    /// True when the *named* engine is registered and routable for `primitive`.
+    /// Uses `rac_plugin_find_for_engine` (not `rac_plugin_find`) so a stale
+    /// plugin left registered by another test can't satisfy the assertion — the
+    /// resolved plugin must actually be the backend under test.
+    private func routes(_ primitive: rac_primitive_t, engine: String) -> Bool {
+        rac_plugin_find_for_engine(primitive, engine) != nil
     }
 
     // MARK: - LlamaCPP (LLM / GENERATE_TEXT)
@@ -59,12 +61,12 @@ final class BackendRegistrationTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(afterFirst, baseline, "registration must not shrink the registry")
         XCTAssertEqual(afterFirst, afterSecond, "re-registering llama.cpp must not add a duplicate plugin")
 
-        guard canRoute(RAC_PRIMITIVE_GENERATE_TEXT) else {
+        guard routes(RAC_PRIMITIVE_GENERATE_TEXT, engine: "llamacpp") else {
             throw XCTSkip("llama.cpp LLM not routable in the linked XCFramework; validated by the release build")
         }
         XCTAssertNotNil(
-            rac_plugin_find(RAC_PRIMITIVE_GENERATE_TEXT),
-            "llama.cpp must serve GENERATE_TEXT once registered"
+            rac_plugin_find_for_engine(RAC_PRIMITIVE_GENERATE_TEXT, "llamacpp"),
+            "the llama.cpp engine must serve GENERATE_TEXT once registered"
         )
     }
 
@@ -79,7 +81,7 @@ final class BackendRegistrationTests: XCTestCase {
 
         // Sherpa speech (STT/TTS/VAD) only routes when RABackendSherpa was built
         // routable (RAC_SHERPA_ROUTABLE=1); the shipped slice may be a stub.
-        if !canRoute(RAC_PRIMITIVE_TRANSCRIBE) {
+        if !routes(RAC_PRIMITIVE_TRANSCRIBE, engine: "sherpa") {
             throw XCTSkip("Sherpa speech not routable in the linked XCFramework; validated by the release build")
         }
     }
@@ -95,20 +97,27 @@ final class BackendRegistrationTests: XCTestCase {
         XCTAssertGreaterThanOrEqual(afterFirst, baseline)
         XCTAssertFalse(ANE.version.isEmpty, "ANE module must report a version")
 
-        // Registration + unregistration must be symmetric and crash-free even
-        // when the NeuRT slice is a stub.
+        // Teardown then re-register must be crash-free and keep the registry
+        // consistent (verified via rac_plugin_count before/after each step).
         ANE.unregister()
-        ANE.register() // must be able to re-register after teardown
+        let afterUnregister = rac_plugin_count()
+        XCTAssertLessThanOrEqual(afterUnregister, afterFirst, "unregister must not grow the registry")
+
+        ANE.register()
+        XCTAssertGreaterThanOrEqual(
+            rac_plugin_count(), afterUnregister,
+            "re-registering after teardown must not shrink the registry"
+        )
     }
 
     func testANERoutesDiffusionWhenRoutable() throws {
         ANE.register()
-        guard canRoute(RAC_PRIMITIVE_DIFFUSION) else {
+        guard routes(RAC_PRIMITIVE_DIFFUSION, engine: "neurt") else {
             throw XCTSkip("NeuRT is a stub on the linked binaries; ANE diffusion routing is validated by the routable release build")
         }
         XCTAssertNotNil(
-            rac_plugin_find(RAC_PRIMITIVE_DIFFUSION),
-            "NeuRT must serve DIFFUSION once ANE is registered against routable binaries"
+            rac_plugin_find_for_engine(RAC_PRIMITIVE_DIFFUSION, "neurt"),
+            "the neurt engine must serve DIFFUSION once ANE is registered against routable binaries"
         )
     }
 

--- a/sdk/runanywhere-swift/Tests/RunAnywhereTests/BackendRegistrationTests.swift
+++ b/sdk/runanywhere-swift/Tests/RunAnywhereTests/BackendRegistrationTests.swift
@@ -1,0 +1,128 @@
+//
+//  BackendRegistrationTests.swift
+//  RunAnywhere SDK
+//
+//  End-to-end registration coverage for every shipped backend product —
+//  LlamaCPP (LLM), ONNX + Sherpa (embeddings / STT / TTS / VAD), MLX (Apple
+//  MLX LLM/VLM/embeddings/speech), and ANE / NeuRT (Apple Neural Engine LLM +
+//  CoreML diffusion). These exercise the real commons plugin registry through
+//  each XCFramework, so they are the "does the whole Swift SDK still wire up"
+//  smoke test we run before a release.
+//
+//  Two layers of assertion:
+//    1. Always: `register()` is callable, idempotent (a second call is a
+//       no-op, never a crash), and the registry stays internally consistent
+//       (plugin count never shrinks across a re-register).
+//    2. Routing: a backend that is actually routable in the linked XCFramework
+//       resolves its primitive through `rac_plugin_find`. On stub binaries
+//       (e.g. a NeuRT/Sherpa slice built without the sibling engine sources)
+//       the routing assertion is `XCTSkip`ped rather than failed — the same
+//       test then fully validates routing once the routable release binaries
+//       are staged into Binaries/.
+//
+
+import CRACommons
+import Foundation
+import XCTest
+
+@testable import RunAnywhere
+
+import ANERuntime
+import LlamaCPPRuntime
+import ONNXRuntime
+
+// NOTE: MLXRuntime is intentionally NOT imported here. Its `MLXBackend`
+// C-bridge module re-exposes the commons `rac_vlm_types.h`, whose
+// `rac_vlm_result` struct in the shipped RABackendMLX.xcframework has drifted
+// from the one in RACommons — importing both into one test module makes clang
+// reject the mismatched C struct. MLX registration is covered by the release
+// build and the example app until the MLX xcframework re-syncs its headers.
+
+@MainActor
+final class BackendRegistrationTests: XCTestCase {
+
+    /// True when the commons plugin router can resolve a backend for `primitive`
+    /// (i.e. some routable plugin serving it is registered).
+    private func canRoute(_ primitive: rac_primitive_t) -> Bool {
+        rac_plugin_find(primitive) != nil
+    }
+
+    // MARK: - LlamaCPP (LLM / GENERATE_TEXT)
+
+    func testLlamaCPPRegistrationIsIdempotentAndRoutesLLM() throws {
+        let baseline = rac_plugin_count()
+        LlamaCPP.register()
+        let afterFirst = rac_plugin_count()
+        LlamaCPP.register() // second call must be a safe no-op
+        let afterSecond = rac_plugin_count()
+
+        XCTAssertGreaterThanOrEqual(afterFirst, baseline, "registration must not shrink the registry")
+        XCTAssertEqual(afterFirst, afterSecond, "re-registering llama.cpp must not add a duplicate plugin")
+
+        guard canRoute(RAC_PRIMITIVE_GENERATE_TEXT) else {
+            throw XCTSkip("llama.cpp LLM not routable in the linked XCFramework; validated by the release build")
+        }
+        XCTAssertNotNil(
+            rac_plugin_find(RAC_PRIMITIVE_GENERATE_TEXT),
+            "llama.cpp must serve GENERATE_TEXT once registered"
+        )
+    }
+
+    // MARK: - ONNX + Sherpa (EMBED / TRANSCRIBE / SYNTHESIZE)
+
+    func testONNXRegistrationIsIdempotent() throws {
+        ONNX.register()
+        let afterFirst = rac_plugin_count()
+        ONNX.register()
+        XCTAssertEqual(afterFirst, rac_plugin_count(), "re-registering ONNX must not add a duplicate plugin")
+        XCTAssertFalse(ONNX.version.isEmpty, "ONNX module must report a version")
+
+        // Sherpa speech (STT/TTS/VAD) only routes when RABackendSherpa was built
+        // routable (RAC_SHERPA_ROUTABLE=1); the shipped slice may be a stub.
+        if !canRoute(RAC_PRIMITIVE_TRANSCRIBE) {
+            throw XCTSkip("Sherpa speech not routable in the linked XCFramework; validated by the release build")
+        }
+    }
+
+    // MARK: - ANE / NeuRT (Apple Neural Engine LLM + CoreML diffusion)
+
+    func testANERegistrationIsIdempotentAndUnregisters() throws {
+        let baseline = rac_plugin_count()
+        ANE.register()
+        let afterFirst = rac_plugin_count()
+        ANE.register() // idempotent — must not double-register
+        XCTAssertEqual(afterFirst, rac_plugin_count(), "re-registering ANE must not add a duplicate plugin")
+        XCTAssertGreaterThanOrEqual(afterFirst, baseline)
+        XCTAssertFalse(ANE.version.isEmpty, "ANE module must report a version")
+
+        // Registration + unregistration must be symmetric and crash-free even
+        // when the NeuRT slice is a stub.
+        ANE.unregister()
+        ANE.register() // must be able to re-register after teardown
+    }
+
+    func testANERoutesDiffusionWhenRoutable() throws {
+        ANE.register()
+        guard canRoute(RAC_PRIMITIVE_DIFFUSION) else {
+            throw XCTSkip("NeuRT is a stub on the linked binaries; ANE diffusion routing is validated by the routable release build")
+        }
+        XCTAssertNotNil(
+            rac_plugin_find(RAC_PRIMITIVE_DIFFUSION),
+            "NeuRT must serve DIFFUSION once ANE is registered against routable binaries"
+        )
+    }
+
+    // MARK: - Whole-SDK wiring
+
+    func testAllBackendsRegisterTogether() throws {
+        LlamaCPP.register()
+        ONNX.register()
+        ANE.register()
+
+        // At least one real backend must be present after wiring everything up.
+        XCTAssertGreaterThan(
+            rac_plugin_count(), 0,
+            "registering every backend must leave a non-empty plugin registry"
+        )
+    }
+}

--- a/sdk/runanywhere-swift/Tests/RunAnywhereTests/BackendRegistrationTests.swift
+++ b/sdk/runanywhere-swift/Tests/RunAnywhereTests/BackendRegistrationTests.swift
@@ -105,7 +105,8 @@ final class BackendRegistrationTests: XCTestCase {
 
         ANE.register()
         XCTAssertGreaterThanOrEqual(
-            rac_plugin_count(), afterUnregister,
+            rac_plugin_count(),
+            afterUnregister,
             "re-registering after teardown must not shrink the registry"
         )
     }
@@ -130,7 +131,8 @@ final class BackendRegistrationTests: XCTestCase {
 
         // At least one real backend must be present after wiring everything up.
         XCTAssertGreaterThan(
-            rac_plugin_count(), 0,
+            rac_plugin_count(),
+            0,
             "registering every backend must leave a non-empty plugin registry"
         )
     }


### PR DESCRIPTION
## What

Adds `RunAnywhereANE`, a standalone Swift package product for the NeuRT backend (Apple Neural Engine text generation + CoreML diffusion). Until now NeuRT shipped inside the SDK but was reachable only as a hidden dependency of `RunAnywhereONNX` — there was no way to import it on its own. This exposes it the same way `RunAnywhereLlamaCPP` / `RunAnywhereONNX` / `RunAnywhereMLX` are exposed.

It is a prerequisite for the 0.20.13 release, which ships ANE as its own package.

## How

- New `Sources/ANERuntime` module: `ANE.swift` registers the engine via `rac_plugin_register(rac_plugin_entry_neurt())`, mirroring how `ONNX.swift` registers Sherpa, plus a small C-bridge (`include/`).
- `RunAnywhereANE` product + `ANERuntime`/`ANEBackend` targets added to both the root and local manifests.
- Additive only: NeuRT stays bundled in `RunAnywhereONNX`, so existing ONNX/diffusion consumers are unchanged. No new binary is needed — `RABackendNeuRT` already ships in the release zips.

## Tests

New `BackendRegistrationTests` exercises the real plugin registry through each shipped XCFramework: registration is callable and idempotent, unregister/re-register is clean, and routing is asserted when the backend is routable (otherwise skipped). Full suite locally: 86 tests, 0 failures, 1 skipped. The one skip is the ANE diffusion-routing assertion, which activates automatically once the routable release binaries (built with the `neurun` checkout) are staged.

## Notes for review

- MLX is intentionally not imported by the tests. The shipped `RABackendMLX.xcframework` carries a `rac_vlm_types.h` whose `rac_vlm_result` struct has drifted from the one in `RACommons`; importing `MLXRuntime` and core into one test module makes clang reject the mismatched struct. Worth a separate fix to re-sync the MLX xcframework headers. MLX stays covered by the release build and the example app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Apple Neural Engine and Core ML diffusion support for Swift applications.
  * Added the standalone `RunAnywhereANE` library with automatic backend registration.
  * Added controls to register, unregister, and check the ANE backend version.

* **Bug Fixes**
  * Improved handling of repeated registration attempts and registration failures.

* **Tests**
  * Added coverage for ANE registration, routing, version reporting, and re-registration behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->