### PR TITLE
docs: correct the lint path and Solutions default, replace diagrams with tables

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,17 +6,17 @@ This file provides guidance to AI coding assistants (Claude Code, Cursor, etc.) 
 > **`AGENTS.md` is the real file; each `CLAUDE.md` is a symlink to the `AGENTS.md` beside it.**
 > Editing either name edits the same bytes, so the two can never drift and Claude Code, Cursor, and every
 > other assistant read identical guidance. The symlinks are committed, so a fresh clone recreates them
-> automatically on macOS/Linux — and `scripts/setup/setup.sh` plus the post-checkout/post-merge git hooks
+> automatically on macOS/Linux, and `scripts/setup/setup.sh` plus the post-checkout/post-merge git hooks
 > re-create any missing link (e.g. on Windows). To add the symlink in a new directory (or repair a broken
 > one), run `bash scripts/validation/gates/check_agents_claude_sync.sh --fix`; a pre-commit hook and the
 > `pr-build.yml` gate fail if any tracked `AGENTS.md` is missing its committed `CLAUDE.md` symlink.
 
-### ⚠️ Resource discipline — use available capacity responsibly
+### Resource discipline
 Use the machine's available capacity for local builds and verification instead of defaulting to low worker caps:
-- **Builds should use full local capacity by default.** Prefer explicit worker counts based on the host CPU count for reproducibility, e.g. `cmake --build <dir> -j "$(sysctl -n hw.logicalcpu)"`, `make -j"$(sysctl -n hw.logicalcpu)"`, `ninja -j "$(sysctl -n hw.logicalcpu)"`, Gradle `--max-workers="$(sysctl -n hw.logicalcpu)"`, and Xcode `-jobs "$(sysctl -n hw.logicalcpu)"`.
-- **Use lower caps only when there is real pressure.** Scale down if the machine is memory constrained, swapping, thermally throttling, or a build is failing because of resource exhaustion; do not wait solely because load average is above an arbitrary threshold.
-- **Parallelize with intent.** Running independent light checks or agents in parallel is fine. Avoid uncontrolled process storms, repeated repo-wide scans, or multiple native rebuilds that compete for the same memory-heavy toolchain without a clear benefit.
-- **Check `uptime` before a heavy step** as situational awareness, then proceed with the worker count that fits the current machine state and user urgency.
+- Use full local capacity by default. Prefer explicit worker counts based on the host CPU count for reproducibility, e.g. `cmake --build <dir> -j "$(sysctl -n hw.logicalcpu)"`, `make -j"$(sysctl -n hw.logicalcpu)"`, `ninja -j "$(sysctl -n hw.logicalcpu)"`, Gradle `--max-workers="$(sysctl -n hw.logicalcpu)"`, and Xcode `-jobs "$(sysctl -n hw.logicalcpu)"`.
+- Lower the cap only under real pressure. Scale down if the machine is memory constrained, swapping, thermally throttling, or a build is failing because of resource exhaustion; do not wait solely because load average is above an arbitrary threshold.
+- Parallelize with intent. Running independent light checks or agents in parallel is fine. Avoid uncontrolled process storms, repeated repo-wide scans, or multiple native rebuilds that compete for the same memory-heavy toolchain without a clear benefit.
+- Check `uptime` before a heavy step for situational awareness, then proceed with the worker count that fits the current machine state and user urgency.
 
 ### Before starting work.
 - Do NOT write ANY MOCK IMPLEMENTATION unless specified otherwise.
@@ -32,33 +32,32 @@ Use the machine's available capacity for local builds and verification instead o
 - Always make sure that you're using structured types, never use strings directly so that we can keep things consistent and scalable and not make mistakes.
 - Read files FULLY to understand the FULL context. Only use offset/limit when the file is large and you are short on context.
 - When fixing issues focus on SIMPLICITY, and following Clean SOLID principles, do not add complicated logic unless necessary!
-- When looking up something: It's December 2025 FYI
 
 ## Swift specific rules:
 - Use the latest Swift 6 APIs always.
 - Do not use NSLock as it is outdated.
 
-## Business Logic Layering Rules
+## Business logic layering rules
 
-**The single most important architectural rule in this repo:** logic must live at the lowest layer that can serve all consumers.
+The most important architectural rule in this repo: logic lives at the lowest layer that can serve all consumers.
 
-> **Corollary — the SDK must be seamless inside every example app.** Each feature/modality (LLM, STT, TTS, VAD, VLM, RAG, LoRA, Voice) is invoked through **one** SDK entry point; the SDK — and below it, C++ commons — does *all* the heavy lifting: segmentation, derivation, download, orchestration, prompt control. If an example app builds a multi-step sequence, hardcodes a model/engine constant, or post-processes model output, that is a bug in the **SDK**, not the app — fix it down a layer.
+> Corollary: the SDK must be seamless inside every example app. Each feature/modality (LLM, STT, TTS, VAD, VLM, RAG, LoRA, Voice) is invoked through **one** SDK entry point; the SDK, and below it C++ commons, does all the heavy lifting: segmentation, derivation, download, orchestration, prompt control. If an example app builds a multi-step sequence, hardcodes a model/engine constant, or post-processes model output, that is a bug in the SDK, not the app. Fix it down a layer.
 
 ### Decision hierarchy (top = preferred)
 
-1. **C++ commons** (`core/`) — If logic is cross-platform and not I/O-specific, it belongs here. All 5 SDKs get the fix for free. Examples: model lifecycle, registry management, download orchestration, RAG session management, inference routing.
+1. C++ commons (`core/`). If logic is cross-platform and not I/O-specific, it belongs here. All 5 SDKs get the fix for free. Examples: model lifecycle, registry management, download orchestration, RAG session management, inference routing.
 
-2. **Platform SDK layer** — If logic is platform-specific I/O or runtime bridging (e.g. Web OPFS persistence, iOS Keychain, Android Keystore, WASM MEMFS mirroring), it belongs in the platform SDK, not the example app. Examples: `OPFSBridge`, platform adapter registration, WASM module broadcast, MEMFS hydration.
+2. Platform SDK layer. If logic is platform-specific I/O or runtime bridging (e.g. Web OPFS persistence, iOS Keychain, Android Keystore, WASM MEMFS mirroring), it belongs in the platform SDK, not the example app. Examples: `OPFSBridge`, platform adapter registration, WASM module broadcast, MEMFS hydration.
 
-3. **Example apps** — Only UI rendering, tab navigation, and thin SDK API calls. **No business logic, no workarounds, no internal SDK knowledge.** If you find yourself writing multi-step bootstrap sequences, duplicating internal constants (e.g. filesystem path patterns), or routing around SDK limitations inside an example, **stop and fix the SDK instead**.
+3. Example apps. Only UI rendering, tab navigation, and thin SDK API calls. No business logic, no workarounds, no internal SDK knowledge. If you find yourself writing multi-step bootstrap sequences, duplicating internal constants (e.g. filesystem path patterns), or routing around SDK limitations inside an example, stop and fix the SDK instead.
 
 ### Concrete rules
 
-- **Example apps call SDK APIs directly.** `downloadModel()`, `loadModel()`, `ragIngest()` — these are the right entry points. The SDK handles everything beneath.
-- **Never duplicate SDK-internal knowledge in example apps.** Framework→directory mappings, OPFS path patterns, MEMFS write helpers, WASM module iteration — all belong in the SDK.
-- **Never add workaround logic to example apps.** If a download path is broken for multi-file models, fix `downloadModel()` in the SDK. If OPFS state needs cold-start hydration, add `hydrateModelRegistry()` to the SDK. Don't paper over SDK bugs in example code.
-- **Never add multi-step bootstrap in example views.** If a view needs to call `register()` + `reRegisterCatalog()` + `downloadDependency()` + `createPipeline()` before it can work, those steps belong in the SDK's single entry point (e.g. `createPipeline()` should handle its own prerequisites or surface a clear error).
-- **When fixing a bug, always ask: can this be fixed at the C++ level?** A C++ fix benefits iOS, Android, Flutter, React Native, and Web simultaneously. A TS/Swift/Kotlin fix only helps one SDK. Only go to the platform layer when the fix is genuinely platform-specific.
+- Example apps call SDK APIs directly. `downloadModel()`, `loadModel()`, `ragIngest()` are the right entry points. The SDK handles everything beneath.
+- Never duplicate SDK-internal knowledge in example apps. Framework→directory mappings, OPFS path patterns, MEMFS write helpers, WASM module iteration all belong in the SDK.
+- Never add workaround logic to example apps. If a download path is broken for multi-file models, fix `downloadModel()` in the SDK. If OPFS state needs cold-start hydration, add `hydrateModelRegistry()` to the SDK. Don't paper over SDK bugs in example code.
+- Never add multi-step bootstrap in example views. If a view needs to call `register()` + `reRegisterCatalog()` + `downloadDependency()` + `createPipeline()` before it can work, those steps belong in the SDK's single entry point (e.g. `createPipeline()` should handle its own prerequisites or surface a clear error).
+- When fixing a bug, ask whether it can be fixed at the C++ level. A C++ fix benefits iOS, Android, Flutter, React Native, and Web simultaneously. A TS/Swift/Kotlin fix only helps one SDK. Only go to the platform layer when the fix is genuinely platform-specific.
 
 ### iOS SDK as source of truth
 
@@ -66,13 +65,13 @@ When the correct behavior is ambiguous, check the iOS Swift implementation first
 
 ---
 
-## Repository Overview
+## Repository overview
 
 Cross-platform on-device AI SDK monorepo. A single C/C++ core (`runanywhere-commons`, ~118K first-party LOC plus ~420K generated proto bindings) implements all AI business logic behind a pure C ABI (`rac_*` prefix). Five platform SDKs are thin bridges that supply platform services (file I/O, HTTP, Keychain, audio) via an inversion-of-control struct and call into the C core for all inference. Protobuf IDL schemas generate type-safe bindings for every language.
 
 **Current version**: `0.20.17` (canonical source: `core/VERSION`)
 
-### SDK Implementations
+### SDK implementations
 | SDK | Path | Bridge Mechanism | Platforms |
 |-----|------|-----------------|-----------|
 | Swift | `bindings/swift/` | XCFramework + CRACommons module map | iOS 17.5+, macOS 14.5+ |
