### PR TITLE
fix(commons): handle LoRA entry allocation failures

### DIFF
--- a/sdk/runanywhere-commons/src/foundation/rac_proto_adapters.cpp
+++ b/sdk/runanywhere-commons/src/foundation/rac_proto_adapters.cpp
@@ -810,15 +810,30 @@ bool rac_lora_entry_from_proto(const ::runanywhere::v1::LoraAdapterCatalogEntry&
         return false;
     std::memset(out, 0, sizeof(*out));
     out->id = copy_string(in.id());
+    if (!in.id().empty() && !out->id) {
+        return false;
+    }
     out->name = copy_string(in.name());
+    if (!in.name().empty() && !out->name) {
+        return false;
+    }
     // Preserve an explicit catalog 0.0; only absent default_scale falls back.
     out->default_scale = in.has_default_scale() ? in.default_scale() : 1.0f;
     if (in.compatible_models_size() > 0) {
         out->compatible_model_count = static_cast<size_t>(in.compatible_models_size());
         out->compatible_model_ids =
-            static_cast<char**>(rac_alloc(sizeof(char*) * out->compatible_model_count));
+            static_cast<char**>(std::calloc(out->compatible_model_count, sizeof(char*)));
+        if (!out->compatible_model_ids) {
+            // Keep the count consistent with the null pointer so the entry never
+            // advertises elements that were never allocated.
+            out->compatible_model_count = 0;
+            return false;
+        }
         for (int i = 0; i < in.compatible_models_size(); ++i) {
             out->compatible_model_ids[i] = rac_strdup(in.compatible_models(i).c_str());
+            if (!out->compatible_model_ids[i]) {
+                return false;
+            }
         }
     }
     return true;

--- a/sdk/runanywhere-commons/src/infrastructure/model_management/lora_registry.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/model_management/lora_registry.cpp
@@ -542,8 +542,8 @@ extern "C" rac_result_t rac_lora_registry_register_catalog_entry_proto(
     }
     if (!rac::foundation::rac_lora_entry_from_proto(proto, entry)) {
         rac_lora_entry_free(entry);
-        return rac_proto_buffer_set_error(out_entry, RAC_ERROR_DECODING_ERROR,
-                                          "failed to convert LoraAdapterCatalogEntry");
+        return rac_proto_buffer_set_error(out_entry, RAC_ERROR_OUT_OF_MEMORY,
+                                          "failed to allocate LoRA entry fields");
     }
 
     rc = rac_lora_registry_register(registry, entry);


### PR DESCRIPTION
## Description

### Problem

`rac_lora_entry_from_proto` copied owned LoRA entry fields without consistently checking allocation results. A failed compatible-model array allocation was followed by writes through a null pointer, while failed string copies could leave a partial entry that the function still reported as successfully converted.

### Root cause

The conversion zeroed the destination but did not apply the allocation-and-cleanup discipline used by the LoRA registry's deep-copy path. Its caller also classified every conversion failure as a decoding error even though the validated proto had already parsed successfully and the reachable failures were allocation failures.

### Change

- Check allocations for nonempty adapter `id` and `name` fields.
- Allocate the compatible-model pointer array with `calloc` so unpopulated slots remain null during partial cleanup.
- Check the pointer-array allocation and every compatible-model string copy.
- Return `false` immediately after an allocation failure; the existing caller-owned cleanup releases all completed allocations.
- Report the conversion failure as `RAC_ERROR_OUT_OF_MEMORY` from the sole registry caller.

This does not change the public API, native ABI, wire format, catalog validation, or successful registration behavior.

### Expected and actual behavior

- Expected: allocation failure stops conversion, safely releases partial state, and returns an out-of-memory result.
- Before: array allocation failure could cause a null-pointer write, while field allocation failure could produce an incomplete entry or a misleading decoding error.
- After: every owned allocation in this conversion is checked, partial state is null-safe for `rac_lora_entry_free`, and the caller reports the correct error category.

### Related issue

No linked issue. This was found by comparing proto conversion with `deep_copy_lora_entry`, which already uses zero-initialized compatible-model storage and checks partial allocation failures. Repository searches found no open issue or overlapping pull request for this behavior.

### Risk and reviewer guidance

Risk is low and limited to failure handling. Successful conversions retain the same field values. Please verify allocation/free symmetry between `rac_lora_entry_from_proto`, `rac_lora_entry_free`, and the registry caller, especially that `compatible_model_count` is set before the zero-initialized array is populated.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally — the required C++ lint tooling is unavailable on this Windows host (`clang-format`, `pre-commit`, and a WSL distribution are not installed).
- [ ] Added/updated tests for changes — no unit test was added because repository guidance asks contributors not to add unit tests unless specifically requested; the failure-path behavior was verified through ownership and cleanup inspection.

Validation completed:

- `git diff --check origin/main...HEAD` — passed.
- Confirmed the branch is based on current `origin/main` (`ac9aebbcd5c1f49395cc25c0376bedb7bf1bb7f1`).
- Confirmed the published diff changes only `rac_proto_adapters.cpp` and `lora_registry.cpp`.
- Confirmed `rac_lora_entry_free` releases `id`, `name`, each nonnull compatible-model string, and the pointer array.
- Confirmed the compatible-model array is zero-initialized and its count is set before population, making partial cleanup safe.
- Confirmed `rac_lora_registry_register_catalog_entry_proto` is the sole caller and passes a nonnull, zero-initialized entry.
- Reviewed the commit and pull-request text for prohibited attribution references — none found.

Recommended CI validation:

- C++ formatting and commons build gates.
- Platform SDK builds that consume the commons LoRA registry ABI.

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device) — not run; no Apple build environment or simulator is available on this Windows host.
- [ ] Tested on iPad / Tablet — not run; no Apple build environment or simulator is available on this Windows host.
- [ ] Tested on Mac (macOS target) — not run; macOS is unavailable on this host.

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device) — not run; native Android artifacts and a device environment are unavailable in this clean worktree.
- [ ] Tested on Android Tablet — not run; no tablet environment is available.

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS — not run; no Apple or Flutter environment is available.
- [ ] Tested on Android — not run; no Flutter environment is available.

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS — not run; no Apple build environment is available.
- [ ] Tested on Android — not run; native Android artifacts are not staged in this clean worktree.

