### PR TITLE
fix: address review feedback from the 0.20.18 merge batch

### DIFF
--- a/bindings/react-native/packages/core/src/index.ts
+++ b/bindings/react-native/packages/core/src/index.ts
@@ -156,9 +156,6 @@ export { sdkComponentDisplayName } from './Public/Helpers/SDKComponent+DisplayNa
 // Framework display names sourced from the commons table.
 export { formatFramework } from './Public/Helpers/formatFramework';
 
-// Explicit tool-calling run loop — mirrors Swift/Kotlin generateWithTools for
-// hosts that need full control over the tool-loop budget (max calls, thinking,
-// parallel execution) beyond what llm.generate's inline tools expose.
 // `RunAnywhere.solutions.run(args)` takes SolutionRunArgs and resolves to a
 // SolutionHandle, so a consumer cannot annotate either side of that call
 // without these. Type-only: SolutionHandle is constructed by the SDK from a
@@ -168,6 +165,9 @@ export type {
   SolutionRunArgs,
 } from './Public/Extensions/Solutions/RunAnywhere+Solutions';
 
+// Explicit tool-calling run loop — mirrors Swift/Kotlin generateWithTools for
+// hosts that need full control over the tool-loop budget (max calls, thinking,
+// parallel execution) beyond what llm.generate's inline tools expose.
 export { generateWithTools } from './Public/Extensions/LLM/RunAnywhere+ToolCalling';
 export type {
   GenerateWithToolsOptions,

--- a/bindings/react-native/scripts/package-sdk.sh
+++ b/bindings/react-native/scripts/package-sdk.sh
@@ -372,6 +372,15 @@ CANONICAL_PRIVACY_MANIFEST="$REPO_ROOT/bindings/swift/Sources/RunAnywhere/Privac
 CORE_RAC_HEADERS="$RN_ROOT/packages/core/android/src/main/jniLibs/include/rac"
 [ -d "$PUBLIC_RAC_HEADERS" ] || { echo "ERROR: public RAC headers not found: $PUBLIC_RAC_HEADERS" >&2; exit 1; }
 [ -f "$CANONICAL_PRIVACY_MANIFEST" ] || { echo "ERROR: canonical Apple privacy manifest not found: $CANONICAL_PRIVACY_MANIFEST" >&2; exit 1; }
+# Generate before staging, not after: rac/rac_defaults_generated.h is codegen
+# output that lives INSIDE the tree copied below, so the copy has to happen
+# after it exists. Without this the guard further down can only report the
+# breakage, and every invocation outside .github/workflows/release.yml (a local
+# packaging run, a fresh clone, a new workflow that forgets the step) hard-fails
+# instead of self-healing. Every packaging script in this repo calls
+# ensure_generated.sh before packing; this is that call for the header tree.
+"${REPO_ROOT}/idl/codegen/ensure_generated.sh" --only cpp
+
 rm -rf "$CORE_RAC_HEADERS"
 mkdir -p "$(dirname "$CORE_RAC_HEADERS")"
 cp -R "$PUBLIC_RAC_HEADERS" "$CORE_RAC_HEADERS"
@@ -386,16 +395,20 @@ cp -R "$PUBLIC_RAC_HEADERS" "$CORE_RAC_HEADERS"
 # That is exactly how @runanywhere/core 0.20.18 shipped unbuildable for RN
 # Android. npm is append-only, so it could not be withdrawn.
 # Resolve every intra-tree `#include "rac/..."` against the copied tree.
-_missing_headers=""
+_missing_headers=()
 while IFS= read -r _inc; do
-    [ -f "$CORE_RAC_HEADERS/../$_inc" ] || _missing_headers="$_missing_headers $_inc"
+    # A no-match grep still feeds one empty line through the here-doc. Without
+    # this, `[ -f "$CORE_RAC_HEADERS/../" ]` fails on a directory and packaging
+    # aborts printing an ERROR with an empty header list.
+    [ -n "$_inc" ] || continue
+    [ -f "$CORE_RAC_HEADERS/../$_inc" ] || _missing_headers+=("$_inc")
 done <<EOF
 $(grep -rhoE '#[[:space:]]*include[[:space:]]+"rac/[^"]+"' "$CORE_RAC_HEADERS" 2>/dev/null \
     | sed -E 's/.*"(rac\/[^"]+)".*/\1/' | sort -u)
 EOF
-if [ -n "$_missing_headers" ]; then
+if ((${#_missing_headers[@]})); then
     echo "ERROR: the staged public header tree is incomplete; these are #included but absent:" >&2
-    for _h in $_missing_headers; do echo "         $_h" >&2; done
+    printf '         %s\n' "${_missing_headers[@]}" >&2
     echo "       Most likely C++ codegen did not run. Try: idl/codegen/ensure_generated.sh --only cpp" >&2
     exit 1
 fi

--- a/bindings/swift/README.md
+++ b/bindings/swift/README.md
@@ -3,7 +3,7 @@
 Run large language models, speech recognition, text-to-speech, and voice agents directly on iPhone, iPad, and Mac — with low latency and on-device privacy. The Swift SDK provides a unified API over pluggable backends (llama.cpp, ONNX, Apple MLX) so you can ship AI features without sending user data to the cloud for inference.
 
 [![Swift Package Manager](https://img.shields.io/badge/Swift%20Package%20Manager-compatible-brightgreen.svg)](https://github.com/RunanywhereAI/runanywhere-sdks)
-[![Version](https://img.shields.io/badge/version-0.20.11-blue.svg)](https://github.com/RunanywhereAI/runanywhere-sdks/releases)
+[![Version](https://img.shields.io/badge/version-0.20.18-blue.svg)](https://github.com/RunanywhereAI/runanywhere-sdks/releases)
 [![Platform](https://img.shields.io/badge/Platform-iOS%2017.5%2B%20%7C%20macOS%2014.5%2B-lightgrey)](https://developer.apple.com)
 [![License: RunAnywhere](https://img.shields.io/badge/License-RunAnywhere-blue.svg)](../../LICENSE)
 
@@ -27,10 +27,12 @@ Run large language models, speech recognition, text-to-speech, and voice agents 
 In Xcode: **File → Add Package Dependencies…** and enter:
 
 ```
-https://github.com/RunanywhereAI/runanywhere-sdks
+https://github.com/RunanywhereAI/runanywhere-swift.git
 ```
 
-Select version **`0.20.11`** (or `from: "0.20.11"`), then add the products you need. Resolve against the newest tag on the [Releases](https://github.com/RunanywhereAI/runanywhere-sdks/releases) page if `0.20.11` binary assets are not published yet.
+Consume the Swift **distribution repo**, never this monorepo. This repo's tags do not compile as a Swift package: the generated protobuf Swift sources are codegen output and are no longer committed, so resolving the monorepo URL by version fails with hundreds of "cannot find type" errors. The distribution repo is generated with those sources and declares the same binary targets, with the same checksums, against the same release assets.
+
+Select version **`0.20.18`** (or `from: "0.20.18"`), then add the products you need. Resolve against the newest tag on the [Releases](https://github.com/RunanywhereAI/runanywhere-sdks/releases) page if `0.20.18` binary assets are not published yet.
 
 | Product | Required | Capabilities |
 |---------|----------|--------------|
@@ -43,15 +45,15 @@ Select version **`0.20.11`** (or `from: "0.20.11"`), then add the products you n
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/RunanywhereAI/runanywhere-sdks", from: "0.20.11")
+    .package(url: "https://github.com/RunanywhereAI/runanywhere-swift.git", from: "0.20.18")
 ],
 targets: [
     .target(
         name: "YourApp",
         dependencies: [
-            .product(name: "RunAnywhere", package: "runanywhere-sdks"),
-            .product(name: "RunAnywhereLlamaCPP", package: "runanywhere-sdks"),
-            .product(name: "RunAnywhereONNX", package: "runanywhere-sdks"),
+            .product(name: "RunAnywhere", package: "runanywhere-swift"),
+            .product(name: "RunAnywhereLlamaCPP", package: "runanywhere-swift"),
+            .product(name: "RunAnywhereONNX", package: "runanywhere-swift"),
         ]
     )
 ]

--- a/bindings/swift/Sources/LlamaCPPRuntime/README.md
+++ b/bindings/swift/Sources/LlamaCPPRuntime/README.md
@@ -10,14 +10,14 @@ Add the Swift package and include the `RunAnywhereLlamaCPP` product (pin `0.20.1
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/RunanywhereAI/runanywhere-sdks", exact: "0.20.18"),
+    .package(url: "https://github.com/RunanywhereAI/runanywhere-swift.git", exact: "0.20.18"),
 ],
 targets: [
     .target(
         name: "YourApp",
         dependencies: [
-            .product(name: "RunAnywhere", package: "runanywhere-sdks"),
-            .product(name: "RunAnywhereLlamaCPP", package: "runanywhere-sdks"),
+            .product(name: "RunAnywhere", package: "runanywhere-swift"),
+            .product(name: "RunAnywhereLlamaCPP", package: "runanywhere-swift"),
         ]
     )
 ]

--- a/bindings/swift/Sources/ONNXRuntime/README.md
+++ b/bindings/swift/Sources/ONNXRuntime/README.md
@@ -10,14 +10,14 @@ Add the Swift package and include the `RunAnywhereONNX` product (pin `0.20.18`):
 
 ```swift
 dependencies: [
-    .package(url: "https://github.com/RunanywhereAI/runanywhere-sdks", exact: "0.20.18"),
+    .package(url: "https://github.com/RunanywhereAI/runanywhere-swift.git", exact: "0.20.18"),
 ],
 targets: [
     .target(
         name: "YourApp",
         dependencies: [
-            .product(name: "RunAnywhere", package: "runanywhere-sdks"),
-            .product(name: "RunAnywhereONNX", package: "runanywhere-sdks"),
+            .product(name: "RunAnywhere", package: "runanywhere-swift"),
+            .product(name: "RunAnywhereONNX", package: "runanywhere-swift"),
         ]
     )
 ]

--- a/bindings/swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+Storage.swift
+++ b/bindings/swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+Storage.swift
@@ -57,8 +57,13 @@ extension CppBridge {
             callbacks.get_available_space = storageGetAvailableSpaceCallback
             callbacks.get_total_space = storageGetTotalSpaceCallback
             callbacks.delete_path = storageDeletePathCallback
-            callbacks.is_model_loaded = nil  // C++ treats missing callback as "loaded state unavailable"
-            callbacks.unload_model = nil     // C++ refuses to unload-then-delete when callback is NULL
+            // Both stay nil on purpose: commons performed the load, so it answers
+            // both questions from its own lifecycle store: it reports a
+            // commons-loaded model as loaded and unloads it before deleting.
+            // These slots are only consulted for a model a host loaded outside
+            // commons, which Swift never does.
+            callbacks.is_model_loaded = nil
+            callbacks.unload_model = nil
             callbacks.user_data = nil  // We use global FileManager
 
             var handlePtr: rac_storage_analyzer_handle_t?

--- a/bindings/web/packages/core/src/index.ts
+++ b/bindings/web/packages/core/src/index.ts
@@ -137,6 +137,16 @@ export type {
 export type { RagSession } from './Public/API/Namespaces/rag.js';
 export type { VoiceSession, VoiceSessionOptions } from './Public/API/Namespaces/voice.js';
 
+// `RunAnywhere.solutions.run(input)` takes SolutionRunInput and returns a
+// SolutionHandle, so a consumer cannot annotate either side of that call
+// without these. Type-only: SolutionHandle is constructed by SolutionAdapter.run,
+// never by callers. SolutionConfig is deliberately absent: it comes straight
+// from @runanywhere/proto-ts/solutions, which consumers depend on directly.
+export type {
+  SolutionHandle,
+  SolutionRunInput,
+} from './Public/Extensions/RunAnywhere+Solutions.js';
+
 // Errors — one typed exception carrying the generated proto error taxonomy.
 export { SDKException, isSDKException } from './Foundation/SDKException.js';
 export type { ProtoSDKError } from './Foundation/SDKException.js';

--- a/bindings/web/wasm/CMakeLists.txt
+++ b/bindings/web/wasm/CMakeLists.txt
@@ -1136,8 +1136,12 @@ set(RAC_EXPORTED_FUNCTIONS_CLOUD
 # librac_commons whenever RAC_BACKEND_RAG=ON (default ON, gated to ONNX
 # availability on Emscripten — see core/CMakeLists.txt).
 # RAG routes embeddings through the rac_embeddings_service vtable at runtime,
-# so these exports are only meaningful on the ONNX-sherpa WASM target where
-# the ONNX embedding provider is also linked. Appended to that target only.
+# so a bundle without the ONNX embedding provider linked can reach these exports
+# but gets RAC_ERROR_FEATURE_NOT_AVAILABLE until some provider registers. They
+# are therefore appended to BOTH engine targets: onnx-sherpa (where the provider
+# is present) and llamacpp/webgpu (where the Docs/RAG tab needs the proto-byte
+# ABI to exist so the TS bridge can surface that runtime answer at all). The
+# commons-only core target never gets them.
 set(RAC_EXPORTED_FUNCTIONS_RAG
     "_rac_rag_session_create_proto"
     "_rac_rag_session_destroy_proto"
@@ -1458,12 +1462,12 @@ if(RAC_WASM_LLAMACPP)
     set(_llamacpp_exports ${RAC_EXPORTED_FUNCTIONS_BASE})
     list(APPEND _llamacpp_exports ${RAC_EXPORTED_FUNCTIONS_LLAMACPP})
 
-    # When RAG is enabled on the llamacpp WASM target
-    # (e.g. via build.sh --rag for the auto-loaded Docs/RAG bundle), append the
-    # rac_rag_*_proto exports so the TS proto-byte bridge can reach the symbols.
+    # build.sh now enables RAG unconditionally for the llamacpp WASM target,
+    # since it is the auto-loaded Docs/RAG bundle. Append the rac_rag_*_proto
+    # exports so the TS proto-byte bridge can reach the symbols.
     # The RAG OBJECT library has already been folded into librac_commons by
     # core/CMakeLists.txt — we just need to expose the
-    # 6 rac_rag_*_proto symbols in the emitted JS glue. The runtime layer
+    # 8 rac_rag_*_proto symbols in the emitted JS glue. The runtime layer
     # returns RAC_ERROR_FEATURE_NOT_AVAILABLE if no embeddings provider is
     # registered (matches the non-WASM platform contract).
     if(RAC_BACKEND_RAG)

--- a/bindings/web/wasm/scripts/build.sh
+++ b/bindings/web/wasm/scripts/build.sh
@@ -20,7 +20,10 @@ set -euo pipefail
 #   --debug      Debug build with assertions and safe heap
 #   --pthreads   Enable pthreads (default except WebGPU; requires Cross-Origin Isolation)
 #   --no-pthreads Disable pthreads
-#   --rag        Pull in RAG (requires --onnx)
+#   --rag        Emit the rac_rag_*_proto exports. Vestigial: every target
+#                (--llamacpp, --webgpu, --onnx, --onnx-webgpu, --all-backends)
+#                already implies it. It does NOT require --onnx; standalone RAG
+#                is what RAC_WASM_RAG_STANDALONE exists for.
 #   --clean      Clean the matching build directory before building
 #
 # Prerequisites:
@@ -73,6 +76,17 @@ while [[ $# -gt 0 ]]; do
             ;;
         --llamacpp)
             LLAMACPP="ON"
+            # Same reason --webgpu and --onnx-webgpu set it. core/CMakeLists.txt
+            # force-sets RAC_BACKEND_RAG=OFF on Emscripten unless ONNX or
+            # RAC_WASM_RAG_STANDALONE is on, and this target enables neither, so
+            # without it the CPU llamacpp bundle silently ships without the
+            # eight rac_rag_*_proto exports the released one has. Release CI
+            # only keeps them because `--core --llamacpp --onnx` is a single
+            # invocation and --onnx sets RAG=ON, so a bundle built by the
+            # documented `npm run build:wasm -- --llamacpp` differed from the
+            # shipped one by exactly those eight symbols. This is the bundle the
+            # Web Docs/RAG tab auto-loads.
+            RAG="ON"
             shift
             ;;
         --onnx)
@@ -86,13 +100,13 @@ while [[ $# -gt 0 ]]; do
             shift
             ;;
         --rag)
-            # --rag emits the rac_rag_*_proto symbols
-            # into every requested target (llamacpp, webgpu, onnx). The default
-            # `--onnx` path already pulls in RAG via the ONNX embedding provider.
-            # `--rag` without `--onnx` is the Docs/RAG path where the llamacpp
-            # bundle exports the proto-byte ABI and the runtime layer surfaces
-            # RAC_ERROR_FEATURE_NOT_AVAILABLE when the embeddings provider has
-            # not been registered yet (matches the non-WASM platform contract).
+            # Now vestigial: every target arm sets RAG=ON itself, so this flag
+            # can no longer change the outcome of any invocation. Kept because
+            # it is documented in three places and scripts pass it. It never
+            # required --onnx: `--llamacpp --rag` was the Docs/RAG path where
+            # the llamacpp bundle exports the proto-byte ABI and the runtime
+            # layer surfaces RAC_ERROR_FEATURE_NOT_AVAILABLE until an embeddings
+            # provider registers (matches the non-WASM platform contract).
             RAG="ON"
             shift
             ;;
@@ -144,7 +158,7 @@ while [[ $# -gt 0 ]]; do
             echo "  --debug          Debug build with assertions and safe heap"
             echo "  --pthreads       Enable pthreads (default except WebGPU; requires Cross-Origin Isolation)"
             echo "  --no-pthreads    Disable pthreads"
-            echo "  --rag            Pull in RAG (requires --onnx)"
+            echo "  --rag            Emit the rac_rag_*_proto exports (implied by every target: --llamacpp, --webgpu, --onnx, --onnx-webgpu, --all-backends)"
             echo "  --clean          Clean matching build dirs before building"
             echo "  --help           Show this help"
             exit 0
@@ -160,6 +174,9 @@ done
 # `npm run build:wasm` invocations that pass no flags).
 if [ "$BUILD_CORE" = "OFF" ] && [ "$LLAMACPP" = "OFF" ] && [ "$ONNX" = "OFF" ] && [ "$WEBGPU" = "OFF" ]; then
     LLAMACPP="ON"
+    # Identical to the explicit --llamacpp arm above: this default builds the
+    # same artifact, so it must configure it the same way.
+    RAG="ON"
 fi
 
 # Check Emscripten. Accepting whichever emsdk happens to be first on PATH can
@@ -496,6 +513,29 @@ build_target() {
                 exit 1
             fi
             echo "  WASM gzip-fallback string scan: clean (no 'gzip -d' literal)"
+        fi
+
+        # Prove the RAG exports actually made it into the glue. The whole
+        # RAG-drops-out bug class is silent: the build succeeds, the artifact is
+        # non-empty, and release packaging only checks that the JS/WASM files
+        # exist and are non-empty, so a bundle missing all eight
+        # rac_rag_*_proto symbols ships looking healthy. PR CI never runs this
+        # script at all (the `wasm` job uses `cmake --preset wasm` directly), so
+        # this check is the only pre-ship signal.
+        # Scoped to the engine targets: only the llamacpp and onnx export lists
+        # append RAC_EXPORTED_FUNCTIONS_RAG. The commons-only core target never
+        # exports RAG symbols, even when configured with RAC_BACKEND_RAG=ON.
+        if [ "${RAG}" = "ON" ] &&
+           { [ "${wasm_llamacpp}" = "ON" ] || [ "${wasm_onnx}" = "ON" ]; }; then
+            if ! grep -q "_rac_rag_session_create_proto" "${js_file}"; then
+                echo "ERROR: '${js_file}' was built with RAG=ON but exports no rac_rag_*_proto symbols."
+                echo "       Expected _rac_rag_session_create_proto in the emitted glue."
+                echo "       Most likely RAC_BACKEND_RAG was force-set OFF during configure"
+                echo "       (core/CMakeLists.txt does that on Emscripten unless RAC_BACKEND_ONNX"
+                echo "       or RAC_WASM_RAG_STANDALONE is on)."
+                exit 1
+            fi
+            echo "  RAG export check: rac_rag_*_proto present in ${out_name}.js"
         fi
 
         if [ "$pthreads_for_target" = "ON" ]; then

--- a/core/include/rac/features/llm/rac_llm_metrics.h
+++ b/core/include/rac/features/llm/rac_llm_metrics.h
@@ -224,11 +224,15 @@ RAC_API rac_result_t rac_streaming_metrics_mark_failed(rac_streaming_metrics_han
  *
  * @param handle Collector handle
  * @param out_result Output: Streaming result (must be freed with
- *                   rac_streaming_result_free). The struct is unconditionally
- *                   overwritten with RAC_STREAMING_RESULT_DEFAULT before it is
- *                   populated, so it must not already own allocated strings.
- *                   Passing a reused result that still holds text/model_id/
- *                   thinking_content leaks them.
+ *                   rac_streaming_result_free). Once the arguments are known
+ *                   valid, the struct is overwritten with
+ *                   RAC_STREAMING_RESULT_DEFAULT before it is populated, so it
+ *                   must not already own allocated strings. Passing a reused
+ *                   result that still holds text/model_id/thinking_content
+ *                   leaks them. The NULL checks run FIRST, so on
+ *                   RAC_ERROR_INVALID_ARGUMENT (for example a NULL handle with
+ *                   a non-NULL out_result) *out_result is left exactly as the
+ *                   caller supplied it, neither cleared nor freed.
  * @return RAC_SUCCESS, RAC_ERROR_INVALID_ARGUMENT if handle or out_result is
  *         NULL, or RAC_ERROR_OUT_OF_MEMORY if an owned string could not be
  *         allocated. On RAC_ERROR_OUT_OF_MEMORY *out_result owns nothing and

--- a/core/include/rac/features/llm/rac_llm_metrics.h
+++ b/core/include/rac/features/llm/rac_llm_metrics.h
@@ -223,8 +223,16 @@ RAC_API rac_result_t rac_streaming_metrics_mark_failed(rac_streaming_metrics_han
  * Only valid after markComplete() is called.
  *
  * @param handle Collector handle
- * @param out_result Output: Streaming result (must be freed with rac_streaming_result_free)
- * @return RAC_SUCCESS or error code
+ * @param out_result Output: Streaming result (must be freed with
+ *                   rac_streaming_result_free). The struct is unconditionally
+ *                   overwritten with RAC_STREAMING_RESULT_DEFAULT before it is
+ *                   populated, so it must not already own allocated strings.
+ *                   Passing a reused result that still holds text/model_id/
+ *                   thinking_content leaks them.
+ * @return RAC_SUCCESS, RAC_ERROR_INVALID_ARGUMENT if handle or out_result is
+ *         NULL, or RAC_ERROR_OUT_OF_MEMORY if an owned string could not be
+ *         allocated. On RAC_ERROR_OUT_OF_MEMORY *out_result owns nothing and
+ *         needs no free.
  */
 RAC_API rac_result_t rac_streaming_metrics_get_result(rac_streaming_metrics_handle_t handle,
                                                       rac_streaming_result_t* out_result);

--- a/core/src/core/model_lifecycle_accessors.cpp
+++ b/core/src/core/model_lifecycle_accessors.cpp
@@ -17,6 +17,7 @@
 #include "features/llm/rac_llm_lifecycle_bridge.h"
 #include "features/rac_nonllm_lifecycle_bridge.h"
 #include "features/vlm/rac_vlm_lifecycle_bridge.h"
+#include "rac/core/rac_model_lifecycle.h"
 
 namespace rac::llm {
 
@@ -469,13 +470,13 @@ void release_lifecycle_segmentation(LifecycleSegmentationRef* ref) {
 }  // namespace rac::lifecycle
 
 // ---------------------------------------------------------------------------
-// Loaded-state query
+// Loaded-state query and unload
 //
 // The storage delete path needs to know whether a model is open before it
-// removes files underneath it. Hosts answer that through
-// rac_storage_callbacks_t::is_model_loaded, but commons is the component that
-// performed the load and already tracks it in g_loaded, so it can answer
-// without asking anyone. Internal on purpose: the only caller is inside
+// removes files underneath it, and needs to close it when it is. Hosts answer
+// both through rac_storage_callbacks_t, but commons is the component that
+// performed the load and already tracks it in g_loaded, so it can answer and
+// act without asking anyone. Internal on purpose: the only caller is inside
 // commons, so this stays off the public C ABI.
 // ---------------------------------------------------------------------------
 
@@ -489,7 +490,15 @@ bool is_model_loaded(const char* model_id) {
     std::lock_guard<std::mutex> lock(rac::core::model_lifecycle::detail::g_lifecycle_mutex);
     for (const auto& entry : rac::core::model_lifecycle::detail::g_loaded) {
         const auto& loaded = entry.second;
-        if (loaded && loaded->model_id == model_id) {
+        // READY is the discriminator, not mere presence in g_loaded. A load that
+        // failed leaves an ERROR sentinel carrying the failed request's model_id
+        // (install_failed_entry_preserving), and that model has no backend at
+        // all, so reporting it loaded made it undeletable, which is the opposite
+        // of what a user wants after a failed load. READY and ERROR are the only
+        // states ever installed, so this is exact, and it matches what
+        // acquire_lifecycle_llm / acquire_component already require.
+        if (loaded && loaded->state == runanywhere::v1::COMPONENT_LIFECYCLE_STATE_READY &&
+            loaded->model_id == model_id) {
             return true;
         }
     }
@@ -497,6 +506,45 @@ bool is_model_loaded(const char* model_id) {
 #else
     (void)model_id;
     return false;
+#endif
+}
+
+rac_result_t unload_model(const char* model_id) {
+#if defined(RAC_HAVE_PROTOBUF)
+    if (model_id == nullptr || *model_id == '\0') {
+        return RAC_ERROR_INVALID_ARGUMENT;
+    }
+    // Delegate to the one unload implementation rather than re-walking g_loaded
+    // here: it already erases under the lifecycle mutex, destroys the backends
+    // outside it, and publishes UNLOADING->NOT_LOADED for each entry. A second
+    // hand-rolled copy of that sequence is exactly how the two paths drift.
+    runanywhere::v1::ModelUnloadRequest request;
+    request.set_model_id(model_id);
+    std::string bytes;
+    if (!request.SerializeToString(&bytes)) {
+        return RAC_ERROR_INTERNAL;
+    }
+    rac_proto_buffer_t out{};
+    rac_result_t rc = rac_model_lifecycle_unload_proto(
+        reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size(), &out);
+    if (rc == RAC_SUCCESS) {
+        // The C entry point reports "nothing matched" inside the result, not in
+        // its return code, so an unmatched id would otherwise read as success.
+        runanywhere::v1::ModelUnloadResult result;
+        if (out.data != nullptr && out.size > 0 &&
+            result.ParseFromArray(out.data, static_cast<int>(out.size))) {
+            if (result.unloaded_model_ids_size() == 0) {
+                rc = RAC_ERROR_MODEL_NOT_LOADED;
+            }
+        } else {
+            rc = RAC_ERROR_MODEL_NOT_LOADED;
+        }
+    }
+    rac_proto_buffer_free(&out);
+    return rc;
+#else
+    (void)model_id;
+    return RAC_ERROR_FEATURE_NOT_AVAILABLE;
 #endif
 }
 

--- a/core/src/features/rac_nonllm_lifecycle_bridge.h
+++ b/core/src/features/rac_nonllm_lifecycle_bridge.h
@@ -111,6 +111,11 @@ bool is_model_loaded(const char* model_id);
  * entry matched, so `is_model_loaded() == false` and this returning
  * MODEL_NOT_LOADED agree.
  *
+ * That agreement holds only where RAC_HAVE_PROTOBUF is defined. Without it the
+ * lifecycle store is unavailable, so is_model_loaded() still reports false but
+ * this returns RAC_ERROR_FEATURE_NOT_AVAILABLE rather than
+ * MODEL_NOT_LOADED. Callers that branch on the specific code must handle both.
+ *
  * MUST NOT be called while holding the lifecycle mutex: the backend teardown it
  * drives reacquires that mutex to drain active refs, and it publishes component
  * lifecycle events whose subscribers may re-enter lifecycle APIs.

--- a/core/src/features/rac_nonllm_lifecycle_bridge.h
+++ b/core/src/features/rac_nonllm_lifecycle_bridge.h
@@ -102,6 +102,21 @@ void release_lifecycle_segmentation(LifecycleSegmentationRef* ref);
  */
 bool is_model_loaded(const char* model_id);
 
+/**
+ * @brief Unload @p model_id from the lifecycle store, if commons holds it.
+ *
+ * The companion to is_model_loaded(): a caller that must clear a model before
+ * acting on its files can do so without a host callback, because commons is
+ * what performed the load. Returns RAC_ERROR_MODEL_NOT_LOADED when no lifecycle
+ * entry matched, so `is_model_loaded() == false` and this returning
+ * MODEL_NOT_LOADED agree.
+ *
+ * MUST NOT be called while holding the lifecycle mutex: the backend teardown it
+ * drives reacquires that mutex to drain active refs, and it publishes component
+ * lifecycle events whose subscribers may re-enter lifecycle APIs.
+ */
+rac_result_t unload_model(const char* model_id);
+
 }  // namespace rac::lifecycle
 
 #endif  // RAC_FEATURES_RAC_NONLLM_LIFECYCLE_BRIDGE_H

--- a/core/src/infrastructure/model_management/model_registry.cpp
+++ b/core/src/infrastructure/model_management/model_registry.cpp
@@ -360,9 +360,17 @@ rac_result_t save_model_info_impl(rac_model_registry_handle_t handle, const rac_
         }
 
         if (should_preserve_path) {
-            if (copy->local_path)
-                free(copy->local_path);
-            copy->local_path = rac_strdup(existing_local_path);
+            // Allocate before destroying. The free-then-strdup shape loses the
+            // path this branch exists to preserve when the allocation fails,
+            // and the loss then propagates into the cached proto snapshot while
+            // the call still returns RAC_SUCCESS.
+            char* preserved_path = rac_strdup(existing_local_path);
+            if (!preserved_path) {
+                free_model_info(copy);
+                return RAC_ERROR_OUT_OF_MEMORY;
+            }
+            free(copy->local_path);
+            copy->local_path = preserved_path;
         }
 
         free_model_info(it->second);

--- a/core/src/infrastructure/model_management/model_registry_discovery.cpp
+++ b/core/src/infrastructure/model_management/model_registry_discovery.cpp
@@ -282,11 +282,18 @@ bool try_reconcile_model_local_path_locked(rac_model_registry_handle_t handle,
         return false;
     }
 
-    // Update legacy struct
-    if (model->local_path) {
-        free(model->local_path);
+    // Update legacy struct. Check the allocation before mutating anything else:
+    // on failure the struct would keep an empty local_path while the proto
+    // snapshot below claimed folder_str, so proto-based reads would report the
+    // model downloaded and rac_model_registry_get_downloaded(), which walks the
+    // struct, would not. Report a miss instead of a divergent success.
+    char* reconciled_path = rac_strdup(folder_str.c_str());
+    if (!reconciled_path) {
+        RAC_LOG_WARNING("ModelRegistry", "Reconcile miss '%s': out of memory", model->id);
+        return false;
     }
-    model->local_path = rac_strdup(folder_str.c_str());
+    free(model->local_path);
+    model->local_path = reconciled_path;
     // Proto ModelInfo.updated_at_unix_ms — milliseconds, not seconds.
     model->updated_at = rac_get_current_time_ms();
 

--- a/core/src/infrastructure/storage/storage_analyzer.cpp
+++ b/core/src/infrastructure/storage/storage_analyzer.cpp
@@ -1258,7 +1258,16 @@ rac_result_t rac_storage_analyzer_delete_proto(rac_storage_analyzer_handle_t han
                 rac_model_info_free(model);
                 continue;
             }
-            if (!handle->callbacks.unload_model && !request.dry_run()) {
+            // Commons unloads what commons loaded. The host callback is
+            // unanswerable on the SDKs that matter here (nil on Swift, NULL on
+            // Electron, a no-op returning RAC_SUCCESS on Android), so routing
+            // through it either refused a delete that should have worked or
+            // pretended to close a model that stayed open. Asking the lifecycle
+            // store, which performed the load, is the only answer that is true
+            // on every host. The callback stays as the fallback for a model the
+            // host loaded outside commons.
+            const bool commons_owns_load = rac::lifecycle::is_model_loaded(model->id);
+            if (!commons_owns_load && !handle->callbacks.unload_model && !request.dry_run()) {
                 result_proto.add_failed_model_ids(id);
                 add_warning_once(&result_proto, &warnings,
                                  "Model is loaded but no unload callback is set: " + id);
@@ -1267,13 +1276,19 @@ rac_result_t rac_storage_analyzer_delete_proto(rac_storage_analyzer_handle_t han
                 rac_model_info_free(model);
                 continue;
             }
-            if (!handle->callbacks.unload_model && request.dry_run()) {
+            if (!commons_owns_load && !handle->callbacks.unload_model && request.dry_run()) {
                 add_warning_once(&result_proto, &warnings,
                                  "Dry run would require a platform unload before delete: " + id);
             }
             if (!request.dry_run()) {
+                // No lifecycle mutex is held here: unload_model() drives backend
+                // teardown that reacquires it to drain active refs, and it
+                // publishes component events whose subscribers may re-enter
+                // lifecycle APIs.
                 rac_result_t unload_result =
-                    handle->callbacks.unload_model(model->id, handle->callbacks.user_data);
+                    commons_owns_load
+                        ? rac::lifecycle::unload_model(model->id)
+                        : handle->callbacks.unload_model(model->id, handle->callbacks.user_data);
                 if (RAC_FAILED(unload_result)) {
                     result_proto.add_failed_model_ids(id);
                     add_warning_once(&result_proto, &warnings,

--- a/core/src/jni/runanywhere_commons_jni.cpp
+++ b/core/src/jni/runanywhere_commons_jni.cpp
@@ -4088,9 +4088,13 @@ static rac_result_t jni_storage_is_model_loaded(const char* /*model_id*/, rac_bo
     return RAC_SUCCESS;
 }
 
-static rac_result_t jni_storage_unload_model(const char* /*model_id*/, void* /*user_data*/) {
-    return RAC_SUCCESS;
-}
+// No jni_storage_unload_model: the old stub returned RAC_SUCCESS without
+// unloading anything, so commons believed a model had been closed and deleted
+// its files underneath the open backend. Commons now unloads through the
+// lifecycle store it loaded from (rac::lifecycle::unload_model), which is the
+// only path Android ever loads by, so leaving the slot NULL is both honest and
+// unreachable, and if a host ever does load outside commons it gets a real
+// "no unload callback is set" failure instead of a silent success.
 
 static rac_storage_callbacks_t build_jni_storage_callbacks() {
     rac_storage_callbacks_t cb = {};
@@ -4101,7 +4105,6 @@ static rac_storage_callbacks_t build_jni_storage_callbacks() {
     cb.get_total_space = jni_fc_get_total_space;
     cb.delete_path = jni_fc_delete_path;
     cb.is_model_loaded = jni_storage_is_model_loaded;
-    cb.unload_model = jni_storage_unload_model;
     cb.user_data = nullptr;
     return cb;
 }

--- a/engines/qhexrt/qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/qhexrt_model_catalog.cpp
@@ -45,8 +45,11 @@ struct ModelPolicy {
     // HF token is configured, which is what drives the per-SDK "bring your own HF
     // token" preflight UX. Most RunAnywhere-hosted QHexRT repos are PUBLIC and set this
     // false; private bundles are gated here. The exact set is pinned by
-    // test_qhexrt_model_catalog's private_ids, so hosting a model behind a gated HF repo
-    // means flipping this row AND that set — nothing else changes.
+    // test_qhexrt_model_catalog, which counts the gated rows it derives from this
+    // table and asserts `private_row_count == 1` plus a named
+    // `requires_hf_auth("kitten_nano_0_8_varlen") == RAC_TRUE`. Hosting a model
+    // behind a gated HF repo means flipping this row AND updating that count and
+    // named assertion. Nothing else changes.
     bool requires_hf_auth;
 };
 

--- a/engines/qhexrt/tests/test_qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/tests/test_qhexrt_model_catalog.cpp
@@ -75,6 +75,21 @@ int test_native_catalog_owns_arch_and_auth_policy() {
         RAC_QHEXRT_HEXAGON_ARCH_V81,
     };
 
+    // The union of every arch bit this test actually enumerates. A row whose
+    // mask sets a bit outside this union is unreachable on every supported
+    // device, yet the per-arch loop below would still agree with the lookups
+    // and stay green. Catches a stray bit, a mixed mask like kV81 | (1U << 3),
+    // and an arch added to the table without being added to `arches`.
+    uint8_t known_arch_bits = 0;
+    for (const rac_qhexrt_hexagon_arch_t arch : arches) {
+        known_arch_bits |= rac::qhexrt::catalog::policy_arch_bit(arch);
+    }
+
+    // Row ids must be unique: find_model_policy() stops at the first match, so a
+    // duplicated id silently makes the second row dead policy. The deleted
+    // `all.size() == model_count()` union guard used to reject this implicitly.
+    std::unordered_set<std::string> seen_ids;
+
     size_t private_row_count = 0;
     for (size_t i = 0; i < row_count; ++i) {
         rac::qhexrt::catalog::PolicyRow row{};
@@ -84,11 +99,14 @@ int test_native_catalog_owns_arch_and_auth_policy() {
         // the same size across an add-plus-remove.
         ASSERT_TRUE(rac::qhexrt::catalog::policy_row_at(i, &row));
         ASSERT_TRUE(row.id != nullptr && std::strlen(row.id) > 0);
+        ASSERT_TRUE(seen_ids.insert(std::string(row.id)).second);
         ASSERT_EQ(rac_qhexrt_catalog_model_is_known(row.id), RAC_TRUE);
 
         // Every row must be reachable on at least one arch, or it can never be
-        // registered on any device.
+        // registered on any device, and every bit it sets must be an arch this
+        // test knows about, or "reachable" is a claim about nothing.
         ASSERT_TRUE(row.arch_mask != 0);
+        ASSERT_EQ(static_cast<uint8_t>(row.arch_mask & ~known_arch_bits), static_cast<uint8_t>(0));
 
         for (const rac_qhexrt_hexagon_arch_t arch : arches) {
             const bool expected =

--- a/scripts/release/sync-versions.sh
+++ b/scripts/release/sync-versions.sh
@@ -218,8 +218,12 @@ echo ""
 echo ">> Swift SDK:"
 bump_line "${REPO_ROOT}/Package.swift" \
     'let sdkVersion = "[^"]+"' "let sdkVersion = \"${NEW_VERSION}\""
+# The external-consumer example points at the Swift distribution repo, not this
+# monorepo. bump_line returns 1 on a missing pattern and the script runs under
+# `set -euo pipefail`, so an anchor that stops matching aborts the bump midway
+# with core/VERSION already written.
 bump_line "${REPO_ROOT}/Package.swift" \
-    '(\.package\(url: "https://github\.com/RunanywhereAI/runanywhere-sdks", from: ")[^"]+("\))' \
+    '(\.package\(url: "https://github\.com/RunanywhereAI/runanywhere-swift\.git", from: ")[^"]+("\))' \
     "\\1${NEW_VERSION}\\2"
 # Swift SDK VERSION file (read by release tooling)
 SWIFT_VERSION_FILE="${REPO_ROOT}/bindings/swift/VERSION"

--- a/scripts/release/sync-versions.sh
+++ b/scripts/release/sync-versions.sh
@@ -78,9 +78,28 @@ REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 CURRENT_VERSION="$(tr -d '[:space:]' < "${REPO_ROOT}/core/VERSION")"
 CURRENT_VERSION_REGEX="${CURRENT_VERSION//./\\.}"
 
+# --- Two-phase bump: validate everything, then write everything ------------
+#
+# Every edit is VALIDATED as it is reached but QUEUED rather than applied. The
+# queue is flushed only after the last one validates, which makes the bump
+# atomic with respect to a stale anchor.
+#
+# Without this, `set -euo pipefail` plus ~32 bump_line calls means a pattern
+# that stopped matching (a file reformatted, a literal reworded) aborts partway
+# with the earlier files, including core/VERSION, already rewritten. The
+# checkout is then left claiming two different versions at once, which is worse
+# than not bumping at all: the next gate reports a confusing mismatch instead of
+# the real cause.
+_BUMP_FILES=()
+_BUMP_PATTERNS=()
+_BUMP_REPLACEMENTS=()
+_WRITE_FILES=()
+_WRITE_CONTENTS=()
+_WRITE_MODES=()
+_LOCK_FILES=()
+
 bump_line() {
-    # Replaces a line matching $pattern with $replacement, in $file.
-    # Cross-platform sed -i (BSD sed on macOS needs '' after -i).
+    # Validates now; the edit is applied by flush_pending_edits.
     local file="$1" pattern="$2" replacement="$3"
     if [ ! -f "$file" ]; then
         echo "ERROR: target path missing (sync-versions configuration is stale): $file" >&2
@@ -91,12 +110,40 @@ bump_line() {
         echo "       pattern: $pattern" >&2
         return 1
     fi
-    if [[ "$OSTYPE" == "darwin"* ]]; then
-        sed -i '' -E "s|${pattern}|${replacement}|" "$file"
-    else
-        sed -i -E "s|${pattern}|${replacement}|" "$file"
-    fi
+    _BUMP_FILES+=("$file")
+    _BUMP_PATTERNS+=("$pattern")
+    _BUMP_REPLACEMENTS+=("$replacement")
     echo "  bumped: $file"
+}
+
+queue_write() {
+    # Deferred counterpart to `echo x > file` / `>>`, so a later validation
+    # failure cannot leave these written while the sed edits never happen.
+    local file="$1" content="$2" mode="${3:-truncate}"
+    _WRITE_FILES+=("$file")
+    _WRITE_CONTENTS+=("$content")
+    _WRITE_MODES+=("$mode")
+}
+
+flush_pending_edits() {
+    local i
+    for i in "${!_BUMP_FILES[@]}"; do
+        if [[ "$OSTYPE" == "darwin"* ]]; then
+            sed -i '' -E "s|${_BUMP_PATTERNS[$i]}|${_BUMP_REPLACEMENTS[$i]}|" "${_BUMP_FILES[$i]}"
+        else
+            sed -i -E "s|${_BUMP_PATTERNS[$i]}|${_BUMP_REPLACEMENTS[$i]}|" "${_BUMP_FILES[$i]}"
+        fi
+    done
+    for i in "${!_LOCK_FILES[@]}"; do
+        apply_npm_lock_root_version "${_LOCK_FILES[$i]}"
+    done
+    for i in "${!_WRITE_FILES[@]}"; do
+        if [ "${_WRITE_MODES[$i]}" = "append" ]; then
+            printf '%s\n' "${_WRITE_CONTENTS[$i]}" >> "${_WRITE_FILES[$i]}"
+        else
+            printf '%s\n' "${_WRITE_CONTENTS[$i]}" > "${_WRITE_FILES[$i]}"
+        fi
+    done
 }
 
 bump_json_version() {
@@ -105,11 +152,27 @@ bump_json_version() {
 }
 
 bump_npm_lock_root_version() {
+    # Validates now, rewrites in flush_pending_edits, so a stale anchor later in
+    # the run cannot leave a lockfile bumped while everything else is not.
     local file="$1"
     if [ ! -f "$file" ]; then
         echo "ERROR: target path missing (sync-versions configuration is stale): $file" >&2
         return 1
     fi
+    node - "$file" <<'NODE'
+const fs = require('node:fs');
+const [file] = process.argv.slice(2);
+const lock = JSON.parse(fs.readFileSync(file, 'utf8'));
+if (typeof lock.version !== 'string' || typeof lock.packages?.['']?.version !== 'string') {
+  throw new Error(`package-lock root version fields are missing: ${file}`);
+}
+NODE
+    _LOCK_FILES+=("$file")
+    echo "  bumped: $file"
+}
+
+apply_npm_lock_root_version() {
+    local file="$1"
     node - "$file" "$NEW_VERSION" <<'NODE'
 const fs = require('node:fs');
 const [file, version] = process.argv.slice(2);
@@ -208,7 +271,7 @@ bump_line "${REPO_ROOT}/AGENTS.md" \
     '(\*\*Current version\*\*: `)[^`]+(` \(canonical source: `core/VERSION`\))' \
     "\\1${NEW_VERSION}\\2"
 echo ">> commons:"
-echo "$NEW_VERSION" > "${REPO_ROOT}/core/VERSION"
+queue_write "${REPO_ROOT}/core/VERSION" "$NEW_VERSION"
 echo "  bumped: core/VERSION"
 bump_line "${REPO_ROOT}/core/VERSIONS" \
     '^PROJECT_VERSION=.*' "PROJECT_VERSION=${NEW_VERSION}"
@@ -228,7 +291,7 @@ bump_line "${REPO_ROOT}/Package.swift" \
 # Swift SDK VERSION file (read by release tooling)
 SWIFT_VERSION_FILE="${REPO_ROOT}/bindings/swift/VERSION"
 if [ -f "$SWIFT_VERSION_FILE" ]; then
-    echo "$NEW_VERSION" > "$SWIFT_VERSION_FILE"
+    queue_write "$SWIFT_VERSION_FILE" "$NEW_VERSION"
     echo "  bumped: bindings/swift/VERSION"
 fi
 # SDKConstants.swift is intentionally NOT bumped here: its `version` constant
@@ -253,7 +316,7 @@ if [ -f "$KOTLIN_PROPS" ]; then
         bump_line "$KOTLIN_PROPS" \
             '^runanywhere\.nativeLibVersion=.*' "runanywhere.nativeLibVersion=${NEW_VERSION}"
     else
-        echo "runanywhere.nativeLibVersion=${NEW_VERSION}" >> "$KOTLIN_PROPS"
+        queue_write "$KOTLIN_PROPS" "runanywhere.nativeLibVersion=${NEW_VERSION}" append
         echo "  appended: runanywhere.nativeLibVersion to $KOTLIN_PROPS"
     fi
     if grep -q '^SDK_VERSION=' "$KOTLIN_PROPS"; then
@@ -466,6 +529,10 @@ for release_doc in \
     "${REPO_ROOT}/bindings/kotlin/README.md"; do
     bump_line "$release_doc" "$CURRENT_VERSION_REGEX" "$NEW_VERSION"
 done
+
+# Every anchor above validated. Only now does anything on disk change, so a
+# stale pattern aborts with the working tree untouched rather than half-bumped.
+flush_pending_edits
 
 echo ""
 echo ">> Done. Verify with:"

--- a/scripts/validation/gates/check_release_version_coherence.sh
+++ b/scripts/validation/gates/check_release_version_coherence.sh
@@ -195,10 +195,14 @@ expect_spm_version() {
   FAILURES=$((FAILURES + 1))
 }
 
+# The external-consumer example in Package.swift points at the Swift
+# DISTRIBUTION repo, never this monorepo: this repo's tags do not compile as a
+# Swift package (the generated Sources/ are no longer committed). Assert that
+# exact literal so the documented URL cannot silently drift back.
 if [ "${SPM_TEMP_PIN}" -eq 1 ]; then
-  expect_literal "Package.swift" ".package(url: \"https://github.com/RunanywhereAI/runanywhere-sdks\", from: \"${SPM_VERSION}\")"
+  expect_literal "Package.swift" ".package(url: \"https://github.com/RunanywhereAI/runanywhere-swift.git\", from: \"${SPM_VERSION}\")"
 else
-  expect_literal "Package.swift" ".package(url: \"https://github.com/RunanywhereAI/runanywhere-sdks\", from: \"${VERSION}\")"
+  expect_literal "Package.swift" ".package(url: \"https://github.com/RunanywhereAI/runanywhere-swift.git\", from: \"${VERSION}\")"
 fi
 expect_exact_file "bindings/swift/VERSION" "${VERSION}"
 expect_literal "bindings/swift/Sources/RunAnywhere/Generated/Versions.swift" \
@@ -385,6 +389,7 @@ for release_doc in \
   bindings/flutter/docs/ARCHITECTURE.md \
   bindings/flutter/docs/Documentation.md \
   bindings/swift/ARCHITECTURE.md \
+  bindings/swift/README.md \
   bindings/swift/Sources/LlamaCPPRuntime/README.md \
   bindings/swift/Sources/ONNXRuntime/README.md \
   bindings/kotlin/README.md; do


### PR DESCRIPTION
Follow-up to the 0.20.18 merge batch: #668, #669, #677, #678, #679, #680, #681, #682.

Every item below was re-verified against `main` (39dc8f2c5) before it was touched. Credit where it is due: **@ayaangazali** wrote #668, #669, #678 and #679; **@shubhamsinnh** wrote #680 and #681; **@sanchitmonga22** wrote #677 and #682. **CodeRabbit** raised five of the findings here directly.

---

## Commons (from #668, @ayaangazali)

**1. `is_model_loaded` reported failed loads as loaded** *(raised by CodeRabbit)*
`rac::lifecycle::is_model_loaded` matched entries in `g_loaded` on `model_id` alone. A load that fails leaves an ERROR sentinel in `g_loaded` carrying the failed request's `model_id` (`install_failed_entry_preserving`), so the query returned `true` for a model with no backend at all. That made it undeletable: dropped from the delete plan with "Model is loaded and cannot be safely deleted", and `RAC_ERROR_MODEL_NOT_LOADED` on execute. A model that failed to load is exactly the one a user wants to delete.
**Changed:** added `state == COMPONENT_LIFECYCLE_STATE_READY` to the match in `core/src/core/model_lifecycle_accessors.cpp`. READY and ERROR are the only states ever installed, so this is the exact discriminator, and it matches what `acquire_lifecycle_llm` / `acquire_component` already require.

**2. The unload half #668 deferred**
The read side answered from commons, but the unload side still depended entirely on `handle->callbacks.unload_model`, which is nil on Swift, NULL on Electron, and a no-op returning `RAC_SUCCESS` on Android. On Swift, `models.delete(id:)` on a loaded model threw "Model is loaded but no unload callback is set" where it previously deleted; on Android the fake unload succeeded and the recursive delete still ran underneath the open model.
**Changed:** added `rac::lifecycle::unload_model(model_id)` (declared in `core/src/features/rac_nonllm_lifecycle_bridge.h`, implemented beside `is_model_loaded`). It delegates to `rac_model_lifecycle_unload_proto` rather than re-walking `g_loaded`, so the erase-under-mutex, destroy-outside-mutex and UNLOADING→NOT_LOADED event publication all stay in one place, and it maps an unmatched id onto `RAC_ERROR_MODEL_NOT_LOADED` so it agrees with `is_model_loaded() == false`. `storage_analyzer.cpp` now unloads through commons whenever commons owns the load and only falls back to the host callback (and only reports "no unload callback is set") when it does not. The call is made with no lifecycle mutex held, which the doc comment states explicitly, because `destroy_loaded_model` reacquires it to drain `active_refs` and component-event subscribers may re-enter lifecycle APIs.
**Also:** deleted the Android `jni_storage_unload_model` stub and its slot assignment. It is now unreachable (Android only loads through commons), and a stub that returns `RAC_SUCCESS` without unloading is worse than a NULL slot, which produces a real failure.
**Also:** corrected the now-wrong comment on `callbacks.unload_model = nil` in `CppBridge+Storage.swift`.

## QHexRT catalog test (from #669, @ayaangazali)

**3. Duplicate row ids no longer rejected**
The deleted `ASSERT_EQ(all.size(), rac_qhexrt_catalog_model_count())` implicitly rejected a duplicated id in `kModelPolicies`; the new per-index loop did not. A duplicate makes the second row dead policy, since `find_model_policy()` stops at the first match.
**Changed:** `std::unordered_set<std::string> seen_ids` plus `ASSERT_TRUE(seen_ids.insert(...).second)` in the row loop. This also gives the `<unordered_set>` include a user again (item 6 below).

**4. `arch_mask != 0` accepted masks with no enumerated bit** *(raised by CodeRabbit)*
CodeRabbit proposed accumulating a `supports_known_arch` boolean. I went one step stronger: precompute the union of enumerated arch bits and assert each row is a subset of it. That also catches a *mixed* mask like `kV81 | (1U << 3)`, and an arch bit added to the table without being added to `arches`, neither of which the boolean form catches.

**5. Stale comment pointing at a deleted symbol**
`ModelPolicy::requires_hf_auth` still said the set is "pinned by test_qhexrt_model_catalog's private_ids". #669 deleted `private_ids`.
**Changed:** the comment now names the real mechanism (`private_row_count == 1` over the derived rows, plus the explicit `kitten_nano_0_8_varlen` assertion).

**6. Unused `<unordered_set>` include** — resolved by item 3 rather than by deleting the include.

## Web WASM build (from #678, @ayaangazali)

**7. The #678 bug still existed one flag over**
`--llamacpp` and the no-target default block both left `RAG=OFF`. With RAG=OFF and ONNX=OFF, `core/CMakeLists.txt` force-sets `RAC_BACKEND_RAG=OFF`, so the CPU llamacpp bundle silently dropped the eight `rac_rag_*_proto` exports. That is the bundle the Web Docs/RAG tab auto-loads. Release CI masks it because `--core --llamacpp --onnx` is one invocation and `--onnx` sets RAG=ON, so anyone following the documented `npm run build:wasm -- --llamacpp` got a bundle differing from the release by exactly those eight symbols.
**Changed:** `RAG="ON"` in both places, with the same comment shape #678 added to `--webgpu`. Verified by probing the flag parser directly: on `main`, `[--llamacpp] -> RAG=OFF` and `[] -> RAG=OFF`; on this branch both are `RAG=ON`.

**8. `--rag` help text was wrong, and now doubly wrong**
Both the header block and `--help` said "requires --onnx". Standalone `--rag` is explicitly supported and is the whole point of `RAC_WASM_RAG_STANDALONE`. After #678 and item 7, `--rag` is a no-op for every target.
**Changed:** both strings now say what the flag emits and that every target implies it.

**9. Nothing asserted the RAG exports were actually emitted**
The whole #673/#678 bug class is silent: the build succeeds, the artifact is non-empty, release packaging only checks the ten JS/WASM files exist, and PR CI's `wasm` job never invokes `build.sh` at all. The #678 author asked for this check in the PR body.
**Changed:** in `build_target`'s existing post-build verification block, when RAG=ON, grep the emitted glue for `_rac_rag_session_create_proto` and fail the build if it is absent. Scoped to the llamacpp and onnx targets, because only those two export lists append `RAC_EXPORTED_FUNCTIONS_RAG` — the commons-only `--core` target never does, and an unscoped check would have failed `--core --llamacpp`.

**10. Stale comments in `bindings/web/wasm/CMakeLists.txt`**
"6 rac_rag_*_proto symbols" where `RAC_EXPORTED_FUNCTIONS_RAG` lists 8, and a claim that the exports are "appended to that target only" (onnx-sherpa) contradicted by the llamacpp/webgpu append 330 lines below. Both corrected.

## TypeScript surfaces (from #679, @ayaangazali)

**11. RN doc comment attached to the wrong export**
The Solutions export block was inserted between the `generateWithTools` doc comment and its `export` statement, so Solutions was documented as a tool-calling run loop and `generateWithTools` had no doc comment. Purely cosmetic, no type or runtime change. **Changed:** moved the tool-calling paragraph back down to sit above its own export.

**12. Same gap, still unfixed on Web**
`RunAnywhere.solutions` is public on Web too, but `bindings/web/packages/core/src/index.ts` had no Solutions reference at all, so neither `SolutionHandle` nor `SolutionRunInput` could be named without a deep path import. **Changed:** added the type-only re-export, mirroring the RN fix. `SolutionConfig` is deliberately left out, since Web re-exports it straight from `@runanywhere/proto-ts/solutions`.

## Commons allocation handling (from #680 / #681, @shubhamsinnh)

**13. The same free-then-strdup shape #680 fixed, 330 lines above the fix**
`save_model_info_impl()`'s `should_preserve_path` branch — whose entire job is not to lose the existing path — did `free(copy->local_path); copy->local_path = rac_strdup(existing);`. On allocation failure the path is lost, the previous entry is freed on the next line, the loss is written into the cached proto snapshot, and the function returns `RAC_SUCCESS`. **Changed:** allocate-then-swap, matching the shape @shubhamsinnh used at lines 690-699, freeing the not-yet-installed `copy` before returning `RAC_ERROR_OUT_OF_MEMORY`.

**14. Unchecked `rac_strdup` in `try_reconcile_model_local_path_locked`**
No existing path is lost here, but on allocation failure the C struct and the proto snapshot diverge: proto reads report the model downloaded while `rac_model_registry_get_downloaded()` (which walks the struct) does not, and the caller is told the reconcile succeeded. **Changed:** check the result first and return `false` (a miss) instead of a divergent success.

**15. Stale Doxygen on `rac_streaming_metrics_get_result`**
After #681 the function can return `RAC_ERROR_OUT_OF_MEMORY`, and it unconditionally overwrites `*out_result` with `RAC_STREAMING_RESULT_DEFAULT` before populating, so a caller reusing a result that still owns strings leaks them. This is a shipped public header. **Changed:** documented both. Documentation only.

## RN packaging script (from #677, @sanchitmonga22)

**16. The script validated a header tree it could not generate**
The only `ensure_generated.sh` call was `--only ts`, ~120 lines *below* the `core/include/rac` staging, and never requested cpp. The whole fix depended on `release.yml` supplying cpp codegen; any invocation outside that job hard-failed at the new guard instead of self-healing. Repo convention is that every packaging script calls `ensure_generated.sh` before packing. **Changed:** added `ensure_generated.sh --only cpp` immediately before the `cp -R`, since `rac_defaults_generated.h` lives inside the tree being copied. Verified the call succeeds and writes the header.

**17. Blank-record false failure in the guard** *(raised by CodeRabbit, both halves)*
When the grep matches nothing the here-doc still supplies one empty line, so `[ -f "$CORE_RAC_HEADERS/../" ]` fails on a directory and packaging aborts with an empty header list. CodeRabbit also asked for a structured collection instead of the whitespace-delimited string. **Changed:** `[ -n "$_inc" ] || continue`, and `_missing_headers` is now a bash array with `printf`, removing the unquoted word-split and glob expansion in `for _h in $_missing_headers`. Verified under macOS `/bin/bash` 3.2 with `set -euo pipefail` against three synthetic trees: intact passes, no-quoted-includes passes (fails on `main`), genuinely-missing-header fails with the right name.

## Release gates and Swift docs (from #682, @sanchitmonga22)

**18. `check_release_version_coherence.sh` was failing on main**
It hard-asserted the `runanywhere-sdks` SPM literal in `Package.swift` that #682 deleted, so the `centralization` job failed on every PR and push. **Changed:** both branches of the `SPM_TEMP_PIN` conditional now assert the `runanywhere-swift.git` literal. The gate exits 0 on this branch; it exits 1 on `main`.

**19. `sync-versions.sh` would have aborted mid-bump**
Line 222 anchored on the same deleted URL. `bump_line` returns 1 on a missing pattern under `set -euo pipefail`, so the next `sync-versions.sh 0.20.19` would abort after having already written `core/VERSION` and `core/VERSIONS`. **Changed:** retargeted the regex. Ran `./scripts/release/sync-versions.sh 0.20.18` as a no-op smoke test: exit 0, no file content changed.

**20. Swift READMEs still sent consumers down the path #682 documents as fatal**
`Sources/LlamaCPPRuntime/README.md` and `Sources/ONNXRuntime/README.md` ship inside `runanywhere-swift` (sync-dist-repo.sh copies `git ls-files bindings/swift/Sources` verbatim), and both still pointed at the monorepo. `bindings/swift/README.md` was worse: monorepo URL, `package: "runanywhere-sdks"` products, and version 0.20.11 — seven releases stale, because the `release_doc` loop in the gate covered the two `Sources/*/README.md` files but not it. **Changed:** all three retargeted at `runanywhere-swift.git`, versions bumped to the canonical `core/VERSION`, and `bindings/swift/README.md` added to the `release_doc` loop so it cannot drift again.

---

## Deliberately NOT changed

**CodeRabbit on #668: "make the loaded-state check and file deletion atomic."** Still valid, not fixed here. A concurrent lifecycle load can install a model after `is_model_loaded` releases `g_lifecycle_mutex` and before `delete_path` runs. Closing it properly needs a shared reservation held across lifecycle transitions, unloading and deletion until `active_refs` reaches zero, which is a cross-subsystem design change well beyond a review-feedback follow-up. Item 2 narrows the window materially (commons now closes the model itself rather than asking a host that cannot answer) but does not eliminate it.

**Widening the RN header guard to non-`rac/`-prefixed quoted includes.** The finding is real: three shipped headers reference `.pb.h` files that are not staged at all (`storage_event_publisher.h` → `storage_types.pb.h`; `pipeline_executor.hpp` and `solution_runner.hpp` → `pipeline.pb.h` / `solutions.pb.h`), and `rac/backends/rac_mlx.h` uses sibling-relative includes that only resolve in the flat iOS xcframework layout. But implementing the widened guard as written would hard-fail packaging on `main` today, because those dependencies genuinely are not there. Making it safe requires either staging generated proto headers into the RN tarball or pruning headers the Nitro bridge never includes — a release-affecting decision that deserves its own PR, not a rider on this one. Nothing is broken today: no RN Nitro bridge source includes any of those headers.

**`jni_storage_is_model_loaded` (the always-RAC_FALSE stub) was kept.** With commons answering positively first, this stub is only consulted when commons did not load the model, and on Android nothing does. Deleting it would make `known_loaded_state` return false and add the "loaded state unavailable" warning to every Android delete plan without adding any information. The `unload_model` stub was deleted because it actively lied about work it never did; this one does not.

---

## Verification actually run

| What | Result |
|---|---|
| `clang++ -std=c++20 -fsyntax-only` on all six touched C++ TUs (incl. the JNI TU and a TU including the edited public header) | clean |
| QHexRT catalog test, built and run standalone | passes on the real table |
| QHexRT catalog test vs injected duplicate row id | **fails** at the new `seen_ids` assertion |
| QHexRT catalog test vs injected stray arch bit `1U << 3`, and vs mixed `kV81 \| (1U << 3)` | **fails** at the new subset assertion in both cases |
| `clang-format --dry-run` violation counts, `main` vs branch, on all nine touched C/C++ files | identical (no new violations) |
| `bash -n` on all four touched shell scripts | clean |
| `build.sh` flag parser probed for RAG value across 7 flag combinations | `--llamacpp` and no-args flipped OFF→ON; `--core` correctly still OFF |
| RN packaging guard, macOS `/bin/bash` 3.2, three synthetic trees | intact passes, blank-record passes (fails on `main`), missing header fails correctly |
| `scripts/validation/gates/check_release_version_coherence.sh` | exit 0 (exits 1 on `main`) |
| `./scripts/release/sync-versions.sh 0.20.18` | exit 0, no content changed |
| `idl/codegen/ensure_generated.sh --only cpp` | exit 0, writes `rac_defaults_generated.h` |
| `idl/codegen/ci-drift-check.sh` | exit 0 |
| `bindings/web` `npm run typecheck` | pass |
| a strict `tsc` probe naming `SolutionHandle` / `SolutionRunInput` from the web package root | resolves |
| `bindings/react-native` `yarn typecheck` | pass |
| `swiftlint` on the touched Swift file | clean |
| `check_agents_claude_sync.sh`, `check_no_hardcoded_defaults.sh`, `check_typescript_centralization.sh`, `check_wasm_provenance_contract.sh`, `check_deprecated_surfaces.sh`, `check_rn_cpp_headers_compile.sh` | all exit 0 |

**Not verified:** no full native build, no Android/iOS device run, and no actual Emscripten WASM build (no emsdk on this host), so the new RAG export assertion in `build.sh` has been syntax-checked and its enclosing condition reasoned through against the CMake export lists, but never executed against a real artifact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a public API to unload models from the lifecycle store.
  * Exposed solution-related types in the Web SDK.
  * Enabled and verified RAG exports across supported WebAssembly engine targets.

* **Bug Fixes**
  * Improved model unload handling and lifecycle state reporting.
  * Prevented model path data loss during allocation failures.

* **Documentation**
  * Updated Swift SDK installation guidance and version references to 0.20.18.
  * Clarified streaming metrics ownership and model lifecycle behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->