### PR TITLE
fix(react-native): ship rac_defaults_generated.h in the Android header set

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -920,7 +920,18 @@ jobs:
       # PATH. RN packaging runs ensure_generated.sh --only ts; without ts-proto it exits 127.
       - uses: ./.github/actions/generate-idl
         with:
-          languages: ts
+          # ts for the proto-ts bindings the packaging script regenerates, AND
+          # cpp because package-sdk.sh copies core/include/rac wholesale into
+          # packages/core/android/src/main/jniLibs/include. One of those public
+          # headers, rac/rac_defaults_generated.h, is gitignored codegen output
+          # (.gitignore:543). Generating only ts left it absent while the five
+          # rac_{llm,stt,tts,vad,vlm}_types.h headers beside it still #include
+          # it, so @runanywhere/core@0.20.18 cannot compile for RN Android:
+          #   rac_llm_types.h:27:10: fatal error:
+          #   'rac/rac_defaults_generated.h' file not found
+          # The copy is an unguarded `cp -R`, so a missing generated header does
+          # not fail the build, it just ships an unusable package.
+          languages: ts,cpp
       # The RN tree pins `packageManager: yarn@3.6.1` (Yarn Berry). Activate it
       # via Corepack at the workflow level so package-sdk.sh (and any later
       # `yarn` invocation against the RN workspace) doesn't silently fall back

--- a/bindings/react-native/scripts/package-sdk.sh
+++ b/bindings/react-native/scripts/package-sdk.sh
@@ -376,6 +376,30 @@ rm -rf "$CORE_RAC_HEADERS"
 mkdir -p "$(dirname "$CORE_RAC_HEADERS")"
 cp -R "$PUBLIC_RAC_HEADERS" "$CORE_RAC_HEADERS"
 
+# FAIL CLOSED: the copy above is an unguarded `cp -R`, so it happily ships an
+# INCOMPLETE header set. Some public headers are gitignored codegen output --
+# rac/rac_defaults_generated.h is written by generate_cpp_defaults.py and is
+# #included by all five rac_{llm,stt,tts,vad,vlm}_types.h. If codegen did not
+# run for cpp, those five ship while their dependency does not, and the package
+# installs fine and then fails at NDK compile time in the consumer's app with
+#   rac_llm_types.h:27:10: fatal error: 'rac/rac_defaults_generated.h' file not found
+# That is exactly how @runanywhere/core 0.20.18 shipped unbuildable for RN
+# Android. npm is append-only, so it could not be withdrawn.
+# Resolve every intra-tree `#include "rac/..."` against the copied tree.
+_missing_headers=""
+while IFS= read -r _inc; do
+    [ -f "$CORE_RAC_HEADERS/../$_inc" ] || _missing_headers="$_missing_headers $_inc"
+done <<EOF
+$(grep -rhoE '#[[:space:]]*include[[:space:]]+"rac/[^"]+"' "$CORE_RAC_HEADERS" 2>/dev/null \
+    | sed -E 's/.*"(rac\/[^"]+)".*/\1/' | sort -u)
+EOF
+if [ -n "$_missing_headers" ]; then
+    echo "ERROR: the staged public header tree is incomplete; these are #included but absent:" >&2
+    for _h in $_missing_headers; do echo "         $_h" >&2; done
+    echo "       Most likely C++ codegen did not run. Try: idl/codegen/ensure_generated.sh --only cpp" >&2
+    exit 1
+fi
+
 # Defense in depth: a public package tree must never contain a private backend
 # or QNN runtime, even if an input directory combines public and private builds.
 if find \


### PR DESCRIPTION
## The break

`@runanywhere/core@0.20.18` **cannot compile for React Native Android**:

```
rac_llm_types.h:27:10: fatal error: 'rac/rac_defaults_generated.h' file not found
```

The published tarball carries that header in all three iOS xcframework `Headers/` directories but **not** in `android/src/main/jniLibs/include/rac/` — while five headers in that same Android bundle (`rac_{llm,stt,tts,vad,vlm}_types.h`) `#include` it.

## Cause

The header is gitignored codegen output (`.gitignore:543`), written by `generate_cpp_defaults.py`. `release.yml`'s `sdk_react_native` job generated only `ts`, so the C++ side never ran — and `package-sdk.sh` stages headers with a bare `cp -R` that copies whatever happens to exist.

An incomplete header set is not an error there. So the package built, validated, published, and failed only later inside a consumer's NDK compile.

## Fix

1. **`sdk_react_native` generates `ts,cpp`** so the header exists before staging. Sibling jobs audited: only this one stages `core/include/rac`.
2. **`package-sdk.sh` now fails closed** — after staging it resolves every intra-tree `#include "rac/..."` against the copied tree and aborts naming any header referenced but absent.

## The guard is verified, not assumed

Run against the actual broken 0.20.18 payload, it fails and names the culprit:

```
GUARD WOULD FAIL (correct) — missing:
   rac/rac_defaults_generated.h
```

Without it, the next missing codegen output ships the same silent way.

## Scope

npm is append-only, so `@runanywhere/core@0.20.18` stays broken for RN Android and needs a follow-up publish. **Only that package is affected** — `llamacpp`, `onnx` and `mlx` ship no Android headers at all (verified: 0 entries under `android/**/include/rac/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHnqxh9weAVMc6g2UcmbC9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved React Native SDK packaging for Android by including required generated native bindings.
  * Added validation to detect incomplete native header packages before release, preventing SDKs with missing dependencies from being distributed.
  * Packaging now stops with an actionable error when required generated files are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->