### PR TITLE
fix(web): tear down the voice fan-out when the last subscriber throws

### DIFF
--- a/sdk/runanywhere-web/packages/core/src/Adapters/VoiceAgentStreamAdapter.ts
+++ b/sdk/runanywhere-web/packages/core/src/Adapters/VoiceAgentStreamAdapter.ts
@@ -165,6 +165,13 @@ class HandleFanOut {
             this.subscribers.delete(s);
           }
         }
+        // Dropping the last subscriber here leaves nobody to receive events,
+        // so release the native callback exactly as `detach()` does. Without
+        // this the C callback and its function-table entry stay installed on
+        // a fan-out with no subscribers.
+        if (this.subscribers.size === 0) {
+          this.tearDown();
+        }
       },
       'viii',
     );


### PR DESCRIPTION
## What is wrong

`HandleFanOut`'s broadcast loop drops a subscriber whose `onMessage` throws, but never checks whether that leaves the set empty:

```ts
const snapshot = Array.from(this.subscribers);
for (const s of snapshot) {
  try {
    s.onMessage(event);
  } catch (e) {
    try { s.onError(e instanceof Error ? e : new Error(String(e))); }
    catch { /* swallow */ }
    this.subscribers.delete(s);
  }
}
```

When the last remaining subscriber throws, it is removed and nothing is listening, yet the fan-out stays installed.

## Why that is wrong

Every other path that empties the set releases the native callback. `detach()`:

```ts
private detach(sub: Subscriber): void {
  this.subscribers.delete(sub);
  if (this.subscribers.size === 0) {
    this.tearDown();
  }
}
```

and `broadcastError()` calls `this.subscribers.clear(); this.tearDown();`. Only the throw path skips it, so it is an omission rather than a deliberate difference.

What leaks is not just memory: `tearDown()` clears the C-side callback slot and frees the Emscripten function-table entry.

```ts
private tearDown(): void {
  if (!this.installed) return;
  const m = this.module;
  try { m._rac_voice_agent_set_proto_callback(this.handle, 0, 0); } catch { /* swallow */ }
  try { m.removeFunction(this.cbPtr); } catch { /* swallow */ }
  ...
}
```

So C++ keeps invoking a trampoline for a voice agent nobody is subscribed to, for the lifetime of the handle, and the function-table slot is never reclaimed.

This is the same defect that was just fixed for React Native in #622, which added the identical check to that SDK's `HandleFanOut` after its own drop-on-throw loop.

## What this does

Adds the emptiness check the sibling paths already perform. `tearDown()` is idempotent (`if (!this.installed) return`), so the added call is safe on a fan-out that was already released.

I checked the rest of the Web core for the same shape. The only other `subscribers.delete` on a native-backed fan-out is `detach()`, which is already correct; the one in `RunAnywhere+VoiceAgent.ts` is a plain in-memory emitter with no C callback behind it, so it needs nothing.

## Testing

`npm run typecheck -w packages/core` passes (`tsc --noEmit`, exit 0).

I did not add a unit test, per CONTRIBUTING's note that behaviour is validated E2E through the example apps. Reproducing this one in a test would mean driving a real voice-agent handle and forcing the last subscriber to throw, which is a fair amount of scaffolding for a four-line guard that mirrors an already-merged fix.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved cleanup of voice agent event callbacks when the final subscriber is removed after an error.
  * Prevents lingering callback resources during voice agent stream handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->