### PR TITLE
fix(commons): answer loaded-state from the lifecycle store before the host

### DIFF
--- a/core/src/core/model_lifecycle_accessors.cpp
+++ b/core/src/core/model_lifecycle_accessors.cpp
@@ -467,3 +467,37 @@ void release_lifecycle_segmentation(LifecycleSegmentationRef* ref) {
 }
 
 }  // namespace rac::lifecycle
+
+// ---------------------------------------------------------------------------
+// Loaded-state query
+//
+// The storage delete path needs to know whether a model is open before it
+// removes files underneath it. Hosts answer that through
+// rac_storage_callbacks_t::is_model_loaded, but commons is the component that
+// performed the load and already tracks it in g_loaded, so it can answer
+// without asking anyone. Internal on purpose: the only caller is inside
+// commons, so this stays off the public C ABI.
+// ---------------------------------------------------------------------------
+
+namespace rac::lifecycle {
+
+bool is_model_loaded(const char* model_id) {
+#if defined(RAC_HAVE_PROTOBUF)
+    if (model_id == nullptr || *model_id == '\0') {
+        return false;
+    }
+    std::lock_guard<std::mutex> lock(rac::core::model_lifecycle::detail::g_lifecycle_mutex);
+    for (const auto& entry : rac::core::model_lifecycle::detail::g_loaded) {
+        const auto& loaded = entry.second;
+        if (loaded && loaded->model_id == model_id) {
+            return true;
+        }
+    }
+    return false;
+#else
+    (void)model_id;
+    return false;
+#endif
+}
+
+}  // namespace rac::lifecycle

--- a/core/src/features/rac_nonllm_lifecycle_bridge.h
+++ b/core/src/features/rac_nonllm_lifecycle_bridge.h
@@ -89,6 +89,19 @@ void release_lifecycle_diarization(LifecycleDiarizationRef* ref);
 rac_result_t acquire_lifecycle_segmentation(LifecycleSegmentationRef* out_ref);
 void release_lifecycle_segmentation(LifecycleSegmentationRef* ref);
 
+
+/**
+ * @brief Whether commons currently holds @p model_id loaded on any component.
+ *
+ * Answers from the lifecycle store, so it is true wherever commons performed
+ * the load regardless of what a host reports through
+ * rac_storage_callbacks_t::is_model_loaded. Callers that must not act while a
+ * model is open should treat `true` as authoritative; `false` only means
+ * commons did not load it, and a host that loads outside commons may still
+ * have it open.
+ */
+bool is_model_loaded(const char* model_id);
+
 }  // namespace rac::lifecycle
 
 #endif  // RAC_FEATURES_RAC_NONLLM_LIFECYCLE_BRIDGE_H

--- a/core/src/infrastructure/storage/storage_analyzer.cpp
+++ b/core/src/infrastructure/storage/storage_analyzer.cpp
@@ -32,6 +32,7 @@
 #include <unordered_set>
 #include <vector>
 
+#include "features/rac_nonllm_lifecycle_bridge.h"
 #include "rac/core/rac_logger.h"
 #include "rac/foundation/rac_proto_adapters.h"
 #include "rac/infrastructure/download/rac_download_orchestrator.h"
