### PR TITLE
feat(catalog): add LiquidAI LFM2.5-VL-3B (GGUF, MLX 4-bit, HNPU v81)

### DIFF
--- a/core/src/infrastructure/model_management/hf_resolver.cpp
+++ b/core/src/infrastructure/model_management/hf_resolver.cpp
@@ -713,6 +713,22 @@ static std::unordered_set<std::string> manifest_referenced_paths(
             refs.insert(s);
             continue;
         }
+        // A manifest leaf can name a SUBDIRECTORY instead of a file (QHexRT bundles
+        // carry a "fixture_dir": "vlm" naming the host-weight folder). Keep every
+        // file under that prefix: a directory's contents are not enumerated
+        // elsewhere, so the >=1 MiB prune below would drop the projector/positional
+        // weights and ship a VLM that fails at load with ArtifactMissing.
+        const std::string dir_prefix = (!s.empty() && s.back() == '/') ? s : s + "/";
+        bool any_under = false;
+        for (const auto& p : bundle_paths) {
+            if (p.starts_with(dir_prefix)) {
+                refs.insert(p);
+                any_under = true;
+            }
+        }
+        if (any_under) {
+            continue;
+        }
         const std::string base = basename_of(s);
         // Otherwise fall back to basename matching only when that basename is unambiguous.
         const auto it = unique_basename_to_path.find(base);

--- a/engines/qhexrt/qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/qhexrt_model_catalog.cpp
@@ -96,6 +96,8 @@ constexpr ModelPolicy kModelPolicies[] = {
     {"cosmos3_edge_vlm", kV79V81, false},    // Cosmos3-Edge image-understanding path (SigLIP vision + W8 decode via cosmos3vl_generate); v79 + v81
     {"cosmos3_edge_diffusion", kV79V81, false},  // Cosmos3-Edge text->image (4-shard W8 DiT + UniPC denoise + tiled VAE via cosmos3_diffusion_generate); v79 + v81
     {"internvl3_5_1b", kAllSupportedArches, false},
+    // SigLIP2-NaFlex vision + LFM2.5 hybrid W8 decode. Only the v81 bundle is published.
+    {"lfm2_5_vl_3b", kV81, false},
     {"gemma4_e2b_vlm", kV79V81, false},
     {"gemma4_e4b_vlm", kV81, false},
     {"nemotron_nano_vl_8b", kV81, false},

--- a/rcli/src/catalog/catalog.cpp
+++ b/rcli/src/catalog/catalog.cpp
@@ -36,6 +36,18 @@ constexpr CatalogFile kLfm2VlFiles[] = {
      "mmproj-LFM2-VL-450M-Q8_0.gguf", true},
 };
 
