### PR TITLE
fix(commons): handle RAG answer allocation failures

### DIFF
--- a/core/src/features/rag/rag_backend.cpp
+++ b/core/src/features/rag/rag_backend.cpp
@@ -613,7 +613,14 @@ rac_result_t RAGBackend::query(const std::string& question, const rac_llm_option
         return status;
 
     if (out_result) {
-        out_result->text = !g_out.answer.empty() ? rac_strdup(g_out.answer.c_str()) : nullptr;
+        if (!g_out.answer.empty()) {
+            out_result->text = rac_strdup(g_out.answer.c_str());
+            if (out_result->text == nullptr) {
+                return RAC_ERROR_OUT_OF_MEMORY;
+            }
+        } else {
+            out_result->text = nullptr;
+        }
         out_result->completion_tokens = 0;
         out_result->prompt_tokens = 0;
         out_result->total_tokens = 0;


### PR DESCRIPTION
﻿## Description

The RAG query pipeline can report success while failing to allocate the generated answer.
`RAGBackend::query` copies the accumulated answer into `rac_llm_result_t::text` with an
unchecked `rac_strdup`:

```cpp
out_result->text = !g_out.answer.empty() ? rac_strdup(g_out.answer.c_str()) : nullptr;
```

`rac_strdup` returns `nullptr` when `malloc` fails, but the result was never checked, so a
failed allocation produced `text == nullptr` while the function still returned `RAC_SUCCESS`.
Downstream, `execute_rag_query` maps a null `text` to an empty string, yielding a successful
but empty answer.

This change returns `RAC_ERROR_OUT_OF_MEMORY` when the answer is non-empty and the
`rac_strdup` allocation fails, matching the existing handling in `voice_agent.cpp` and the
sibling allocation-failure fixes (#680, #681).

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] `git diff --check` passes on the change
- [ ] Added/updated tests for changes

Local validation on this host:
- `git diff --check` passes.
- A full native build cannot run on this Windows host (no clang-format; the core's generated
  `rac_defaults_generated.h` header is produced by the IDL codegen toolchain). Build
  verification is left to CI (`pr-build.yml`).

### Platform-Specific Testing
C++ commons change only - no SDK or example app code touched. All platform builds are
exercised by upstream CI.

## Labels
- [x] `Commons` - Changes to shared native code (`core`)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of memory allocation failures when generating answers.
  * The system now returns a clear out-of-memory error instead of producing an incomplete result.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->