### PR TITLE
fix(react-native): reject files when creating existing directories

### DIFF
--- a/sdk/runanywhere-react-native/packages/core/cpp/bridges/FileManagerBridge.cpp
+++ b/sdk/runanywhere-react-native/packages/core/cpp/bridges/FileManagerBridge.cpp
@@ -60,6 +60,10 @@ static rac_result_t posixCreateDirectory(const char* path, int recursive, void* 
         if (stat(path, &st) == 0 && S_ISDIR(st.st_mode)) {
             return RAC_SUCCESS;
         }
+        // EEXIST on a non-directory entry (or one we cannot stat) is a real
+        // failure: accepting it would let commons treat a regular file as a
+        // usable directory and fail later, opaquely, on a model/cache write.
+        LOGE("Failed to create directory '%s': path exists but is not a directory", path);
     }
     return RAC_ERROR_DIRECTORY_CREATION_FAILED;
 }

--- a/sdk/runanywhere-react-native/packages/core/cpp/bridges/FileManagerBridge.cpp
+++ b/sdk/runanywhere-react-native/packages/core/cpp/bridges/FileManagerBridge.cpp
@@ -52,8 +52,14 @@ static rac_result_t posixCreateDirectory(const char* path, int recursive, void* 
         }
     }
 
-    if (mkdir(path, 0755) == 0 || errno == EEXIST) {
+    if (mkdir(path, 0755) == 0) {
         return RAC_SUCCESS;
+    }
+    if (errno == EEXIST) {
+        struct stat st;
+        if (stat(path, &st) == 0 && S_ISDIR(st.st_mode)) {
+            return RAC_SUCCESS;
+        }
     }
     return RAC_ERROR_DIRECTORY_CREATION_FAILED;
 }


### PR DESCRIPTION
## Description

### Problem

The React Native POSIX file-manager callback treated every `mkdir` failure with `errno == EEXIST` as success. `EEXIST` also occurs when the target path is a regular file, so commons could accept an invalid directory structure and encounter less-specific failures during later model or cache writes.

### Root cause

`posixCreateDirectory` used the existence error as a proxy for directory type without inspecting the existing filesystem entry.

### Change

- Return success immediately when `mkdir` creates the directory.
- When `mkdir` reports `EEXIST`, call `stat` and return success only when `S_ISDIR` confirms the existing entry is a directory.
- Return `RAC_ERROR_DIRECTORY_CREATION_FAILED` when the existing entry is not a directory or cannot be inspected.

This is limited to the React Native POSIX file-manager bridge. It does not change the public API, native ABI, directory layout, permissions, or recursive traversal behavior.

### Expected and actual behavior

- Expected: an existing directory is accepted, while a regular file at the requested directory path is rejected.
- Before: both an existing directory and an existing regular file produced `RAC_SUCCESS`.
- After: only an entry confirmed to be a directory produces `RAC_SUCCESS` after `EEXIST`.

### Related issue

No linked issue. This was found by comparing the callback result with the directory-creation contract and the commons helper that verifies an existing path is a directory. Repository searches found no open issue or overlapping pull request for this behavior.

### Risk and reviewer guidance

Risk is low: successful directory creation and existing-directory behavior are unchanged. Please verify the `EEXIST` branch and that `stat` intentionally follows a symlink resolving to a directory, consistent with normal directory-path semantics.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally — the required C++ lint tooling is unavailable on this Windows host (`clang-format`, `pre-commit`, and a WSL distribution are not installed).
- [ ] Added/updated tests for changes — no unit test was added because repository guidance asks contributors not to add unit tests unless specifically requested; this is a focused POSIX callback correction.

Validation completed:

- `git diff --check origin/main...HEAD` — passed.
- Confirmed the branch is based on current `origin/main` (`ac9aebbcd5c1f49395cc25c0376bedb7bf1bb7f1`).
- Confirmed the published diff changes only `FileManagerBridge.cpp`.
- Reviewed the `mkdir`, `errno`, `stat`, and `S_ISDIR` ordering and the downstream commons callback contract.
- Reviewed the commit and pull-request text for prohibited attribution references — none found.

Recommended CI validation:

- C++ formatting and repository validation gates.
- React Native iOS and Android native builds.

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device) — not applicable; no Swift SDK or iOS sample files changed.
- [ ] Tested on iPad / Tablet — not applicable; no Swift SDK or tablet files changed.
- [ ] Tested on Mac (macOS target) — not applicable; no Swift or macOS files changed.

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device) — not applicable; no Kotlin SDK or Android sample files changed.
- [ ] Tested on Android Tablet — not applicable; no Kotlin SDK or Android sample files changed.

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS — not applicable; no Flutter files changed.
- [ ] Tested on Android — not applicable; no Flutter files changed.

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS — not run; no Apple build environment or simulator is available on this Windows host.
- [ ] Tested on Android — not run; the native Android build dependencies are not staged in this clean worktree.

**Playground:**
- [ ] Tested on target platform — not applicable; no Playground files changed.
- [ ] Verified no regressions in existing Playground projects — not applicable; the change is isolated to the React Native filesystem callback.
**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop) — not applicable; no Web files changed.
- [ ] Tested in Firefox — not applicable; no Web files changed.
- [ ] Tested in Safari — not applicable; no Web files changed.
- [ ] WASM backends load (LlamaCpp + ONNX) — not applicable; no WASM files changed.
- [ ] OPFS storage persistence verified (survives page refresh) — not applicable; no Web storage files changed.
- [ ] Settings persistence verified (localStorage) — not applicable; no Web settings files changed.

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`sdk/runanywhere-kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`sdk/runanywhere-flutter`)
- [x] `React Native SDK` - Changes to React Native SDK (`sdk/runanywhere-react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`sdk/runanywhere-web`)
- [ ] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

**Sample Apps:**
- [ ] `iOS Sample` - Changes to iOS example app (`examples/ios`)
- [ ] `Android Sample` - Changes to Android example app (`examples/android`)
- [ ] `Flutter Sample` - Changes to Flutter example app (`examples/flutter`)
- [ ] `React Native Sample` - Changes to React Native example app (`examples/react-native`)
- [ ] `Web Sample` - Changes to Web example app (`examples/web`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed) — no documentation update is needed because there is no public API or usage change.

## Screenshots
No screenshots are applicable. This change has no user-interface output and only corrects native filesystem validation.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved directory creation reliability by confirming that an existing path is a directory.
  * Directory creation now reports an error when the path already exists as a file or another non-directory item.
  * Added clearer failure handling when an existing path cannot be inspected, helping prevent ambiguous directory creation results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->