### PR TITLE
fix(web): measure decodeTokensPerSecond over decode time, not the whole span

### DIFF
--- a/sdk/runanywhere-web/packages/core/src/Public/Extensions/RunAnywhere+TextGeneration.ts
+++ b/sdk/runanywhere-web/packages/core/src/Public/Extensions/RunAnywhere+TextGeneration.ts
@@ -429,7 +429,7 @@ export async function aggregateStream(
       outputTokens,
       totalTokens: (result.usage?.totalTokens ?? 0) || inputTokens + outputTokens,
       decodeTokensPerSecond: (result.usage?.decodeTokensPerSecond ?? 0)
-        || (totalLatencyMs > 0 ? tokenCount / (totalLatencyMs / 1000) : 0),
+        || (decodeMs > 0 ? (tokenCount / decodeMs) * 1000 : 0),
       prefillMs: result.usage?.prefillMs ?? 0,
       ttftMs: result.usage?.ttftMs ?? (ttftMs ?? 0),
     },


### PR DESCRIPTION
Part of #635.

## What is wrong

`aggregateStream`'s throughput fallback divides the token count by the whole request span:

```ts
const generationTimeMs = result.generationTimeMs || totalLatencyMs;
const decodeMs = generationTimeMs - (result.promptEvalTimeMs ?? 0);
...
decodeTokensPerSecond: (result.usage?.decodeTokensPerSecond ?? 0)
  || (totalLatencyMs > 0 ? tokenCount / (totalLatencyMs / 1000) : 0),
```

`totalLatencyMs` starts at the request, so prefill sits inside the denominator of a field named `decodeTokensPerSecond`.

## Why that is wrong

commons excludes prefill deliberately and says why in `llm_module.cpp`:

```cpp
// Tokens/sec over decode time only — including prefill (TTFT) in the
// denominator systematically understates generation speed.
```

So the same run reports a lower rate on this path than commons reports natively. With 100 tokens, 1s prefill and a 5s span that is 20 tok/s here against 25 from commons, and the gap widens with prompt length. It is silent, because both write the same field.

The value needed is already there. `decodeMs` is computed two lines above and is trusted enough to be reported as `decodeTimeMs` in the same object, and the sibling path earlier in this file already does it correctly:

```ts
decodeTokensPerSecond: final?.usage?.decodeTokensPerSecond
  ?? (decodeMs > 0 ? (outputTokens / decodeMs) * 1000 : 0),
```

Only this one fallback still uses the full span.

## What this does

Uses `decodeMs` for the rate, matching the sibling path and commons. One line, no new state, and the guard shape is unchanged so a zero or negative window still yields 0 rather than a divide-by-zero.

Kotlin had the same defect and was fixed in #634.

## Scope

#635 lists three sites. This is the one that is a clean one-liner with the correct value already in scope. The second Web site it mentions has since been fixed independently, and the Swift one has been rewritten around a batch-buffered heuristic that deserves its own discussion rather than being folded in here.

## Testing

`npm run typecheck -w packages/core` passes (`tsc --noEmit`, exit 0).

I could not run the web unit suite on this machine: `vitest` fails to load with `Cannot find module '@bufbuild/protobuf/wire'` after a clean `npm install`, and it fails identically with my diff stashed, so it is pre-existing rather than from this change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved streaming text-generation performance reporting by calculating fallback decode throughput from decode time rather than total request latency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->