### PR TITLE
fix(commons): optimize VLM streaming hot path & fix VAD session leak (#647)

### DIFF
--- a/sdk/runanywhere-commons/include/rac/features/vad/rac_vad_stream.h
+++ b/sdk/runanywhere-commons/include/rac/features/vad/rac_vad_stream.h
@@ -142,6 +142,11 @@ RAC_API rac_result_t rac_vad_stream_stop_proto(uint64_t session_id);
  */
 RAC_API rac_result_t rac_vad_stream_cancel_proto(uint64_t session_id);
 
+/**
+ * @brief Teardown all VAD streaming sessions for a handle.
+ */
+RAC_API void rac_vad_stream_component_teardown(rac_handle_t handle);
+
 #ifdef __cplusplus
 } /* extern "C" */
 #endif

--- a/sdk/runanywhere-commons/include/rac/features/vad/rac_vad_stream.h
+++ b/sdk/runanywhere-commons/include/rac/features/vad/rac_vad_stream.h
@@ -143,9 +143,22 @@ RAC_API rac_result_t rac_vad_stream_stop_proto(uint64_t session_id);
 RAC_API rac_result_t rac_vad_stream_cancel_proto(uint64_t session_id);
 
 /**
- * @brief Teardown all VAD streaming sessions for a handle.
+ * @brief Clear the stream callback slot AND erase every streaming session
+ *        still bound to @p handle.
+ *
+ * Commons-internal: called only from rac_vad_component_destroy() in
+ * vad_module.cpp. Deliberately NOT decorated with RAC_API — it is not part of
+ * the exported SDK ABI (see sdk/runanywhere-commons/exports/RACommons.exports
+ * and scripts/validation/commons/check_rac_api_exports.sh), and SDK bridges
+ * must keep using rac_vad_unset_stream_proto_callback() +
+ * rac_vad_proto_quiesce() for their own teardown.
+ *
+ * Superset of rac_vad_unset_stream_proto_callback(handle): sessions that were
+ * never stopped/cancelled would otherwise outlive the component in the session
+ * registry, holding a dangling handle that a recycled component address makes
+ * indistinguishable from a live session.
  */
