### PR TITLE
fix(release): install the codegen toolchain in jobs that package SDKs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -848,6 +848,12 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
         with:
           platform: node
+      # Generated protobuf bindings are NOT committed. The packaging script
+      # this job runs regenerates them, which needs the codegen toolchain on
+      # PATH. Web packaging runs ensure_generated.sh --only ts; without ts-proto it exits 127.
+      - uses: ./.github/actions/generate-idl
+        with:
+          languages: ts
       - name: Download Web natives
         uses: actions/download-artifact@v8
         with:
@@ -894,6 +900,12 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
         with:
           platform: node
+      # Generated protobuf bindings are NOT committed. The packaging script
+      # this job runs regenerates them, which needs the codegen toolchain on
+      # PATH. RN packaging runs ensure_generated.sh --only ts; without ts-proto it exits 127.
+      - uses: ./.github/actions/generate-idl
+        with:
+          languages: ts
       # The RN tree pins `packageManager: yarn@3.6.1` (Yarn Berry). Activate it
       # via Corepack at the workflow level so package-sdk.sh (and any later
       # `yarn` invocation against the RN workspace) doesn't silently fall back
@@ -1534,6 +1546,12 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
         with:
           platform: flutter
+      # Generated protobuf bindings are NOT committed. The packaging script
+      # this job runs regenerates them, which needs the codegen toolchain on
+      # PATH. Flutter packaging runs ensure_generated.sh --only dart; without protoc-gen-dart it exits 127.
+      - uses: ./.github/actions/generate-idl
+        with:
+          languages: dart
       - uses: actions/setup-java@v5
         with:
           distribution: temurin

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -318,9 +318,16 @@ jobs:
       # core/include + core/src/generated/proto without ever configuring CMake,
       # so the configure-time codegen hook does not cover this job. Both are
       # protoc output and neither is tracked — generate them here.
+      # cpp for the C headers this job reads without configuring CMake, AND
+      # swift because the step below runs `swift build` over the root
+      # Package.swift, which compiles the generated *Swift* bindings
+      # (RALLMStreamEvent, RAVoiceEvent, RADownloadPlanResult, ...). Generating
+      # only cpp left those absent and the build failed with a wall of
+      # "cannot find type 'RA...' in scope", plus cascading "'Any' cannot be
+      # constructed" noise from the resulting bad inference.
       - uses: ./.github/actions/generate-idl
         with:
-          languages: cpp
+          languages: cpp,swift
       - uses: actions/download-artifact@v8
         with:
           name: native-ios-macos

--- a/bindings/swift/scripts/build-core-xcframework.sh
+++ b/bindings/swift/scripts/build-core-xcframework.sh
@@ -1384,18 +1384,43 @@ build_mlx_runtime_swift_slice() {
 
     echo "▶ Build ${label} canonical Swift MLX runtime"
     run rm -rf "${scratch}"
-    run env \
-        RUNANYWHERE_BUILD_MLX_DISTRIBUTION_FRAMEWORK=1 \
-        RUNANYWHERE_USE_LOCAL_NATIVES=1 \
-        swift build \
-        --package-path "${REPO_ROOT}" \
-        --configuration release \
-        --product RunAnywhereMLXRuntime \
-        --jobs "${BUILD_JOBS}" \
-        --triple "${triple}" \
-        --sdk "${sdk_path}" \
-        --scratch-path "${scratch}" \
-        "${prefix_flags[@]}"
+    # SwiftPM fetches this package's ~20 dependencies CONCURRENTLY into the
+    # shared repositories cache, and that fetch races with itself: a clone
+    # directory the resolver has already recorded disappears mid-resolve, e.g.
+    #   error: Git command 'git -C .../repositories/mlx-swift-064e4cad config
+    #          --get remote.origin.url' failed: ... No such file or directory
+    #   error: binary target 'RACommonsBinary' could not be mapped to an
+    #          artifact with expected name 'RACommonsBinary'
+    # The second error is FALLOUT, not the cause: resolution aborted, so no
+    # artifact mapping happened. Do not chase it as a checksum problem.
+    # Observed on two different packages (mlx-swift, swift-transformers) across
+    # separate runs, so it is a race and not one bad pin. Purge the cache and
+    # retry; a warm, complete cache resolves cleanly.
+    local attempt=1 max_attempts=3
+    while :; do
+        if run env \
+            RUNANYWHERE_BUILD_MLX_DISTRIBUTION_FRAMEWORK=1 \
+            RUNANYWHERE_USE_LOCAL_NATIVES=1 \
+            swift build \
+            --package-path "${REPO_ROOT}" \
+            --configuration release \
+            --product RunAnywhereMLXRuntime \
+            --jobs "${BUILD_JOBS}" \
+            --triple "${triple}" \
+            --sdk "${sdk_path}" \
+            --scratch-path "${scratch}" \
+            "${prefix_flags[@]}"; then
+            break
+        fi
+        if [ "${attempt}" -ge "${max_attempts}" ]; then
+            echo "ERROR: swift build for ${label} failed ${max_attempts} times" >&2
+            return 1
+        fi
+        echo "WARN: swift build for ${label} failed (attempt ${attempt}/${max_attempts}); purging the SwiftPM repositories cache and retrying" >&2
+        rm -rf "${HOME}/Library/Caches/org.swift.swiftpm/repositories" 2>/dev/null || true
+        rm -rf "${scratch}"
+        attempt=$((attempt + 1))
+    done
 
     run mkdir -p "$(dirname "${staged_archive}")"
     run cp "${built_archive}" "${staged_archive}"


### PR DESCRIPTION
## What broke

Generated protobuf bindings are no longer committed, so every packaging script regenerates them through `idl/codegen/ensure_generated.sh --only <lang>`. Three `release.yml` jobs run those scripts **without the codegen toolchain on PATH** and die at exit 127:

| job | error |
|---|---|
| `validate_consumer_flutter` | `error: protoc-gen-dart not found.` |
| `sdk_react_native` | `error: the ts-proto package is not installed anywhere this script looks.` |
| `sdk_web` | same ts-proto path as RN |

Observed live in the v0.20.18 release run: both `validate_consumer_flutter` and `sdk_react_native` failed exactly this way.

## Why it was invisible

These jobs have not executed since **v0.20.14**. Every packaging job declares `needs: native_ios`, and `native_ios` has failed since v0.20.15 on a stale neurun pin, so all of them were **skipped**, not run. Fixing `native_ios` is what exposed this second, older breakage sitting underneath it.

## The fix

`pr-build.yml` already gets this right, pairing `setup-toolchain` with `generate-idl`. `release.yml` was simply never updated to match:

| job | added |
|---|---|
| `validate_consumer_flutter` | `generate-idl (languages: dart)` |
| `sdk_react_native` | `generate-idl (languages: ts)` |
| `sdk_web` | `generate-idl (languages: ts)` |

`sdk_kotlin` deliberately gets nothing: its Gradle build wires `generateIdlKotlinBindings` into `preBuild` and generates its own bindings. That is precisely why it is the one packaging job that passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHnqxh9weAVMc6g2UcmbC9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Packaging**
  * Improved SDK packaging and validation workflows by automatically generating required TypeScript and Dart protobuf code.
  * Web, React Native, and Flutter releases now include up-to-date generated interfaces.
  * macOS command-line builds now generate both C++ and Swift protobuf bindings.

* **Reliability**
  * Improved macOS Swift build reliability with automatic retries when temporary build or cache issues occur.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->