### PR TITLE
docs(swift): point NeuRT at the framework case that exists

### DIFF
--- a/sdk/runanywhere-swift/Sources/NeuRTRuntime/NeuRT.swift
+++ b/sdk/runanywhere-swift/Sources/NeuRTRuntime/NeuRT.swift
@@ -19,7 +19,12 @@ import RunAnywhere
 ///
 /// Serves on-device text generation on the Apple Neural Engine and image
 /// generation (diffusion) over CoreML. Import this module and register it to
-/// route `framework == .neurt` model loads through the commons plugin router.
+/// route `framework == .coreml` model loads through the commons plugin router.
+///
+/// The ENGINE id is `neurt` but the FRAMEWORK case is `.coreml`: the engine is
+/// named for the implementing runtime, not for Apple's framework. commons maps
+/// `INFERENCE_FRAMEWORK_COREML` to `RAC_ENGINE_ID_NEURT` in
+/// `engine_name_for_framework()`; there is no `.neurt` framework case.
 ///
 /// ## Registration
 ///


### PR DESCRIPTION
## What is wrong

`NeuRT.swift`'s doc comment points consumers at a framework case that does not exist:

```swift
/// Serves on-device text generation on the Apple Neural Engine and image
/// generation (diffusion) over CoreML. Import this module and register it to
/// route `framework == .neurt` model loads through the commons plugin router.
```

Anyone following that writes `framework: .neurt` and does not get past the compiler.

## Why that is wrong

`.neurt` is not a case of the generated `InferenceFramework`. `model_types.proto` declares only:

```proto
INFERENCE_FRAMEWORK_COREML             = 6;   // Apple
```

and the generated Swift accordingly has `case coreml // = 6` and no `neurt`. Grepping the whole Swift SDK for `.neurt` returns exactly one hit, that doc line.

`neurt` is real, but it is the ENGINE id, which is a different namespace from the framework enum. commons is explicit about the split in `framework_for_engine_name()`:

```cpp
// The engine is `neurt`, the FRAMEWORK is COREML: the engine is named for the implementing
// runtime, not for Apple's framework. This is the exact reverse of
// engine_name_for_framework()'s INFERENCE_FRAMEWORK_COREML -> RAC_ENGINE_ID_NEURT
```

The iOS example already registers these models the working way, which is what a consumer would otherwise have to reverse-engineer:

```swift
name: "LFM2.5 230M (NeuRT / Neural Engine)",
url: "hf.co/runanywhere/LFM2.5-230M_ANE/int8",
framework: .coreml,
```

The sibling module gets this right for its own backend: `ONNX.swift` documents `framework == .sherpa`, and `.sherpa` does exist.

Renaming the module to NeuRT makes the wording more tempting to believe, not less, since the module, the engine and the product are all now spelled NeuRT while the framework case stays `.coreml`.

## What this does

Names the case that exists and states the engine/framework split, so the next reader does not have to rediscover that `neurt` and `.coreml` are the same thing at two different layers.

## Testing

Comment-only, no code paths touched. `swiftc -parse` on the file is clean.

SwiftLint is not runnable on this machine, which has Command Line Tools but no full Xcode, so `swiftlint` aborts loading `sourcekitdInProc.framework`. I am relying on the `swift-spm` CI job for lint rather than implying I ran it locally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that `.coreml` model loads use the commons plugin router.
  * Explained the distinction between the `neurt` engine identifier and framework mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->