@@ -81,16 +80,16 @@ Cross-platform on-device AI SDK monorepo. A single C/C++ core (`runanywhere-comm
 | React Native | `bindings/react-native/` | NitroModules (JSI HybridObject) | iOS 17.5+, Android arm64 |
 | Web | `bindings/web/` | Emscripten WASM + TypeScript | Browsers (Chrome, Safari, Firefox) |
 
-### Native Core
+### Native core
 | Directory | Contents |
 |-----------|----------|
-| `core/` | C/C++ core library — all AI logic, plugin registry, event system |
+| `core/` | C/C++ core library: all AI logic, plugin registry, event system |
 | `engines/` | 7 backend plugins: llamacpp, sherpa, onnx, cloud, mlx, qhexrt, neurt |
 | `runtimes/` | 3 runtime adapters: cpu (always), onnxrt, coreml |
 | `idl/` | 23 Protobuf schemas + per-language codegen scripts |
 
-### Consumer Applications
-The four full consumer apps were extracted into standalone repositories (history preserved). They are **not** in this tree; open PRs against them there.
+### Consumer applications
+The four full consumer apps were extracted into standalone repositories (history preserved). They are not in this tree; open PRs against them there.
 
 | App | Repository | Build System |
 |-----|-----------|-------------|
@@ -106,75 +105,71 @@ Two example apps remain in-tree:
 | Flutter | `bindings/flutter/example/` | Flutter + Dart FFI |
 | React Native | `bindings/react-native/example/` | RN 0.85 + NitroModules |
 
-All example apps share one visual identity — brand orange `#FF6900` (the logo primary, **not** the legacy `#FF5500`), documented in `docs/DESIGN_GUIDELINE.md`. Each app hand-maintains a small theme file that mirrors that doc; see the "Design System" section in each app's `AGENTS.md`.
+All example apps share one visual identity, brand orange `#FF6900` (the logo primary, not the legacy `#FF5500`), documented in `docs/DESIGN_GUIDELINE.md`. Each app hand-maintains a small theme file that mirrors that doc; see the "Design System" section in each app's `AGENTS.md`.
 
-### Minimal Examples (in-repo harnesses)
-These are how you verify an SDK change locally — and what monorepo CI builds. Each consumes the SDK **from local source**, so an edit is visible without staging or publishing anything.
+### Minimal examples (in-repo harnesses)
+These are how you verify an SDK change locally, and what monorepo CI builds. Each consumes the SDK from local source, so an edit is visible without staging or publishing anything.
 
 | SDK | Path | How it consumes the SDK |
 |-----|------|-------------------------|
 | Swift | `bindings/swift/example/` | SwiftPM package depending on the repo-root manifest (`RUNANYWHERE_USE_LOCAL_NATIVES=1`) |
-| Kotlin | `bindings/kotlin/example/` | Gradle composite build (`includeBuild` + `dependencySubstitution`) — no AAR staging |
+| Kotlin | `bindings/kotlin/example/` | Gradle composite build (`includeBuild` + `dependencySubstitution`), no AAR staging |
 | Web | `bindings/web/example/` | Vite aliases + `tsconfig` paths into `packages/*/src`; `RAC_USE_INSTALLED_SDK=1` switches to installed tarballs |
 
-Each is deliberately small: one prompt in, one streamed completion out. They are contributor harnesses, not showcases — feature-complete UI belongs in the consumer repos above.
+Each is deliberately small: one prompt in, one streamed completion out. They are contributor harnesses, not showcases: feature-complete UI belongs in the consumer repos above.
 
 ---
 
-## Cross-Platform Architecture
+## Cross-platform architecture
 
-```
-                          idl/*.proto
-                              │
-                    idl/codegen/generate_all.sh
-                              │
-          ┌───────────────────┼───────────────────┐
-          ▼                   ▼                   ▼
-   *.pb.swift          Wire Kotlin        ts-proto / protoc-gen-dart
-   (committed)          (committed)            (committed)
+Four layers, top to bottom.
 
-Platform SDKs (thin bridges — supply platform services, call C ABI)
-  ┌──────────┬──────────┬──────────┬──────────┬──────────┐
-  │  Swift   │  Kotlin  │ Flutter  │React Nat.│   Web    │
-  │XCFramewk │   JNI    │ Dart FFI │NitroMods │  WASM    │
-  └────┬─────┴────┬─────┴────┬─────┴────┬─────┴────┬─────┘
-       │          │          │          │          │
-       └──────────┴──────────┴──────┬───┴──────────┘
-                                    │ rac_* C API
-                    ┌───────────────▼───────────────┐
-                    │      runanywhere-commons       │
-                    │  Component Layer (lifecycle)   │
-                    │  Service Layer (dispatch)      │
-                    │  Plugin Registry               │
-                    └───────────────┬───────────────┘
-                                    │ rac_engine_vtable_t (v9)
-          ┌─────────────┬───────────┼───────────┬─────────────┐
-          ▼             ▼           ▼           ▼             ▼
-      llamacpp      sherpa-onnx  qhexrt      neurt/cloud       onnx
-     (LLM,VLM)    (STT,TTS,VAD) (HNPU)     (ANE/HTTP)     (Embed,Segment)
-```
+`idl/*.proto` is the schema root. `idl/codegen/generate_all.sh` emits `*.pb.swift`, Wire
+Kotlin, and ts-proto / protoc-gen-dart output, all committed.
 
-### Key Architectural Patterns
+Platform SDKs are thin bridges: they supply platform services and call the C ABI.
 
-**Platform Adapter IoC**: `rac_platform_adapter_t` is a flat C struct of function pointers populated by each SDK before calling `rac_init()`. C++ never calls platform APIs directly — all file I/O, HTTP, Keychain, logging, and memory queries pass through this struct.
+| SDK | Bridge |
+|---|---|
+| Swift | XCFramework |
+| Kotlin | JNI |
+| Flutter | Dart FFI |
+| React Native | NitroModules |
+| Web | WASM |
 
-**Two-Phase SDK Initialization**: All SDKs follow the same pattern: Phase 1 (synchronous — register platform adapter, load native libs, configure logging) then Phase 2 (async — authenticate, register device, fetch model assignments, discover downloaded models).
+All five reach `runanywhere-commons` through the `rac_*` C API. Commons holds the component
+layer (lifecycle), the service layer (dispatch), and the plugin registry, and reaches engines
+through `rac_engine_vtable_t` v9.
 
-**Plugin ABI v9**: Every backend publishes a `rac_engine_vtable_t` with 10 active primitive slots (`llm_ops`, `stt_ops`, `tts_ops`, `vad_ops`, `embedding_ops`, `vlm_ops`, `diffusion_ops`, `diarization_ops`, `segmentation_ops`, `rerank_ops`) and 7 reserved slots. LLM publishers may implement `get_stream_token_counts` on `rac_llm_service_ops_t`; when it is NULL, commons estimates counts and marks them as estimated. NULL primitive slot = not supported. `RAC_PLUGIN_API_VERSION = 9u` — version mismatch causes immediate rejection. (`rerank_ops`/`RAC_PRIMITIVE_RERANK` was revived as a first-class cross-encoder reranking primitive in ABI v8 at **wire value 11**, promoted from `reserved_slot_2` at the same binary offset; the original wire value 6 — retired in ABI v4 — stays permanently retired.)
+| Engine | Primitives |
+|---|---|
+| llamacpp | LLM, VLM |
+| sherpa-onnx | STT, TTS, VAD |
+| onnx | Embed, Segment |
+| qhexrt | Hexagon NPU |
+| neurt, cloud | Apple Neural Engine, HTTP |
 
-**Static vs Dynamic Plugins**: iOS and WASM force `RAC_STATIC_PLUGINS=ON` (no `dlopen`). Android/Linux/macOS default to dynamic loading via `rac_registry_load_plugin()`. Static registration uses `RAC_STATIC_PLUGIN_REGISTER(name)` macro with `-force_load` / `--whole-archive` linker flags.
+### Key architectural patterns
 
-**Streaming Fan-Out**: C++ allows only one proto-byte callback per component handle. Each SDK implements a `HandleFanOut` that multiplexes one C callback to multiple subscribers (Swift `AsyncStream`, Kotlin `Flow`, Dart `StreamController`, TS `AsyncIterable`).
+Platform adapter IoC: `rac_platform_adapter_t` is a flat C struct of function pointers populated by each SDK before calling `rac_init()`. C++ never calls platform APIs directly: all file I/O, HTTP, Keychain, logging, and memory queries pass through this struct.
 
-**Proto Types Are Canonical**: All structured types (environments, model formats, error codes, voice events, LLM stream events) are defined in `idl/*.proto` and code-generated per SDK. Never hand-write enum values — use the generated types and typealiases.
+Two-phase SDK initialization: All SDKs follow the same pattern: Phase 1 (synchronous: register platform adapter, load native libs, configure logging) then Phase 2 (async: authenticate, register device, fetch model assignments, discover downloaded models).
+
+Plugin ABI v9: Every backend publishes a `rac_engine_vtable_t` with 10 active primitive slots (`llm_ops`, `stt_ops`, `tts_ops`, `vad_ops`, `embedding_ops`, `vlm_ops`, `diffusion_ops`, `diarization_ops`, `segmentation_ops`, `rerank_ops`) and 7 reserved slots. LLM publishers may implement `get_stream_token_counts` on `rac_llm_service_ops_t`; when it is NULL, commons estimates counts and marks them as estimated. NULL primitive slot = not supported. `RAC_PLUGIN_API_VERSION = 9u`, and a version mismatch causes immediate rejection. (`rerank_ops`/`RAC_PRIMITIVE_RERANK` was revived as a first-class cross-encoder reranking primitive in ABI v8 at **wire value 11**, promoted from `reserved_slot_2` at the same binary offset; the original wire value 6, retired in ABI v4, stays permanently retired.)
+
+Static and dynamic plugins: iOS and WASM force `RAC_STATIC_PLUGINS=ON` (no `dlopen`). Android/Linux/macOS default to dynamic loading via `rac_registry_load_plugin()`. Static registration uses `RAC_STATIC_PLUGIN_REGISTER(name)` macro with `-force_load` / `--whole-archive` linker flags.
+
+Streaming fan-out: C++ allows only one proto-byte callback per component handle. Each SDK implements a `HandleFanOut` that multiplexes one C callback to multiple subscribers (Swift `AsyncStream`, Kotlin `Flow`, Dart `StreamController`, TS `AsyncIterable`).
+
+Proto types are canonical: All structured types (environments, model formats, error codes, voice events, LLM stream events) are defined in `idl/*.proto` and code-generated per SDK. Never hand-write enum values; use the generated types and typealiases.
 
 ---
 
-## Building the Native Core
+## Building the native core
 
 The root `CMakeLists.txt` is the single entry point for all native builds. Version is read from `core/VERSION`.
 
-### CMake Presets (`CMakePresets.json`)
+### CMake presets (`CMakePresets.json`)
 
 ```bash
 # macOS (development)
@@ -198,7 +193,7 @@ cmake --preset android-arm64 && cmake --build build/android-arm64
 cmake --preset wasm && cmake --build build/wasm
 ```
 
-### Cross-Platform Build Scripts (in `scripts/`)
+### Cross-platform build scripts
 
 ```bash
 # iOS: Build XCFrameworks for all slices → bindings/swift/Binaries/
@@ -220,11 +215,11 @@ cmake --preset wasm && cmake --build build/wasm
 # Cut the runanywhere-swift SPM distribution repo at the current version
 ./bindings/swift/scripts/sync-dist-repo.sh --zips <zip_dir> --tag <checkout>
 
-# Full IDL codegen (requires protoc toolchain — see scripts/setup/setup-toolchain.sh)
+# Full IDL codegen (requires protoc toolchain; see scripts/setup/setup-toolchain.sh)
 ./idl/codegen/generate_all.sh
 ```
 
-### Native Build Outputs
+### Native build outputs
 
 | Platform | Output | Consumed by |
 |----------|--------|------------|
@@ -235,9 +230,9 @@ cmake --preset wasm && cmake --build build/wasm
 
 ---
 
-## SDK Development Commands
+## SDK development commands
 
-### C++ Core (`core/`)
+### C++ core (`core/`)
 
 See `core/AGENTS.md` for detailed architecture and C++ conventions.
 
@@ -248,8 +243,8 @@ cmake --build build
 ctest --test-dir build --output-on-failure
 
 # Lint C++
-./scripts/lint-cpp.sh          # Check formatting
-./scripts/lint-cpp.sh --fix    # Auto-fix
+core/scripts/lint-cpp.sh          # Check formatting
+core/scripts/lint-cpp.sh --fix    # Auto-fix
 ```
 
 ### Swift SDK (`bindings/swift/`)
@@ -343,7 +338,7 @@ The current artifact and deployment contract is maintained in
 `bindings/web/AGENTS.md`; it supersedes historical standalone
 `wasm/sherpa/` paths. Do not use or recreate those removed paths.
 
-### IDL Codegen
+### IDL codegen
 
 ```bash
 # Install toolchain (protoc, protoc-gen-swift, wire-compiler, ts-proto, etc.)
@@ -364,9 +359,9 @@ Generated files are committed. CI `idl-drift-check.yml` fails if they're out of 
 
 ---
 
-## Example App Commands
+## Example app commands
 
-### Swift Minimal Example
+### Swift minimal example
 
 ```bash
 cd bindings/swift/example/
@@ -375,7 +370,7 @@ RUNANYWHERE_USE_LOCAL_NATIVES=1 swift build
 RUNANYWHERE_USE_LOCAL_NATIVES=1 swift run
 ```
 
-Requires the XCFrameworks in `bindings/swift/Binaries/` (`RACommons`, `RABackendLLAMACPP`, `RABackendONNX`, `RABackendSherpa`) — build them with `./bindings/swift/scripts/build-core-xcframework.sh`. `./run example ios {build|run|clean}` wraps this.
+Requires the XCFrameworks in `bindings/swift/Binaries/` (`RACommons`, `RABackendLLAMACPP`, `RABackendONNX`, `RABackendSherpa`). Build them with `./bindings/swift/scripts/build-core-xcframework.sh`. `./run example ios {build|run|clean}` wraps this.
 
 SDK logs (in a separate terminal):
 
@@ -383,7 +378,7 @@ SDK logs (in a separate terminal):
 log stream --predicate 'subsystem CONTAINS "com.runanywhere"' --info --debug
 ```
 
-### Kotlin Minimal Example
+### Kotlin minimal example
 
 ```bash
 cd bindings/kotlin/example/
@@ -394,11 +389,11 @@ cd bindings/kotlin/example/
 
 `settings.gradle.kts` pulls `bindings/kotlin` in as a **composite build** with `dependencySubstitution`, so Gradle recompiles the SDK from source on every app build and its transitive runtime deps (coroutines, OkHttp, Wire) come along automatically. There is no AAR staging step.
 
-- `./run sdk commons build-android` — build the commons `.so` for all Android ABIs (needed once, and after any C++ change; `runanywhere.useLocalNatives=true` expects them under `src/main/jniLibs/`).
-- `./run example android build` — `:app:assembleDebug`.
-- `./run example android install` — `:app:installDebug` and launch.
+- `./run sdk commons build-android` builds the commons `.so` for all Android ABIs (needed once, and after any C++ change; `runanywhere.useLocalNatives=true` expects them under `src/main/jniLibs/`).
+- `./run example android build` runs `:app:assembleDebug`.
+- `./run example android install` runs `:app:installDebug` and launches.
 
-### Web Minimal Example
+### Web minimal example
 
 ```bash
 cd bindings/web/example/
@@ -412,9 +407,9 @@ npm run preview      # Serve dist/ on port 3000
 
 Requires the four canonical WASM pairs (`npm run build:wasm:all` from `bindings/web/`); the build fails naming the missing files rather than emitting a broken bundle. `SharedArrayBuffer` needs cross-origin isolation (COOP + COEP).
 
-The example publishes `window.__RUNANYWHERE_SDK__` and `window.__RUNANYWHERE_AI_READY__` — the readiness contract `bindings/web/tests/browser/` probes. `RA_E2E_APP_DIR` points Playwright at a different app (e.g. a checkout of `RunanywhereAI/runanywhere-web` for the full release journey).
+The example publishes `window.__RUNANYWHERE_SDK__` and `window.__RUNANYWHERE_AI_READY__`, the readiness contract `bindings/web/tests/browser/` probes. `RA_E2E_APP_DIR` points Playwright at a different app (e.g. a checkout of `RunanywhereAI/runanywhere-web` for the full release journey).
 
-### Flutter Example
+### Flutter example
 
 ```bash
 cd bindings/flutter/example/
@@ -426,7 +421,7 @@ flutter run -d "iPhone 16 Pro"
 RUN_IOS=1 ./scripts/verify.sh  # Also builds iOS
 ```
 
-### React Native Example
+### React Native example
 
 ```bash
 cd bindings/react-native/example/
@@ -439,11 +434,11 @@ yarn typecheck      # Primary verification gate
 ./scripts/verify.sh # typecheck + optional builds
 ```
 
-**Hermes caveat**: Does not support `for await...of` with NitroModules async iterables. Use manual `iterator.next()` loops.
+Hermes caveat: Does not support `for await...of` with NitroModules async iterables. Use manual `iterator.next()` loops.
 
 ---
 
-## Version Management
+## Version management
 
 Canonical version: `core/VERSION` (single-line file, e.g. `0.20.0`).
 
@@ -452,25 +447,25 @@ Canonical version: `core/VERSION` (single-line file, e.g. `0.20.0`).
 ./scripts/release/sync-versions.sh 0.20.0
 ```
 
-Release lifecycle: `sync-versions.sh` → PR with `release:minor` label → merge → `auto-tag.yml` pushes `v0.20.0` tag → `release.yml` builds all artifacts and creates draft GitHub Release → **cut the Swift distribution repo** (below).
+Release lifecycle: `sync-versions.sh` → PR with `release:minor` label → merge → `auto-tag.yml` pushes `v0.20.0` tag → `release.yml` builds all artifacts and creates draft GitHub Release → cut the Swift distribution repo, below.
 
 ### Cutting `runanywhere-swift` (required, every release)
 
 [`RunanywhereAI/runanywhere-swift`](https://github.com/RunanywhereAI/runanywhere-swift)
 is a generated, Swift-only SPM distribution of `bindings/swift` (Package.swift +
 Sources/ + LICENSE + README). It exists so Swift consumers clone ~3 MB instead of
-the ~340 MB monorepo. Its manifest declares the **same** remote binaryTargets
-against the **same** release assets on `runanywhere-sdks`, with the **same**
-checksums — the XCFrameworks are never re-uploaded.
+the ~340 MB monorepo. Its manifest declares the same remote binaryTargets
+against the same release assets on `runanywhere-sdks`, with the same
+checksums, so the XCFrameworks are never re-uploaded.
 
-**Its tag must track every release.** Publish `v<version>` here without cutting it
+Its tag must track every release. Publish `v<version>` here without cutting it
 and `from: "<version>"` resolves to nothing for every Swift consumer.
 
 ```bash
 git clone https://github.com/RunanywhereAI/runanywhere-swift.git /tmp/ra-swift
 
 # Regenerate Sources/ + bump sdkVersion/README, sync this release's checksums,
-# commit, and tag (bare semver — no 'v' prefix; SwiftPM `from:` needs that).
+# commit, and tag (bare semver, no 'v' prefix; SwiftPM `from:` needs that).
 ./bindings/swift/scripts/sync-dist-repo.sh \
     --zips release-artifacts/native-ios-macos --tag /tmp/ra-swift
 
@@ -501,32 +496,32 @@ carries the matching tag.
 
 ---
 
-## Key Architectural Decisions
+## Key architectural decisions
 
-### iOS SDK is Source of Truth
+### iOS SDK is the source of truth
 When implementing features in any other SDK (especially Kotlin), always check the iOS Swift implementation first. Copy logic exactly, adapting only for language syntax, not business logic.
 
-### All Business Logic in C++ commons (or the SDK shared layer)
-Platform-specific code should only handle: native library loading, platform adapter registration, audio capture/playback, secure storage, and UI. All AI inference, model management, event routing, and pipeline orchestration live in C++ (`runanywhere-commons`) or — when intentionally Kotlin-side — under the Kotlin SDK's shared `src/main/kotlin/com/runanywhere/sdk/` tree.
+### All business logic in C++ commons (or the SDK shared layer)
+Platform-specific code should only handle: native library loading, platform adapter registration, audio capture/playback, secure storage, and UI. All AI inference, model management, event routing, and pipeline orchestration live in C++ (`runanywhere-commons`) or, when intentionally Kotlin-side, under the Kotlin SDK's shared `src/main/kotlin/com/runanywhere/sdk/` tree.
 
-### Backend Registration Pattern
+### Backend registration pattern
 All SDKs follow the same pattern:
 1. Load the backend native library
 2. Call `rac_backend_*_register()` (which registers the engine's vtable with the plugin registry)
 3. The registry orders registered plugins by base priority, per primitive
 4. On inference, the highest-priority plugin that serves the primitive is selected via `rac_plugin_find()` (or `rac_plugin_find_for_engine()` for a name-pinned engine)
 
-Backend base priorities: qhexrt=150 (QNN-context models only), mlx=110 (Apple), llamacpp=100, sherpa=90, onnx/cloud=50. Selection is plain priority order — there is no runtime/format scoring or pinned-engine bonus; an explicit engine name is honored via `rac_plugin_find_for_engine()`.
+Backend base priorities: qhexrt=150 (QNN-context models only), mlx=110 (Apple), llamacpp=100, sherpa=90, onnx/cloud=50. Selection is plain priority order, with no runtime/format scoring or pinned-engine bonus; an explicit engine name is honored through `rac_plugin_find_for_engine()`.
 
-### HTTP Transport is Platform-Provided
+### HTTP transport is platform-provided
 libcurl was removed. Each SDK registers a `rac_http_transport_ops_t` vtable: Swift uses URLSession, Kotlin/Flutter/RN use OkHttp (Android) or URLSession (iOS), Web uses `emscripten_fetch`.
 
-### Proto-Generated Types Replace Hand-Written Enums
-All cross-platform types are defined in `idl/*.proto`. SDKs use typealiases to the generated types (e.g., `typealias SDKEnvironment = RASDKEnvironment` in Swift, `typealias SDKEnvironment = ai.runanywhere.proto.v1.SDKEnvironment` in Kotlin). Never add enum values by hand — modify the `.proto` file and regenerate.
+### Proto-generated types replace hand-written enums
+All cross-platform types are defined in `idl/*.proto`. SDKs use typealiases to the generated types (e.g., `typealias SDKEnvironment = RASDKEnvironment` in Swift, `typealias SDKEnvironment = ai.runanywhere.proto.v1.SDKEnvironment` in Kotlin). Never add enum values by hand; modify the `.proto` file and regenerate.
 
 ---
 
-## Platform Requirements
+## Platform requirements
 
 | Platform | Min Version | Build Tool | Key Versions |
 |----------|------------|------------|--------------|
@@ -541,11 +536,11 @@ All cross-platform types are defined in `idl/*.proto`. SDKs use typealiases to t
 
 ---
 
-## Kotlin SDK - Critical Implementation Rules
+## Kotlin SDK: critical implementation rules
 
 The Kotlin SDK (`bindings/kotlin/`) ships as an Android library (`alias(libs.plugins.android.library)` in `bindings/kotlin/build.gradle.kts`), not as a Kotlin Multiplatform module. It targets Android only and consumes the C++ commons core through JNI (`librunanywhere_jni.so`). JVM 17 is the toolchain for the Gradle build itself, not a published target.
 
-### iOS as Source of Truth
+### iOS as the source of truth
 **NEVER make assumptions when implementing the Kotlin SDK. ALWAYS refer to the iOS implementation as the definitive source of truth.**
 
 1. **iOS First**: When encountering missing logic or unclear requirements in the Kotlin SDK, check the corresponding iOS implementation, copy the logic exactly, adapt only for Kotlin syntax.
@@ -554,19 +549,19 @@ The Kotlin SDK (`bindings/kotlin/`) ships as an Android library (`alias(libs.plu
 
 3. **Platform naming convention**: Android-only adapters keep an explicit `Android` prefix (e.g. `AndroidTTSService.kt`) so file naming makes the target unambiguous if a JVM-only or KMP variant is ever reintroduced.
 
-### Source Set Layout
+### Source set layout
 
 ```
 bindings/kotlin/
-    src/main/kotlin/        (all Kotlin sources — public API, JNI bridges, generated Wire proto types)
+    src/main/kotlin/        (all Kotlin sources: public API, JNI bridges, generated Wire proto types)
     src/main/jniLibs/       (prebuilt .so files staged by build-core-android.sh)
-    src/test/kotlin/        (unit tests — no JNI required)
+    src/test/kotlin/        (unit tests, no JNI required)
     modules/runanywhere-core-{llamacpp,onnx}/  (Android library sub-modules that register C++ backends)
 ```
 
 Standard Android library layout. There is no `commonMain`/`jvmAndroidMain`/`androidMain`/`jvmMain` hierarchy at this level (the SDK was migrated away from KMP). Any `expect`/`actual` pairs you see in legacy documentation describe the previous topology; the current build is single-target Android. Reviewer-area names like `A-kotlin-common-domain` in `test_workflows/.../SCOPE_MANIFEST.json` are kept for historical filtering and do not imply KMP source sets exist today.
 
-### Cross-SDK Alignment
+### Cross-SDK alignment
 
 | Concern | iOS Swift | Kotlin (Android) | Flutter | React Native | Web |
 |---------|-----------|------------------|---------|-------------|-----|
@@ -581,27 +576,27 @@ Standard Android library layout. There is no `commonMain`/`jvmAndroidMain`/`andr
 
 ---
 
-## Non-Obvious Configuration Details
+## Non-obvious configuration details
 
-**`Package.swift`** — remote release artifacts are the fail-closed default. Local builds opt into staged XCFrameworks with `RUNANYWHERE_USE_LOCAL_NATIVES=1`; scripts set this explicitly and never rewrite the manifest.
+`Package.swift`: remote release artifacts are the fail-closed default. Local builds opt into staged XCFrameworks with `RUNANYWHERE_USE_LOCAL_NATIVES=1`; scripts set this explicitly and never rewrite the manifest.
 
-**`Package.swift:186-191`** — Three `.grpc.swift` files are excluded from compilation. They require iOS 18 / macOS 15, above the SDK's minimums. In-process C callback path replaces gRPC.
+`Package.swift:186-191`: three `.grpc.swift` files are excluded from compilation. They require iOS 18 / macOS 15, above the SDK's minimums. In-process C callback path replaces gRPC.
 
-**`gradle.properties`** — `runanywhere.useLocalNatives=true` means local `.so` files. CI overrides with `-Prunanywhere.useLocalNatives=false` to download from GitHub Releases.
+`gradle.properties`: `runanywhere.useLocalNatives=true` means local `.so` files. CI overrides with `-Prunanywhere.useLocalNatives=false` to download from GitHub Releases.
 
-**NDK version** — `racNdkVersion=27.3.13750724` (matches `core/VERSIONS::NDK_VERSION`, the single source of truth) is the pin for the Kotlin SDK in `bindings/kotlin/gradle.properties`. NDK 27 is the current LTS line (r27d) and provides 16 KB page-alignment required by Android 15+ (NDK 25.x's 4 KB-aligned `libc++_shared.so` / `libomp.so` would trip Android 16's 16 KB page-size enforcement). Flutter/RN Android build files carry their own `?: "..."` fallback literals but the canonical version lives in `VERSIONS`; mirror it whenever bumping.
+NDK version: `racNdkVersion=27.3.13750724` (matches `core/VERSIONS::NDK_VERSION`, the single source of truth) is the pin for the Kotlin SDK in `bindings/kotlin/gradle.properties`. NDK 27 is the current LTS line (r27d) and provides 16 KB page-alignment required by Android 15+ (NDK 25.x's 4 KB-aligned `libc++_shared.so` / `libomp.so` would trip Android 16's 16 KB page-size enforcement). Flutter/RN Android build files carry their own `?: "..."` fallback literals but the canonical version lives in `VERSIONS`; mirror it whenever bumping.
 
-**Web cross-origin isolation** — `SharedArrayBuffer` requires COOP/COEP headers. Safari needs `coi-serviceworker.js` polyfill.
+Web cross-origin isolation: `SharedArrayBuffer` requires COOP/COEP headers. Safari needs `coi-serviceworker.js` polyfill.
 
-**Web VLM Worker crash recovery** — If `rac_vlm_component_process` causes WASM OOM (`"memory access out of bounds"`), the Worker auto-recovers by creating a fresh WASM instance on the next `process()` call.
+Web VLM Worker crash recovery: if `rac_vlm_component_process` causes WASM OOM (`"memory access out of bounds"`), the Worker auto-recovers by creating a fresh WASM instance on the next `process()` call.
 
-**Web Qwen2-VL WebGPU workaround** — Qwen2-VL models produce NaN logits on WebGPU due to f16 M-RoPE overflow. VLM Worker forces CPU WASM for Qwen2-VL even when WebGPU is active.
+Web Qwen2-VL WebGPU workaround: Qwen2-VL models produce NaN logits on WebGPU due to f16 M-RoPE overflow. VLM Worker forces CPU WASM for Qwen2-VL even when WebGPU is active.
 
-**Web struct offsets** — TypeScript never hard-codes C struct field offsets. `wasm_exports.cpp` exposes `EMSCRIPTEN_KEEPALIVE` offset functions; the `Offsets` proxy reads them at runtime from the WASM module.
+Web struct offsets: TypeScript never hard-codes C struct field offsets. `wasm_exports.cpp` exposes `EMSCRIPTEN_KEEPALIVE` offset functions; the `Offsets` proxy reads them at runtime from the WASM module.
 
 ---
 
-## Pre-commit Hooks
+## Pre-commit hooks
 
 ```bash
 pre-commit run --all-files        # Run all checks
@@ -612,46 +607,46 @@ Configured hooks: gitleaks (secrets), trailing-whitespace, end-of-file-fixer, ch
 
 ---
 
-## Active Issues
+## Active issues
 
 > The old `thoughts/shared/issues/` directory (regressions 001/002/003/005 on
-> `feat/v2-architecture`) **does not exist** in this tree. Those bullets claimed
+> `feat/v2-architecture`) does not exist in this tree. Those bullets claimed
 > Swift/Kotlin/Web had collapsed backends into monoliths; those SDKs already ship
 > split backend packages. Do not revive that section from memory.
 
-### Electron (`smonga/electron_upgrade`) — in progress
+### Electron (`smonga/electron_upgrade`), in progress
 
-Work is active on branch `smonga/electron_upgrade`. **Do not claim packaging or
-per-backend Electron packages are done.** Entry points:
+Work is active on branch `smonga/electron_upgrade`. Do not claim packaging or
+per-backend Electron packages are done. Entry points:
 
-- [`thoughts/shared/plans/electron_HANDOFF.md`](thoughts/shared/plans/electron_HANDOFF.md) — master state
-- [`thoughts/shared/plans/electron_takeover.md`](thoughts/shared/plans/electron_takeover.md) — remaining executable plan
+- [`thoughts/shared/plans/electron_HANDOFF.md`](thoughts/shared/plans/electron_HANDOFF.md): master state
+- [`thoughts/shared/plans/electron_takeover.md`](thoughts/shared/plans/electron_takeover.md): the remaining executable plan
 
 Current shape (honest): TypeScript SDK + example shell are far along; feature
 views, visual gate, electron-builder packaging, and the backend packaging split
 (#9 / `RAC_HAVE_BACKEND_*` fat addon → runtime plugins) remain open. Parallel
-Tracks A/B/C plus Phase 0 commits may be in flight — check the HANDOFF status
+Tracks A/B/C plus Phase 0 commits may be in flight, so check the HANDOFF status
 pointer before assuming anything landed.
 
 ---
 
 ## Cursor Cloud specific instructions
 
-### Environment Overview
+### Environment overview
 
 This is a cross-platform SDK monorepo. On a Linux cloud VM, the buildable services are:
 
 | Component | Build | Test | Lint | Notes |
 |-----------|-------|------|------|-------|
 | Kotlin SDK (Android target) | `cd bindings/kotlin && ./gradlew compileDebugKotlin -Prunanywhere.useLocalNatives=false` | Android unit tests require device/emulator | `cd bindings/kotlin && ./gradlew ktlintCheck` | Single-target Android library (no KMP). `androidx.annotation` is always available because the build only targets Android. |
-| Web SDK (TypeScript) | `npm run build -w packages/core` (from `bindings/web/`) | N/A | Prefer workspace `npm run typecheck` (builds core `dist/` before backends). Isolated `npm run typecheck -w packages/{llamacpp,onnx}` needs a fresh `npm run build -w packages/core` first — backends resolve `@runanywhere/web/backend` via gitignored `packages/core/dist` types |
+| Web SDK (TypeScript) | `npm run build -w packages/core` (from `bindings/web/`) | N/A | Prefer workspace `npm run typecheck` (builds core `dist/` before backends). Isolated `npm run typecheck -w packages/{llamacpp,onnx}` needs a fresh `npm run build -w packages/core` first, backends resolve `@runanywhere/web/backend` through the gitignored `packages/core/dist` types |
 | Web minimal example | `npm run dev` (from `bindings/web/example/`) | Manual browser testing at `localhost:3000` | N/A | Streams one completion; needs the WASM pairs built |
 | C++ Commons (core) | `cmake -B build ... && cmake --build build` (from `core/`) | `./build/tests/test_core --run-all` (13 tests, no models needed) | N/A | Must use `gcc`/`g++` via `CC=gcc CXX=g++` (clang lacks C++ stdlib headers). Pass `-DRAC_BUILD_PLATFORM=OFF` on Linux |
 | C++ Commons (full backends) | `CC=gcc CXX=g++ ./scripts/build-linux.sh` | Backend tests need downloaded models | N/A | Builds the canonical Linux release preset and packages the staged shared libraries and public headers. |
 | iOS/Swift SDK | Not buildable | Not buildable | Not available | Requires macOS + Xcode |
 | Android emulator | Not runnable | Not runnable | N/A | No KVM support in cloud VM |
 
-### Key Gotchas
+### Key gotchas
 
 - **Android SDK**: Installed at `/opt/android-sdk`. `ANDROID_HOME` and `JAVA_HOME` are set in `~/.bashrc`.
 - **JDK 17**: Required by Gradle JVM toolchain. Both JDK 17 and JDK 21 are installed.

--- a/bindings/swift/AGENTS.md
+++ b/bindings/swift/AGENTS.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Build Commands
+## Build commands
 
 ```bash
 # Build
@@ -30,11 +30,11 @@ periphery scan
 xcodebuild build -scheme RunAnywhere -destination 'platform=iOS Simulator,name=iPhone 16 Pro' CODE_SIGNING_REQUIRED=NO
 ```
 
-## Package Structure
+## Package structure
 
 Two `Package.swift` files exist:
-- **Root** (`runanywhere-sdks/Package.swift`): For external SPM consumers — downloads XCFrameworks from GitHub releases.
-- **Local** (`bindings/swift/Package.swift`): For SDK development — references `Binaries/` directory (git-ignored).
+- Root (`runanywhere-sdks/Package.swift`): for external SPM consumers; downloads XCFrameworks from GitHub releases.
+- Local (`bindings/swift/Package.swift`): for SDK development; references the git-ignored `Binaries/` directory.
 
 Products: `RunAnywhere` (all backends), `RunAnywhereCore` (core only), `RunAnywhereLlamaCPP`, `RunAnywhereONNX`.
 
@@ -44,21 +44,15 @@ Three `.grpc.swift` files are excluded from compilation (require macOS 15/iOS 18
 
 ## Architecture
 
-### Three-Layer Design
+### Three-layer design
 
 All business logic lives in the C++ `RACommons.xcframework`. Swift's role is platform adaptation.
 
-```
-Public API (RunAnywhere enum + extensions)
-    ↓
-CppBridge (enum namespace with actor sub-namespaces)
-    ↓
-C ABI (rac_* functions from CRACommons module)
-    ↓
-RACommons.xcframework (prebuilt C++ binary)
-```
+The public API (the `RunAnywhere` enum and its extensions) calls `CppBridge`, an enum
+namespace with actor sub-namespaces. `CppBridge` calls the `rac_*` C ABI from the CRACommons
+module, which is implemented by the prebuilt `RACommons.xcframework`.
 
-### Entry Point
+### Entry point
 
 `RunAnywhere` is a `public enum` (namespace, never instantiated) at `Sources/RunAnywhere/Public/RunAnywhere.swift`. All consumer API is static methods on this enum or its extensions.
 
@@ -81,10 +75,10 @@ Two verbs hand back long-lived sessions. `voice.createSession(...)` returns a
 so subscribing to `session.events` is safe on its own. `rag.open(...)` returns a
 `RagSession` with its own native handle, so two corpora can be open at once.
 
-### Two-Phase Initialization
+### Two-phase initialization
 
-- **Phase 1** (synchronous, ~1-5ms): Validates params, registers platform callbacks (logging, file I/O, Keychain, HTTP transport, telemetry, device), stores to Keychain. Sets `_isInitialized = true`.
-- **Phase 2** (async background `Task`): Sets up HTTP transport, authenticates, initializes C++ state, registers platform services (`@MainActor`), sets model paths, registers device, discovers downloaded models. Guarded by a single shared `Task` under `_servicesInitLock: DispatchQueue` to prevent duplicate concurrent inits.
+- Phase 1 (synchronous, roughly 1 to 5 ms): Validates params, registers platform callbacks (logging, file I/O, Keychain, HTTP transport, telemetry, device), stores to Keychain. Sets `_isInitialized = true`.
+- Phase 2 (async background `Task`): Sets up HTTP transport, authenticates, initializes C++ state, registers platform services (`@MainActor`), sets model paths, registers device, discovers downloaded models. Guarded by a single shared `Task` under `_servicesInitLock: DispatchQueue` to prevent duplicate concurrent inits.
 
 Every public API method calls `ensureServicesReady()` which is O(1) after Phase 2 completes. If HTTP failed during offline init, it retries via `retryHTTPSetup()`.
 
@@ -92,26 +86,26 @@ Every public API method calls `ensureServicesReady()` which is O(1) after Phase 
 
 `CppBridge` at `Sources/RunAnywhere/Foundation/Bridge/CppBridge.swift` is an enum namespace. Its state is guarded by `OSAllocatedUnfairLock<CppBridgeSharedState>`. Sub-namespaces are organized as extensions in `Foundation/Bridge/Extensions/CppBridge+*.swift` (~26 extension files).
 
-**Component actors** (one per AI domain): `CppBridge.LLM`, `.STT`, `.TTS`, `.VAD`, `.VLM`, `.VoiceAgent` — each is a Swift `actor` holding a single opaque `rac_handle_t`, with lazy creation via `getHandle()`, and `destroy()` for cleanup. `VoiceAgent.getHandle()` is `async throws` because it must gather handles from all four component actors before creating its composite handle.
+Component actors, one per AI domain: `CppBridge.LLM`, `.STT`, `.TTS`, `.VAD`, `.VLM`, `.VoiceAgent`. Each is a Swift `actor` holding a single opaque `rac_handle_t`, with lazy creation via `getHandle()`, and `destroy()` for cleanup. `VoiceAgent.getHandle()` is `async throws` because it must gather handles from all four component actors before creating its composite handle.
 
-**Infrastructure actors**: `CppBridge.ModelRegistry`, `CppBridge.Download` — also Swift actors wrapping C++ state.
+Infrastructure actors: `CppBridge.ModelRegistry` and `CppBridge.Download`, also Swift actors wrapping C++ state.
 
-**Pure namespaces** (no actors): `CppBridge.PlatformAdapter`, `.Environment`, `.DevConfig`, `.Endpoints`, `.Events`, `.Telemetry`, `.Device`, `.State`, `.HTTP`, `.Auth`, `.ModelPaths`, `.Services`, `.Platform`, `.FileManager`, `.Storage`, `.Strategy`, `.LoraRegistry`.
+Pure namespaces, no actors: `CppBridge.PlatformAdapter`, `.Environment`, `.DevConfig`, `.Endpoints`, `.Events`, `.Telemetry`, `.Device`, `.State`, `.HTTP`, `.Auth`, `.ModelPaths`, `.Services`, `.Platform`, `.FileManager`, `.Storage`, `.Strategy`, `.LoraRegistry`.
 
 Shutdown sequence in `CppBridge.shutdown()`: destroys AI actors sequentially (LLM → STT → TTS → VAD → VoiceAgent → VLM), then Telemetry and Events.
 
-### C↔Swift Interop Pattern
+### C to Swift interop
 
-All cross-boundary communication uses **vtable-based function pointer structs**:
-- `rac_platform_adapter_t` — file ops, logging, Keychain, clock, memory
-- `rac_http_transport_ops_t` — HTTP transport (URLSession)
-- `rac_secure_storage_t` — auth token persistence
-- `rac_platform_llm/tts/diffusion_callbacks_t` — Apple platform services
-- `rac_discovery_callbacks_t` — filesystem callbacks for model discovery
+All cross-boundary communication uses vtable-based function pointer structs:
+- `rac_platform_adapter_t`: file ops, logging, Keychain, clock, memory
+- `rac_http_transport_ops_t`: HTTP transport (URLSession)
+- `rac_secure_storage_t`: auth token persistence
+- `rac_platform_llm/tts/diffusion_callbacks_t`: Apple platform services
+- `rac_discovery_callbacks_t`: filesystem callbacks for model discovery
 
 Async Swift bridged to synchronous C ABI via `DispatchSemaphore` or `DispatchGroup.wait()`.
 
-### Backend Module Pattern
+### Backend module pattern
 
 Each runtime backend (`LlamaCPPRuntime`, `ONNXRuntime`) is a thin `public enum` exposing static `register(priority:)` / `unregister()` / `autoRegister` whose primary job is calling the relevant `rac_backend_*_register()` C function. Registration state is main-actor isolated so register/unregister cannot race; ONNX also explicitly registers/unregisters the Sherpa engine plugin for STT/TTS/VAD parity.
 
@@ -120,29 +114,29 @@ Each runtime backend (`LlamaCPPRuntime`, `ONNXRuntime`) is a thin `public enum` 
 | `LlamaCPP` | LLM + VLM (unified llama.cpp vtable) | `.llamaCpp` |
 | `ONNX` | Embeddings + Sherpa-ONNX engine plugin (STT / TTS / VAD) | `.onnx` |
 
-### Streaming Architecture
+### Streaming architecture
 
-`LLMStreamAdapter` and `VoiceAgentStreamAdapter` use a **fan-out pattern**: one C callback registration per native handle, fanning out to multiple Swift `AsyncStream` consumers via UUID-keyed continuations. State guarded by `OSAllocatedUnfairLock`. Proto events deserialized from bytes via `RALLMStreamEvent(serializedBytes:)` / `RAVoiceEvent(serializedBytes:)`.
+`LLMStreamAdapter` and `VoiceAgentStreamAdapter` use a fan-out pattern: one C callback registration per native handle, fanning out to multiple Swift `AsyncStream` consumers via UUID-keyed continuations. State guarded by `OSAllocatedUnfairLock`. Proto events deserialized from bytes via `RALLMStreamEvent(serializedBytes:)` / `RAVoiceEvent(serializedBytes:)`.
 
-### HTTP Layer
+### HTTP layer
 
 Two paths sharing the same transport vtable:
-- **`URLSessionHttpTransport`** — registered as `rac_http_transport_ops_t` vtable; three slots: `request_send` (buffered), `request_stream` (per-chunk), `request_resume` (with `Range: bytes=N-` header). All C++ HTTP flows through Apple's URLSession.
-- **`HTTPClientAdapter`** (actor, aliased as `HTTPService`) — wraps `rac_http_client_*` for SDK-level requests (auth, device registration, telemetry). Runs blocking calls on a concurrent `DispatchQueue`.
+- `URLSessionHttpTransport` is registered as the `rac_http_transport_ops_t` vtable; three slots: `request_send` (buffered), `request_stream` (per-chunk), `request_resume` (with `Range: bytes=N-` header). All C++ HTTP flows through Apple's URLSession.
+- `HTTPClientAdapter` (an actor aliased as `HTTPService`) wraps `rac_http_client_*` for SDK-level requests (auth, device registration, telemetry). Runs blocking calls on a concurrent `DispatchQueue`.
 
-### Type System
+### Type system
 
 Proto-generated types (`RA*` prefix from `.pb.swift` files in `Generated/`) are the canonical wire types. A small set of public Swift typealiases strip the prefix where the type is part of the SDK surface (e.g., `typealias InferenceFramework = RAInferenceFramework` in `Public/Extensions/Models/ModelTypes.swift`); the rest of the SDK uses the `RA`-prefixed proto types directly (e.g., `RASDKComponent` on `Public/Extensions/Models/RunAnywhere+ModelLifecycle.swift`). Extensions on these types add Swift-side computed properties, C-bridge methods (`withCOptions<T>(_:)`, `init(from cResult:)`), and `Codable` conformance.
 
-### Error System
+### Error system
 
 `SDKException` (struct at `Foundation/Errors/SDKException.swift`) wraps proto `RASDKError`. Captures `Thread.callStackSymbols` at construction. Category-specific static factories: `.stt(code, message)`, `.llm(...)`, `.network(...)`, etc. Codes `.cancelled` and `.streamCancelled` are classified as "expected" (suppress logging).
 
-### Event System
+### Event system
 
 `EventBus` (singleton) backed by Combine `PassthroughSubject<any SDKEvent, Never>`. Categories: `sdk`, `model`, `llm`, `stt`, `tts`, `voice`, `rag`, `storage`, `device`, `network`, `error`. Accessed via `RunAnywhere.events`.
 
-### Model Management
+### Model management
 
 Models stored at `Documents/RunAnywhere/Models/{framework}/{modelId}/`. Path computation delegated to C++ via `rac_model_paths_*`. Model registry is a Swift actor wrapping the C++ global registry. Model file type detection: `.gguf`/`.bin` → LlamaCPP, `.onnx`/`.ort` → ONNX, `.mlmodelc`/`.mlpackage` → CoreML, `.json` QNN bundles → QHexRT when explicitly registered as that framework.
 
@@ -160,19 +154,19 @@ Download orchestration runs `rac_http_download_execute` on a concurrent `Dispatc
 
 C++ logs arrive via `platformLogCallback`; structured metadata in `"message | key=value"` format is parsed.
 
-## Conventions and Rules
+## Conventions and rules
 
 ### Enforced by SwiftLint (errors, not warnings)
 
-- No `print()`, `NSLog()`, `os_log()`, `debugPrint()`, or `Logger(` — use `SDKLogger` exclusively
+- No `print()`, `NSLog()`, `os_log()`, `debugPrint()`, or `Logger(`; use `SDKLogger` exclusively
 - No `as!` force casts
 - No `force_cast`, `force_try`
 - TODOs must reference a GitHub issue number: `// TODO: #123 - description`
 
 ### Enforced by SwiftLint (warnings)
 
-- No `Any` or `AnyObject` types — use specific types or protocols
-- No `[String: Any]` dictionaries — define a struct
+- No `Any` or `AnyObject` types; use specific types or protocols
+- No `[String: Any]` dictionaries; define a struct
 - No implicitly unwrapped optionals
 - Sorted imports
 - Lines: warn at 150 chars, error at 200
@@ -182,10 +176,10 @@ C++ logs arrive via `platformLogCallback`; structured metadata in `"message | ke
 
 ### Concurrency
 
-- **Never use `NSLock`** — use `OSAllocatedUnfairLock` (Swift 6 API) or Swift actors
+- Never use `NSLock`; use `OSAllocatedUnfairLock` (Swift 6 API) or Swift actors
 - Bridge actors hold one opaque C handle each; all access is concurrency-safe via actor isolation
 - C callback trampolines use `@convention(c)` free functions (no captures) with `Unmanaged.passRetained`/`.release()` for context passing
-- Async-to-sync bridging uses `DispatchSemaphore` or `DispatchGroup.wait()` — required because the C ABI is synchronous
+- Async-to-sync bridging uses `DispatchSemaphore` or `DispatchGroup.wait()`, required because the C ABI is synchronous
 
 ### Naming
 
@@ -197,7 +191,7 @@ C++ logs arrive via `platformLogCallback`; structured metadata in `"message | ke
 
 Configured in `.periphery.yml`. Scans `RunAnywhere`, `ONNXRuntime`, `LlamaCPPRuntime` targets. `retain_public: true`, `retain_codable_properties: true`.
 
-## Key File Locations
+## Key file locations
 
 | File | Purpose |
 |------|---------|
@@ -225,7 +219,7 @@ Configured in `.periphery.yml`. Scans `RunAnywhere`, `ONNXRuntime`, `LlamaCPPRun
 | ml-stable-diffusion | CoreML image generation |
 | swift-protobuf | Proto-generated type support |
 
-## Capability Notes
+## Capability notes
 
 Speaker diarization is exposed through `RunAnywhere.diarization` and semantic
 segmentation through `RunAnywhere.segmentation`, both of which require the

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -2,16 +2,16 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
-## Core Principles
+## Core principles
 
-- Focus on **SIMPLICITY**, following Clean SOLID principles. Reusability, clean architecture, clear separation of concerns.
+- Focus on simplicity, following Clean SOLID principles. Reusability, clean architecture, clear separation of concerns.
 - Do NOT write ANY MOCK IMPLEMENTATION unless specified otherwise.
 - DO NOT PLAN or WRITE any unit tests unless specified otherwise.
-- Always use **structured types**, never use strings directly for consistency and scalability.
-- When fixing issues focus on **SIMPLICITY** - do not add complicated logic unless necessary.
-- Don't over plan it, always think **MVP**.
+- Always use structured types, never raw strings for consistency and scalability.
+- When fixing issues focus on simplicity; do not add complicated logic unless necessary.
+- Don't over plan it; always think MVP.
 
-## C++ Specific Rules
+## C++ rules
 
 - C++20 standard required (`CMAKE_CXX_STANDARD 20`)
 - Google C++ Style Guide with project customizations (`.clang-format`: 4-space indent, 100-column limit)
@@ -19,7 +19,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Run `./scripts/lint-cpp.sh --tidy` for clang-tidy (requires `compile_commands.json` in a build dir)
 - All public C API symbols prefixed with `rac_`; types suffixed `_t`; error codes `RAC_ERROR_*`; macros `RAC_*`
 
-## Build Commands
+## Build commands
 
 ```bash
 # Desktop/macOS build (core only, no backends)
@@ -63,7 +63,7 @@ scripts/build-windows.bat
 ./scripts/lint-cpp.sh --tidy     # Static analysis (needs compile_commands.json)
 ```
 
-## CMake Options
+## CMake options
 
 | Option | Default | Description |
 |--------|---------|-------------|
@@ -73,52 +73,47 @@ scripts/build-windows.bat
 | `RAC_BUILD_PLATFORM` | ON (Apple only) | Apple Foundation Models, System TTS, CoreML Diffusion |
 | `RAC_BUILD_BACKENDS` | OFF | ML backend compilation |
 | `RAC_BUILD_SERVER` | OFF | OpenAI-compatible HTTP server (`src/server/`, `tools/`) |
-| `RAC_ENABLE_SOLUTIONS` | ON desktop, OFF mobile/WASM | Full Protobuf + Abseil Solutions API; OFF → stub returns `RAC_ERROR_FEATURE_NOT_AVAILABLE` |
+| `RAC_ENABLE_SOLUTIONS` | Follows `RAC_ENABLE_PROTOBUF`; forced OFF under Emscripten | Full Protobuf + Abseil Solutions API; OFF makes the stub return `RAC_ERROR_FEATURE_NOT_AVAILABLE`. Mobile builds enable protobuf, so Solutions is ON there too. |
 | `RAC_STATIC_PLUGINS` | Forced ON for iOS/WASM | Static plugin linking vs `dlopen` at runtime |
 | `RAC_REGENERATE_PROTO` | OFF | Re-run `idl/codegen/generate_cpp.sh` when `.proto` files change |
 | `RAC_BACKEND_RAG` | ON (except Emscripten) | RAG pipeline OBJECT library folded into `rac_commons` |
 
-## Project Overview
+## Project overview
 
-`runanywhere-commons` is a unified C/C++ library (C++20 internals, pure C API surface) that sits between platform SDKs (Swift, Kotlin, Web/WASM) and ML inference backends. It is the single source of truth for business logic — platform SDKs are thin bridges.
+`runanywhere-commons` is a unified C/C++ library (C++20 internals, pure C API surface) that sits between platform SDKs (Swift, Kotlin, Web/WASM) and ML inference backends. It is the single source of truth for business logic; platform SDKs are thin bridges.
 
 ## Architecture
 
-```
-┌─────────────────────────────────────────────────────────────────┐
-│               Swift / Kotlin / Web SDKs                         │
-│         (CRACommons module map / JNI / Emscripten ccall)        │
-└──────────────────────────┬──────────────────────────────────────┘
-                           │ C API (rac_*)
-┌──────────────────────────▼──────────────────────────────────────┐
-│  Component Layer  (rac_*_component_*)                            │
-│  Owns lifecycle, emits analytics, exposes clean public API       │
-│  LLM | STT | TTS | VAD | VLM | Diffusion | Embed | Segment     │
-└──────────────────────────┬──────────────────────────────────────┘
-                           │ rac_*_create() → rac_plugin_find() → vtable dispatch
-┌──────────────────────────▼──────────────────────────────────────┐
-│  Service Layer  (rac_*_service.cpp)                              │
-│  Looks up model in registry → resolves framework → optional      │
-│  engine pin → rac_plugin_find[_for_engine]() → vtable dispatch    │
-└──────────────────────────┬──────────────────────────────────────┘
-                           │
-┌──────────────────────────▼──────────────────────────────────────┐
-│  Plugin Registry  (src/plugin/)                                 │
-│  ABI-versioned vtable handshake (RAC_PLUGIN_API_VERSION = 9u)    │
-│  Priority order: highest-priority plugin per primitive wins, no  │
-│  scoring. Static (RAC_STATIC_PLUGIN_REGISTER) or                 │
-│  dynamic (rac_registry_load_plugin / dlopen).                    │
-└──────────────────────────┬──────────────────────────────────────┘
-                           │
-┌──────────────────────────▼──────────────────────────────────────┐
-│                    Engine Plugins                                 │
-│  llamacpp (LLM+VLM) | sherpa (STT+TTS+VAD)                       │
-│  onnx (Embed+Segment) | neurt (ANE LLM + Diffusion, Apple)       │
-│  qhexrt (LLM+VLM+STT+TTS, HNPU) | platform (Apple FM+TTS+Diff)  │
-└─────────────────────────────────────────────────────────────────┘
-```
+Five layers, top to bottom.
 
-### Two-Layer Feature Pattern
+Swift, Kotlin, and Web SDKs enter through the `rac_*` C API, reached by the CRACommons module
+map, JNI, or an Emscripten `ccall`.
+
+The component layer (`rac_*_component_*`) owns lifecycle, emits analytics, and exposes the
+public API for LLM, STT, TTS, VAD, VLM, diffusion, embed, and segment.
+
+Below it, `rac_*_create()` calls `rac_plugin_find()` and dispatches through a vtable to the
+service layer (`rac_*_service.cpp`), which looks the model up in the registry, resolves its
+framework, applies an optional engine pin, and calls
+`rac_plugin_find[_for_engine]()`.
+
+The plugin registry (`src/plugin/`) performs the ABI-versioned vtable handshake at
+`RAC_PLUGIN_API_VERSION = 9u`. The highest-priority plugin per primitive wins; there is no
+scoring. Registration is static through `RAC_STATIC_PLUGIN_REGISTER` or dynamic through
+`rac_registry_load_plugin` and `dlopen`.
+
+Engine plugins sit at the bottom.
+
+| Plugin | Primitives |
+|---|---|
+| llamacpp | LLM, VLM |
+| sherpa | STT, TTS, VAD |
+| onnx | Embed, Segment |
+| neurt (Apple) | ANE LLM, Diffusion |
+| qhexrt (Hexagon NPU) | LLM, VLM, STT, TTS |
+| platform (Apple) | Foundation Models, TTS, Diffusion |
+
+### Two-layer feature pattern
 
 Every AI capability follows the same two-layer design:
 
@@ -126,13 +121,13 @@ Every AI capability follows the same two-layer design:
 
 2. **Component layer** (merged into `src/features/*/*_module.cpp`): Owns model lifecycle via `rac_lifecycle_t`, emits analytics events (`RAC_EVENT_*`), handles cancel, streams tokens/audio, exposes the public `rac_*_component_*()` API that platform SDKs call.
 
-**Feature-family classification** — not every capability fits one mold:
+Feature-family classification, because not every capability fits one mold:
 
-- **Single-backend capabilities** (`llm`, `stt`, `tts`, `vad`, `vlm`, `diffusion`, `embeddings`, `segmentation`) follow the Service+Component split above: each resolves a single `rac_engine_vtable_t*` and wraps it in a `rac_*_service_t`.
-- **Composed pipelines** (`rag`, `voice_agent`) are intentionally different: they orchestrate other services and have no single backend vtable of their own, so they deliberately skip the service wrapper.
-- **VAD is a dual-backend special case**: a plugin-provided model VAD service (e.g. sherpa Silero) plus a component-owned energy-VAD fallback. The component selects between them rather than always dispatching to one backend.
+- Single-backend capabilities (`llm`, `stt`, `tts`, `vad`, `vlm`, `diffusion`, `embeddings`, `segmentation`) follow the Service+Component split above: each resolves a single `rac_engine_vtable_t*` and wraps it in a `rac_*_service_t`.
+- Composed pipelines (`rag`, `voice_agent`) are intentionally different: they orchestrate other services and have no single backend vtable of their own, so they deliberately skip the service wrapper.
+- VAD is a dual-backend special case: a plugin-provided model VAD service (e.g. sherpa Silero) plus a component-owned energy-VAD fallback. The component selects between them rather than always dispatching to one backend.
 
-### Unified Plugin ABI (v9)
+### Unified plugin ABI (v9)
 
 All backends publish a `rac_engine_vtable_t` (`include/rac/plugin/rac_engine_vtable.h`) with 10 active primitive slots, one optional terminal token-count callback, and 6 reserved slots (the single source of truth for primitive slots is the `RAC_PRIMITIVE_TABLE` X-macro in that header):
 
@@ -149,72 +144,72 @@ All backends publish a `rac_engine_vtable_t` (`include/rac/plugin/rac_engine_vta
 | `RAC_PRIMITIVE_SEGMENT` | `segmentation_ops` | onnx |
 | `RAC_PRIMITIVE_RERANK` | `rerank_ops` | llamacpp (rank-pooling GGUF) |
 
-NULL primitive slot = "not supported." ABI version mismatch → immediate rejection at registration.
-Current handshake is **`RAC_PLUGIN_API_VERSION = 9u`**: ABI v9 widens
+A NULL primitive slot means not supported. An ABI version mismatch is rejected at registration.
+The current handshake is `RAC_PLUGIN_API_VERSION = 9u`: ABI v9 widens
 `rac_llm_stream_callback_fn` with `tokens_in_delta` and adds
 `get_stream_token_counts` on `rac_llm_service_ops_t`. A NULL callback makes commons estimate counts and set
 `TokenUsage.counts_estimated`.
-`RAC_PRIMITIVE_RERANK` (wire value **11**, `rerank_ops`, promoted from `reserved_slot_2` at the same binary offset) was **revived as a first-class cross-encoder reranking primitive in ABI v8**. The *original* rerank slot (wire value 6, retired in ABI v4) stays permanently retired — the revived primitive is a new wire value, not a reuse of 6.
+`RAC_PRIMITIVE_RERANK` (wire value 11, `rerank_ops`, promoted from `reserved_slot_2` at the same binary offset) was revived as a first-class cross-encoder reranking primitive in ABI v8. The original rerank slot (wire value 6, retired in ABI v4) stays permanently retired; the revived primitive is a new wire value, not a reuse of 6.
 
-### Platform Adapter Inversion-of-Control
+### Platform adapter inversion of control
 
 `rac_platform_adapter_t` (`include/rac/core/rac_platform_adapter.h`) is the single struct through which all platform services enter C++. The platform SDK populates it before calling `rac_init()`:
 
-- **Mandatory**: `file_exists`, `file_read`, `file_write`, `file_delete`, `secure_get/set/delete`, `log`, `now_ms`
-- **Optional (NULL-safe, each slot is null-checked at the call site with a documented fallback)**: `get_memory_info`, `http_download/cancel`, `extract_archive` (currently unused — commons extracts via built-in libarchive `rac_extract_archive_native` directly), `file_list_directory`, `is_non_empty_directory`, `get_vendor_id` (Apple-only)
+- Mandatory: `file_exists`, `file_read`, `file_write`, `file_delete`, `secure_get/set/delete`, `log`, `now_ms`
+- Optional, NULL-safe, each null-checked at the call site with a documented fallback: `get_memory_info`, `http_download/cancel`, `extract_archive` (currently unused, since commons extracts through built-in libarchive `rac_extract_archive_native` directly), `file_list_directory`, `is_non_empty_directory`, `get_vendor_id` (Apple-only)
 
-`rac_init()` validates the adapter's `abi_version` + `struct_size` (rejecting a mismatch with `RAC_ERROR_ABI_VERSION_MISMATCH`) **and** all 9 Mandatory slots above (returning `RAC_ERROR_ADAPTER_NOT_SET` if any is NULL) — see `rac_core.cpp:151-195`. Optional slots are not enforced; each is null-checked before use with a documented fallback (e.g. Kotlin's JNI ships without `get_memory_info`, which is why it is Optional). There is no `track_error` slot.
+`rac_init()` validates the adapter's `abi_version` + `struct_size` (rejecting a mismatch with `RAC_ERROR_ABI_VERSION_MISMATCH`) and all 9 mandatory slots above (returning `RAC_ERROR_ADAPTER_NOT_SET` if any is NULL); see `rac_core.cpp:151-195`. Optional slots are not enforced; each is null-checked before use with a documented fallback (e.g. Kotlin's JNI ships without `get_memory_info`, which is why it is Optional). There is no `track_error` slot.
 
 All file I/O, secure storage, HTTP, and logging pass through this struct. C++ code never calls platform APIs directly.
 