+// LiquidAI's own GGUF export. general.architecture is "lfm2" (same as the
+// LFM2-VL 450M row above) and the mmproj is a standard clip/mmproj projector,
+// verified by reading both GGUF headers off HF.
+constexpr CatalogFile kLfm2_5Vl3BFiles[] = {
+    {"https://huggingface.co/LiquidAI/LFM2.5-VL-3B-GGUF/resolve/main/"
+     "LFM2.5-VL-3B-Q4_K_M.gguf",
+     "LFM2.5-VL-3B-Q4_K_M.gguf", true, 1674454240LL},
+    {"https://huggingface.co/LiquidAI/LFM2.5-VL-3B-GGUF/resolve/main/"
+     "mmproj-LFM2.5-VL-3B-Q8_0.gguf",
+     "mmproj-LFM2.5-VL-3B-Q8_0.gguf", true, 583109120LL},
+};
+
 constexpr CatalogFile kQwen2VlFiles[] = {
     {"https://huggingface.co/ggml-org/Qwen2-VL-2B-Instruct-GGUF/resolve/main/"
      "Qwen2-VL-2B-Instruct-Q4_K_M.gguf",
@@ -343,6 +355,43 @@ constexpr CatalogFile kMlxFastVlm05BFiles[] = {
     {"https://huggingface.co/mlx-community/FastVLM-0.5B-bf16/resolve/main/"
      "vocab.json",
      "vocab.json", true},
+};
+
+// LiquidAI's own MLX 4-bit export. config.json model_type is "lfm2_vl", which
+// the pinned mlx-swift-lm 3.31.4 registers in VLMModelFactory (together with
+// the "Lfm2VlProcessor" processor class this repo declares). It ships no
+// merges.txt/vocab.json — tokenizer.json is the self-contained fast-tokenizer
+// format — and its processor lives in processor_config.json rather than
+// preprocessor_config.json, which the factory also accepts. Verified via the HF
+// API file listing this session; do not add filenames that are not below.
+constexpr CatalogFile kMlxLfm2_5Vl3BFiles[] = {
+    {"https://huggingface.co/LiquidAI/LFM2.5-VL-3B-MLX-4bit/resolve/main/"
+     "chat_template.jinja",
+     "chat_template.jinja", true},
+    {"https://huggingface.co/LiquidAI/LFM2.5-VL-3B-MLX-4bit/resolve/main/"
+     "config.json",
+     "config.json", true},
+    {"https://huggingface.co/LiquidAI/LFM2.5-VL-3B-MLX-4bit/resolve/main/"
+     "generation_config.json",
+     "generation_config.json", true},
+    {"https://huggingface.co/LiquidAI/LFM2.5-VL-3B-MLX-4bit/resolve/main/"
+     "model.safetensors",
+     "model.safetensors", true},
+    {"https://huggingface.co/LiquidAI/LFM2.5-VL-3B-MLX-4bit/resolve/main/"
+     "model.safetensors.index.json",
+     "model.safetensors.index.json", true},
+    {"https://huggingface.co/LiquidAI/LFM2.5-VL-3B-MLX-4bit/resolve/main/"
+     "processor_config.json",
+     "processor_config.json", true},
+    {"https://huggingface.co/LiquidAI/LFM2.5-VL-3B-MLX-4bit/resolve/main/"
+     "special_tokens_map.json",
+     "special_tokens_map.json", true},
+    {"https://huggingface.co/LiquidAI/LFM2.5-VL-3B-MLX-4bit/resolve/main/"
+     "tokenizer.json",
+     "tokenizer.json", true},
+    {"https://huggingface.co/LiquidAI/LFM2.5-VL-3B-MLX-4bit/resolve/main/"
+     "tokenizer_config.json",
+     "tokenizer_config.json", true},
 };
 
 constexpr CatalogFile kMlxQwen3Embedding06BFiles[] = {
@@ -757,6 +806,12 @@ constexpr CatalogEntry kCatalog[] = {
     {"lfm2-vl-450m-q8_0", "lfm2-vl", "LFM2-VL 450M Q8_0",
      v1::MODEL_CATEGORY_MULTIMODAL, v1::INFERENCE_FRAMEWORK_LLAMA_CPP,
      v1::MODEL_FORMAT_GGUF, nullptr, kLfm2VlFiles, 2, 600 * MB, 0, false},
+    // Native window is 128k (lfm2.context_length in the GGUF); 4096 is the
+    // on-device working context, matching the other multi-GB VLM row.
+    {"lfm2.5-vl-3b-q4_k_m", "lfm2.5-vl", "LFM2.5-VL 3B Q4_K_M",
+     v1::MODEL_CATEGORY_MULTIMODAL, v1::INFERENCE_FRAMEWORK_LLAMA_CPP,
+     v1::MODEL_FORMAT_GGUF, nullptr, kLfm2_5Vl3BFiles, 2, 2257563360LL, 4096,
+     false},
     {"qwen2-vl-2b-instruct-q4_k_m", "qwen2-vl", "Qwen2-VL 2B Instruct Q4_K_M",
      v1::MODEL_CATEGORY_MULTIMODAL, v1::INFERENCE_FRAMEWORK_LLAMA_CPP,
      v1::MODEL_FORMAT_GGUF, nullptr, kQwen2VlFiles, 2, 1800 * MB, 2048, false},
@@ -949,6 +1004,10 @@ constexpr CatalogEntry kCatalog[] = {
      v1::MODEL_CATEGORY_MULTIMODAL, v1::INFERENCE_FRAMEWORK_MLX,
      v1::MODEL_FORMAT_SAFETENSORS, nullptr, kMlxFastVlm05BFiles, 14, 1256926974,
      2048, false},
+    {"mlx-lfm2.5-vl-3b-4bit", "mlx-lfm2.5-vl", "LFM2.5-VL 3B 4-bit (MLX)",
+     v1::MODEL_CATEGORY_MULTIMODAL, v1::INFERENCE_FRAMEWORK_MLX,
+     v1::MODEL_FORMAT_SAFETENSORS, nullptr, kMlxLfm2_5Vl3BFiles, 9,
+     2388258432LL, 4096, false},
     {"mlx-qwen3-embedding-0.6b-4bit-dwq", "mlx-qwen3-embed",
      "Qwen3 Embedding 0.6B 4-bit DWQ (MLX)", v1::MODEL_CATEGORY_EMBEDDING,
      v1::INFERENCE_FRAMEWORK_MLX, v1::MODEL_FORMAT_SAFETENSORS, nullptr,


### PR DESCRIPTION
Adds LiquidAI **LFM2.5-VL-3B** to the monorepo catalog as three variants, one per platform that can actually load it. Every filename was read off the HuggingFace file-listing API this session rather than guessed.

## What landed

### `rcli/src/catalog/catalog.cpp` — the built-in C++ catalog

| id | alias | category | engine | size |
|---|---|---|---|---|
| `lfm2.5-vl-3b-q4_k_m` | `lfm2.5-vl` | `MODEL_CATEGORY_MULTIMODAL` | llama.cpp | 2.1 GB |
| `mlx-lfm2.5-vl-3b-4bit` | `mlx-lfm2.5-vl` | `MODEL_CATEGORY_MULTIMODAL` | MLX | 2.2 GB |

Both registered as `MULTIMODAL` (the VLM category the catalog already uses for `smolvlm2`, `lfm2-vl-450m`, `qwen2-vl`, `fara`, `mlx-qwen2-vl`, `mlx-fastvlm`), not plain `LANGUAGE`.

**GGUF** — `LiquidAI/LFM2.5-VL-3B-GGUF`, `LFM2.5-VL-3B-Q4_K_M.gguf` (1,674,454,240 B) + `mmproj-LFM2.5-VL-3B-Q8_0.gguf` (583,109,120 B). I read both GGUF headers over HTTP range requests: the weights say `general.architecture = lfm2` (30 blocks, 2.7B) — the same architecture the existing `lfm2-vl-450m-q8_0` row already runs on the pinned `LLAMACPP_VERSION=prism-b9591-62061f9` — and the companion is `general.architecture = clip`, `general.type = mmproj`. Q4_K_M + Q8_0-mmproj matches the quant pairing the sibling LFM2-VL row uses.

**MLX 4-bit** — `LiquidAI/LFM2.5-VL-3B-MLX-4bit`, all 9 load-bearing files. `config.json` declares `model_type: "lfm2_vl"` / `Lfm2VlForConditionalGeneration`, and `processor_config.json` declares `processor_class: "Lfm2VlProcessor"`. Both are registered in `VLMModelFactory.swift` of the pinned **mlx-swift-lm 3.31.4** (`Package.resolved` revision `bd4b7434`), which also carries a built-in `LFM2VL.swift` port — so this is loadable on the Apple Silicon MLX host, not aspirational. The repo ships no `merges.txt`/`vocab.json` (tokenizer.json is the self-contained fast-tokenizer format) and no `preprocessor_config.json`; the factory explicitly falls back to `processor_config.json`.

### `engines/qhexrt/qhexrt_model_catalog.cpp` — HNPU policy row

`{"lfm2_5_vl_3b", kV81, false}`. `runanywhere/lfm2_5_vl_3b_HNPU` publishes a `v81/` tree and nothing else, so v75/v79 devices filter the row before registration instead of failing at load with -423.

`requires_hf_auth` is **false**, deviating from the earlier `feat/qhexrt-lfm2-5-vl-3b` draft which had it `true`. The repo is public today: the HF API reports `private=false, gated=false`, and its manifest + file tree fetch unauthenticated. That also makes this a one-line change — the policy-table-derived test from #669 pins `private_row_count == 1`, which still holds.

### `core/src/infrastructure/model_management/hf_resolver.cpp` — bundle-subdirectory refs

A pinned bundle manifest can name a **subdirectory** instead of a file. This one carries `"fixture_dir": "vlm"` for its host-weight folder. Keep every file under such a prefix: a directory's contents are not enumerated anywhere else, so the `>= 1 MiB` prune would drop `proj_w1.bin` (37 MB), `proj_w2.bin` (16 MB), `pos_embed_32.bin` (4.7 MB), `pe_w.bin` (3.5 MB) and `pos_embed.bin` (1.2 MB) and ship a VLM that fails at load with `ArtifactMissing` on pe/pos. Consistent with the file's existing fail-safe-toward-inclusion policy (see the ambiguous-basename and external-data-sidecar branches directly above and below it).

Honest scope note: as the manifest is published *today* it also lists those ten host files individually under `host_files`, so the exact-path branch already resolves them. This change is what makes the `fixture_dir` form correct on its own, which is the shape the bundle grammar allows.

## Verification (what I actually ran)

Configured `cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DRAC_BUILD_TESTS=ON -DRAC_BACKEND_QHEXRT=ON -DRAC_DESKTOP_ADAPTER=ON -DRAC_BUILD_CLI=ON` on macOS arm64 and built `test_qhexrt_model_catalog`, `test_rcli_unit`, `rcli`.

- `test_qhexrt_model_catalog` — **9/9 pass**, unmodified. Confirms the claim that #669's refactor makes the hand-copied expectation sets unnecessary: the arch/auth expectations are read out of `kModelPolicies` via `policy_row_at`, so the new row needs no test edit.
- `test_rcli_unit --run-all` — **26/26 pass** (includes `catalog_lookup`, `mlx_catalog_registration`, `hf_ref_registration`).
- `rcli list --all` shows both new rows as `vlm` under `llama.cpp` / `MLX`, and `rcli show lfm2.5-vl` / `rcli show mlx-lfm2.5-vl` resolve by alias and print the full file lists — i.e. both entries register cleanly through the real commons registry.
- `core/scripts/lint-cpp.sh` reports the same 62 pre-existing clang-format issues with and without this diff; no new ones. My added lines are clang-format-clean in all three files.

**Not verified:** neither model was downloaded, loaded, or run. No inference happened. Support is argued from architecture identifiers and the pinned runtimes' own registries, not from a successful decode.

## Skipped on purpose

- `bindings/python/runanywhere/catalog.py` — its `_vlm()` helper hardcodes `resolve/main/{file}` → `model.gguf` + `mmproj.gguf`, which would work, but the Python wheel is CPU-desktop and its catalog is deliberately a small curated starter set; a 2.1 GB VLM does not belong there without a product decision.
- `bindings/electron/src/catalog.ts` — that file is the entry *shape*, not a model table; the model list is app-owned.
- The Flutter/RN example NPU catalogs carry app-owned URLs for HNPU rows and are a separate, app-side change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for the LiquidAI LFM2.5-VL 3B model in the model catalog.
  * Added GGUF and MLX 4-bit model formats, including required files, download details, and context limits.
  * Added QHexRT support for Hexagon v81 devices without requiring Hugging Face authentication.

* **Bug Fixes**
  * Improved model bundle handling so files in manifest-referenced subdirectories are preserved correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->