### PR TITLE
fix(web): make --webgpu imply RAG the way --onnx-webgpu already does

### DIFF
--- a/bindings/web/wasm/scripts/build.sh
+++ b/bindings/web/wasm/scripts/build.sh
@@ -99,6 +99,13 @@ while [[ $# -gt 0 ]]; do
         --webgpu)
             WEBGPU="ON"
             LLAMACPP="ON"  # WebGPU accelerates llama.cpp
+            # Same reason --onnx-webgpu sets it below. core/CMakeLists.txt
+            # force-sets RAC_BACKEND_RAG=OFF on Emscripten unless ONNX or
+            # RAC_WASM_RAG_STANDALONE is on, and this target enables neither, so
+            # without it the WebGPU bundle silently ships without the eight
+            # rac_rag_*_proto exports its CPU twin has (that twin only keeps
+            # them because it is built in the same invocation as --onnx).
+            RAG="ON"
             shift
             ;;
         --onnx-webgpu)


### PR DESCRIPTION
Complements #673 rather than redoing it. That PR fixed the two call sites; this fixes the flag they were working around, so the trap cannot be stepped in again.

## What is wrong

`--onnx-webgpu` turns RAG on for itself. `--webgpu` does not:

```sh
--webgpu)
    WEBGPU="ON"
    LLAMACPP="ON"  # WebGPU accelerates llama.cpp
    shift
    ;;
--onnx-webgpu)
    ONNX="ON"
    ONNX_WEBGPU="ON"
    ONNX_REQUESTED="ON"
    RAG="ON"
    shift
    ;;
```

`--webgpu` enables neither ONNX nor `RAC_WASM_RAG_STANDALONE`, which is exactly the condition under which `core/CMakeLists.txt` force-sets RAG off:

```cmake
set(RAC_BACKEND_RAG OFF CACHE BOOL "RAG requires ONNX embeddings on Emscripten; force off when RAC_BACKEND_ONNX is not enabled" FORCE)
```

So a bare `--webgpu` build silently drops the eight `rac_rag_*_proto` exports its CPU twin has, which is the failure #673 describes.

## Why the call-site fix is not the whole fix

Three places still document the command that produces the broken bundle:

- `AGENTS.md:327` — `npm run build:wasm -- --webgpu   # WebGPU variant`
- `bindings/web/AGENTS.md:113`
- `bindings/web/docs/DEVELOPMENT.md:18`

Anyone following those gets the RAG-less bundle, and the next call site added anywhere gets it too. Fixing the flag makes all three correct without editing them.

## Verification

No Emscripten on this machine, so I could not build the bundle and compare exports. What I could do is prove the flag resolution deterministically, by printing the resolved variables just before the script's `emcc` check.

Before, on `main`:

```
$ bash bindings/web/wasm/scripts/build.sh --webgpu
PROBE RAG=OFF LLAMACPP=ON WEBGPU=ON ONNX=OFF
$ bash bindings/web/wasm/scripts/build.sh --onnx-webgpu
PROBE RAG=ON LLAMACPP=OFF WEBGPU=OFF ONNX=ON
$ bash bindings/web/wasm/scripts/build.sh --webgpu --rag     # what #673 pinned
PROBE RAG=ON LLAMACPP=ON WEBGPU=ON ONNX=OFF
```

`RAG=OFF` with `ONNX=OFF` is precisely the state that trips the force-off above.

After this change:

```
$ bash bindings/web/wasm/scripts/build.sh --webgpu
PROBE RAG=ON LLAMACPP=ON WEBGPU=ON ONNX=OFF
```

`bash -n` on the script is clean. The probe line was temporary and is not part of the diff.

Being explicit about the gap: I have shown the flag now resolves the way #673 wants, not that the emitted `.wasm` exports match. That last step needs an emsdk build, so it is worth a CI run confirming the WebGPU artifact still carries the `rac_rag_*_proto` symbols.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * WebGPU builds now include RAG support alongside WebGPU and llama.cpp functionality.
  * RAG protocol symbols are available in WebGPU bundles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->