-### Swift Callback Pattern (Apple-only backends)
+### Swift callback pattern (Apple-only backends)
 
 Foundation Models, System TTS, and CoreML Diffusion all use the same pattern:
 1. Swift calls `rac_*_set_callbacks(&callback_struct)` to register function pointers
 2. Swift calls `rac_backend_*_register()` which registers the vtable with the plugin registry
 3. At runtime, vtable dispatch calls back into Swift through the stored function pointers
 
-### Dual Event System
+### Dual event system
 
-1. **Legacy struct-based** (`rac_event_publish/subscribe/track` in `src/infrastructure/events/event_publisher.cpp`): category-keyed pub/sub with lock-copy-dispatch (snapshot subscribers under mutex, dispatch outside to prevent deadlock). Still live — used by `LifecycleManager` and the engine plugins (sherpa, llamacpp) to emit analytics breadcrumbs via `rac_event_track`.
+1. Legacy struct-based (`rac_event_publish/subscribe/track` in `src/infrastructure/events/event_publisher.cpp`): category-keyed pub/sub with lock-copy-dispatch (snapshot subscribers under mutex, dispatch outside to prevent deadlock). Still live, used by `LifecycleManager` and the engine plugins (sherpa, llamacpp) to emit analytics breadcrumbs via `rac_event_track`.
 
