### PR TITLE
fix(web): measure HTTP elapsed time after fetch completion

### DIFF
--- a/core/src/infrastructure/http/rac_http_client_emscripten.cpp
+++ b/core/src/infrastructure/http/rac_http_client_emscripten.cpp
@@ -286,7 +286,6 @@ rac_result_t do_fetch(const rac_http_request_t* req, rac_http_response_t* out,
 
     const auto t_start = std::chrono::steady_clock::now();
     emscripten_fetch_t* fetch = emscripten_fetch(&attr, req->url);
-    const auto t_end = std::chrono::steady_clock::now();
 
     if (!fetch) {
         RAC_LOG_ERROR(kTag, "emscripten_fetch returned NULL for url=%s", req->url);
@@ -303,6 +302,7 @@ rac_result_t do_fetch(const rac_http_request_t* req, rac_http_response_t* out,
         }
     }
 
+    const auto t_end = std::chrono::steady_clock::now();
     out->status = static_cast<int32_t>(fetch->status);
     out->elapsed_ms = static_cast<uint64_t>(
         std::chrono::duration_cast<std::chrono::milliseconds>(t_end - t_start).count());


### PR DESCRIPTION
## Description

Measure Emscripten HTTP elapsed time after the fetch has completed.

On the browser main thread, `emscripten_fetch()` returns immediately for the asynchronous `WAITABLE` path. The previous timestamp was captured before the Asyncify polling loop waited for `fetch_done`, so multi-second requests could report approximately zero milliseconds instead of the documented total wall-clock duration.

This moves the ending timestamp after the completion wait. Worker-thread behavior is unchanged because synchronous fetches have already completed at that point.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

`git diff --check origin/main...HEAD` passes.

The C++ lint script could not run because this Windows host has no installed WSL distribution and no native `clang-format`. The WASM build and browser timing check could not run because Emscripten (`emcc`/`emcmake`) is unavailable. No tests were added for this focused timing correction.

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels

**SDKs:**
- [ ] Swift SDK
- [ ] Kotlin SDK
- [ ] Flutter SDK
- [ ] React Native SDK
- [x] Web SDK
- [x] Commons

**Sample Apps:**
- [ ] Flutter Sample
- [ ] React Native Sample
- [ ] Minimal Examples

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (not needed; behavior now matches the existing public contract)

## Screenshots

Not applicable; there are no UI changes.

## Compatibility and risk

The change only adjusts when a monotonic timestamp is captured. It does not change request execution, callbacks, response ownership, or public API shape.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request timing measurements to include time spent waiting for asynchronous operations to complete.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->