-RAC_API void rac_vad_stream_component_teardown(rac_handle_t handle);
+void rac_vad_stream_component_teardown(rac_handle_t handle);
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/sdk/runanywhere-commons/src/features/vad/rac_vad_stream.cpp
+++ b/sdk/runanywhere-commons/src/features/vad/rac_vad_stream.cpp
@@ -277,7 +277,7 @@ void rac_vad_stream_component_teardown(rac_handle_t handle) {
         return;
     std::lock_guard<std::mutex> lock(g_mu());
     g_slots().erase(handle);
-    for (auto it = g_sessions().begin(); it != g_sessions().end(); ) {
+    for (auto it = g_sessions().begin(); it != g_sessions().end();) {
         if (it->second.handle == handle) {
             it = g_sessions().erase(it);
         } else {

--- a/sdk/runanywhere-commons/src/features/vad/rac_vad_stream.cpp
+++ b/sdk/runanywhere-commons/src/features/vad/rac_vad_stream.cpp
@@ -272,6 +272,20 @@ rac_result_t rac_vad_unset_stream_proto_callback(rac_handle_t handle) {
     return RAC_SUCCESS;
 }
 
+void rac_vad_stream_component_teardown(rac_handle_t handle) {
+    if (handle == nullptr)
+        return;
+    std::lock_guard<std::mutex> lock(g_mu());
+    g_slots().erase(handle);
+    for (auto it = g_sessions().begin(); it != g_sessions().end(); ) {
+        if (it->second.handle == handle) {
+            it = g_sessions().erase(it);
+        } else {
+            ++it;
+        }
+    }
+}
+
 // Public quiesce helper. Mirrors
 // rac_vlm_proto_quiesce / rac_llm_proto_quiesce. Spin-waits until every
 // in-flight dispatch_vad_stream_event invocation has returned. Callers

--- a/sdk/runanywhere-commons/src/features/vad/vad_module.cpp
+++ b/sdk/runanywhere-commons/src/features/vad/vad_module.cpp
@@ -699,7 +699,7 @@ extern "C" void rac_vad_component_destroy(rac_handle_t handle) {
     // in addition to the proto_activity_slot cleared above. Without this, the
     // wire-seq + stale user_data UAF triggers when the handle heap address is
     // reused by a fresh component (rac_vad_component_create).
-    rac_vad_unset_stream_proto_callback(handle);
+    rac_vad_stream_component_teardown(handle);
     // Spin-wait for any in-flight
     // dispatch_vad_stream_event() invocation on another thread before freeing
     // the component. Mirrors rac_vlm_component_destroy / rac_llm_component_destroy.

--- a/sdk/runanywhere-commons/src/features/vlm/vlm_module.cpp
+++ b/sdk/runanywhere-commons/src/features/vlm/vlm_module.cpp
@@ -1114,17 +1114,14 @@ rac_bool_t dispatch_vlm_terminal_once(GeneratedStreamCtx* ctx,
         return RAC_TRUE;
     }
     ctx->terminal_sent = true;
-    
-    runanywhere::v1::SDKEvent event;
-    populate_envelope(&event, error_code != 0 ? runanywhere::v1::ERROR_SEVERITY_ERROR : runanywhere::v1::ERROR_SEVERITY_INFO);
-    auto* generation = event.mutable_generation();
-    generation->set_kind(error_code != 0 ? runanywhere::v1::GENERATION_EVENT_KIND_FAILED : runanywhere::v1::GENERATION_EVENT_KIND_COMPLETED);
-    generation->set_streaming_text(ctx->text);
-    generation->set_output_tokens(ctx->token_count);
-    if (ctx->ref && ctx->ref->model_id)
-        generation->set_model_id(ctx->ref->model_id);
-    publish_event(event);
-
+    // No terminal SDKEvent is published here on purpose. The VLM stream's
+    // terminal telemetry row is already owned by the
+    // CAPABILITY_OPERATION_EVENT_KIND_VLM_COMPLETED / VLM_FAILED capability
+    // events emitted by rac_vlm_stream_proto (and publish_failure). Publishing
+    // a GenerationEvent COMPLETED/FAILED here would emit a SECOND terminal row
+    // ("vlm.generation.completed" alongside "vlm.process.completed") — both are
+    // flagged as completions by telemetry_manager and both charge the same
+    // output_tokens, double-counting every streamed VLM turn.
     return dispatch_vlm_stream_event(ctx, kind, nullptr, true, result, error_message, error_code);
 }
 

--- a/sdk/runanywhere-commons/src/features/vlm/vlm_module.cpp
+++ b/sdk/runanywhere-commons/src/features/vlm/vlm_module.cpp
@@ -1075,7 +1075,8 @@ rac_bool_t dispatch_vlm_stream_event(GeneratedStreamCtx* ctx,
     }
     (void)is_final;  // kind (COMPLETED/ERROR) is the sole terminal discriminator now.
 
-    runanywhere::v1::VLMStreamEvent event;
+    thread_local runanywhere::v1::VLMStreamEvent event;
+    event.Clear();
     event.set_timestamp_us(now_us());
     event.set_request_id(ctx->request_id);
     event.set_kind(kind);
@@ -1098,7 +1099,7 @@ rac_bool_t dispatch_vlm_stream_event(GeneratedStreamCtx* ctx,
         }
     }
 
-    std::vector<uint8_t> bytes;
+    thread_local std::vector<uint8_t> bytes;
     if (!serialize_vlm_stream_event(event, &bytes)) {
         return RAC_FALSE;
     }
@@ -1113,6 +1114,17 @@ rac_bool_t dispatch_vlm_terminal_once(GeneratedStreamCtx* ctx,
         return RAC_TRUE;
     }
     ctx->terminal_sent = true;
+    
+    runanywhere::v1::SDKEvent event;
+    populate_envelope(&event, error_code != 0 ? runanywhere::v1::ERROR_SEVERITY_ERROR : runanywhere::v1::ERROR_SEVERITY_INFO);
+    auto* generation = event.mutable_generation();
+    generation->set_kind(error_code != 0 ? runanywhere::v1::GENERATION_EVENT_KIND_FAILED : runanywhere::v1::GENERATION_EVENT_KIND_COMPLETED);
+    generation->set_streaming_text(ctx->text);
+    generation->set_output_tokens(ctx->token_count);
+    if (ctx->ref && ctx->ref->model_id)
+        generation->set_model_id(ctx->ref->model_id);
+    publish_event(event);
+
     return dispatch_vlm_stream_event(ctx, kind, nullptr, true, result, error_message, error_code);
 }
 
@@ -1137,7 +1149,6 @@ rac_bool_t generated_stream_token_trampoline(const char* token, void* user_data)
                              ? runanywhere::v1::GENERATION_EVENT_KIND_FIRST_TOKEN_GENERATED
                              : runanywhere::v1::GENERATION_EVENT_KIND_TOKEN_GENERATED);
     generation->set_token(display);
-    generation->set_streaming_text(ctx->text);
     generation->set_output_tokens(ctx->token_count);
     if (ctx->ref->model_id)
         generation->set_model_id(ctx->ref->model_id);
@@ -1427,6 +1438,7 @@ rac_result_t rac_vlm_stream_proto(const uint8_t* request_proto_bytes, size_t req
     ctx.ref = &ref;
     ctx.request_id = request.request_id();
     ctx.started_ms = now_ms();
+    ctx.text.reserve(2048);
 
     dispatch_vlm_stream_event(&ctx, runanywhere::v1::VLM_STREAM_EVENT_KIND_STARTED, nullptr, false,
                               nullptr, nullptr, 0);

--- a/sdk/runanywhere-commons/src/infrastructure/model_management/model_assignment.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/model_management/model_assignment.cpp
@@ -63,8 +63,10 @@ static void clear_cache_internal() {
         rac_model_info_free(model);
     }
     g_cached_models.clear();
+    g_cached_models.shrink_to_fit();
 #ifdef RAC_HAVE_PROTOBUF
     g_cached_model_proto_bytes.clear();
+    g_cached_model_proto_bytes.shrink_to_fit();
 #endif
     g_cache_valid = false;
 }

--- a/sdk/runanywhere-commons/src/infrastructure/model_management/model_assignment.cpp
+++ b/sdk/runanywhere-commons/src/infrastructure/model_management/model_assignment.cpp
@@ -63,10 +63,8 @@ static void clear_cache_internal() {
         rac_model_info_free(model);
     }
     g_cached_models.clear();
-    g_cached_models.shrink_to_fit();
 #ifdef RAC_HAVE_PROTOBUF
     g_cached_model_proto_bytes.clear();
-    g_cached_model_proto_bytes.shrink_to_fit();
 #endif
     g_cache_valid = false;
 }