-2. **Canonical proto** (`rac::events::emit_*` in `src/core/events.cpp`, published through `src/infrastructure/events/sdk_event_publish.cpp`): builds `runanywhere.v1.SDKEvent` payloads carrying a **destination bitmask** (`EVENT_DESTINATION_PUBLIC` | `TELEMETRY` | `LOG`; `ALL` = PUBLIC\|TELEMETRY). `route()` fans out to the public proto stream, the telemetry manager, and an opt-in log breadcrumb. The former fixed analytics/public callback registry (`rac_analytics_event_emit`, `rac_event_get_destination`) was removed.
+2. Canonical proto (`rac::events::emit_*` in `src/core/events.cpp`, published through `src/infrastructure/events/sdk_event_publish.cpp`): builds `runanywhere.v1.SDKEvent` payloads carrying a **destination bitmask** (`EVENT_DESTINATION_PUBLIC` | `TELEMETRY` | `LOG`; `ALL` = PUBLIC\|TELEMETRY). `route()` fans out to the public proto stream, the telemetry manager, and an opt-in log breadcrumb. The former fixed analytics/public callback registry (`rac_analytics_event_emit`, `rac_event_get_destination`) was removed.
 
-### Thread Safety Patterns
+### Thread-safety patterns
 
-- **Meyers singleton** for all global state (`SDKState`, `ModuleRegistryState`, `LoggerState`, plugin registry) — avoids static initialization order fiasco
-- **Lock-copy-dispatch** in event publisher — prevents deadlock if callbacks re-enter
-- **Atomic cancel** in LLM component — `cancel_requested` is `std::atomic<bool>`, read without mutex in the token callback to avoid deadlock with the generating thread
-- **Lifecycle refcount pinning** — `rac_lifecycle_acquire_service/release_service` prevents model unload during active inference; unload waits on `condition_variable` for refcount == 0
-- **VAD component backend selection** — `rac_vad_component_*` routes model-backed operations through the selected plugin and falls back to the component-owned energy VAD when no model is loaded
-- **Energy VAD hot path** — mean-square computed without sqrt (compares `mean_sq > threshold_sq`); 4-way loop unrolling; callbacks deferred outside lock
+- Meyers singleton for all global state (`SDKState`, `ModuleRegistryState`, `LoggerState`, plugin registry), which avoids static initialization order fiasco
+- Lock-copy-dispatch in the event publisher prevents deadlock if callbacks re-enter
+- Atomic cancel in the LLM component: `cancel_requested` is `std::atomic<bool>`, read without mutex in the token callback to avoid deadlock with the generating thread
+- Lifecycle refcount pinning: `rac_lifecycle_acquire_service/release_service` prevents model unload during active inference; unload waits on `condition_variable` for refcount == 0
+- VAD component backend selection: `rac_vad_component_*` routes model-backed operations through the selected plugin and falls back to the component-owned energy VAD when no model is loaded
+- Energy VAD hot path: mean-square computed without sqrt (compares `mean_sq > threshold_sq`); 4-way loop unrolling; callbacks deferred outside lock
 
