### PR TITLE
fix(web): share one RAG session across concurrent ensureSession callers

### DIFF
--- a/sdk/runanywhere-web/packages/core/src/Public/Extensions/RunAnywhere+RAG.ts
+++ b/sdk/runanywhere-web/packages/core/src/Public/Extensions/RunAnywhere+RAG.ts
@@ -313,6 +313,7 @@ function requireProvider(feature = 'RAG'): RAGProvider {
 class NativeRAGSessionProvider implements RAGProvider {
   readonly providerKind = 'wasm-session' as const;
   private session: number | null = null;
+  private sessionInit: Promise<number> | null = null;
   private config: RAGConfiguration;
 
   constructor(
@@ -464,11 +465,22 @@ class NativeRAGSessionProvider implements RAGProvider {
     };
   }
 
-  private async ensureSession(): Promise<number> {
-    if (this.session != null) return this.session;
-    validateNativeRAGConfiguration(this.config, 'RAG.session');
-    await this.ragCreatePipeline(this.config);
-    return this.session!;
+  private ensureSession(): Promise<number> {
+    if (this.session != null) return Promise.resolve(this.session);
+    // Concurrent callers share one creation. `ragCreatePipeline` is not
+    // idempotent: it destroys any existing session and creates a fresh one, so
+    // a second caller arriving while the first awaits would still see a null
+    // session, create a second native session, and orphan whichever handle
+    // lost the assignment race. Cleared once settled so a failed creation can
+    // be retried.
+    this.sessionInit ??= (async () => {
+      validateNativeRAGConfiguration(this.config, 'RAG.session');
+      await this.ragCreatePipeline(this.config);
+      return this.session!;
+    })().finally(() => {
+      this.sessionInit = null;
+    });
+    return this.sessionInit;
   }
 
   private async statistics(): Promise<RAGStatistics> {


### PR DESCRIPTION
## What is wrong

`NativeRAGSessionProvider.ensureSession()` is a lazy initialiser with no in-flight guard:

```ts
private async ensureSession(): Promise<number> {
  if (this.session != null) return this.session;
  validateNativeRAGConfiguration(this.config, 'RAG.session');
  await this.ragCreatePipeline(this.config);
  return this.session!;
}
```

The `session == null` check and the assignment are separated by an `await`, so two callers that arrive before the first one finishes both pass the check.

## Why that is wrong

`ragCreatePipeline` is not idempotent. It tears down any existing session and creates a new one:

```ts
async ragCreatePipeline(config: RAGConfiguration): Promise<void> {
  validateNativeRAGConfiguration(config, 'RAG.createPipeline');
  if (this.session != null) {
    await this.adapter.destroySession(this.session);
    this.session = null;
  }
  const session = await this.adapter.createSession(config);
  ...
```

Its own guard cannot help here, because the racing caller still observes `this.session === null` — the first caller has not assigned yet. So both reach `adapter.createSession`, two native RAG sessions are created, and only the one that assigns last is reachable through `this.session`. The other handle is never passed to `destroySession`, so it lives until the WASM instance goes away.

This is reachable from ordinary use: `ensureSession()` backs five public entry points on this provider (`ragIngest`, `ragQuery`, `ragQueryStream`, `ragSearch`, `ragClearDocuments`). Anything that kicks off two of them without awaiting in between hits it, for example ingesting a document while a query is already in flight, or a UI that mounts two RAG-backed views at once.

To be clear about scope: this is pre-existing rather than a regression from the recent Web work. I found it while reviewing the RAG changes in #641 and confirmed it is still present at HEAD.

## What this does

Memoises the in-flight creation so concurrent callers await the same promise, and clears the memo once it settles so a failed creation can still be retried.

I kept it to one field and one branch rather than introducing a lock or a state machine, since the only invariant that needs restoring is "at most one creation in flight".

## Testing

`npm run typecheck -w packages/core` passes (`tsc --noEmit`, exit 0).

I did not add a unit test. Reproducing this deterministically means interleaving two `ensureSession` callers around the `createSession` await, which needs a fake adapter that parks that promise — noticeably more scaffolding than the fix, and CONTRIBUTING points behaviour coverage at the example apps.

I also could not run the existing web unit suite on this machine: `vitest` fails to load with `Cannot find module '@bufbuild/protobuf/wire'` after a clean `npm install` in `sdk/runanywhere-web`, and it fails identically with my diff stashed, so it is pre-existing and not from this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when multiple requests initialize a native RAG session simultaneously.
  * Prevented duplicate initialization attempts while preserving the ability to retry after failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->