@@ -161,7 +162,23 @@ int64_t model_metric_size(rac_storage_analyzer_handle_t handle, const rac_model_
 
 bool known_loaded_state(rac_storage_analyzer_handle_t handle, const char* model_id,
                         bool* out_is_loaded) {
-    if (!handle || !model_id || !out_is_loaded || !handle->callbacks.is_model_loaded) {
+    if (!handle || !model_id || !out_is_loaded) {
+        return false;
+    }
+    // Ask commons before asking the host. The lifecycle store is what actually
+    // performed the load, whereas the callback is unanswerable for several
+    // hosts: the JNI one reports RAC_FALSE unconditionally, and Swift and
+    // Electron leave the slot NULL, which used to make every model look
+    // unloaded and let the delete path run underneath an open model.
+    //
+    // Only the positive answer is taken as final. A false answer means commons
+    // did not load it, not that nobody did, so that case still defers to the
+    // host. This can therefore only prevent a delete, never permit a new one.
+    if (rac::lifecycle::is_model_loaded(model_id)) {
+        *out_is_loaded = true;
+        return true;
+    }
+    if (!handle->callbacks.is_model_loaded) {
         return false;
     }
     rac_bool_t is_loaded = RAC_FALSE;


### PR DESCRIPTION
Follows up #615, which you closed on the premise. You were right that the resolved-id fallback was unreachable, and you pointed at the real bug underneath it:

> `is_model_loaded` is not wired to any lifecycle store — the JNI stub above literally lies to commons. Wiring that up for real, and aligning `storage_analyzer.cpp:1209` (the site that actually *deletes files* based on loaded state), is a genuinely valuable fix.

This is the read side of that.

## What is wrong

`known_loaded_state` can only answer through the host callback:

```cpp
if (!handle || !model_id || !out_is_loaded || !handle->callbacks.is_model_loaded) {
    return false;
}
```

No host answers it correctly:

- JNI hardcodes the answer (`core/src/jni/runanywhere_commons_jni.cpp:4083`):
  ```cpp
  static rac_result_t jni_storage_is_model_loaded(const char* /*model_id*/, rac_bool_t* out_is_loaded, void*) {
      if (out_is_loaded != nullptr) { *out_is_loaded = RAC_FALSE; }
      return RAC_SUCCESS;
  }
  ```
- Swift and Electron leave the slot NULL, so the guard above returns "unknown".

So the delete path believes nothing is ever loaded. `unload_if_loaded` never fires, and the recursive delete runs underneath a model the engine still has open.

## Why the fix belongs here

Commons is the component that performed the load, and it already tracks it: `g_loaded` maps each component to a `LoadedModel`, which carries `model_id`. It has been able to answer this question all along and was never asked.

Fixing it here fixes Android, Swift and Electron at once rather than asking three hosts to each implement a callback they are not well placed to answer, which is also what the layering rule in AGENTS.md asks for.

## What this does

Adds `rac::lifecycle::is_model_loaded(const char*)` on the existing internal lifecycle bridge (`core/src/features/rac_nonllm_lifecycle_bridge.h`), implemented beside the other accessors, reading `g_loaded` under `g_lifecycle_mutex`, and has `known_loaded_state` consult it before the callback.

Kept off the public C ABI: the only caller is inside commons, so a new `RAC_API` export would widen the surface every platform carries for no reason. `core/include` is untouched by this PR.

(Edited after the v2 rework. The first revision added a public `RAC_API rac_model_lifecycle_is_model_loaded`; the `RAC_API export drift check (strict)` gate correctly flagged it, and the merged shape is the internal one described above.)

**Only the positive answer is treated as final.** `RAC_FALSE` means commons did not load it, not that nobody did, so that path still defers to the host callback exactly as before. The consequence worth stating plainly: this can only ever *prevent* a delete, never permit one that was previously blocked. That asymmetry is documented on the declaration and at the call site.

I left the JNI stub in place rather than deleting it. With the lifecycle consulted first its wrong answer is no longer reachable for commons-loaded models, and removing it is a separate question about whether the callback should stay in the struct at all.

## Scope

Read side only, deliberately. `unload_model` has the same hole, but actually unloading from inside the delete path means calling into the lifecycle unload, which is a heavier change with its own reentrancy questions. I would rather land the read side so the path stops lying, then do the unload wiring separately. Say the word if you would rather see them together.

## Testing

Built and run locally, macOS, `-DRAC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug`:

- `test_storage_analyzer_proto` — exit 0, `0 test(s) failed`, including `test_delete_plan_blocks_loaded_missing_and_missing_path`, which is the loaded-state delete guard.
- `test_core --run-all` — exit 0, `18 passed, 0 failed, 18 total`.

Both are targets that exist in `core/tests/CMakeLists.txt` and I watched both run. On #615 I cited `test_storage_service_proto_abi`, which does not exist in this repo; that was my error and I have fixed how I verify target names.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of whether models are loaded across supported components.
  * Storage analysis now recognizes lifecycle-managed model loads even when platform callbacks are unavailable.
  * Model load status checks now handle invalid or missing model identifiers more reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