-### Voice Agent Pipeline
+### Voice agent pipeline
 
 Orchestrates VAD → STT → LLM → TTS with 8 pipeline states (`rac_audio_pipeline_state_t`):
 `IDLE → LISTENING → PROCESSING_SPEECH → GENERATING_RESPONSE → PLAYING_TTS → COOLDOWN → IDLE`
 (plus `WAITING_WAKEWORD` and `ERROR`). Microphone blocked during processing/TTS. 800ms cooldown after TTS. State transitions validated by `rac_audio_pipeline_is_valid_transition()`.
 
-## Key Subsystems
+## Key subsystems
 
 ### Lifecycle Manager (`src/core/capabilities/lifecycle_manager.cpp`)
 
-The `rac_lifecycle_*` C API is a thin **per-handle facade over the canonical global `g_loaded` store** (`src/core/model_lifecycle.cpp`), not a separate state machine. A `LifecycleManager` owns no model state — only its config, per-handle metrics, and a pin token. `load()` calls the feature module's own `create_fn` (path-based — no registry lookup, no download) and stores the resulting `rac_<mod>_service_t` into `g_loaded`; the single store/pin is `g_loaded` + `LoadedModel::active_refs` + `g_lifecycle_cv`. Every facade op is **owner-scoped** (only touches the `g_loaded[component]` slot whose `owner_lifecycle` is this handle), so destroying a never-loaded component handle never evicts a user's registry-loaded model. State maps READY→LOADED, ERROR→FAILED. `get_state`/`get_service` take `g_lifecycle_mutex` briefly (never held across model creation). Auto-unload of a previous model drains in-flight refs via `g_lifecycle_cv` before destroying. Under `#if !defined(RAC_HAVE_PROTOBUF)` (no `g_loaded`), the original self-contained per-handle implementation is retained verbatim.
+The `rac_lifecycle_*` C API is a thin per-handle facade over the canonical global `g_loaded` store (`src/core/model_lifecycle.cpp`), not a separate state machine. A `LifecycleManager` owns no model state, only its config, per-handle metrics, and a pin token. `load()` calls the feature module's own `create_fn` (path-based, with no registry lookup and no download) and stores the resulting `rac_<mod>_service_t` into `g_loaded`; the single store/pin is `g_loaded` + `LoadedModel::active_refs` + `g_lifecycle_cv`. Every facade op is **owner-scoped** (only touches the `g_loaded[component]` slot whose `owner_lifecycle` is this handle), so destroying a never-loaded component handle never evicts a user's registry-loaded model. State maps READY→LOADED, ERROR→FAILED. `get_state`/`get_service` take `g_lifecycle_mutex` briefly (never held across model creation). Auto-unload of a previous model drains in-flight refs via `g_lifecycle_cv` before destroying. Under `#if !defined(RAC_HAVE_PROTOBUF)` (no `g_loaded`), the original self-contained per-handle implementation is retained verbatim.
 
