### PR TITLE
fix(flutter,electron): stop the podspecs fetching a release that does not exist

### DIFF
--- a/bindings/electron/package-lock.json
+++ b/bindings/electron/package-lock.json
@@ -30,19 +30,15 @@
         "node": ">=20"
       },
       "peerDependencies": {
-        "@runanywhere/proto-ts": "^0.20.16"
+        "@runanywhere/proto-ts": "^0.20.20"
       }
     },
     "node_modules/@bufbuild/protobuf": {
       "version": "2.13.0",
-      "resolved": "https://registry.npmjs.org/@bufbuild/protobuf/-/protobuf-2.13.0.tgz",
-      "integrity": "sha512-acq7c49vxfm1ggJ95P70TX7ABDM0vxr1SYD3BB0o0jnBLB4OAqeHyKuN+cD3w80gXEDQ2zxHpR6CUeA+O/aU9g==",
       "license": "(Apache-2.0 AND BSD-3-Clause)"
     },
     "node_modules/@electron-internal/extract-zip": {
       "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@electron-internal/extract-zip/-/extract-zip-1.0.4.tgz",
-      "integrity": "sha512-Zr1Vs7E9tpCNhZHDAbFVXc2gEVCG9RqPDjrno5+bdgB6LRAuvgyMHJut4NCVyYwtAieapMzc3fiQ3CSTi75ARg==",
       "dev": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -51,8 +47,6 @@
     },
     "node_modules/@electron/get": {
       "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@electron/get/-/get-5.0.0.tgz",
-      "integrity": "sha512-pjoBpru1KdEtcExBnuHAP1cAc/5faoedw0hzJkL3o4/IJp7HNF1+fbrdxT3gMYRX2oJfvnA/WXeCTVQpYYxyJA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -71,7 +65,7 @@
       }
     },
     "node_modules/@runanywhere/proto-ts": {
-      "version": "0.20.14",
+      "version": "0.20.20",
       "resolved": "file:../proto-ts",
       "license": "SEE LICENSE IN LICENSE",
       "dependencies": {
@@ -80,8 +74,6 @@
     },
     "node_modules/@types/node": {
       "version": "22.20.1",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
-      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -90,8 +82,6 @@
     },
     "node_modules/debug": {
       "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -108,8 +98,6 @@
     },
     "node_modules/electron": {
       "version": "43.1.1",
-      "resolved": "https://registry.npmjs.org/electron/-/electron-43.1.1.tgz",
-      "integrity": "sha512-I5c5vfuVvaXpWx3IZdwvXgxQW44+e7OP1wXGVQkogLeSFSkUZ6sLCcWV05AdEcs65AO5tAIJJwbp7ixw+LdarA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -127,8 +115,6 @@
     },
     "node_modules/electron/node_modules/@types/node": {
       "version": "24.13.3",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
-      "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -137,15 +123,11 @@
     },
     "node_modules/electron/node_modules/undici-types": {
       "version": "7.18.2",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
-      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/env-paths": {
       "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-3.0.0.tgz",
-      "integrity": "sha512-dtJUTepzMW3Lm/NPxRf3wP4642UWhjL2sQxc+ym2YMj1m/H2zDNQOlezafzkHwn6sMstjHTwG6iQQsctDW/b1A==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -157,22 +139,16 @@
     },
     "node_modules/graceful-fs": {
       "version": "4.2.11",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
-      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true,
       "license": "ISC"
     },
     "node_modules/ms": {
       "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/progress": {
       "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -181,8 +157,6 @@
     },
     "node_modules/semver": {
       "version": "7.8.5",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
-      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -194,8 +168,6 @@
     },
     "node_modules/sumchecker": {
       "version": "3.0.1",
-      "resolved": "https://registry.npmjs.org/sumchecker/-/sumchecker-3.0.1.tgz",
-      "integrity": "sha512-MvjXzkz/BOfyVDkG0oFOtBxHX2u3gKbMHIF/dXblZsgD3BWOFLmHovIpZY7BykJdAjcqRCBi1WYBNdEC9yI7vg==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -207,8 +179,6 @@
     },
     "node_modules/typescript": {
       "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -221,8 +191,6 @@
     },
     "node_modules/undici": {
       "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-7.28.0.tgz",
-      "integrity": "sha512-cRZYrTDwWznlnRiPjggAGxZXanty6M8RV1ff8Wm4LWXBp7/IG8v5DnOm74DtUBp9OONpK75YlPnIjQqX0dBDtA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -232,8 +200,6 @@
     },
     "node_modules/undici-types": {
       "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
       "dev": true,
       "license": "MIT"
     }

--- a/bindings/flutter/packages/runanywhere/ios/runanywhere.podspec
+++ b/bindings/flutter/packages/runanywhere/ios/runanywhere.podspec
@@ -21,6 +21,12 @@ end
 Pod::Spec.new do |s|
   s.name             = 'runanywhere'
   s.version          = '0.20.20'
+  # TEMP: iOS archives are downloaded from the v#{asset_version} GitHub release.
+  # s.version leads the published release because 0.20.20 republished only the
+  # Electron npm packages -- no v0.20.20 tag or iOS archives were ever cut, and
+  # the checksums below are still the 0.20.19 ones. Bump this back to
+  # s.version once a matching release exists.
+  asset_version      = '0.20.19'
   s.summary          = 'RunAnywhere: Privacy-first, on-device AI SDK for Flutter'
   s.description      = <<-DESC
 Privacy-first, on-device AI SDK for Flutter. This package provides the core
@@ -64,7 +70,7 @@ download_xcframework() {
   fi
   [ ! -e "$destination" ] || fail "$destination exists but is not an XCFramework directory"
 
-  archive_url="$release_base_url/v#{s.version}/$name-ios-v#{s.version}.zip"
+  archive_url="$release_base_url/v#{asset_version}/$name-ios-v#{asset_version}.zip"
   case "$archive_url" in
     https://*|file://*) ;;
     *) fail "unsupported release URL: $archive_url" ;;

--- a/bindings/flutter/packages/runanywhere_llamacpp/ios/runanywhere_llamacpp.podspec
+++ b/bindings/flutter/packages/runanywhere_llamacpp/ios/runanywhere_llamacpp.podspec
@@ -21,6 +21,12 @@ end
 Pod::Spec.new do |s|
   s.name             = 'runanywhere_llamacpp'
   s.version          = '0.20.20'
+  # TEMP: iOS archives are downloaded from the v#{asset_version} GitHub release.
+  # s.version leads the published release because 0.20.20 republished only the
+  # Electron npm packages -- no v0.20.20 tag or iOS archives were ever cut, and
+  # the checksums below are still the 0.20.19 ones. Bump this back to
+  # s.version once a matching release exists.
+  asset_version      = '0.20.19'
   s.summary          = 'RunAnywhere LlamaCPP: LLM text generation for Flutter'
   s.description      = <<-DESC
 LlamaCPP backend for RunAnywhere Flutter SDK. Provides LLM text generation
@@ -61,7 +67,7 @@ download_xcframework() {
   fi
   [ ! -e "$destination" ] || fail "$destination exists but is not an XCFramework directory"
 
-  archive_url="$release_base_url/v#{s.version}/$name-ios-v#{s.version}.zip"
+  archive_url="$release_base_url/v#{asset_version}/$name-ios-v#{asset_version}.zip"
   case "$archive_url" in
     https://*|file://*) ;;
     *) fail "unsupported release URL: $archive_url" ;;

--- a/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
+++ b/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
@@ -26,6 +26,12 @@ end
 Pod::Spec.new do |s|
   s.name             = 'runanywhere_mlx'
   s.version          = '0.20.20'
+  # TEMP: iOS archives are downloaded from the v#{asset_version} GitHub release.
+  # s.version leads the published release because 0.20.20 republished only the
+  # Electron npm packages -- no v0.20.20 tag or iOS archives were ever cut, and
+  # the checksums below are still the 0.20.19 ones. Bump this back to
+  # s.version once a matching release exists.
+  asset_version      = '0.20.19'
   s.summary          = 'RunAnywhere MLX backend for physical iOS devices'
   s.description      = <<-DESC
 Apple MLX backend for the RunAnywhere Flutter SDK. Provides on-device LLM,
@@ -119,7 +125,7 @@ download_archive() {
   asset_name="$1"
   expected_checksum="$2"
   archive="$work_root/$asset_name.zip"
-  archive_url="$release_base_url/v#{s.version}/$asset_name-ios-v#{s.version}.zip"
+  archive_url="$release_base_url/v#{asset_version}/$asset_name-ios-v#{asset_version}.zip"
   case "$archive_url" in
     https://*|file://*) ;;
     *) fail "unsupported release URL: $archive_url" ;;

--- a/bindings/flutter/packages/runanywhere_onnx/ios/runanywhere_onnx.podspec
+++ b/bindings/flutter/packages/runanywhere_onnx/ios/runanywhere_onnx.podspec
@@ -25,6 +25,12 @@ end
 Pod::Spec.new do |s|
   s.name             = 'runanywhere_onnx'
   s.version          = '0.20.20'
+  # TEMP: iOS archives are downloaded from the v#{asset_version} GitHub release.
+  # s.version leads the published release because 0.20.20 republished only the
+  # Electron npm packages -- no v0.20.20 tag or iOS archives were ever cut, and
+  # the checksums below are still the 0.20.19 ones. Bump this back to
+  # s.version once a matching release exists.
+  asset_version      = '0.20.19'
   s.summary          = 'RunAnywhere ONNX: STT, TTS, VAD for Flutter'
   s.description      = <<-DESC
 ONNX Runtime backend for RunAnywhere Flutter SDK. Provides speech-to-text (STT),
@@ -67,7 +73,7 @@ download_xcframework() {
   fi
   [ ! -e "$destination" ] || fail "$destination exists but is not an XCFramework directory"
 
-  archive_url="$release_base_url/v#{s.version}/$name-ios-v#{s.version}.zip"
+  archive_url="$release_base_url/v#{asset_version}/$name-ios-v#{asset_version}.zip"
   case "$archive_url" in
     https://*|file://*) ;;
     *) fail "unsupported release URL: $archive_url" ;;

--- a/scripts/validation/gates/check_release_version_coherence.sh
+++ b/scripts/validation/gates/check_release_version_coherence.sh
@@ -362,12 +362,25 @@ expect_count "bindings/flutter/packages/runanywhere/ios/runanywhere/Sources/runa
 expect_literal "bindings/flutter/packages/runanywhere_qhexrt/android/src/main/kotlin/ai/runanywhere/sdk/qhexrt/QhexrtPlugin.kt" \
   "private const val BACKEND_VERSION = \"${VERSION}\""
 
+# The podspecs carry TWO versions, and conflating them ships a dangling download.
+# `s.version` is the CocoaPods version and tracks the canonical release, but the
+# iOS archives are fetched from a GitHub release URL built from `asset_version`.
+# When the repo version leads the published assets — as it does whenever a release
+# republishes only some packages — an `s.version`-derived URL 404s, and the
+# checksums in the podspec still describe the OLDER archives anyway, because
+# sync-versions.sh deliberately never rewrites checksums. So asset_version must
+# track the SwiftPM pin (both name the last release that actually has assets).
 for podspec in \
   bindings/flutter/packages/runanywhere/ios/runanywhere.podspec \
   bindings/flutter/packages/runanywhere_llamacpp/ios/runanywhere_llamacpp.podspec \
   bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec \
   bindings/flutter/packages/runanywhere_onnx/ios/runanywhere_onnx.podspec; do
   expect_literal "${podspec}" "s.version          = '${VERSION}'"
+  expect_literal "${podspec}" "asset_version      = '${SPM_VERSION}'"
+  if grep -qF 'ios-v#{s.version}' "${REPO_ROOT}/${podspec}" 2>/dev/null; then
+    echo "[FAIL] ${podspec}: archive URL interpolates s.version; it must use asset_version so it points at a release that exists" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
 done
 
 for package_manifest in \


### PR DESCRIPTION
Addresses the two **Major** CodeRabbit findings on #695 that are genuine functional breaks.

## 1. Flutter podspecs 404 on `pod install`

All four podspecs built their iOS archive URL from `s.version`, which `sync-versions.sh` moved to `0.20.20`. **No `v0.20.20` tag or release assets were ever cut** — 0.20.20 republished only the Electron npm packages — so the URL resolves to a 404:

```
RunAnywhereMLXRuntime-ios-v0.20.20.zip -> HTTP 404
```

Doubly wrong: the checksums in those podspecs are still the **0.20.19** ones, because `sync-versions.sh` deliberately never rewrites checksums (that fail-closed design is what forces CI-built checksums into the tag). So even a hypothetical 0.20.20 asset would fail validation.

This was not theoretical — `validate_consumer_flutter` runs `flutter build ios --simulator`, so it would have broken CI on the next PR touching Flutter.

**Fix:** split the two concepts apart. `s.version` stays the canonical CocoaPods version (the coherence gate still pins it to `VERSION`); a new `asset_version` names the last release that actually has archives. This is the same escape hatch `Package.swift` already had via its `TEMP: pin to …` marker — the podspecs simply never got one.

## 2. `bindings/electron/package-lock.json` was six versions stale

It recorded `@runanywhere/proto-ts` at **0.20.14** while the manifest required 0.20.20. Root cause: the Electron SDK sets `install-links=true` so `file:../proto-ts` is *copied* rather than symlinked, and npm kept reusing a stale vendored copy under `node_modules`. Clearing that copy alone was not enough; the lock needed a clean regeneration.

Verified with `npm ci --dry-run` (exit 0, no EUSAGE).

## Gate learns both rules

`check_release_version_coherence.sh` now asserts:
- `asset_version` equals the SwiftPM pin (both name the last release with assets)
- an archive URL interpolating `s.version` is a **hard failure**

Verified by reverting one podspec URL and confirming the gate fails on exactly it, then restoring.

## Not addressed (deliberate)

CodeRabbit's other 7 findings ask to revert manifests/READMEs from 0.20.20 to 0.20.19. Those are the *normal* repo-ahead-of-registry state after any `sync-versions.sh` — the repo always leads the registries between releases, and 0.20.21 will reconcile them. Only the two above are functional breaks, because no v0.20.20 release will ever exist to catch up to.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed iOS package setup so release archives download from the correct available release, while preserving the published package version.
  * Maintained checksum validation and extraction for iOS framework assets.
  * Improved release validation to detect mismatched archive versions before publishing, reducing installation and integration failures across Flutter packages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->