### PR TITLE
fix(commons): preserve model download path when allocation fails

### DIFF
--- a/core/src/infrastructure/model_management/model_registry.cpp
+++ b/core/src/infrastructure/model_management/model_registry.cpp
@@ -687,13 +687,16 @@ rac_result_t rac_model_registry_update_download_status(rac_model_registry_handle
 
     rac_model_info_t* model = it->second;
 
-    // Free old local path
-    if (model->local_path) {
-        free(model->local_path);
+    char* replacement_path = nullptr;
+    if (local_path) {
+        replacement_path = rac_strdup(local_path);
+        if (!replacement_path) {
+            return RAC_ERROR_OUT_OF_MEMORY;
+        }
     }
 
-    // Set new local path
-    model->local_path = rac_strdup(local_path);
+    free(model->local_path);
+    model->local_path = replacement_path;
     // Proto ModelInfo.updated_at_unix_ms — milliseconds, not seconds.
     model->updated_at = rac_get_current_time_ms();
 


### PR DESCRIPTION
## Description
Fix `rac_model_registry_update_download_status()` so replacing a model's download path is transactional when allocation fails.

Previously, the registry freed the existing `local_path` before duplicating the replacement. If `rac_strdup()` failed, the previous path was lost, `updated_at` was still mutated, and the function could persist the partial state and return success.

The replacement path is now allocated before registry mutation. Allocation failure returns `RAC_ERROR_OUT_OF_MEMORY` while preserving the existing path and timestamp. Passing `NULL` still explicitly clears the path without requiring an allocation.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

Validation performed:
- `git diff --check origin/main...HEAD` — passed.
- Full diff, diff stat, and commit range inspected; only `core/src/infrastructure/model_management/model_registry.cpp` changed in one commit.
- `bash core/scripts/lint-cpp.sh` — not run because this Windows host has no installed WSL distribution.
- Direct `clang-format --dry-run --Werror` — not run because `clang-format` is unavailable.
- `cmake --preset windows-debug` — configuration attempted but could not run because Visual Studio 2022 is not installed.
- No tests were added because this focused change did not request new tests.

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`bindings/swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`bindings/kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`bindings/flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`bindings/react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`bindings/web`)
- [x] `Commons` - Changes to shared native code (`core`)

**Sample Apps:**
- [ ] `Flutter Sample` - Changes to Flutter example app (`bindings/flutter/example`)
- [ ] `React Native Sample` - Changes to React Native example app (`bindings/react-native/example`)
- [ ] `Minimal Examples` - Changes to an in-repo SDK harness (`bindings/{swift,kotlin,web}/example`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)

## Screenshots
Not applicable; this is a commons registry-state fix with no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when updating model download locations.
  * Prevented existing paths from being lost if a new path cannot be stored.
  * Safely clears the download location when no local path is provided.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->