-### Model Registry & Paths
+### Model registry and paths
 
-- `rac_model_registry_t` — CRUD for model metadata; `discover_downloaded()` scans filesystem; `refresh()` combines remote catalog + local rescan + orphan pruning
-- `rac_model_paths_t` — All paths follow `{base_dir}/RunAnywhere/Models/{framework}/{modelId}/`
-- `rac_lora_registry_t` — LoRA adapter entries with compatible model ID matching
-- Model assignment (`rac_model_assignment_*` functions in `model_assignment.cpp`) — fetches device-assigned models from the backend API with a TTL cache. Function-based API; there is no `rac_model_assignment_t` handle type.
+- `rac_model_registry_t`: CRUD for model metadata; `discover_downloaded()` scans filesystem; `refresh()` combines remote catalog + local rescan + orphan pruning
+- `rac_model_paths_t`: all paths follow `{base_dir}/RunAnywhere/Models/{framework}/{modelId}/`
+- `rac_lora_registry_t`: LoRA adapter entries with compatible model ID matching
+- Model assignment (`rac_model_assignment_*` functions in `model_assignment.cpp`) fetches device-assigned models from the backend API with a TTL cache. Function-based API; there is no `rac_model_assignment_t` handle type.
 
-### Download Manager (`include/rac/infrastructure/download/rac_download_orchestrator.h`)
+### Download manager (`include/rac/infrastructure/download/rac_download_orchestrator.h`)
 
 Orchestration (not HTTP transport). Stages: `DOWNLOADING` (0-80%) → `EXTRACTING` (80-95%) → `VALIDATING` (95-99%) → `COMPLETED` (100%). HTTP delegated to `rac_http_download` (platform adapter).
 
