### PR TITLE
fix(kotlin): fail closed when the JNI download cannot produce native libs

### DIFF
--- a/bindings/kotlin/build.gradle.kts
+++ b/bindings/kotlin/build.gradle.kts
@@ -550,6 +550,7 @@ tasks.register("downloadJniLibs") {
         tempDir.mkdirs()
 
         var totalDownloaded = 0
+        val downloadFailures = mutableListOf<String>()
 
         targetAbis.forEach { abi ->
             val abiOutputDir = file("$outputDir/$abi")
@@ -581,11 +582,38 @@ tasks.register("downloadJniLibs") {
 
                 tempZip.delete()
             } catch (e: Exception) {
-                logger.warn("Failed to download $packageName: ${e.message}")
+                // FAIL CLOSED. This used to be a bare logger.warn, which meant a 404
+                // (or any network error) produced an AAR with ZERO .so files, no build
+                // error, and — because the version marker was written unconditionally
+                // below — a cache entry that made every later build skip the download
+                // too. The result installs fine and dies at runtime with
+                // UnsatisfiedLinkError. That is exactly how empty backend AARs shipped
+                // before; a release must never be able to publish a native-less AAR.
+                downloadFailures += "$packageName: ${e.message}"
+                logger.error("Failed to download $packageName: ${e.message}")
             }
         }
 
         tempDir.deleteRecursively()
+
+        if (downloadFailures.isNotEmpty()) {
+            throw GradleException(
+                "downloadJniLibs failed for ${downloadFailures.size} archive(s) from $releaseBaseUrl:\n" +
+                    downloadFailures.joinToString("\n") { "  - $it" } +
+                    "\nCheck that the v$nativeLibVersion GitHub release exists and carries " +
+                    "$packageType-<abi>-v$nativeLibVersion.zip. Set runanywhere.nativeLibVersion " +
+                    "to a release that has assets, or build with -Prunanywhere.useLocalNatives=true.",
+            )
+        }
+        if (totalDownloaded == 0) {
+            throw GradleException(
+                "downloadJniLibs produced 0 .so files from $releaseBaseUrl. Refusing to write the " +
+                    "version marker: an AAR with no native libraries would install and then fail at " +
+                    "runtime with UnsatisfiedLinkError.",
+            )
+        }
+
+        // Only now is it safe to record the cache marker.
         nativeLibVersionMarker.parentFile.mkdirs()
         nativeLibVersionMarker.writeText(nativeLibVersion)
         logger.lifecycle("Commons JNI libs: $totalDownloaded .so files downloaded")

--- a/bindings/kotlin/gradle.properties
+++ b/bindings/kotlin/gradle.properties
@@ -11,7 +11,12 @@ racNdkVersion=27.3.13750724
 
 runanywhere.useLocalNatives=true
 runanywhere.rebuildCommons=false
-runanywhere.nativeLibVersion=0.20.20
+# This names the GitHub RELEASE whose android .so archives downloadJniLibs fetches
+# (build.gradle.kts builds releases/download/v$nativeLibVersion/RACommons-android-*),
+# NOT the package version. 0.20.20 republished only the Electron npm packages, so
+# no v0.20.20 tag or android archives exist and the download 404s. Keep this at the
+# last release that actually has assets; move it with the next real release train.
+runanywhere.nativeLibVersion=0.20.19
 
 # Enabled parallel sync for Gradle 9.4+
 org.gradle.tooling.parallel=true

--- a/scripts/validation/gates/check_release_version_coherence.sh
+++ b/scripts/validation/gates/check_release_version_coherence.sh
@@ -208,7 +208,19 @@ expect_exact_file "bindings/swift/VERSION" "${VERSION}"
 expect_literal "bindings/swift/Sources/RunAnywhere/Generated/Versions.swift" \
   "public static let sdkVersion = \"${VERSION}\""
 
-expect_literal "bindings/kotlin/gradle.properties" "runanywhere.nativeLibVersion=${VERSION}"
+# nativeLibVersion is an ASSET version, not a package version: build.gradle.kts
+# builds releases/download/v$nativeLibVersion/RACommons-android-*.zip from it. When
+# the repo version leads the published assets it must stay on the last release that
+# has them, exactly like the SwiftPM pin and the podspec asset_version.
+if grep -Fq -- "runanywhere.nativeLibVersion=${VERSION}" "${REPO_ROOT}/bindings/kotlin/gradle.properties"; then
+  :
+elif [ "${SPM_TEMP_PIN}" -eq 1 ] && \
+     grep -Fq -- "runanywhere.nativeLibVersion=${SPM_VERSION}" "${REPO_ROOT}/bindings/kotlin/gradle.properties"; then
+  echo "[OK] bindings/kotlin/gradle.properties pins nativeLibVersion ${SPM_VERSION} until v${VERSION} assets are published"
+else
+  echo "[FAIL] bindings/kotlin/gradle.properties: expected runanywhere.nativeLibVersion=${VERSION} (or ${SPM_VERSION} under the unpublished-assets pin)" >&2
+  FAILURES=$((FAILURES + 1))
+fi
 expect_literal "bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/foundation/constants/SDKConstants.kt" \
   "const val VERSION = \"${VERSION}\""
 for kotlin_publication in \


### PR DESCRIPTION
Found by a release-readiness audit run before cutting releases. One of these silently ships a native-less AAR.

## 1. `downloadJniLibs` swallowed failures and cached the result

```kotlin
} catch (e: Exception) {
    logger.warn("Failed to download $packageName: ${e.message}")   // swallowed
}
...
nativeLibVersionMarker.writeText(nativeLibVersion)   // written regardless
logger.lifecycle("Commons JNI libs: $totalDownloaded .so files downloaded")  // "0"
```

A 404 or a network timeout produced an AAR with **zero .so files, no build error**, and a cache marker that made every later build skip the download too. It installs fine and dies at runtime with `UnsatisfiedLinkError`. This is the mechanism behind the empty backend AARs seen previously.

Now: failures are collected and thrown naming each missing archive, the marker is written only on success, and 0 downloaded libs is itself a hard failure.

**It caught a real partial failure on its very first run** — the arm64-v8a archive (largest, and the primary Android ABI) timed out while the other two ABIs succeeded. The old code would have reported success and shipped an AAR with no arm64 natives.

## 2. `nativeLibVersion` pointed at a release that does not exist

`sync-versions.sh` moved it to 0.20.20, but 0.20.20 republished only the Electron npm packages — no v0.20.20 tag or android archives exist:

```
releases/download/v0.20.20/RACommons-android-arm64-v8a-v0.20.20.zip -> HTTP 404
releases/download/v0.20.19/RACommons-android-arm64-v8a-v0.20.19.zip -> HTTP 302
```

It is an **asset** version, not a package version — the third instance of that conflation this release (after `Package.swift`'s `sdkVersion` and the podspecs' `asset_version`). It now pins the last release with assets, and the coherence gate accepts it under the same unpublished-assets rule, so it cannot drift silently again.

## Verification

| case | result |
|---|---|
| `-Prunanywhere.nativeLibVersion=0.20.20` | build **fails**, names all 3 missing archives |
| `-Prunanywhere.nativeLibVersion=0.20.19` | 18 .so across 3 ABIs, marker written |
| `check_release_version_coherence.sh` | `[OK] ... pins nativeLibVersion 0.20.19 until v0.20.20 assets are published` |


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Native library downloads now report failures clearly after processing all supported architectures.
  * Builds fail when no native libraries are downloaded, preventing invalid success states.
  * Version markers are no longer saved after incomplete or failed downloads.
  * Release validation now supports approved temporary asset versions and provides clearer mismatch errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->