### PR TITLE
fix(swift): rate decodeTokensPerSecond over the decode window

### DIFF
--- a/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+TextGeneration.swift
+++ b/sdk/runanywhere-swift/Sources/RunAnywhere/Public/Extensions/LLM/RunAnywhere+TextGeneration.swift
@@ -285,6 +285,11 @@ private extension RunAnywhere {
         let wallTps = generationTimeMs > 0 && outputTokens > 0
             ? Double(outputTokens) / (generationTimeMs / 1000.0) : 0
         let decodeWindow = reportedTtft.map { generationTimeMs - Double($0) } ?? generationTimeMs
+        // Rate over the decode window, matching commons' llm_module.cpp. Falls
+        // back to the full span when TTFT is unknown, in which case
+        // `decodeWindow` already IS the full span, so this is wallTps.
+        let decodeTps = decodeWindow > 0 && outputTokens > 0
+            ? Double(outputTokens) / (decodeWindow / 1000.0) : wallTps
         let batchBuffered =
             reportedTtft != nil && decodeWindow < max(50.0, generationTimeMs * 0.05)
         if batchBuffered {
@@ -293,7 +298,7 @@ private extension RunAnywhere {
             result.promptEvalTimeMs = 0
             result.decodeTimeMs = Int64(generationTimeMs.rounded())
         } else {
-            result.usage.decodeTokensPerSecond = reportedTps > 0 ? reportedTps : wallTps
+            result.usage.decodeTokensPerSecond = reportedTps > 0 ? reportedTps : decodeTps
             if let reportedTtft { result.usage.ttftMs = reportedTtft }
             result.promptEvalTimeMs = final?.promptEvalTimeMs ?? (reportedTtft ?? 0)
             result.decodeTimeMs = final?.decodeTimeMs ?? 0


### PR DESCRIPTION
Part of #635. Companion to #662 (Web) and #634 (Kotlin, merged).

## What is wrong

`applyTimingMetrics` computes the decode window, then never uses it as a denominator:

```swift
let wallTps = generationTimeMs > 0 && outputTokens > 0
    ? Double(outputTokens) / (generationTimeMs / 1000.0) : 0
let decodeWindow = reportedTtft.map { generationTimeMs - Double($0) } ?? generationTimeMs
let batchBuffered =
    reportedTtft != nil && decodeWindow < max(50.0, generationTimeMs * 0.05)
if batchBuffered {
    ...
} else {
    result.usage.decodeTokensPerSecond = reportedTps > 0 ? reportedTps : wallTps
```

`decodeWindow` exists only to detect the batch-buffered case. In the ordinary branch, where TTFT is trustworthy and the window is real, the fallback is still `wallTps`, which is measured across the whole span.

## Why that is wrong

`generationTimeMs` starts at the request, so prefill is inside the denominator of a field named `decodeTokensPerSecond`. commons excludes it deliberately:

```cpp
// Tokens/sec over decode time only — including prefill (TTFT) in the
// denominator systematically understates generation speed.
```

So the same run reports a lower rate on Swift than commons reports natively, silently, and the gap widens with prompt length. Kotlin had exactly this and was fixed in #634; the Web equivalent is #662.

## What this does

Rates the fallback over `decodeWindow`, the value the function already computes.

Deliberately narrow:

- The `batchBuffered` branch is untouched. Its `wallTps` is correct, and the comment above the function explains why: for Maple/Bonsai the tokens arrive in one dump, `decode = total - ttft` collapses to a few ms, and rating over it would produce an absurd tok/s and a fake TTFT.
- When TTFT is unknown, `decodeWindow` is already `generationTimeMs`, so the new expression reduces to exactly the old `wallTps`. That path is unchanged by construction.
- `reportedTps` still wins whenever the backend supplies a rate.

## Testing

`swiftc -parse` on the file is clean.

SwiftLint is not runnable on this machine, which has Command Line Tools but no full Xcode, so `swiftlint` aborts loading `sourcekitdInProc.framework`. I am relying on the `swift-spm` CI job for lint rather than implying I ran it.

Worth flagging separately: `swift-spm` is currently failing on `main` itself, at link time with `Undefined symbols for architecture arm64` for `rac::desktop::install_device_manager_provider()` and the three `rac_desktop_*` symbols. That is unrelated to this diff, which touches one Swift expression.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reported text-generation throughput when backend metrics are unavailable.
  - Decode performance is now calculated over the appropriate generation window, including a fallback when time-to-first-token data is unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->