-### Error Categories (`include/rac/core/rac_structured_error.h`)
+### Error categories (`include/rac/core/rac_structured_error.h`)
 
-SDK-facing errors cross the boundary as `runanywhere.v1.SDKError` proto bytes via `rac_result_to_proto_error()` — the canonical, single error path. `rac_structured_error.h` now holds only the `rac_error_category_t` taxonomy (`RAC_CATEGORY_*`), mapped onto the proto `ErrorCategory` by `rac_proto_adapters`. The old structured-error subsystem (`rac_error_t`, stack-trace capture, thread-local last-error, `rac_error_log_and_track`, the bespoke JSON / `rac::Error` surface) was retired — it had no remaining callers once the proto path became canonical. Per-result message/expectedness lookups live in `rac_error.cpp` (`rac_error_message`, `rac_error_is_expected`).
+SDK-facing errors cross the boundary as `runanywhere.v1.SDKError` proto bytes through `rac_result_to_proto_error()`, the canonical single error path. `rac_structured_error.h` now holds only the `rac_error_category_t` taxonomy (`RAC_CATEGORY_*`), mapped onto the proto `ErrorCategory` by `rac_proto_adapters`. The old structured-error subsystem (`rac_error_t`, stack-trace capture, thread-local last-error, `rac_error_log_and_track`, the bespoke JSON / `rac::Error` surface) was retired because it had no remaining callers once the proto path became canonical. Per-result message/expectedness lookups live in `rac_error.cpp` (`rac_error_message`, `rac_error_is_expected`).
 
 ### Logging
 
