### PR TITLE
fix(example/ios): stop claiming three accelerators when CPU is compiled out

### DIFF
--- a/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Services/ModelCatalogBootstrap.swift
+++ b/examples/ios/RunAnywhereAI/RunAnywhereAI/Core/Services/ModelCatalogBootstrap.swift
@@ -1376,7 +1376,13 @@ enum ModelCatalogBootstrap {
             memoryRequirement: 1_583_349_760,
             supportsThinking: true
         )
+        // Only the ANE and MLX registrations above are unconditional; the CPU one
+        // is compiled out when LlamaCPPRuntime is not linked, so do not claim it.
+        #if canImport(LlamaCPPRuntime)
         logger.info("LFM2.5-2.6B registered on all three accelerators")
+        #else
+        logger.info("LFM2.5-2.6B registered on ANE and GPU/MLX; CPU (llama.cpp) not linked")
+        #endif
 
         // --- LoRA adapters ------------------------------------------------------
         // Mirrors Android `ModelBootstrap.seedLora` / `ModelCatalog.loraAdapters`.


### PR DESCRIPTION
## What is wrong

`ModelCatalogBootstrap` logs that one model landed on three accelerators, unconditionally:

```swift
#if canImport(LlamaCPPRuntime)
await registerLLM(
    id: "lfm2.5-2.6b-q4-k-m",
    name: "LFM2.5 2.6B Q4_K_M (CPU)",
    ...
)
#endif
// ... MLX registration, not conditional ...
logger.info("LFM2.5-2.6B registered on all three accelerators")
```

The CPU registration is compiled out when `LlamaCPPRuntime` is not linked. The log line is not, so that build registers two accelerators and reports three.

## Why that is wrong

The comment above the block states the intent, which is exactly what the log is used to confirm:

```swift
// LFM2.5-2.6B is registered three ways on purpose, so one model can be
// compared across CPU (llama.cpp), GPU (MLX) and the Neural Engine
// (neurt) on identical hardware.
```

The ANE and MLX registrations are unconditional, so in a build without `LlamaCPPRuntime` the CPU entry is simply absent from the catalog. Someone checking why the CPU variant is missing greps the log, reads "all three accelerators", and concludes registration succeeded and the bug is downstream in the catalog or the UI. That is the wrong place to look.

## What this does

Logs what the build actually registered.

## Testing

`swiftc -parse` on the file is clean. The change is one log statement split across the same `#if canImport(LlamaCPPRuntime)` condition that already guards the registration it describes, so both branches are covered by the existing compile paths.

SwiftLint is not runnable on this machine, which has Command Line Tools but no full Xcode, so `swiftlint` aborts loading `sourcekitdInProc.framework`. I did not run it and am relying on CI for lint.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model registration logging to accurately report catalog availability across CPU/llama.cpp, ANE, and MLX accelerators.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->