### PR DESCRIPTION
## Summary
Fixes performance bottlenecks and memory leaks identified in issue #647.

### Key Fixes
1. **VLM Streaming Hot Path Optimization (\lm_module.cpp\)**:
   - Added \	hread_local\ reuse for \VLMStreamEvent\ proto and scratch byte vector in \dispatch_vlm_stream_event()\, eliminating ~6 heap allocations per token at steady state.
   - Eliminated O(N^2) streaming text re-serialization on intermediate tokens in \generated_stream_token_trampoline()\ by sending delta tokens instead of full accumulated text on intermediate events. Full accumulated text is dispatched upon completion.
   - Added \ctx.text.reserve(2048)\ before starting generation to prevent string reallocations.

2. **VAD Stream Registry Memory Leak Fix (\ac_vad_stream.h\, \ac_vad_stream.cpp\, \ad_module.cpp\)**:
   - Declared and implemented \ac_vad_stream_component_teardown(handle)\ to sweep and erase orphaned sessions from \g_sessions()\ when a VAD component is destroyed.
   - Wired teardown into \ac_vad_component_destroy()\ in \ad_module.cpp\, matching STT/TTS cleanup patterns.

3. **Assignment Cache Memory Reclamation (\model_assignment.cpp\)**:
   - Added \.shrink_to_fit()\ on \g_cached_models\ and \g_cached_model_proto_bytes\ inside \clear_cache_internal()\.

Fixes #647

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved voice activity detection component cleanup to prevent lingering streaming sessions and callbacks.
  * Enhanced shutdown reliability by ensuring active stream dispatch is fully quiesced before release.

* **Improvements**
  * Streamlined vision-language streaming events for more consistent terminal status reporting.
  * Reduced redundant streaming payload data and improved handling of text accumulated during streaming.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->