### PR TITLE
fix(electron): say which platforms actually have prebuilds

### DIFF
--- a/bindings/electron/AGENTS.md
+++ b/bindings/electron/AGENTS.md
@@ -94,13 +94,27 @@ Adapted from `thoughts/shared/plans/BEST_PRACTISES.md` for this package:
 
 - Document what is true today. Do not claim encryption or remote Phase-2 auth unless
   packaging and runtime are wired end-to-end.
-- **Windows QHexRT/NPU is wired** on Windows ARM64 (Snapdragon X / X2 Elite, Hexagon
-  v81): `@runanywhere/electron-qhexrt` ships `runanywhere_qhexrt.dll` plus the flat
-  QAIRT set in its own `prebuilds/win32-arm64/`, and a v81 bundle loads and generates
-  through the thin addon. What is NOT wired on that host: llama.cpp, ONNX and Sherpa
-  do not build for win-arm64 (ggml rejects MSVC for ARM; `FetchONNXRuntime.cmake` has
-  no win-arm64 URL — see the `windows-arm64-release` preset comments), so the NPU is
-  the only engine there and there is no CPU fallback to hide behind.
+- **Windows QHexRT/NPU is NOT wired, and neither is Windows.** As of 0.20.18 this SDK
+  ships prebuilds for **`darwin-arm64` only** — the addon at `prebuilds/darwin-arm64/`
+  plus one directory each in the llamacpp / onnx / sherpa packages. There is nothing
+  for linux, win32, or x64. `package.json` keeps `os`/`cpu` permissive on purpose,
+  because the TypeScript facade genuinely is cross-platform and narrowing them would
+  also block TS-only consumers and our own Linux CI; `resolveAddon()` in
+  `src/bridge.ts` instead names the gap explicitly against `PREBUILT_PLATFORMS`.
+- **`@runanywhere/electron-qhexrt` ships no native plugin on any platform.** It is
+  pinned at 0.20.17 and npm-deprecated saying so. `register()` records a path with no
+  binary behind it, so the plugin never loads and the app must degrade gracefully.
+  Windows ARM64 (Snapdragon X / X2 Elite, Hexagon v81) is the only host where it could
+  ever work, and that build does not exist: every payload under
+  `engines/qhexrt/prebuilt/` is Android `arm64-v8a` only, and a win-arm64 runner
+  hard-fails at configure on the "Partial QHexRT prebuilt" FATAL_ERROR. Do not
+  describe this package as NPU-accelerated until a real win-arm64 DLL passes
+  `check_plugin_natives.py`; a shell build exports `rac_plugin_entry_qhexrt` and looks
+  healthy by size and export count, so gate on `g_qhexrt_llm_ops` via `nm -a`.
+- What is separately true on that host once it lands: llama.cpp, ONNX and Sherpa do not
+  build for win-arm64 (ggml rejects MSVC for ARM; `FetchONNXRuntime.cmake` has no
+  win-arm64 URL — see the `windows-arm64-release` preset comments), so the NPU would be
+  the only engine there with no CPU fallback to hide behind.
 - Win32 secure store is DPAPI; do not label it "plaintext M0" in headers/docs.
 - Phase-2 `completeServicesInitialization` is a local lifecycle seam unless real auth
   lands.

--- a/bindings/electron/package.json
+++ b/bindings/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@runanywhere/electron",
   "version": "0.20.18",
-  "description": "RunAnywhere Electron SDK — on-device LLM/VLM/STT/TTS/embeddings for Electron & Node (Windows-first; QHexRT NPU seam open, not claimed).",
+  "description": "RunAnywhere Electron SDK — on-device LLM/VLM/STT/TTS/embeddings for Electron & Node (ships macOS arm64 prebuilds only today; QHexRT NPU seam open, not claimed).",
   "publishConfig": {
     "access": "public"
   },

--- a/bindings/electron/src/bridge.ts
+++ b/bindings/electron/src/bridge.ts
@@ -556,6 +556,10 @@ function prepareNativeLoad(addonPath: string): void {
   }
 }
 
