### PR TITLE
release: point the Flutter MLX podspec at the published MLXRuntime archive

### DIFF
--- a/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
+++ b/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
@@ -9,7 +9,7 @@
 
 mlx_checksums = {
   'RABackendMLX' => '0802fe58480c3e03e94498d46adb50fda7b9ade491807c7e0392a7fd68b83b59',
-  'RunAnywhereMLXRuntime' => 'c0495cf3430401cf675d2fdf036bf3f98c991985b5421906d240dc322f0cbb75',
+  'RunAnywhereMLXRuntime' => 'adf1bc80e2fcc92625cb114fd6efe7a46905d0bc87292cb652edb864b8c279df',
   'RunAnywhereMLXMetal' => '17a2f8c4ce09ef691cde5e7d04171ce749fca89315205f90eb2eed5a76b682b1',
   'RunAnywhereMLXResources' => '70de4c70143b4544204b2c0e8af296546bc31ccf3ffda2f7b813fffb5b720ae9'
 }.freeze


### PR DESCRIPTION
One-line checksum correction. `RunAnywhereMLXRuntime` is the single non-byte-reproducible archive (hence `RAC_CHECKSUM_SKIP`). The v0.20.18 tag was re-cut after the pipeline fixes, so the second run rebuilt it: the published asset is `adf1bc80e2fc`, not the `c0495cf34304` captured from the first run.

Every other archive is identical across both independent CI runs — including RACommons, RABackendSherpa and RABackendNeuRT — so this is confined to MLXRuntime.

Without it, `pod install` for `runanywhere_mlx` fails against the real release asset, and pub.dev is append-only so a bad pin cannot be withdrawn.

Verified: `sync-checksums.sh --check` against the published v0.20.18 assets — 9 processed, 0 missing, 0 failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHnqxh9weAVMc6g2UcmbC9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the integrity checksum for the iOS MLX runtime release asset.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->