@@ -233,36 +228,36 @@ Okapi BM25 inverted index (`bm25_index.cpp`). Per-session `RAGBackend` guarded b
 `mutex_`; the graph runs outside the lock. Multi-session; each handle independent.
 
 Design rules for RAG work (do not relitigate):
-- **Keep USearch** as the dense ANN store. Do not replace it with a brute-force
-  Hamming/binary-quantized scan — techniques may be borrowed from reference engines, the
+- Keep USearch as the dense ANN store. Do not replace it with a brute-force
+  Hamming/binary-quantized scan. Techniques may be borrowed from reference engines, the
   storage engine is not.
-- **RAG's default rerank is LLM-pointwise** (score fused candidates 1–5 with the existing
+- RAG's default rerank is LLM-pointwise (score fused candidates 1 to 5 with the existing
   LLM handle) and is the only reranking path wired into the RAG query flow today. The
   first-class `RAC_PRIMITIVE_RERANK` cross-encoder primitive (`rerank_ops`, revived in plugin
-  ABI v8) exists and is reachable standalone via `rac_rerank_*`, but it is **not yet invoked
-  from the RAG query path** — `RAGBackend`/`rag_pipeline_graph` do not score fused candidates
+  ABI v8) exists and is reachable standalone through `rac_rerank_*`, but it is not yet invoked
+  from the RAG query path: `RAGBackend`/`rag_pipeline_graph` do not score fused candidates
   through it. Until that wiring lands, `rac_rag_proto_abi` **rejects** a `reranker_model_id`
   at session-create with `RAC_ERROR_NOT_IMPLEMENTED` (rather than accepting it and silently
   no-op'ing); callers wanting reranking today use `rerank_results` (LLM-pointwise). With no
   `reranker_model_id` the default fusion path is unchanged.
-- **All RAG persistence goes through the platform adapter** file I/O
+- All RAG persistence goes through the platform adapter file I/O
   (`file_read`/`file_write`/`file_delete`/`file_exists`, `rac_platform_adapter.h`), never
   direct `std::ofstream`/`fopen`. This is what makes persistence work on Web (OPFS) as well
   as mobile.
-- **Content-addressed dedup: never re-embed the same input.** Documents are keyed by
+- Content-addressed dedup: never re-embed the same input. Documents are keyed by
   `sha256(raw_bytes)` (files) or `sha256(normalized_text)` (text); chunk embeddings are
   cached by `sha256(chunk_text) + embedding_model_fingerprint`. A matching hash + matching
-  fingerprint skips chunking/embedding. Embedding caches are **namespaced by embedding
-  fingerprint**, so switching models is safe and reversible.
-- **SHA-256 is the shared foundation util** `src/foundation/rac_sha256`. Do not add a
+  fingerprint skips chunking/embedding. Embedding caches are namespaced by embedding
+  fingerprint, so switching models is safe and reversible.
+- SHA-256 is the shared foundation util `src/foundation/rac_sha256`. Do not add a
   second SHA-256 implementation (the old file-local one in `rac_http_download.cpp` is being
   consolidated here).
-- **Persisted indexes are fingerprint-guarded** (embedding model + dim + format version).
-  On mismatch, discard and re-embed — never load stale vectors against a different embedder.
-- Proto changes to `idl/rag.proto` are **additive only** (new optional fields); regenerate
+- Persisted indexes are fingerprint-guarded (embedding model + dim + format version).
+  On mismatch, discard and re-embed; never load stale vectors against a different embedder.
+- Proto changes to `idl/rag.proto` are additive only (new optional fields); regenerate
   all SDK bindings, no version bump.
 
-## Error Code Ranges
+## Error code ranges
 
 | Range | Category |
 |-------|----------|
@@ -283,7 +278,7 @@ Design rules for RAG work (do not relitigate):
 
 Add new codes to `rac_error.h`, add case to `rac_error_message()` in `rac_error.cpp`, add mapping in platform SDK error converters.
 
-## Backend Details
+## Backend details
 
 | Backend | Primitives | Models | Engine | Registration |
 |---------|-----------|--------|--------|-------------|
@@ -294,20 +289,20 @@ Add new codes to `rac_error.h`, add case to `rac_error_message()` in `rac_error.
 | **qhexrt** | LLM, VLM, STT, TTS | QNN context bundle | QHexRT / Hexagon NPU | `rac_backend_qhexrt_register()` |
 | **platform** | LLM, TTS, Diffusion (Apple) | builtin:// | Swift callbacks | `rac_backend_platform_register()` |
 
-## Version Management
+## Version management
 
 All versions centralized in `VERSIONS` file. Consumed three ways:
 - **Shell**: `source scripts/load-versions.sh` → exports `$LLAMACPP_VERSION`, `$ONNX_VERSION_IOS`, etc.
 - **CMake**: `include(LoadVersions)` → sets cache variables `RAC_<KEY>` and bare `<KEY>`
 - **Windows**: `for /f` parsing in `.bat` scripts
 
-## Symbol Visibility
+## Symbol visibility
 
 - **Apple**: `exports/RACommons.exports` lists 465 curated `_rac_*` symbols; applied via `-exported_symbols_list`
 - **Android**: Currently `-fvisibility=default` (all symbols exported) as workaround; TODO(v0.21) to annotate all public functions with `RAC_API`
 - **Shared builds**: Global `-fvisibility=hidden` + `RAC_API` attribute (`__attribute__((visibility("default")))` / `__declspec(dllexport)`) on public C functions
 
-## Build Outputs
+## Build outputs
 
 **Apple**: XCFrameworks under `../bindings/swift/Binaries/`; versioned reproducible archives under `dist/packages/`.
 
@@ -342,11 +337,11 @@ Key test categories: core infrastructure, plugin registry/routing, graph schedul
 
 ## CI/CD
 
-- **Build**: `.github/workflows/build-commons.yml` — macOS, iOS, Android parallel builds + lint
-- **Release**: `.github/workflows/release.yml` — triggered by `commons-v*` tags; publishes to `RunanywhereAI/runanywhere-binaries`
-- **Size Check**: `.github/workflows/size-check.yml` — xcframework must stay under 3 MB
+- Build: `.github/workflows/build-commons.yml` runs macOS, iOS, and Android builds in parallel plus lint
+- Release: `.github/workflows/release.yml` is triggered by `commons-v*` tags and publishes to `RunanywhereAI/runanywhere-binaries`
+- Size check: `.github/workflows/size-check.yml` holds the xcframework under 3 MB
 
-## Common Tasks
+## Common tasks
 
 ### Adding a new backend
 


### PR DESCRIPTION
Three corrections and a readability pass over the AGENTS files.

The root file told you to run `./scripts/lint-cpp.sh`, but there is no `.sh` at the top level
of `scripts/`; the script lives at `core/scripts/lint-cpp.sh`. It also carried a note saying
"It's December 2025 FYI", which is now wrong and was misleading anything that read it.

`core/AGENTS.md` documented `RAC_ENABLE_SOLUTIONS` as "ON desktop, OFF mobile/WASM". The
option actually defaults to `RAC_ENABLE_PROTOBUF` and is forced off only under Emscripten
(`core/CMakeLists.txt:1406-1411`), so mobile builds have Solutions on.

The rest is presentation. The box-drawing architecture diagrams are now tables and prose,
which say the same thing and survive a narrow terminal. Em dashes, emoji, title-case headings,
and bold inline-header bullets are gone.

No content was dropped. Verified with `check_agents_claude_sync.sh`, which still reports all
14 symlinks present.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Reorganized and expanded repository, Swift integration, and core architecture guidance.
  * Clarified build processes, platform requirements, plugin integration, streaming, initialization, lifecycle management, error handling, and verification steps.
  * Improved headings, formatting, diagrams, and explanations while preserving existing commands and policies.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->