### PR TITLE
docs(swift): point external consumers at runanywhere-swift, not this monorepo

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,9 +9,29 @@ import Foundation
 // This is the SINGLE Package.swift for both local development and SPM consumption.
 //
 // FOR EXTERNAL USERS (consuming via GitHub):
-//   .package(url: "https://github.com/RunanywhereAI/runanywhere-sdks", from: "0.20.18")
-//   No environment override is needed. SPM downloads the checksum-verified
-//   XCFramework archives from the GitHub release by default.
+//   .package(url: "https://github.com/RunanywhereAI/runanywhere-swift.git", from: "0.20.18")
+//
+//   Consume the SWIFT DISTRIBUTION REPO, never this monorepo. Two reasons, and
+//   the first one is fatal:
+//
+//   1. This repo's tags DO NOT COMPILE as a Swift package. The generated
+//      protobuf Swift sources under bindings/swift/Sources/RunAnywhere/Generated/
+//      are no longer committed (they are codegen output), so tag v0.20.18
+//      carries 1 file there where v0.20.17 carried 42. Resolving this URL by
+//      version yields ~347 errors of the form
+//      "cannot find type 'RAModelInfo' in scope". The distribution repo is
+//      generated WITH those sources, so it builds.
+//   2. This monorepo is ~340 MB of C++, Kotlin, WASM and Dart. The distribution
+//      repo is ~3 MB of Swift.
+//
+//   Both manifests declare the SAME remote binaryTargets with the SAME
+//   checksums, pointing at the SAME release assets on runanywhere-sdks, so the
+//   XCFrameworks are never duplicated or re-uploaded. No environment override is
+//   needed; SPM downloads the checksum-verified archives from the GitHub release.
+//
+//   bindings/swift/scripts/sync-dist-repo.sh cuts that repo, and
+//   scripts/validation/gates/check_swift_dist_repo_sync.sh fails every PR here
+//   until it carries the matching tag.
 //
 // FOR LOCAL DEVELOPMENT:
 //   1. Build native XCFrameworks from the repo root:


### PR DESCRIPTION
`Package.swift` told external users to depend on:

```swift
.package(url: "https://github.com/RunanywhereAI/runanywhere-sdks", from: "0.20.18")
```

**That does not work.** The generated protobuf Swift sources under `bindings/swift/Sources/RunAnywhere/Generated/` are codegen output and no longer committed, so tag `v0.20.18` carries **1** file there where `v0.20.17` carried **42**. Resolving this URL by version fails with ~347 errors of the form `cannot find type 'RAModelInfo' in scope`.

Nothing warned about it: the de-commit landed between the two tags and the manifest kept advertising the old path, so a consumer following our own documentation gets a package that cannot build.

`RunanywhereAI/runanywhere-swift` is generated **with** those sources and is the supported path. It declares the same remote binaryTargets with the same checksums against the same release assets here, so no XCFramework is duplicated, and it is ~3 MB against this repo's ~340 MB. Verified: a scratch package with `from: "0.20.18"` against the distribution repo resolves cleanly (exit 0, all 6 binary targets checksum-validated).

Comment-only change. No target, dependency or checksum is touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHnqxh9weAVMc6g2UcmbC9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated external-consumer guidance to reference the dedicated Swift distribution repository.
  * Added clarification about generated sources, repository size, and matching binary targets and checksums.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->