### PR TITLE
fix(web): build the WebGPU WASM with --rag so it matches its CPU twin

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -742,7 +742,15 @@ jobs:
         run: npm run build:wasm -- --core --llamacpp --onnx
       - name: Build WASM (WebGPU llama.cpp)
         working-directory: bindings/web
-        run: npm run build:wasm -- --webgpu
+        # --rag is REQUIRED here. core/CMakeLists.txt force-sets
+        # RAC_BACKEND_RAG=OFF on Emscripten when neither RAC_BACKEND_ONNX nor
+        # RAC_WASM_RAG_STANDALONE is set. The CPU twin above is built in the
+        # same invocation as --onnx so it keeps RAG; this WebGPU invocation
+        # stands alone, so without --rag it silently drops the 8
+        # rac_rag_*_proto exports and the WebGPU bundle differs from its CPU
+        # sibling by exactly those symbols. (--onnx-webgpu below sets RAG=ON
+        # itself, which is why only this line was affected.)
+        run: npm run build:wasm -- --webgpu --rag
       - name: Build WASM (WebGPU ONNX + Sherpa)
         working-directory: bindings/web
         run: npm run build:wasm -- --onnx-webgpu

--- a/bindings/web/package.json
+++ b/bindings/web/package.json
@@ -11,7 +11,7 @@
   ],
   "scripts": {
     "build:wasm": "cd wasm && ./scripts/build.sh",
-    "build:wasm:all": "npm run build:wasm -- --core --llamacpp --onnx && npm run build:wasm -- --webgpu && npm run build:wasm -- --onnx-webgpu",
+    "build:wasm:all": "npm run build:wasm -- --core --llamacpp --onnx && npm run build:wasm -- --webgpu --rag && npm run build:wasm -- --onnx-webgpu",
     "build:wasm:onnx-webgpu": "cd wasm && ./scripts/build.sh --onnx-webgpu",
     "build:wasm:debug": "cd wasm && ./scripts/build.sh --debug",
     "build:wasm:clean": "npm run clean:wasm && npm run build:wasm:all",


### PR DESCRIPTION
## The defect

`core/CMakeLists.txt` force-sets `RAC_BACKEND_RAG=OFF` on Emscripten unless either `RAC_BACKEND_ONNX` or `RAC_WASM_RAG_STANDALONE` is set:

```cmake
if(EMSCRIPTEN AND NOT RAC_BACKEND_ONNX AND NOT RAC_WASM_RAG_STANDALONE)
    set(RAC_BACKEND_RAG OFF ... FORCE)
endif()
```

The CPU llama.cpp bundle is built in the same invocation as `--onnx`, so it keeps RAG. The WebGPU bundle is built by a **separate** invocation passing neither flag, so it silently drops the 8 `rac_rag_*_proto` exports.

Two bundles that are meant to be interchangeable are not. A symbol diff of the CPU and WebGPU llama.cpp twins is exactly those 8 symbols and nothing else. An app that turns on WebGPU loses RAG with no build error and no runtime message naming the cause.

`--onnx-webgpu` was never affected because it sets `RAG="ON"` itself, which is why this went unnoticed.

## The fix

Pass `--rag` to the WebGPU invocation, in **both** places that build it so they cannot drift:

| file | step |
|---|---|
| `.github/workflows/release.yml` | "Build WASM (WebGPU llama.cpp)" |
| `bindings/web/package.json` | `build:wasm:all` |

## Evidence

`bindings/web/wasm/scripts/build.sh` flag handling: `--onnx-webgpu` sets `RAG="ON"`, plain `--webgpu` does not, and `--rag` sets `-DRAC_WASM_RAG_STANDALONE`, which is exactly the escape hatch the CMake comment describes for this case.

## Note

There is currently no gate asserting CPU/WebGPU export parity. Adding one to `bindings/web/scripts/validate_public_packages.py` would prevent this class from recurring; it is deliberately not in this PR to keep the fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHnqxh9weAVMc6g2UcmbC9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Restored RAG functionality in standalone WebGPU builds.
  * Ensured the full WebAssembly build includes the RAG target.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->