### PR TITLE
fix(qhexrt): add the lfm2_5_1_2b_thinking policy row the apps already ship

### DIFF
--- a/engines/qhexrt/qhexrt_model_catalog.cpp
+++ b/engines/qhexrt/qhexrt_model_catalog.cpp
@@ -62,6 +62,12 @@ constexpr ModelPolicy kModelPolicies[] = {
     // v75/v79/v81 context binaries are published (public repo, no HF auth gate). v75 + v81 ship the 2-part
     // hybrid decode split (each part < 2 GiB); v79 ships the monolithic decode.
     {"lfm2_5_2_6b", kAllSupportedArches, false},
+    // v81 only, and published public (runanywhere/lfm2_5_1_2b_thinking_HNPU has
+    // just a v81/ tree, no auth gate). Without this row the engine answers
+    // RAC_ERROR_QHEXRT_UNKNOWN_MODEL (-259, "unknown QHexRT native catalog model
+    // id") for a model the app catalogs already ship, which is what the Android
+    // app hits at startup: "npu catalog: lfm2_5_1_2b_thinking failed".
+    {"lfm2_5_1_2b_thinking", kV81, false},
     {"qwen3_5_0_8b", kAllSupportedArches, false},
     {"qwen3_5_2b", kAllSupportedArches, false},
     {"qwen3_5_4b", kV79V81, false},


### PR DESCRIPTION
## Observed on a real device

Android app built from Maven Central 0.20.18, running on an **SM8850 (Hexagon v81)**:

```
E JNI.QHexRT: nativeCatalogRegisterModelProto: QHexRT device-aware model
  registration failed (code=-259): unknown QHexRT native catalog model id
E ModelBootstrap: npu catalog: lfm2_5_1_2b_thinking failed
I ModelBootstrap: catalog seeded: ok=103 failed=1 skippedNative=5
```

It is the **only** failure in the seed. The other 103 models register fine.

## Cause

`ModelCatalog.kt` catalogs LFM2.5 1.2B Thinking as a QHexRT model, but `kModelPolicies` in `qhexrt_model_catalog.cpp` has no row for it. The engine correctly refuses an id it does not know.

Verified the shipped engine binary itself is missing the id, so this is not a build-staging problem:

```
strings librac_backend_qhexrt.so | grep '^lfm2_5_1_2b_thinking$'   ->  0 hits
```
(the four sibling rows `lfm2_5_230m`, `lfm2_5_350m`, `lfm2_5_2_6b`, `lfm2_5_vl_3b` are all present)

## The row

```cpp
{"lfm2_5_1_2b_thinking", kV81, false},
```

Both fields checked against the HuggingFace API rather than copied from a neighbour:

| | value | evidence |
|---|---|---|
| arch | `kV81` | `runanywhere/lfm2_5_1_2b_thinking_HNPU` carries only a `v81/` tree |
| auth | `false` | `private: false`, `gated: false`, HTTP 200 anonymously |

Worth noting the neighbouring rows are `kAllSupportedArches`, so copying the pattern would have been wrong here.

## No test change needed

#669 already refactored `test_qhexrt_model_catalog.cpp` to derive its expectations from this table through `policy_row_at()`. Adding the row is sufficient, which is precisely the drift that refactor was meant to prevent.

## Verification

`clang++ -std=c++20 -fsyntax-only` over `qhexrt_model_catalog.cpp` with the engine include paths: exit 0, 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHnqxh9weAVMc6g2UcmbC9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for the `lfm2_5_1_2b_thinking` model in the QHexRT catalog for V81 devices.
  * The model is available without Hugging Face authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->