### PR TITLE
fix(web): snapshot streaming fetch status before close

### DIFF
--- a/sdk/runanywhere-commons/src/infrastructure/http/rac_http_client_emscripten.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/http/rac_http_client_emscripten.cpp
@@ -342,12 +342,12 @@ rac_result_t do_fetch(const rac_http_request_t* req, rac_http_response_t* out,
         out->body_bytes = nullptr;
         out->body_len = 0;
         // Finished with fetch resources regardless of status.
-        const bool http_ok = fetch->status >= 200 && fetch->status < 400;
+        const bool network_failure = fetch->status == 0;
         emscripten_fetch_close(fetch);
         if (cancelled) {
             return RAC_ERROR_CANCELLED;
         }
-        if (!http_ok && fetch->status == 0) {
+        if (network_failure) {
             return RAC_ERROR_NETWORK_ERROR;
         }
         return RAC_SUCCESS;


### PR DESCRIPTION
## Description

### Problem

The Emscripten streaming HTTP path closed its `emscripten_fetch_t` handle and then read `fetch->status` while deciding whether to return `RAC_ERROR_NETWORK_ERROR`. Accessing the released fetch is undefined behavior and can make network-failure handling unreliable.

### Root cause

Unlike the buffered path in the same function, the streaming path did not snapshot the status-derived network-failure flag before releasing the fetch resources.

### Change

- Snapshot whether `fetch->status` is zero before calling `emscripten_fetch_close(fetch)`.
- Use the snapshot after close instead of dereferencing the released handle.
- Preserve cancellation precedence and the transport contract that nonzero HTTP error statuses are surfaced through the response rather than converted into transport failures.

This is limited to the Emscripten streaming transport. It does not change the public API, native ABI, request behavior, or buffered response path.

### Expected and actual behavior

- Expected: the streaming path decides whether a network failure occurred using state captured while the fetch handle is valid.
- Before: the network-failure branch read `fetch->status` after the handle was closed.
- After: no fetch fields are accessed after `emscripten_fetch_close(fetch)`.

### Related issue

No linked issue. This was found by comparing the streaming cleanup order with the buffered implementation in the same function. Repository searches found no open issue or overlapping pull request for this behavior.

### Risk and reviewer guidance

Risk is low: the change snapshots an existing status predicate before cleanup and leaves cancellation and HTTP-status semantics unchanged. Please verify the ordering around `emscripten_fetch_close(fetch)` in the streaming branch.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally — the required C++ lint tooling is unavailable on this Windows host (`clang-format`, `pre-commit`, and a WSL distribution are not installed).
- [ ] Added/updated tests for changes — no unit test was added because repository guidance asks contributors not to add unit tests unless specifically requested; this is a focused cleanup-order correction.

Validation completed:

- `git diff --check origin/main...HEAD` — passed.
- Confirmed the branch is based on current `origin/main` (`ac9aebbcd5c1f49395cc25c0376bedb7bf1bb7f1`).
- Confirmed the published diff changes only `rac_http_client_emscripten.cpp`.
- Compared the streaming cleanup order with the buffered path, which already snapshots network failure before closing the fetch.
- Reviewed the commit and pull-request text for prohibited attribution references — none found.

Recommended CI validation:

- C++ formatting and repository validation gates.
- WASM build and browser transport checks.

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device) — not applicable; no Swift or iOS sample files changed.
- [ ] Tested on iPad / Tablet — not applicable; no Swift or tablet files changed.
- [ ] Tested on Mac (macOS target) — not applicable; the changed transport is compiled for Emscripten.

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device) — not applicable; no Kotlin or Android files changed.
- [ ] Tested on Android Tablet — not applicable; no Kotlin or Android files changed.

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS — not applicable; no Flutter files changed.
- [ ] Tested on Android — not applicable; no Flutter files changed.

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS — not applicable; no React Native files changed.
- [ ] Tested on Android — not applicable; no React Native files changed.

**Playground:**
- [ ] Tested on target platform — not applicable; no Playground files changed.
- [ ] Verified no regressions in existing Playground projects — not applicable; the change is isolated to the Emscripten HTTP transport.
**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop) — not run; no Emscripten SDK or browser test environment is available on this host.
- [ ] Tested in Firefox — not run; no Emscripten SDK or browser test environment is available on this host.
- [ ] Tested in Safari — not run; Safari is unavailable on this Windows host.
- [ ] WASM backends load (LlamaCpp + ONNX) — not run; the Emscripten SDK and WASM artifacts are unavailable locally.
- [ ] OPFS storage persistence verified (survives page refresh) — not applicable; no storage code changed.
- [ ] Settings persistence verified (localStorage) — not applicable; no settings code changed.

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`sdk/runanywhere-kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`sdk/runanywhere-flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`sdk/runanywhere-react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`sdk/runanywhere-web`)
- [x] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

**Sample Apps:**
- [ ] `iOS Sample` - Changes to iOS example app (`examples/ios`)
- [ ] `Android Sample` - Changes to Android example app (`examples/android`)
- [ ] `Flutter Sample` - Changes to Flutter example app (`examples/flutter`)
- [ ] `React Native Sample` - Changes to React Native example app (`examples/react-native`)
- [ ] `Web Sample` - Changes to Web example app (`examples/web`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed) — no documentation update is needed because there is no public API or usage change.

## Screenshots
No screenshots are applicable. This change has no user-interface output and only corrects native resource-cleanup ordering.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of streaming network requests that return no HTTP status.
  - Such requests now consistently report a network error after cancellation cleanup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->