### PR TITLE
fix(commons): rate VLM decode_tokens_per_second over the decode window

### DIFF
--- a/core/src/features/vlm/vlm_module.cpp
+++ b/core/src/features/vlm/vlm_module.cpp
@@ -688,10 +688,21 @@ extern "C" rac_result_t rac_vlm_component_process_stream(
         final_result.time_to_first_token_ms = ttft_duration.count();
     }
 
-    // Calculate tokens per second
-    if (final_result.total_time_ms > 0) {
+    // Tokens per second over the decode window, not the whole span. This value
+    // is mapped onto TokenUsage.decode_tokens_per_second by
+    // rac_proto_adapters.cpp, and llm_module.cpp states the rule: prefill in
+    // the denominator systematically understates generation speed. TTFT is
+    // computed immediately above, so the window is already known here.
+    // Falls back to the full span when no token was seen, or when TTFT is not
+    // strictly inside the span.
+    const int64_t vlm_decode_ms =
+        (final_result.time_to_first_token_ms > 0 &&
+         final_result.time_to_first_token_ms < final_result.total_time_ms)
+            ? final_result.total_time_ms - final_result.time_to_first_token_ms
+            : final_result.total_time_ms;
+    if (vlm_decode_ms > 0) {
         final_result.tokens_per_second = static_cast<float>(final_result.completion_tokens) /
-                                         (static_cast<float>(final_result.total_time_ms) / 1000.0f);
+                                         (static_cast<float>(vlm_decode_ms) / 1000.0f);
     }
 
     if (complete_callback) {
@@ -1029,6 +1040,7 @@ rac_result_t check_lifecycle_model(const runanywhere::v1::VLMGenerationRequest& 
 struct StreamCtx {
     std::string text;
     int32_t token_count{0};
+    int64_t ttft_ms{0};
 };
 
 void populate_result_from_stream(const StreamCtx& ctx, int64_t elapsed_ms,
@@ -1038,11 +1050,21 @@ void populate_result_from_stream(const StreamCtx& ctx, int64_t elapsed_ms,
     out->mutable_usage()->set_total_tokens(ctx.token_count);
     // processing_time_ms renamed to total_time_ms.
     out->set_total_time_ms(elapsed_ms);
-    if (elapsed_ms > 0) {
-        // TokenUsage has no tokens_per_second field; decode_tokens_per_second
-        // is the decode-phase-only throughput this maps onto.
+    if (ctx.ttft_ms > 0) {
+        out->mutable_usage()->set_ttft_ms(ctx.ttft_ms);
+    }
+    // Rate over the decode window, not the whole span. The field is
+    // decode_tokens_per_second, and llm_module.cpp states the reason: including
+    // prefill in the denominator systematically understates generation speed.
+    // For a VLM the prefill is the image encode, so the gap is wider here than
+    // for text. Falls back to the full span when the first-token time is
+    // unknown or not strictly inside it, which keeps a cancelled stream that
+    // produced no token reporting exactly what it did before.
+    const int64_t decode_ms =
+        (ctx.ttft_ms > 0 && ctx.ttft_ms < elapsed_ms) ? elapsed_ms - ctx.ttft_ms : elapsed_ms;
+    if (decode_ms > 0) {
         out->mutable_usage()->set_decode_tokens_per_second(
-            static_cast<double>(ctx.token_count) / (static_cast<double>(elapsed_ms) / 1000.0));
+            static_cast<double>(ctx.token_count) / (static_cast<double>(decode_ms) / 1000.0));
     }
 }
 
@@ -1054,6 +1076,9 @@ struct GeneratedStreamCtx {
     std::string text;
     int32_t token_count{0};
     int64_t started_ms{0};
+    // now_ms() of the first token that survived the sentinel filter, 0 until
+    // one does. Drives usage.ttft_ms and the decode window above.
+    int64_t first_token_ms{0};
     bool terminal_sent{false};
 
     // Per-stream sentinel filter; see vlm_stream_context::filter.
@@ -1137,6 +1162,9 @@ rac_bool_t generated_stream_token_trampoline(const char* token, void* user_data)
     if (!display.empty()) {
         ctx->text += display;
         ++ctx->token_count;
+        if (ctx->token_count == 1) {
+            ctx->first_token_ms = now_ms();
+        }
     }
 
     runanywhere::v1::SDKEvent event;
@@ -1450,8 +1478,11 @@ rac_result_t rac_vlm_stream_proto(const uint8_t* request_proto_bytes, size_t req
                            rc == RAC_ERROR_CANCELLED || rc == RAC_ERROR_STREAM_CANCELLED;
     if (cancelled) {
         runanywhere::v1::VLMResult result;
-        populate_result_from_stream(StreamCtx{.text = ctx.text, .token_count = ctx.token_count},
-                                    elapsed_ms, &result);
+        populate_result_from_stream(
+            StreamCtx{.text = ctx.text,
+                      .token_count = ctx.token_count,
+                      .ttft_ms = ctx.first_token_ms > 0 ? ctx.first_token_ms - ctx.started_ms : 0},
+            elapsed_ms, &result);
         dispatch_vlm_terminal_once(&ctx, runanywhere::v1::VLM_STREAM_EVENT_KIND_COMPLETED, &result,
                                    nullptr, 0);
         rc = RAC_SUCCESS;
@@ -1461,8 +1492,11 @@ rac_result_t rac_vlm_stream_proto(const uint8_t* request_proto_bytes, size_t req
         publish_failure(rc, "vlm.stream", rac_error_message(rc));
     } else {
         runanywhere::v1::VLMResult result;
-        populate_result_from_stream(StreamCtx{.text = ctx.text, .token_count = ctx.token_count},
-                                    elapsed_ms, &result);
+        populate_result_from_stream(
+            StreamCtx{.text = ctx.text,
+                      .token_count = ctx.token_count,
+                      .ttft_ms = ctx.first_token_ms > 0 ? ctx.first_token_ms - ctx.started_ms : 0},
+            elapsed_ms, &result);
         dispatch_vlm_terminal_once(&ctx, runanywhere::v1::VLM_STREAM_EVENT_KIND_COMPLETED, &result,
                                    nullptr, 0);
         const std::string vlm_stream_res =

--- a/core/tests/test_advanced_modality_proto_abi.cpp
+++ b/core/tests/test_advanced_modality_proto_abi.cpp
@@ -783,12 +783,15 @@ int test_vlm_stream_decode_rate_excludes_prefill() {
 
     // And it is genuinely a different number from what the old arithmetic gave,
     // so the assertion above cannot pass on a tree that still divides by the
-    // whole span. Prefill is 400ms against a ~40ms decode, so the gap is wide
-    // enough that no runner jitter closes it.
+    // whole span. Strictly greater, not a multiple of it: the two rates differ
+    // by exactly the ttft pinned above, which makes this hold for any prefill a
+    // runner actually produces. A multiple would encode how loaded the machine
+    // was. On the old code ttft is 0, the window collapses to the span, and the
+    // two rates are equal, so this still fails there.
     const double whole_span_rate =
         static_cast<double>(kDecodeTokens) / (static_cast<double>(total_ms) / 1000.0);
-    CHECK(usage.decode_tokens_per_second() > whole_span_rate * 3.0,
-          "the decode-window rate is well clear of the whole-span rate");
+    CHECK(usage.decode_tokens_per_second() > whole_span_rate,
+          "the decode-window rate is above the whole-span rate");
 
     unload_mock_vlm("mock-vlm-decode-rate", registry);
     return 0;

--- a/core/tests/test_advanced_modality_proto_abi.cpp
+++ b/core/tests/test_advanced_modality_proto_abi.cpp
@@ -5,6 +5,7 @@
 
 #include <atomic>
 #include <chrono>
+#include <cmath>
 #include <cstdio>
 #include <cstring>
 #include <exception>
@@ -191,6 +192,39 @@ rac_result_t dummy_vlm_stream(void*, const rac_vlm_image_t*, const char*, const 
         return RAC_ERROR_CANCELLED;
     if (callback(" vision", user_data) != RAC_TRUE)
         return RAC_ERROR_CANCELLED;
+    return RAC_SUCCESS;
+}
+
+// Milliseconds spent before the first token, standing in for the image encode.
+// Large relative to the decode burst below so the two windows cannot be
+// confused by scheduler jitter on a loaded runner.
+constexpr int64_t kPrefillMs = 400;
+constexpr int64_t kDecodeGapMs = 10;
+constexpr int kDecodeTokens = 4;
+
+rac_result_t slow_prefill_vlm_stream(void*, const rac_vlm_image_t*, const char*,
+                                     const rac_vlm_options_t*, rac_vlm_stream_callback_fn callback,
+                                     void* user_data) {
+    if (!callback)
+        return RAC_ERROR_NULL_POINTER;
+    std::this_thread::sleep_for(std::chrono::milliseconds(kPrefillMs));
+    for (int i = 0; i < kDecodeTokens; ++i) {
+        if (callback("tok ", user_data) != RAC_TRUE)
+            return RAC_ERROR_CANCELLED;
+        // Decode has to be measurable in whole milliseconds. A tight loop puts
+        // the first token in the same millisecond as the last, and the guard
+        // that requires ttft strictly inside the span then falls back to the
+        // full span for a reason that has nothing to do with the arithmetic.
+        std::this_thread::sleep_for(std::chrono::milliseconds(kDecodeGapMs));
+    }
+    return RAC_SUCCESS;
+}
+
+rac_result_t silent_vlm_stream(void*, const rac_vlm_image_t*, const char*, const rac_vlm_options_t*,
+                               rac_vlm_stream_callback_fn callback, void* user_data) {
+    (void)callback;
+    (void)user_data;
+    std::this_thread::sleep_for(std::chrono::milliseconds(20));
     return RAC_SUCCESS;
 }
 
@@ -628,6 +662,168 @@ int test_vlm_process_stream_events() {
     (void)rac_plugin_unregister("llamacpp");
     rac_model_registry_destroy(stream_registry);
 
+    return 0;
+}
+
+// Stand up a lifecycle-loaded mock VLM under the given stream op and hand back
+// the registry so the caller can tear it down. Everything here mirrors the
+// setup in test_vlm_process_stream_events; only the stream op varies.
+rac_model_registry_handle_t load_mock_vlm(const char* model_id, rac_vlm_service_ops_t* ops,
+                                          rac_engine_vtable_t* vtable) {
+    auto root = temp_root(model_id);
+    auto model_path = root / "model.gguf";
+    write_file(model_path, "GGUFmodel");
+
+    *vtable = make_vtable("llamacpp", nullptr, nullptr, ops);
+    (void)rac_plugin_unregister("llamacpp");
+    CHECK(rac_plugin_register(vtable) == RAC_SUCCESS, "decode-rate test plugin registers");
+
+    rac_model_registry_handle_t registry = nullptr;
+    CHECK(rac_model_registry_create(&registry) == RAC_SUCCESS && registry != nullptr,
+          "decode-rate test registry creates");
+
+    runanywhere::v1::ModelInfo model;
+    model.set_id(model_id);
+    model.set_name(model_id);
+    model.set_category(runanywhere::v1::MODEL_CATEGORY_MULTIMODAL);
+    model.set_format(runanywhere::v1::MODEL_FORMAT_GGUF);
+    model.set_framework(runanywhere::v1::INFERENCE_FRAMEWORK_LLAMA_CPP);
+    model.set_local_path(model_path.string());
+    model.set_registry_status(runanywhere::v1::MODEL_REGISTRY_STATUS_DOWNLOADED);
+    model.set_is_available(true);
+    std::vector<uint8_t> model_bytes;
+    CHECK(serialize(model, &model_bytes), "decode-rate ModelInfo serializes");
+    CHECK(rac_model_registry_register_proto(registry, model_bytes.data(), model_bytes.size()) ==
+              RAC_SUCCESS,
+          "decode-rate model registers");
+
+    runanywhere::v1::ModelLoadRequest load;
+    load.set_model_id(model_id);
+    std::vector<uint8_t> load_bytes;
+    CHECK(serialize(load, &load_bytes), "decode-rate ModelLoadRequest serializes");
+    rac_proto_buffer_t out;
+    rac_proto_buffer_init(&out);
+    runanywhere::v1::ModelLoadResult load_result;
+    CHECK(rac_model_lifecycle_load_proto(registry, load_bytes.data(), load_bytes.size(), &out) ==
+                  RAC_SUCCESS &&
+              parse_buffer(out, &load_result) && !load_result.has_error(),
+          "decode-rate lifecycle load succeeds");
+    rac_proto_buffer_free(&out);
+    return registry;
+}
+
+void unload_mock_vlm(const char* model_id, rac_model_registry_handle_t registry) {
+    runanywhere::v1::ModelUnloadRequest unload;
+    unload.set_model_id(model_id);
+    unload.set_category(runanywhere::v1::MODEL_CATEGORY_MULTIMODAL);
+    std::vector<uint8_t> unload_bytes;
+    CHECK(serialize(unload, &unload_bytes), "decode-rate unload serializes");
+    rac_proto_buffer_t out;
+    rac_proto_buffer_init(&out);
+    (void)rac_model_lifecycle_unload_proto(unload_bytes.data(), unload_bytes.size(), &out);
+    rac_proto_buffer_free(&out);
+    (void)rac_plugin_unregister("llamacpp");
+    rac_model_registry_destroy(registry);
+}
+
+std::vector<uint8_t> vlm_stream_request_bytes(const char* request_id) {
+    runanywhere::v1::VLMImage image;
+    image.set_file_path("/tmp/test-image.png");
+    runanywhere::v1::LLMGenerationOptions options;
+    options.set_max_output_tokens(16);
+
+    runanywhere::v1::VLMGenerationRequest request;
+    request.set_request_id(request_id);
+    request.set_prompt("describe");
+    *request.add_images() = image;
+    *request.mutable_options() = options;
+    std::vector<uint8_t> bytes;
+    CHECK(serialize(request, &bytes), "decode-rate VLMGenerationRequest serializes");
+    return bytes;
+}
+
+// The streaming path used to rate throughput over the whole request span, so
+// the image encode sat in the denominator of a field named
+// decode_tokens_per_second. It also never recorded a first-token time, so
+// usage.ttft_ms was 0 for every streamed VLM generation.
+int test_vlm_stream_decode_rate_excludes_prefill() {
+    rac_sdk_event_clear_queue();
+
+    rac_vlm_service_ops_t ops = make_vlm_ops();
+    ops.process_stream = slow_prefill_vlm_stream;
+    rac_engine_vtable_t vtable{};
+    auto registry = load_mock_vlm("mock-vlm-decode-rate", &ops, &vtable);
+
+    const auto request_bytes = vlm_stream_request_bytes("vlm-decode-rate");
+    StreamCapture capture;
+    CHECK(rac_vlm_stream_proto(request_bytes.data(), request_bytes.size(), vlm_stream_capture,
+                               &capture) == RAC_SUCCESS,
+          "decode-rate stream succeeds");
+
+    runanywhere::v1::VLMStreamEvent terminal;
+    CHECK(!capture.events.empty() &&
+              terminal.ParseFromArray(capture.events.back().data(),
+                                      static_cast<int>(capture.events.back().size())) &&
+              terminal.kind() == runanywhere::v1::VLM_STREAM_EVENT_KIND_COMPLETED,
+          "decode-rate stream ends with COMPLETED");
+
+    const auto& usage = terminal.result().usage();
+    const int64_t total_ms = terminal.result().total_time_ms();
+    CHECK(usage.total_tokens() == kDecodeTokens, "decode-rate stream counts every token");
+    CHECK(usage.ttft_ms() >= kPrefillMs, "decode-rate stream publishes a real ttft_ms");
+    CHECK(usage.ttft_ms() < total_ms, "ttft_ms stays inside the request span");
+
+    // Both numbers come off the same result, so the expected rate is exact
+    // rather than a tolerance on wall-clock: the assertion pins the formula,
+    // not the machine it ran on.
+    const double decode_window_s = static_cast<double>(total_ms - usage.ttft_ms()) / 1000.0;
+    const double expected_rate = static_cast<double>(kDecodeTokens) / decode_window_s;
+    CHECK(std::fabs(usage.decode_tokens_per_second() - expected_rate) < expected_rate * 1e-6,
+          "decode_tokens_per_second is rated over the decode window");
+
+    // And it is genuinely a different number from what the old arithmetic gave,
+    // so the assertion above cannot pass on a tree that still divides by the
+    // whole span. Prefill is 400ms against a ~40ms decode, so the gap is wide
+    // enough that no runner jitter closes it.
+    const double whole_span_rate =
+        static_cast<double>(kDecodeTokens) / (static_cast<double>(total_ms) / 1000.0);
+    CHECK(usage.decode_tokens_per_second() > whole_span_rate * 3.0,
+          "the decode-window rate is well clear of the whole-span rate");
+
+    unload_mock_vlm("mock-vlm-decode-rate", registry);
+    return 0;
+}
+
+// A stream that produces no token has no decode window to rate over. The
+// fallback must leave it reporting exactly what it did before rather than
+// dividing by a window it never measured.
+int test_vlm_stream_without_tokens_falls_back() {
+    rac_sdk_event_clear_queue();
+
+    rac_vlm_service_ops_t ops = make_vlm_ops();
+    ops.process_stream = silent_vlm_stream;
+    rac_engine_vtable_t vtable{};
+    auto registry = load_mock_vlm("mock-vlm-silent", &ops, &vtable);
+
+    const auto request_bytes = vlm_stream_request_bytes("vlm-silent");
+    StreamCapture capture;
+    CHECK(rac_vlm_stream_proto(request_bytes.data(), request_bytes.size(), vlm_stream_capture,
+                               &capture) == RAC_SUCCESS,
+          "tokenless stream succeeds");
+
+    runanywhere::v1::VLMStreamEvent terminal;
+    CHECK(!capture.events.empty() &&
+              terminal.ParseFromArray(capture.events.back().data(),
+                                      static_cast<int>(capture.events.back().size())) &&
+              terminal.kind() == runanywhere::v1::VLM_STREAM_EVENT_KIND_COMPLETED,
+          "tokenless stream ends with COMPLETED");
+
+    const auto& usage = terminal.result().usage();
+    CHECK(usage.total_tokens() == 0, "tokenless stream reports no tokens");
+    CHECK(usage.ttft_ms() == 0, "tokenless stream leaves ttft_ms unset");
+    CHECK(usage.decode_tokens_per_second() == 0.0, "tokenless stream reports no decode rate");
+
+    unload_mock_vlm("mock-vlm-silent", registry);
     return 0;
 }
 
@@ -1754,6 +1950,8 @@ int main() {
     try {
         test_missing_component_and_parse_error();
         test_vlm_process_stream_events();
+        test_vlm_stream_decode_rate_excludes_prefill();
+        test_vlm_stream_without_tokens_falls_back();
         test_vlm_companion_resolution();
         test_embeddings_mocked_result();
         test_embeddings_options_mapping();


### PR DESCRIPTION
This is the same metric the Kotlin fix (#634) corrected, found one layer down in commons itself. Both VLM paths were affected; see the comment below for the non-streaming half added after opening.

## What is wrong

`populate_result_from_stream` rates the throughput over the whole request span:

```cpp
out->set_total_time_ms(elapsed_ms);
if (elapsed_ms > 0) {
    // TokenUsage has no tokens_per_second field; decode_tokens_per_second
    // is the decode-phase-only throughput this maps onto.
    out->mutable_usage()->set_decode_tokens_per_second(
        static_cast<double>(ctx.token_count) / (static_cast<double>(elapsed_ms) / 1000.0));
}
```

`elapsed_ms` is `now_ms() - ctx.started_ms`, measured from before `process_stream`, so prefill is inside the denominator of a field named `decode_tokens_per_second`. The comment above it concedes the mapping rather than the arithmetic, which is what makes it easy to miss.

## Why that is wrong

`llm_module.cpp` excludes prefill from this metric deliberately and states why:

```cpp
// Tokens/sec over decode time only — including prefill (TTFT) in the
// denominator systematically understates generation speed.
```

So the two modules in the same library disagree about what the same field means, and the LLM one is the definition every SDK was pointed at. For a VLM the prefill is the image encode rather than a text prompt, so the understatement is larger here than the text case that motivated the original rule.

There is a second, quieter half. `GeneratedStreamCtx` never recorded a first-token time, so `usage.ttft_ms` stayed 0 on this path, while the telemetry a few lines below reads `result.usage().ttft_ms()` (`vlm_module.cpp:1321`, `:1477`) and therefore reported 0 for every streamed VLM generation.

## What this does

- Records `first_token_ms` for the first token that survives the sentinel filter. The trampoline already distinguishes that token to emit `GENERATION_EVENT_KIND_FIRST_TOKEN_GENERATED`, so this reuses the existing point rather than adding a second notion of "first".
- Publishes it as `usage.ttft_ms`.
- Rates the throughput over `elapsed_ms - ttft_ms`.

Falls back to the full span when the first-token time is unknown or is not strictly inside the span, so a cancelled stream that produced no token reports exactly what it reported before. Both call sites, the cancelled and the completed one, go through the same helper.

## Scope

Only the streaming path. The non-streaming path already tracks `first_token_time` separately (`vlm_module.cpp:527-528`, `:562-564`) and sets `time_to_first_token_ms` from it, so it was already honest about the distinction; this brings the streaming path in line rather than changing that one.

## Testing

Built and run locally on macOS with `-DRAC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug`:

- `test_core --run-all` — exit 0, `18 passed, 0 failed, 18 total`
- `test_vlm_options_defaults` — exit 0, `vlm option default tests passed`
- `test_llm_stream_proto` — exit 0, `0 test(s) failed`

Being explicit about what those do and do not cover: they exercise the surrounding proto and options surface, not the streaming rate arithmetic itself, which has no test today. I did not add one, because reaching `populate_result_from_stream` means driving `ref.ops->process_stream` through a fake VLM engine and controlling the clock, which is a fair amount of scaffolding. Happy to add it if you would rather the arithmetic were pinned.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Streaming results now include time-to-first-token metrics.
  * Added decode throughput calculations based on the interval after the first token.
  * Added accurate metrics for streams with delayed prefill.

* **Bug Fixes**
  * Timing and usage data now appear for completed and cancelled streams.
  * Added fallback throughput calculations when first-token timing is unavailable.
  * Corrected token and throughput reporting for streams that produce no tokens.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
