### PR TITLE
release: sync Apple checksums to the CI-built v0.20.18 archives

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -723,7 +723,7 @@ func binaryTargets() -> [Target] {
             .binaryTarget(
                 name: "RACommonsBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RACommons-ios-v\(sdkVersion).zip",
-                checksum: "056f47c0e4b0280396613cb808ae627ffbbb9aa623d9a5b71f6e1cdc11581abc"
+                checksum: "c58e0618eccd7af0f24543172ee2801600696a8fe2c688a6a08f2637d63ecdc1"
             ),
             .binaryTarget(
                 name: "RABackendLlamaCPPBinary",
@@ -738,7 +738,7 @@ func binaryTargets() -> [Target] {
             .binaryTarget(
                 name: "RABackendSherpaBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RABackendSherpa-ios-v\(sdkVersion).zip",
-                checksum: "b31080387c3de252497dfbf9aa0ea7bec6c5f3e62b24ca545859bf1ae5929e3b"
+                checksum: "95d0621fab7b99200acaca05cd3feceeaf36949751cceafc84e7a1bf7d3cf1ad"
             ),
             // Apple CoreML Stable-Diffusion engine. `ONNXRuntime` declares an
             // unconditional dependency on this, so the remote list must carry it.
@@ -748,7 +748,7 @@ func binaryTargets() -> [Target] {
             .binaryTarget(
                 name: "RABackendNeuRTBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RABackendNeuRT-ios-v\(sdkVersion).zip",
-                checksum: "b85d91f0a6b24ffaa21affa5bc7cb9e5300451dfd2ae876af77c00972374e74d"
+                checksum: "b68886c1f954809c31b556ee7daaa2ddec52da942857164cc445224333feaa1c"
             ),
             .binaryTarget(
                 name: "RABackendMLXBinary",

--- a/bindings/flutter/packages/runanywhere/ios/runanywhere/Package.swift
+++ b/bindings/flutter/packages/runanywhere/ios/runanywhere/Package.swift
@@ -23,7 +23,7 @@ func runAnywhereBinaryTarget(name: String, checksum: String) -> Target {
 
 let raCommonsTarget = runAnywhereBinaryTarget(
     name: "RACommons",
-    checksum: "056f47c0e4b0280396613cb808ae627ffbbb9aa623d9a5b71f6e1cdc11581abc"
+    checksum: "c58e0618eccd7af0f24543172ee2801600696a8fe2c688a6a08f2637d63ecdc1"
 )
 
 let package = Package(

--- a/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
+++ b/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
@@ -9,7 +9,7 @@
 
 mlx_checksums = {
   'RABackendMLX' => '0802fe58480c3e03e94498d46adb50fda7b9ade491807c7e0392a7fd68b83b59',
-  'RunAnywhereMLXRuntime' => '17be249095ddd9a178625f6c2b251f793c9883953ecd782c65cc2e978970008f',
+  'RunAnywhereMLXRuntime' => 'c0495cf3430401cf675d2fdf036bf3f98c991985b5421906d240dc322f0cbb75',
   'RunAnywhereMLXMetal' => '17a2f8c4ce09ef691cde5e7d04171ce749fca89315205f90eb2eed5a76b682b1',
   'RunAnywhereMLXResources' => '70de4c70143b4544204b2c0e8af296546bc31ccf3ffda2f7b813fffb5b720ae9'
 }.freeze

--- a/bindings/flutter/packages/runanywhere_onnx/ios/runanywhere_onnx/Package.swift
+++ b/bindings/flutter/packages/runanywhere_onnx/ios/runanywhere_onnx/Package.swift
@@ -27,7 +27,7 @@ let onnxTarget = runAnywhereBinaryTarget(
 )
 let sherpaTarget = runAnywhereBinaryTarget(
     name: "RABackendSherpa",
-    checksum: "b31080387c3de252497dfbf9aa0ea7bec6c5f3e62b24ca545859bf1ae5929e3b"
+    checksum: "95d0621fab7b99200acaca05cd3feceeaf36949751cceafc84e7a1bf7d3cf1ad"
 )
 // Apple CoreML Stable-Diffusion engine. RACommons references
 // _rac_plugin_entry_neurt (0.20.10 enabled the CoreML backend in commons),
@@ -36,7 +36,7 @@ let sherpaTarget = runAnywhereBinaryTarget(
 // makes on-device image generation (diffusion.generateImage) routable.
 let coremlTarget = runAnywhereBinaryTarget(
     name: "RABackendNeuRT",
-    checksum: "b85d91f0a6b24ffaa21affa5bc7cb9e5300451dfd2ae876af77c00972374e74d"
+    checksum: "b68886c1f954809c31b556ee7daaa2ddec52da942857164cc445224333feaa1c"
 )
 
 let package = Package(


### PR DESCRIPTION
## Why

The checksums committed for v0.20.18 came from a **local** macOS build. `native_ios` now succeeds in CI (it had failed since v0.20.15 on a stale neurun pin), so CI builds and uploads its **own** archives — and for four targets those bytes differ:

| target | committed | CI-built |
|---|---|---|
| RACommons | `056f47c0e4b0` | `c58e0618eccd` |
| RABackendSherpa | `b31080387c3d` | `95d0621fab7b` |
| RABackendNeuRT | `b85d91f0a6b2` | `b68886c1f954` |
| RunAnywhereMLXRuntime | `17be249095dd` | `c0495cf34304` (known non-reproducible) |

The other five match local and CI **byte for byte** (`RABackendLLAMACPP`, `RABackendONNX`, `RABackendMLX`, `RunAnywhereMLXMetal`, `RunAnywhereMLXResources`). That is what rules out general nondeterminism: these four differ for reasons specific to them, not because the build is random.

## Impact

The release job's *"Verify built Apple checksums match tagged package contracts"* gate is fail-closed and aborts publication on any mismatch. **v0.20.18 could not have published as tagged.** The gate was right; the manifest was stale.

Checksums must describe the artifacts that actually ship, and those are CI's.

## Verification

`sync-checksums.sh --check` against the CI archives: **9 processed, 0 missing, 0 failed**, covering the root manifest, both Flutter `Package.swift` files, and the Flutter MLX podspec.

## Note

This requires re-cutting the `v0.20.18` tag, which is safe: the release was never created (packaging failed), so nothing is published against it and no consumer can have resolved it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHnqxh9weAVMc6g2UcmbC9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS binary package checksums to match the latest framework and runtime archives.
  * Refreshed checksum references across the core, MLX, and ONNX Flutter integrations.
  * Improved package integrity verification when retrieving native dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->