### PR TITLE
fix(react-native): export the two types RunAnywhere.solutions.run needs

### DIFF
--- a/bindings/react-native/packages/core/src/index.ts
+++ b/bindings/react-native/packages/core/src/index.ts
@@ -159,6 +159,15 @@ export { formatFramework } from './Public/Helpers/formatFramework';
 // Explicit tool-calling run loop — mirrors Swift/Kotlin generateWithTools for
 // hosts that need full control over the tool-loop budget (max calls, thinking,
 // parallel execution) beyond what llm.generate's inline tools expose.
+// `RunAnywhere.solutions.run(args)` takes SolutionRunArgs and resolves to a
+// SolutionHandle, so a consumer cannot annotate either side of that call
+// without these. Type-only: SolutionHandle is constructed by the SDK from a
+// native handle, never by callers.
+export type {
+  SolutionHandle,
+  SolutionRunArgs,
+} from './Public/Extensions/Solutions/RunAnywhere+Solutions';
+
 export { generateWithTools } from './Public/Extensions/LLM/RunAnywhere+ToolCalling';
 export type {
   GenerateWithToolsOptions,


### PR DESCRIPTION
Same gap #672 closed, two names it missed.

## What is wrong

`RunAnywhere.solutions.run` is public:

```ts
export const solutions = {
  run,
};
```

and `solutions` is on the `RunAnywhere` object (`Public/RunAnywhere.ts:575`). Its signature is:

```ts
async function run(args: SolutionRunArgs): Promise<SolutionHandle>
```

Neither `SolutionRunArgs` nor `SolutionHandle` is re-exported from `packages/core/src/index.ts`, so a consumer cannot annotate the argument they build or the handle they get back without importing from an internal path.

## Why #672 missed them

Both sit outside the shape that sweep covered:

- `SolutionRunArgs` is declared in `Public/Extensions/Solutions/RunAnywhere+Solutions.ts` rather than `Public/Api/Types.ts`, which is where the other 17 came from.
- `SolutionHandle` is a `class`, so a scan for exported `interface` and `type` declarations does not see it at all. That is the one I nearly missed too.

I checked the rest of the surface rather than assuming these were the only two. Every type declared in `Public/Api/Types.ts` is already exported, so that module is clean. Of the other unexported declarations under `src/Public`, I ruled out:

- `RegisterModelInput`, `RegisterArchiveModelInput`, `RegisterMultiFileModelInput` — internal. `Public/Api/Models.ts` builds those object literals itself; the public `models.register*` signatures take already-exported types.
- `StreamController` — only appears in `pushStream`, which is not exported from the entry point.
- `EventBus`, `SDKEventHandler`, `ModelLifecycleChange`, `EventBusCancellable` — no `events` accessor on the public `RunAnywhere` object, so consumers cannot reach them.
- `RegisteredTool`, `STTPartialResultWithOutput` — not in any public signature.

So this is two names, not a sweep.

## What this does

Adds a type-only re-export. `SolutionHandle` is constructed by the SDK from a native handle and its constructor rejects a null one, so callers only ever need to name it, never build it. Keeping it type-only avoids adding a runtime export for a class nobody should instantiate.

## Testing

I could not run the repo's gate on this machine. `yarn` is not installed and `npx yarn@3.6.1` fails here, so `yarn typecheck` was unavailable, and I am not going to claim a gate I did not watch.

What I did verify statically, which is the substance of what `tsc` checks for a re-export: the module path resolves (`Public/Extensions/Solutions/RunAnywhere+Solutions.ts` exists relative to `index.ts`), both names are exported from it (`export class SolutionHandle` at :42, `export type SolutionRunArgs` at :123), and neither name was already exported from `index.ts`, so there is no duplicate-export collision. Relying on the `rn-typecheck` CI job for the real check.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added public type definitions for solution handles and solution execution arguments.
  * Improved type support for integrating with the Solutions extension.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->