**Playground:**
- [ ] Tested on target platform — not run; no Playground files changed and platform binaries are unavailable.
- [ ] Verified no regressions in existing Playground projects — not run; the change is isolated to commons LoRA allocation failure handling.
**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop) — not run; no Emscripten SDK or built WASM artifacts are available locally.
- [ ] Tested in Firefox — not run; no Emscripten SDK or built WASM artifacts are available locally.
- [ ] Tested in Safari — not run; Safari is unavailable on this Windows host.
- [ ] WASM backends load (LlamaCpp + ONNX) — not run; no Emscripten SDK or built WASM artifacts are available locally.
- [ ] OPFS storage persistence verified (survives page refresh) — not applicable; no storage behavior changed.
- [ ] Settings persistence verified (localStorage) — not applicable; no settings behavior changed.

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`sdk/runanywhere-swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`sdk/runanywhere-kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`sdk/runanywhere-flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`sdk/runanywhere-react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`sdk/runanywhere-web`)
- [x] `Commons` - Changes to shared native code (`sdk/runanywhere-commons`)

**Sample Apps:**
- [ ] `iOS Sample` - Changes to iOS example app (`examples/ios`)
- [ ] `Android Sample` - Changes to Android example app (`examples/android`)
- [ ] `Flutter Sample` - Changes to Flutter example app (`examples/flutter`)
- [ ] `React Native Sample` - Changes to React Native example app (`examples/react-native`)
- [ ] `Web Sample` - Changes to Web example app (`examples/web`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed) — no documentation update is needed because there is no public API, ABI, or usage change.

## Screenshots
No screenshots are applicable. This change has no user-interface output and only corrects native allocation-failure behavior.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when registering LoRA catalog entries.
  * Added safer handling for incomplete or unavailable catalog data, preventing invalid entries from being accepted.
  * Registration now reports resource-related failures more accurately, making errors easier to diagnose.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->