+// Platforms this release actually ships a prebuilt addon for. Kept next to the
+// resolver so it cannot drift from what bundle-native staged.
+const PREBUILT_PLATFORMS: readonly string[] = ['darwin-arm64'];
+
 function resolveAddon(): NativeAddon {
   const candidates = [
     process.env.RUNANYWHERE_NATIVE_PATH,
@@ -586,9 +590,24 @@ function resolveAddon(): NativeAddon {
     .filter((p) => !fs.existsSync(p))
     .map((p) => `  missing backend plugin: ${p}`);
 
+  // Say plainly when this platform ships no prebuild at all. Without this the
+  // message reads as "your install is broken" on linux/win32, when the truth is
+  // that the release never carried a binary for them. package.json deliberately
+  // keeps os/cpu permissive, because the TypeScript facade IS cross-platform and
+  // narrowing them would also block TS-only consumers and our own Linux CI.
+  const here = `${process.platform}-${process.arch}`;
+  const unsupported = !PREBUILT_PLATFORMS.includes(here);
+
   throw new Error(
     [
       'runanywhere_native.node not found (core addon).',
+      ...(unsupported
+        ? [
+            `No prebuild ships for ${here}. This release carries ${PREBUILT_PLATFORMS.join(', ')} only.`,
+            'This is a packaging gap, not a broken install: build the addon from source',
+            'or use a supported platform.',
+          ]
+        : []),
       'Set RUNANYWHERE_NATIVE_PATH to the built addon, or run scripts/bundle-native.',
       'Tried:',
       ...tried.map((p) => `  ${p}`),


### PR DESCRIPTION
## The gap

This release ships prebuilds for **`darwin-arm64` only**:

| package | prebuilds |
|---|---|
| `@runanywhere/electron` | `prebuilds/darwin-arm64/runanywhere_native.node` |
| `electron-llamacpp` / `electron-onnx` / `electron-sherpa` | `prebuilds/darwin-arm64/` (3 files each) |

Nothing exists for `linux`, `win32`, or `x64`. Three places said otherwise:

1. **`resolveAddon()`** reported `runanywhere_native.node not found` and listed tried paths. On a platform that never had a binary, that reads as a broken install rather than an unsupported platform.
2. **The package description** called this SDK **"Windows-first"** while shipping macOS arm64 exclusively.
3. **`AGENTS.md`** asserted *"Windows QHexRT/NPU is wired"* and that `electron-qhexrt` ships `runanywhere_qhexrt.dll` plus the flat QAIRT set. None of that is true of any published version: every payload under `engines/qhexrt/prebuilt/` is Android `arm64-v8a` only, and a win-arm64 runner hard-fails at configure on the "Partial QHexRT prebuilt" `FATAL_ERROR`. That claim sat three lines under the section's own rule to document only what is true today.

## What changed

`resolveAddon()` now names the gap against a `PREBUILT_PLATFORMS` constant that sits next to the resolver, so it cannot drift from what `bundle-native` staged.

## What I deliberately did NOT do

The first attempt narrowed `os`/`cpu` to `darwin`+`arm64` so npm would reject with `EBADPLATFORM`. **That was wrong and CI proved it:**

```
npm error notsup Unsupported platform for @runanywhere/electron@0.20.18:
wanted {"os":"darwin","cpu":"arm64"} (current: {"os":"linux","cpu":"x64"})
```

It broke our own Linux `electron-unit` job, and more importantly it would block **TS-only consumers** — the TypeScript facade genuinely is cross-platform; only the addon is not. A runtime message that names the real gap keeps the honest signal without blocking a legitimate install.

## Scope

Claims only, no artifact changes. Adding a platform is staging its prebuilds and appending to `PREBUILT_PLATFORMS`; the prepublish gate (#689) then proves the carriers inside are real rather than stubs.

Found by the 0.20.18 release audit: 32 published artifacts verified with `nm -a`, five apps built and launched on real hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LHnqxh9weAVMc6g2UcmbC9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified that the Electron SDK currently provides prebuilt support for macOS on Apple Silicon.
  * Documented current Windows ARM64 limitations, including unavailable QHexRT/NPU support and required native configuration checks.

* **Bug Fixes**
  * Improved native component error messages to distinguish unsupported platforms from missing or damaged installations.
  * Errors now identify the platforms supported by the available prebuilt packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->