### PR TITLE
fix(windows): make the Electron native stack compile, link, and load on MSVC

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -308,6 +308,44 @@
             "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
         },
         {
+            "name": "electron-win-arm64",
+            "displayName": "Electron \u2014 Windows ARM64 thin addon (Hexagon NPU, QHexRT only)",
+            "description": "Option A packaging for Snapdragon X / X2 Elite: rac_commons.dll + runanywhere_qhexrt.dll + thin runanywhere_native.node, built ARM64-native. This is the NPU lane and it is mutually exclusive with electron-windows — QAIRT ships no QnnHtp*Stub for x86_64, so x64 can never reach the DSP, and the three CPU engines cannot compile for ARM64 (see the per-option comments). Requires an ARM64 Windows host and the ARM64 Native Tools prompt; MSVC's arm64_x64 cross toolset builds the OTHER lane, not this one. Pass, as electron-windows does, -DRAC_NODE_DEV_DIR=<node-gyp cache> and -DQHEXRT_ROOT=<engines/qhexrt/prebuilt/versions/<receipt>> (the global prebuilt/current symlink cannot name an Android and a Windows payload at once). RAC_DESKTOP_ADAPTER=ON needs libcurl and crypt32: crypt32 is a system library, but curl is not, so also pass -DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=arm64-windows-static after `vcpkg install curl:arm64-windows-static`. Without the adapter this lane has no HTTP transport at all — no model downloads, no telemetry, no auth.",
+            "inherits": "base-release",
+            "generator": "Visual Studio 17 2022",
+            "architecture": { "value": "ARM64", "strategy": "set" },
+            "cacheVariables": {
+                "RAC_BUILD_PLATFORM": "OFF",
+                "RAC_BUILD_SHARED": "ON",
+                "RAC_STATIC_PLUGINS": "OFF",
+                "RAC_BUILD_BACKENDS": "ON",
+                "RAC_BACKEND_QHEXRT": "ON",
+                "_comment_llamacpp": "ggml hard-errors 'MSVC is not supported for ARM, use clang' (ggml-cpu/CMakeLists.txt). Switching the toolset to ClangCL clears that but then Abseil fails instead (AbseilDll.cmake:745), so neither toolset builds it here yet.",
+                "RAC_BACKEND_LLAMACPP": "OFF",
+                "_comment_onnx": "cmake/FetchONNXRuntime.cmake selects its download by CMAKE_SIZEOF_VOID_P==8, which is TRUE on ARM64, so it would fetch the x64 ONNX Runtime and fail at link with LNK1112 (module machine type mismatch). There is no win-arm64 URL in it yet.",
+                "RAC_BACKEND_ONNX": "OFF",
+                "RAC_RUNTIME_ONNXRT": "OFF",
+                "RAC_BACKEND_SHERPA": "OFF",
+                "RAC_BACKEND_MLX": "OFF",
+                "RAC_BACKEND_NEURT": "OFF",
+                "_comment_rag": "Pulls protobuf + Abseil, which is the same Abseil that fails above.",
+                "RAC_BACKEND_RAG": "OFF",
+                "RAC_BUILD_SERVER": "OFF",
+                "RAC_DESKTOP_ADAPTER": "ON",
+                "RAC_BUILD_ELECTRON_ADDON": "ON",
+                "RAC_ELECTRON_THIN_ADDON": "ON",
+                "GGML_METAL": "OFF"
+            },
+            "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
+        },
+        {
+            "name": "electron-win-arm64-vs2026",
+            "displayName": "Electron \u2014 Windows ARM64 thin addon on the VS 2026 toolset",
+            "description": "Identical to electron-win-arm64 but pinned to Visual Studio 18 2026, for workstations that only have the newer toolset installed. Requires a CMake build that provides this generator (upstream CMake 4.2+). Note that this preset's binaryDir differs from electron-win-arm64's, so bindings/electron overlay tooling that hardcodes build/electron-win-arm64 needs RA_SDK_BUILD pointed here.",
+            "inherits": "electron-win-arm64",
+            "generator": "Visual Studio 18 2026"
+        },
+        {
             "name": "windows-arm64-release",
             "displayName": "Windows ARM64 \u2014 Release (Snapdragon X/X2 Elite, experimental)",
             "description": "Native ARM64 MSVC build for Snapdragon X / X2 Elite. The Electron addon links arm64/node.lib and the QHexRT engine looks for a lib/win-arm64 prebuilt. Add -DRAC_BACKEND_QHEXRT=ON (+ -DQHEXRT_ROOT=<path>) to link the NPU engine. The four backends turned OFF below CANNOT build on Windows ARM64 today and each fails at CONFIGURE time, so leaving them on would make this preset unusable rather than merely feature-poor — see the per-option comments. Re-enable one only after its upstream blocker is fixed, and MEASURE it.",
@@ -357,6 +395,8 @@
         { "name": "windows-release",  "configurePreset": "windows-release" },
         { "name": "electron-macos",   "configurePreset": "electron-macos" },
         { "name": "electron-windows", "configurePreset": "electron-windows", "configuration": "Release" },
+        { "name": "electron-win-arm64", "configurePreset": "electron-win-arm64", "configuration": "Release" },
+        { "name": "electron-win-arm64-vs2026", "configurePreset": "electron-win-arm64-vs2026", "configuration": "Release" },
         { "name": "windows-arm64-release", "configurePreset": "windows-arm64-release", "configuration": "Release" },
         { "name": "windows-arm64-release-vs2026", "configurePreset": "windows-arm64-release-vs2026", "configuration": "Release" }
     ],

--- a/bindings/electron/native/CMakeLists.txt
+++ b/bindings/electron/native/CMakeLists.txt
@@ -50,10 +50,22 @@ if(RAC_BUILD_ELECTRON_ADDON)
         # build resolves these via cmake-js (CMAKE_JS_INC / CMAKE_JS_LIB) instead.
         set(RAC_NODE_DEV_DIR "$ENV{LOCALAPPDATA}/node-gyp/Cache/24.15.0"
             CACHE PATH "node-gyp dev files dir (contains include/node + <arch>/node.lib)")
-        # node-gyp keys the import library by target arch, so an ARM64 addon must
+        # node-gyp keys the import library by TARGET arch, so an ARM64 addon must
         # link arm64/node.lib — x64/node.lib fails the link with LNK1112.
-        if(CMAKE_SYSTEM_PROCESSOR MATCHES "^([Aa][Rr][Mm]64|aarch64|AARCH64)$" OR
-           CMAKE_GENERATOR_PLATFORM MATCHES "^([Aa][Rr][Mm]64)$")
+        #
+        # Only the target matters here, never the host. CMAKE_GENERATOR_PLATFORM
+        # (-A) is authoritative when set: building the win32-x64 addon on an
+        # ARM64 workstation is a supported cross-compile (MSVC's arm64_x64
+        # toolset), and there CMAKE_SYSTEM_PROCESSOR still reports the ARM64
+        # HOST. Consulting it picked arm64/node.lib for an x64 target, which
+        # links with only a LNK4272 warning and then dies on 65 unresolved
+        # __imp_napi_* externals.
+        if(CMAKE_GENERATOR_PLATFORM)
+            set(_ra_node_target_arch "${CMAKE_GENERATOR_PLATFORM}")
+        else()
+            set(_ra_node_target_arch "${CMAKE_SYSTEM_PROCESSOR}")
+        endif()
+        if(_ra_node_target_arch MATCHES "^([Aa][Rr][Mm]64|aarch64|AARCH64)$")
             set(_ra_node_arch "arm64")
         else()
             set(_ra_node_arch "x64")

--- a/bindings/electron/native/addon.cpp
+++ b/bindings/electron/native/addon.cpp
@@ -32,6 +32,13 @@
 #endif
 
 #include "rac/core/rac_core.h"
+// RAC_LOG_* is used unconditionally (load_plugins_from_env), so it cannot ride
+// in on the desktop-adapter block below. Without this, a build with
+// RAC_DESKTOP_ADAPTER=OFF — the win-arm64 / QHexRT lane — still sees the
+// `rac_log_level_t` enum via rac_core.h but not the macro, so
+// `RAC_LOG_WARNING(...)` parses as a call on an enum constant and fails with
+// "C2064: term does not evaluate to a function taking 4 arguments".
+#include "rac/core/rac_logger.h"
 #include "rac/plugin/rac_plugin_loader.h"
 #ifdef RAC_HAVE_BACKEND_NEURT
 #include "rac/plugin/rac_plugin_entry.h"
@@ -80,7 +87,6 @@
 // (RAC_ELECTRON_HAVE_DESKTOP, set by native/CMakeLists.txt when
 // RAC_DESKTOP_ADAPTER=ON).
 #ifdef RAC_ELECTRON_HAVE_DESKTOP
-#include "rac/core/rac_logger.h"
 #include "rac/core/rac_sdk_state.h"
 #include "rac/desktop/rac_desktop.h"
 #include "rac/infrastructure/device/rac_device_identity.h"

--- a/bindings/electron/native/package-lock.json
+++ b/bindings/electron/native/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@runanywhere/electron-native",
-  "version": "0.1.0",
+  "version": "0.20.20",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@runanywhere/electron-native",
-      "version": "0.1.0",
+      "version": "0.20.20",
       "license": "SEE LICENSE IN ../../../LICENSE",
       "dependencies": {
         "node-addon-api": "^8.9.0",

--- a/bindings/electron/scripts/bundle-native.ts
+++ b/bindings/electron/scripts/bundle-native.ts
@@ -68,10 +68,19 @@ const winArm64 = win && process.arch === 'arm64';
 const platformArch = `${process.platform}-${process.arch}` as const;
 
 // One CMake preset per Windows architecture — the ARM64 build tree is separate
-// because the generator platform (and therefore node.lib) differs. macOS builds
-// through the macos-release preset; the plan's verified local tree is
-// build/electron-macos (fat) and build/electron-shared-macos (thin spike).
-const winPreset = winArm64 ? 'windows-arm64-release' : 'windows-release';
+// because the generator platform (and therefore node.lib) differs, and because
+// the two lanes carry disjoint engines (x64 has no Hexagon stub in QAIRT; ggml
+// and ONNX Runtime have no ARM64 Windows build).
+//
+// These MUST be the electron-* presets. `windows-release` and
+// `windows-arm64-release` both set RAC_BUILD_SHARED=OFF and leave
+// RAC_BUILD_ELECTRON_ADDON off, so they never emit runanywhere_native.node or
+// any plugin DLL at all: staging pointed at a tree that cannot contain what it
+// is looking for, reported nothing found, and every Windows package shipped
+// empty. macOS builds through the macos-release preset; the plan's verified
+// local tree is build/electron-macos (fat) and build/electron-shared-macos
+// (thin spike).
+const winPreset = winArm64 ? 'electron-win-arm64' : 'electron-windows';
 const nativeSubPath = path.join('bindings', 'electron', 'native');
 const macBuildDirs = [
   // Prefer the known-good fat tree for local apps; shared/thin is opt-in via

--- a/core/CMakeLists.txt
+++ b/core/CMakeLists.txt
@@ -1302,6 +1302,15 @@ if(WIN32)
     if(TARGET bz2_bundled)
         target_link_libraries(rac_commons PUBLIC bz2_bundled)
     endif()
+    # zlibstatic / bz2_bundled travel in this INTERFACE link line as BARE NAMES
+    # (libarchive's internal find_package stores them as plain strings — see the
+    # MSVC block above). `link_directories("${RAC_BUNDLED_LIB_DIR}")` there is
+    # DIRECTORY-scoped, so it reaches core/ and its children but not siblings
+    # like engines/ or bindings/. Every sibling consumer therefore inherited the
+    # bare name without the directory that resolves it and died on
+    # "LNK1181: cannot open input file 'bz2_bundled.lib'". Carry the search path
+    # on the INTERFACE that carries the names, so any consumer resolves both.
+    target_link_directories(rac_commons INTERFACE "${RAC_BUNDLED_LIB_DIR}")
 else()
     target_link_libraries(rac_commons PRIVATE archive_static)
 endif()

--- a/core/include/rac/plugin/rac_onnxrt_runtime_ep.h
+++ b/core/include/rac/plugin/rac_onnxrt_runtime_ep.h
@@ -81,7 +81,7 @@ typedef struct rac_onnxrt_ep_config {
  *     current ORT / platform build (caller should fall back to CPU).
  *   - `RAC_ERROR_INVALID_PARAMETER` on malformed config.
  */
-RAC_API rac_result_t
+RAC_PLUGIN_API rac_result_t
 rac_onnxrt_runtime_enable_execution_provider(const rac_onnxrt_ep_config_t* config);
 
 /**
@@ -90,7 +90,7 @@ rac_onnxrt_runtime_enable_execution_provider(const rac_onnxrt_ep_config_t* confi
  * `out` must not be NULL. Returns `RAC_ONNXRT_EP_CPU` when no EP has been
  * activated or activation was cleared.
  */
-RAC_API rac_result_t rac_onnxrt_runtime_get_active_ep(rac_onnxrt_ep_type_t* out);
+RAC_PLUGIN_API rac_result_t rac_onnxrt_runtime_get_active_ep(rac_onnxrt_ep_type_t* out);
 
 /**
  * Query whether an EP is compiled in for the current build.
@@ -98,7 +98,7 @@ RAC_API rac_result_t rac_onnxrt_runtime_get_active_ep(rac_onnxrt_ep_type_t* out)
  * Returns non-zero when the EP's ORT append path is wired up, zero otherwise.
  * Callers can use this to decide at runtime whether to attempt activation.
  */
-RAC_API int rac_onnxrt_runtime_ep_is_available(rac_onnxrt_ep_type_t type);
+RAC_PLUGIN_API int rac_onnxrt_runtime_ep_is_available(rac_onnxrt_ep_type_t type);
 
 /**
  * Map an EP type to its matching device class.
@@ -107,27 +107,27 @@ RAC_API int rac_onnxrt_runtime_ep_is_available(rac_onnxrt_ep_type_t type);
  * class when a non-CPU EP is active. Returns `RAC_DEVICE_CLASS_CPU` for
  * `RAC_ONNXRT_EP_CPU` and for any unrecognised value.
  */
-RAC_API rac_device_class_t rac_onnxrt_runtime_ep_device_class(rac_onnxrt_ep_type_t type);
+RAC_PLUGIN_API rac_device_class_t rac_onnxrt_runtime_ep_device_class(rac_onnxrt_ep_type_t type);
 
 /**
  * Probe whether the linked ORT build can append the WebGPU EP.
  * Returns non-zero only when SessionOptionsAppendExecutionProvider("WebGPU")
  * succeeds (compile-time RAC_ONNXRT_EP_WEBGPU_ENABLED alone is not enough).
  */
-RAC_API int rac_onnxrt_probe_webgpu_ep(void);
+RAC_PLUGIN_API int rac_onnxrt_probe_webgpu_ep(void);
 
 /**
  * Activate WebGPU when `prefer_webgpu != 0` and the probe succeeds; otherwise
  * activate CPU. Returns 1 when WebGPU is active, 0 for CPU.
  */
-RAC_API int rac_onnxrt_activate_preferred_wasm_ep(int prefer_webgpu);
+RAC_PLUGIN_API int rac_onnxrt_activate_preferred_wasm_ep(int prefer_webgpu);
 
 /**
  * NUL-terminated reason for the last failed `rac_onnxrt_probe_webgpu_ep` /
  * activate attempt. Empty string when the last probe succeeded or was never run.
  * Pointer is process-owned; valid until the next probe/activate call.
  */
-RAC_API const char* rac_onnxrt_last_webgpu_probe_error(void);
+RAC_PLUGIN_API const char* rac_onnxrt_last_webgpu_probe_error(void);
 
 #ifdef __cplusplus
 }

--- a/core/src/plugin/plugin_loader.cpp
+++ b/core/src/plugin/plugin_loader.cpp
@@ -37,7 +37,29 @@
 #if defined(_WIN32)
 #include <windows.h>
 using rac_lib_handle_t = HMODULE;
+/* A plugin's siblings (`rac_backend_<id>.dll`, `rac_commons.dll`, the
+ * onnxruntime / sherpa sidecars) are staged in the SAME directory as the
+ * plugin. Plain `LoadLibraryA` does NOT search that directory: the standard
+ * search order starts at the directory of the *executable* (electron.exe,
+ * node.exe), so every dependency beside the plugin is invisible and the load
+ * fails with ERROR_MOD_NOT_FOUND (126) — reported here only as the useless
+ * "LoadLibrary failed".
+ *
+ * `LOAD_WITH_ALTERED_SEARCH_PATH` replaces that first entry with the directory
+ * of the DLL being loaded, which is exactly the sidecar contract the Electron
+ * packaging already relies on (and what QHexRT's own platform::DynLib does).
+ * The flag is only meaningful for an absolute path, so fall back to the plain
+ * call otherwise rather than silently changing relative-path semantics. */
+static bool rac_path_is_absolute(const char* p) {
+    if (p == nullptr || p[0] == '\0')
+        return false;
+    if (p[0] == '\\' || p[0] == '/')
+        return true;
+    return p[1] == ':' && (p[2] == '\\' || p[2] == '/');
+}
 static rac_lib_handle_t rac_dl_open(const char* p) {
+    if (rac_path_is_absolute(p))
+        return LoadLibraryExA(p, nullptr, LOAD_WITH_ALTERED_SEARCH_PATH);
     return LoadLibraryA(p);
 }
 static void* rac_dl_sym(rac_lib_handle_t h, const char* s) {
@@ -46,8 +68,29 @@ static void* rac_dl_sym(rac_lib_handle_t h, const char* s) {
 static void rac_dl_close(rac_lib_handle_t h) {
     FreeLibrary(h);
 }
+/* Carry the Win32 error code: "module could not be found" (a missing sidecar)
+ * and "is not a valid Win32 application" (an arch mismatch) are different bugs
+ * and used to be indistinguishable in the log. */
 static const char* rac_dl_error() {
-    return "LoadLibrary failed";
+    static thread_local char buffer[256];
+    const DWORD code = GetLastError();
+    char* text = nullptr;
+    const DWORD len = FormatMessageA(
+        FORMAT_MESSAGE_ALLOCATE_BUFFER | FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_IGNORE_INSERTS,
+        nullptr, code, 0, reinterpret_cast<LPSTR>(&text), 0, nullptr);
+    if (len == 0 || text == nullptr) {
+        std::snprintf(buffer, sizeof(buffer), "LoadLibrary failed (error %lu)",
+                      static_cast<unsigned long>(code));
+    } else {
+        size_t trimmed = len;
+        while (trimmed > 0 && (text[trimmed - 1] == '\n' || text[trimmed - 1] == '\r'))
+            text[--trimmed] = '\0';
+        std::snprintf(buffer, sizeof(buffer), "LoadLibrary failed (error %lu: %s)",
+                      static_cast<unsigned long>(code), text);
+    }
+    if (text != nullptr)
+        LocalFree(text);
+    return buffer;
 }
 #else
 #include <dlfcn.h>

--- a/engines/onnx/CMakeLists.txt
+++ b/engines/onnx/CMakeLists.txt
@@ -147,7 +147,13 @@ endif()
 # Compose link libs + compile defs. ORT C API ownership lives in
 # runtimes/onnxrt; this engine uses only its thin session wrapper.
 set(ONNX_LINK_LIBS rac_runtime_onnxrt nlohmann_json::nlohmann_json)
-set(ONNX_COMPILE_DEFS RAC_ONNX_BUILDING RAC_HAS_ONNX)
+# FEATURE flags only — shared by rac_backend_onnx and the thin carrier, which
+# compile rac_plugin_entry_onnx.cpp from the same source and must agree on
+# macro state. RAC_ONNX_BUILDING is deliberately NOT here: it flips
+# RAC_ONNX_API to dllexport and belongs to the backend target alone (the
+# carrier needs the dllimport side to reach g_onnx_*_ops across the DLL
+# boundary). Same split as RAC_LLAMACPP_BUILDING in engines/llamacpp.
+set(ONNX_COMPILE_DEFS RAC_HAS_ONNX)
 # Propagate RAG state so rac_plugin_entry_onnx.cpp can NULL the embeddings
 # slot when onnx_embedding_provider.cpp is not compiled in (otherwise the
 # extern symbol g_onnx_embeddings_ops is unresolved at link time).
@@ -181,7 +187,7 @@ rac_add_engine_plugin(onnx
                         ${RAC_COMMONS_ROOT_DIR}/include/rac/backends
                         ${RAC_COMMONS_ROOT_DIR}/src
                         ${ONNX_EXTRA_INCLUDES}
-    COMPILE_DEFINITIONS ${ONNX_COMPILE_DEFS}
+    COMPILE_DEFINITIONS ${ONNX_COMPILE_DEFS} RAC_ONNX_BUILDING
     AVAILABILITY        PUBLIC
     PACKAGE_OWNER       runanywhere
     PACKAGE_NAME        rac_backend_onnx

--- a/engines/onnx/rac_onnx_api.h
+++ b/engines/onnx/rac_onnx_api.h
@@ -1,0 +1,37 @@
+/**
+ * @file rac_onnx_api.h
+ * @brief Export/import decoration for symbols the ONNX engine publishes to its
+ *        thin carrier.
+ *
+ * Peer of RAC_LLAMACPP_API in core/include/rac/backends/rac_llm_llamacpp.h.
+ *
+ * When building rac_backend_onnx.dll: dllexport / default visibility.
+ * When a shared consumer (the thin runanywhere_onnx carrier, JNI, tests) links
+ * that DLL on Windows: dllimport — MANDATORY for DATA symbols such as
+ * g_onnx_{embeddings,segmentation,diarization}_ops, because MSVC cannot fix up
+ * a cross-image data reference the way it can synthesize a function thunk.
+ * RAC_USING_SHARED is the INTERFACE define from shared rac_commons (the
+ * electron / desktop presets).
+ *
+ * RAC_ONNX_BUILDING must therefore be set on rac_backend_onnx ONLY — never on
+ * the carrier, which has to see the dllimport side.
+ */
+
+#ifndef RAC_ONNX_API_H
+#define RAC_ONNX_API_H
+
+#if defined(RAC_ONNX_BUILDING)
+#if defined(_WIN32)
+#define RAC_ONNX_API __declspec(dllexport)
+#elif defined(__GNUC__) || defined(__clang__)
+#define RAC_ONNX_API __attribute__((visibility("default")))
+#else
+#define RAC_ONNX_API
+#endif
+#elif defined(_WIN32) && defined(RAC_USING_SHARED)
+#define RAC_ONNX_API __declspec(dllimport)
+#else
+#define RAC_ONNX_API
+#endif
+
+#endif /* RAC_ONNX_API_H */

--- a/engines/onnx/rac_onnx_diarization_register.cpp
+++ b/engines/onnx/rac_onnx_diarization_register.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <new>
 
+#include "rac_onnx_api.h"
 #include "rac/features/diarization/rac_diarization_service.h"
 
 namespace {
@@ -122,7 +123,7 @@ rac_result_t create(const char* model_id, const char*, void** out_impl) {
 
 }  // namespace
 
-extern "C" const rac_diarization_service_ops_t g_onnx_diarization_ops = {
+extern "C" RAC_ONNX_API const rac_diarization_service_ops_t g_onnx_diarization_ops = {
     .initialize = initialize,
     .diarize = diarize,
     .stream_create = stream_create,

--- a/engines/onnx/rac_onnx_embeddings_register.cpp
+++ b/engines/onnx/rac_onnx_embeddings_register.cpp
@@ -17,6 +17,7 @@
 #include <string>
 #include <vector>
 
+#include "rac_onnx_api.h"
 #include "rac/backends/rac_embeddings_onnx.h"
 #include "rac/core/rac_error.h"
 #include "rac/core/rac_logger.h"
@@ -225,7 +226,7 @@ static rac_result_t onnx_embed_create_impl(const char* model_id, const char* con
 // to fill the unified g_onnx_engine_vtable.embedding_ops slot. Follows
 // the same pattern as g_onnx_{stt,tts,vad}_ops in the sibling
 // engines/onnx/rac_backend_onnx_register.cpp.
-extern "C" const rac_embeddings_service_ops_t g_onnx_embeddings_ops = {
+extern "C" RAC_ONNX_API const rac_embeddings_service_ops_t g_onnx_embeddings_ops = {
     .initialize = onnx_embed_vtable_initialize,
     .embed = onnx_embed_vtable_embed,
     .embed_batch = onnx_embed_vtable_embed_batch,

--- a/engines/onnx/rac_onnx_segmentation_register.cpp
+++ b/engines/onnx/rac_onnx_segmentation_register.cpp
@@ -5,6 +5,7 @@
 #include <memory>
 #include <new>
 
+#include "rac_onnx_api.h"
 #include "rac/features/segmentation/rac_segmentation_service.h"
 
 namespace {
@@ -78,7 +79,7 @@ rac_result_t create(const char* model_id, const char*, void** out_impl) {
 
 }  // namespace
 
-extern "C" const rac_segmentation_service_ops_t g_onnx_segmentation_ops = {
+extern "C" RAC_ONNX_API const rac_segmentation_service_ops_t g_onnx_segmentation_ops = {
     .initialize = initialize,
     .segment = segment,
     .cleanup = cleanup,

--- a/engines/onnx/rac_plugin_entry_onnx.cpp
+++ b/engines/onnx/rac_plugin_entry_onnx.cpp
@@ -9,6 +9,7 @@
 
 #include "rac_runtime_onnxrt.h"
 
+#include "rac_onnx_api.h"
 #include "rac/features/diarization/rac_diarization_service.h"
 #include "rac/features/embeddings/rac_embeddings_service.h"
 #include "rac/features/segmentation/rac_segmentation_service.h"
@@ -38,11 +39,14 @@ void* const volatile rac_onnxrt_runtime_anchor =
  * RAC_BACKEND_RAG is off, onnx_embedding_provider.cpp is not compiled
  * and the symbol is unresolved — the vtable slot stays nullptr below
  * to match. */
+/* RAC_ONNX_API → dllimport on Windows shared consumers. These are DATA
+ * symbols living in rac_backend_onnx.dll; without the import attribute the
+ * carrier link fails with LNK2001. */
 #if defined(RAC_BACKEND_RAG)
-extern const rac_embeddings_service_ops_t g_onnx_embeddings_ops;
+extern RAC_ONNX_API const rac_embeddings_service_ops_t g_onnx_embeddings_ops;
 #endif
-extern const rac_segmentation_service_ops_t g_onnx_segmentation_ops;
-extern const rac_diarization_service_ops_t g_onnx_diarization_ops;
+extern RAC_ONNX_API const rac_segmentation_service_ops_t g_onnx_segmentation_ops;
+extern RAC_ONNX_API const rac_diarization_service_ops_t g_onnx_diarization_ops;
 
 static const rac_runtime_id_t k_onnx_runtimes[] = {
     RAC_RUNTIME_ONNXRT,

--- a/engines/qhexrt/qhexrt_backend.h
+++ b/engines/qhexrt/qhexrt_backend.h
@@ -72,8 +72,19 @@ extern "C" {
  *
  * Lets tests assert the engine compiled against the expected QHexRT visibility
  * without pulling the private QHexRT header.
+ *
+ * RAC_PLUGIN_API is load-bearing, not decoration. QHexRT is the one engine that
+ * keeps WINDOWS_EXPORT_ALL_SYMBOLS off (it has no carrier to export data to), so
+ * on MSVC an undecorated marker is referenced by nothing and exported nowhere —
+ * the linker drops the function AND its string literal, and every consumer below
+ * silently loses its only routability signal on the one platform where the
+ * `g_qhexrt_*_ops` fallback cannot work either (single DLL, internal symbols,
+ * stripped from the PE). Exporting it makes the function a root that survives.
+ *
+ * Consumers: scripts/validation/gates/check_plugin_natives.py,
+ * scripts/release/prepublish_check.py, scripts/build/build-core-android.sh.
  */
-const char* qhexrt_backend_build_info(void);
+RAC_PLUGIN_API const char* qhexrt_backend_build_info(void);
 
 #ifdef __cplusplus
 }

--- a/engines/qhexrt/rac_plugin_entry_qhexrt.cpp
+++ b/engines/qhexrt/rac_plugin_entry_qhexrt.cpp
@@ -67,8 +67,9 @@ rac_result_t qhexrt_capability_check(void) {
 extern "C" {
 
 // Build marker (both modes) — lets tests assert engine visibility without the
-// private QHexRT header.
-const char* qhexrt_backend_build_info(void) {
+// private QHexRT header. Exported (see the declaration in qhexrt_backend.h):
+// on MSVC an unexported, unreferenced marker is discarded along with its string.
+RAC_PLUGIN_API const char* qhexrt_backend_build_info(void) {
 #if RAC_QHEXRT_ROUTABLE
     return "qhexrt:engine-available";
 #else

--- a/engines/sherpa/CMakeLists.txt
+++ b/engines/sherpa/CMakeLists.txt
@@ -449,7 +449,11 @@ rac_add_engine_plugin(sherpa
                         ${RAC_COMMONS_ROOT_DIR}/include/rac/backends
                         ${RAC_COMMONS_ROOT_DIR}/src
                         ${CMAKE_CURRENT_SOURCE_DIR}/..  # engines/ — for engines/common/*.h
-    COMPILE_DEFINITIONS ${SHERPA_COMPILE_DEFS}
+    # RAC_SHERPA_BUILDING is intentionally NOT in SHERPA_COMPILE_DEFS: that list
+    # is shared with the thin carrier (which must see RAC_SHERPA_API as
+    # dllimport to reach g_sherpa_*_ops across the DLL boundary), while this
+    # target is the one that defines and exports them.
+    COMPILE_DEFINITIONS ${SHERPA_COMPILE_DEFS} RAC_SHERPA_BUILDING
 )
 
 # Platform tweaks — hidden visibility handled by rac_add_engine_plugin when

--- a/engines/sherpa/rac_backend_sherpa_register.cpp
+++ b/engines/sherpa/rac_backend_sherpa_register.cpp
@@ -28,6 +28,7 @@
 #include "rac/infrastructure/model_management/rac_model_types.h"
 #include "rac/plugin/rac_plugin_entry.h"
 #include "rac/plugin/rac_plugin_entry_sherpa.h"
+#include "rac_sherpa_api.h"
 
 // =============================================================================
 // STT VTABLE IMPLEMENTATION
@@ -357,7 +358,7 @@ static rac_result_t sherpa_stt_vtable_stream_destroy(void* impl, rac_handle_t st
 // Offline models return RAC_ERROR_NOT_SUPPORTED from stream_create, preserving
 // commons' one-shot fallback. Online transducers keep one Sherpa stream across
 // chunks, emit deduplicated partials, and emit/reset a final at each endpoint.
-extern "C" const rac_stt_service_ops_t g_sherpa_stt_ops = {
+extern "C" RAC_SHERPA_API const rac_stt_service_ops_t g_sherpa_stt_ops = {
     .initialize = sherpa_stt_vtable_initialize,
     .transcribe = sherpa_stt_vtable_transcribe,
     .transcribe_stream = sherpa_stt_vtable_transcribe_stream,
@@ -449,7 +450,7 @@ static rac_result_t sherpa_tts_vtable_get_languages(void* impl, char** out_json)
 
 }  // namespace
 
-extern "C" const rac_tts_service_ops_t g_sherpa_tts_ops = {
+extern "C" RAC_SHERPA_API const rac_tts_service_ops_t g_sherpa_tts_ops = {
     .initialize = sherpa_tts_vtable_initialize,
     .synthesize = sherpa_tts_vtable_synthesize,
     .synthesize_stream = sherpa_tts_vtable_synthesize_stream,
@@ -517,7 +518,7 @@ RAC_DEFINE_CREATE_ADAPTER(vad, sherpa)
 
 }  // namespace
 
-extern "C" const rac_vad_service_ops_t g_sherpa_vad_ops = {
+extern "C" RAC_SHERPA_API const rac_vad_service_ops_t g_sherpa_vad_ops = {
     .process = sherpa_vad_vtable_process,
     .start = sherpa_vad_vtable_start,
     .stop = sherpa_vad_vtable_stop,

--- a/engines/sherpa/rac_plugin_entry_sherpa.cpp
+++ b/engines/sherpa/rac_plugin_entry_sherpa.cpp
@@ -19,6 +19,7 @@
 #include "rac/plugin/rac_engine_manifest.h"
 #include "rac/plugin/rac_engine_vtable.h"
 #include "rac/plugin/rac_plugin_entry.h"
+#include "rac_sherpa_api.h"
 
 #if defined(SHERPA_ONNX_AVAILABLE) && SHERPA_ONNX_AVAILABLE && \
     defined(RAC_SHERPA_SPEECH_OPS_AVAILABLE) && RAC_SHERPA_SPEECH_OPS_AVAILABLE
@@ -29,10 +30,13 @@
 
 extern "C" {
 
+/* RAC_SHERPA_API → dllimport on Windows shared consumers. These are DATA
+ * symbols living in rac_backend_sherpa.dll; without the import attribute the
+ * carrier link fails with LNK2001. */
 #if RAC_SHERPA_ROUTABLE
-extern const rac_stt_service_ops_t g_sherpa_stt_ops;
-extern const rac_tts_service_ops_t g_sherpa_tts_ops;
-extern const rac_vad_service_ops_t g_sherpa_vad_ops;
+extern RAC_SHERPA_API const rac_stt_service_ops_t g_sherpa_stt_ops;
+extern RAC_SHERPA_API const rac_tts_service_ops_t g_sherpa_tts_ops;
+extern RAC_SHERPA_API const rac_vad_service_ops_t g_sherpa_vad_ops;
 #endif
 
 static rac_result_t sherpa_capability_check(void) {

--- a/engines/sherpa/rac_sherpa_api.h
+++ b/engines/sherpa/rac_sherpa_api.h
@@ -1,0 +1,37 @@
+/**
+ * @file rac_sherpa_api.h
+ * @brief Export/import decoration for symbols the Sherpa engine publishes to
+ *        its thin carrier.
+ *
+ * Peer of RAC_LLAMACPP_API (core/include/rac/backends/rac_llm_llamacpp.h) and
+ * RAC_ONNX_API (engines/onnx/rac_onnx_api.h).
+ *
+ * When building rac_backend_sherpa.dll: dllexport / default visibility.
+ * When a shared consumer (the thin runanywhere_sherpa carrier, JNI, tests)
+ * links that DLL on Windows: dllimport — MANDATORY for DATA symbols such as
+ * g_sherpa_{stt,tts,vad}_ops, because MSVC cannot fix up a cross-image data
+ * reference the way it can synthesize a function thunk. RAC_USING_SHARED is
+ * the INTERFACE define from shared rac_commons (electron / desktop presets).
+ *
+ * RAC_SHERPA_BUILDING must therefore be set on rac_backend_sherpa ONLY — never
+ * on the carrier, which has to see the dllimport side.
+ */
+
+#ifndef RAC_SHERPA_API_H
+#define RAC_SHERPA_API_H
+
+#if defined(RAC_SHERPA_BUILDING)
+#if defined(_WIN32)
+#define RAC_SHERPA_API __declspec(dllexport)
+#elif defined(__GNUC__) || defined(__clang__)
+#define RAC_SHERPA_API __attribute__((visibility("default")))
+#else
+#define RAC_SHERPA_API
+#endif
+#elif defined(_WIN32) && defined(RAC_USING_SHARED)
+#define RAC_SHERPA_API __declspec(dllimport)
+#else
+#define RAC_SHERPA_API
+#endif
+
+#endif /* RAC_SHERPA_API_H */

--- a/runtimes/onnxrt/CMakeLists.txt
+++ b/runtimes/onnxrt/CMakeLists.txt
@@ -53,6 +53,15 @@ target_link_libraries(rac_runtime_onnxrt PUBLIC
     rac_commons
 )
 
+# These C ABI symbols live in this static archive, which is linked into the
+# runanywhere_onnx plugin DLL — not rac_commons.dll. Linking shared commons
+# injects RAC_USING_SHARED, so RAC_API becomes dllimport and MSVC rejects
+# defining those functions here (C2491). RAC_PLUGIN_API is dllexport only
+# when RAC_BUILDING_PLUGIN is set, matching rac_plugin_entry.h.
+if(WIN32 AND RAC_BUILD_SHARED)
+    target_compile_definitions(rac_runtime_onnxrt PRIVATE RAC_BUILDING_PLUGIN=1)
+endif()
+
 target_compile_definitions(rac_runtime_onnxrt PUBLIC RAC_HAS_ONNX)
 
 if(ANDROID OR RAC_PLATFORM_ANDROID)

--- a/runtimes/onnxrt/rac_runtime_onnxrt.cpp
+++ b/runtimes/onnxrt/rac_runtime_onnxrt.cpp
@@ -979,19 +979,19 @@ const rac_runtime_vtable_t* runtime_vtable() {
  * the C++ `Session::create` symbol, and only under RAC_BACKEND_RAG=ON), so a
  * RAG-off iOS/static build could strip the registrar and leave
  * `rac_runtime_is_registered(RAC_RUNTIME_ONNXRT)` returning 0. */
-extern "C" RAC_API rac_result_t rac_onnxrt_runtime_require_available(void) {
+extern "C" RAC_PLUGIN_API rac_result_t rac_onnxrt_runtime_require_available(void) {
     return rac_runtime_get_by_id(RAC_RUNTIME_ONNXRT) != nullptr ? RAC_SUCCESS
                                                                 : RAC_ERROR_BACKEND_UNAVAILABLE;
 }
 
-extern "C" RAC_API const rac_runtime_vtable_t* rac_runtime_entry_onnxrt(void) {
+extern "C" RAC_PLUGIN_API const rac_runtime_vtable_t* rac_runtime_entry_onnxrt(void) {
     return &k_onnxrt_vtable;
 }
 
 /* Execution-provider configuration surface. Real linkage is only
  * wired for CoreML today; other EPs accept activation but run on CPU until
  * their follow-up rows bring the ORT append paths online. */
-extern "C" RAC_API rac_result_t
+extern "C" RAC_PLUGIN_API rac_result_t
 rac_onnxrt_runtime_enable_execution_provider(const rac_onnxrt_ep_config_t* config) {
     if (config == nullptr)
         return RAC_ERROR_NULL_POINTER;
@@ -1002,31 +1002,31 @@ rac_onnxrt_runtime_enable_execution_provider(const rac_onnxrt_ep_config_t* confi
     return RAC_SUCCESS;
 }
 
-extern "C" RAC_API rac_result_t rac_onnxrt_runtime_get_active_ep(rac_onnxrt_ep_type_t* out) {
+extern "C" RAC_PLUGIN_API rac_result_t rac_onnxrt_runtime_get_active_ep(rac_onnxrt_ep_type_t* out) {
     if (out == nullptr)
         return RAC_ERROR_NULL_POINTER;
     *out = runanywhere::runtime::onnxrt::ep_state().snapshot(nullptr);
     return RAC_SUCCESS;
 }
 
-extern "C" RAC_API int rac_onnxrt_runtime_ep_is_available(rac_onnxrt_ep_type_t type) {
+extern "C" RAC_PLUGIN_API int rac_onnxrt_runtime_ep_is_available(rac_onnxrt_ep_type_t type) {
     return runanywhere::runtime::onnxrt::ep_is_compiled_in(type) ? 1 : 0;
 }
 
-extern "C" RAC_API rac_device_class_t
+extern "C" RAC_PLUGIN_API rac_device_class_t
 rac_onnxrt_runtime_ep_device_class(rac_onnxrt_ep_type_t type) {
     return runanywhere::runtime::onnxrt::ep_info(type).device_class;
 }
 
-extern "C" RAC_API int rac_onnxrt_probe_webgpu_ep(void) {
+extern "C" RAC_PLUGIN_API int rac_onnxrt_probe_webgpu_ep(void) {
     return runanywhere::runtime::onnxrt::probe_webgpu_ep();
 }
 
-extern "C" RAC_API int rac_onnxrt_activate_preferred_wasm_ep(int prefer_webgpu) {
+extern "C" RAC_PLUGIN_API int rac_onnxrt_activate_preferred_wasm_ep(int prefer_webgpu) {
     return runanywhere::runtime::onnxrt::activate_preferred_wasm_ep(prefer_webgpu);
 }
 
-extern "C" RAC_API const char* rac_onnxrt_last_webgpu_probe_error(void) {
+extern "C" RAC_PLUGIN_API const char* rac_onnxrt_last_webgpu_probe_error(void) {
     return runanywhere::runtime::onnxrt::last_webgpu_probe_error();
 }
 

--- a/runtimes/onnxrt/rac_runtime_onnxrt.h
+++ b/runtimes/onnxrt/rac_runtime_onnxrt.h
@@ -115,7 +115,7 @@ extern "C" {
  * Returns `RAC_SUCCESS` when the runtime is registered, else
  * `RAC_ERROR_BACKEND_UNAVAILABLE`.
  */
-rac_result_t rac_onnxrt_runtime_require_available(void);
+RAC_PLUGIN_API rac_result_t rac_onnxrt_runtime_require_available(void);
 
 #ifdef __cplusplus
 }

--- a/scripts/validation/gates/check_plugin_natives.py
+++ b/scripts/validation/gates/check_plugin_natives.py
@@ -109,6 +109,24 @@ DISPROOF: dict[str, tuple[str, ...]] = {
     "qhexrt": ("qhexrt:engine-unavailable", "g_qhexrt_unavailable_vtable"),
 }
 
+# Backends whose evidence is a string LITERAL in the binary rather than a symbol
+# NAME, and which therefore need the raw bytes even when a symbol dumper works.
+#
+# `nm`/`llvm-nm`/`dumpbin` report the symbol table. "qhexrt:engine-available" is
+# never in it — it is `.rodata` returned by qhexrt_backend_build_info(). So on
+# any host with a working dumper the marker would be absent from the dumper's
+# output and a perfectly routable QHexRT would be rejected. (This hid easily:
+# `nm` cannot read a PE, so a .dll checked on macOS falls through to the byte
+# scan and passes. `llvm-nm` CAN read COFF, so the same file fails the moment
+# LLVM is on PATH.)
+#
+# Scoped to literal contracts on purpose. Appending raw bytes for EVERY backend
+# would let a carrier satisfy its contract on a stray occurrence of an ops name
+# anywhere in the file — a debug string, an assertion — instead of on a real
+# symbol-table reference, which is precisely the stub detection this gate exists
+# to perform.
+LITERAL_CONTRACTS = frozenset({"qhexrt"})
+
 # Shared-library file name -> backend id. Mirrors entry_symbol_from_path() in
 # core/src/plugin/plugin_loader.cpp: strip `lib`, strip `runanywhere_`, strip
 # the extension. The plugin FILE NAME is a load-bearing contract (the loader
@@ -198,6 +216,9 @@ def check_plugin(path: Path, display: str) -> Finding | None:
         # An out-of-tree plugin we have no contract for. Not our call to fail.
         return None
     text, method = symbol_text(path)
+    if backend in LITERAL_CONTRACTS and method != "byte scan":
+        text = f"{text}\n{path.read_bytes().decode('latin-1')}"
+        method = f"{method} + byte scan"
     missing = [sym for sym in required if sym not in text]
     disproved = [sym for sym in DISPROOF.get(backend, ()) if sym in text]
     return Finding(path, display, backend, missing, disproved, method)

--- a/scripts/validation/gates/check_plugin_natives.py
+++ b/scripts/validation/gates/check_plugin_natives.py
@@ -32,6 +32,25 @@ whether the ops names appear at all:
 That is what this script measures: defined OR undefined, either counts, because
 either proves the entry TU compiled its routable branch.
 
+THE ENGINE THAT HAS NO CARRIER: QHEXRT
+--------------------------------------
+QHexRT is the exception, and an ops name cannot be its evidence. It keeps its
+entry and its six op vtables in the SAME binary (engines/qhexrt/CMakeLists.txt
+explains why: MSVC cannot resolve an imported data symbol whose declaration is
+the plain `extern "C" const` shared with the ELF/Mach-O builds). A single-DLL
+engine references those tables internally, so on a PE they are neither exported
+nor imported and vanish from the file entirely — `g_qhexrt_llm_ops` scores zero
+against a perfectly healthy win-arm64 NPU build that demonstrably generates
+tokens.
+
+Its evidence is instead the marker `qhexrt_backend_build_info()` returns, which
+flips with the very same `RAC_QHEXRT_ROUTABLE` switch that admits the op tables,
+and is a string literal so it survives on every object format. That marker is
+already how scripts/build/build-core-android.sh and
+scripts/release/prepublish_check.py answer this question; this gate now agrees
+with them. It only survives MSVC because the declaration is exported — see
+engines/qhexrt/qhexrt_backend.h.
+
 USAGE
     check_plugin_natives.py <path> [<path> ...]     # files and/or directories
     check_plugin_natives.py --tarball <pkg.tgz>     # an npm tarball
@@ -76,7 +95,18 @@ REQUIRED_OPS: dict[str, tuple[str, ...]] = {
     "sherpa": ("g_sherpa_stt_ops", "g_sherpa_tts_ops", "g_sherpa_vad_ops"),
     "llamacpp": ("g_llamacpp_ops",),
     "onnx": ("g_onnx_segmentation_ops", "g_onnx_diarization_ops", "g_onnx_embeddings_ops"),
-    "qhexrt": ("g_qhexrt_llm_ops",),
+    # Not an ops name: QHexRT has no carrier, so its tables are internal and a PE
+    # keeps none of them. See "THE ENGINE THAT HAS NO CARRIER" above.
+    "qhexrt": ("qhexrt:engine-available",),
+}
+
+# A token whose PRESENCE disproves routability, per backend. Requiring the
+# positive marker above is already sufficient — these exist so the failure reads
+# as the diagnosis it is ("you shipped the public shell") rather than as an
+# absence, which is the difference between an actionable gate and a puzzling one.
+# Mirrors check_qhexrt() in scripts/release/prepublish_check.py.
+DISPROOF: dict[str, tuple[str, ...]] = {
+    "qhexrt": ("qhexrt:engine-unavailable", "g_qhexrt_unavailable_vtable"),
 }
 
 # Shared-library file name -> backend id. Mirrors entry_symbol_from_path() in
@@ -96,7 +126,8 @@ BACKEND_TARBALL_RE = re.compile(
 
 
 class Finding:
-    def __init__(self, path: Path, display: str, backend: str, missing: list[str], method: str):
+    def __init__(self, path: Path, display: str, backend: str, missing: list[str],
+                 disproved: list[str], method: str):
         self.path = path
         # Where the caller can find this plugin: the path they passed, or
         # "<tarball>:<archive-relative path>" for a tarball member. The basename
@@ -105,7 +136,20 @@ class Finding:
         self.display = display
         self.backend = backend
         self.missing = missing
+        self.disproved = disproved
         self.method = method
+
+    @property
+    def failed(self) -> bool:
+        return bool(self.missing or self.disproved)
+
+    @property
+    def reason(self) -> str:
+        # A positive disproof is the more specific diagnosis, so lead with it.
+        if self.disproved:
+            return (f"shipped the NON-ROUTABLE shell — carries "
+                    f"{', '.join(self.disproved)}")
+        return f"does not reference {', '.join(self.missing)}"
 
 
 def _run(cmd: list[str]) -> str | None:
@@ -155,7 +199,8 @@ def check_plugin(path: Path, display: str) -> Finding | None:
         return None
     text, method = symbol_text(path)
     missing = [sym for sym in required if sym not in text]
-    return Finding(path, display, backend, missing, method)
+    disproved = [sym for sym in DISPROOF.get(backend, ()) if sym in text]
+    return Finding(path, display, backend, missing, disproved, method)
 
 
 def collect(paths: list[Path]) -> list[tuple[Path, str]]:
@@ -269,13 +314,12 @@ def main() -> int:
                 continue
             checked += 1
             label = f"{finding.backend:<9} {finding.display}"
-            if finding.missing:
-                print(f"  FAIL  {label}  [{finding.method}]  missing: "
-                      f"{', '.join(finding.missing)}")
+            if finding.failed:
+                print(f"  FAIL  {label}  [{finding.method}]  {finding.reason}")
                 findings.append(finding)
             else:
-                print(f"  ok    {label}  [{finding.method}]  "
-                      f"references all {len(REQUIRED_OPS[finding.backend])} ops tables")
+                print(f"  ok    {label}  [{finding.method}]  satisfies its "
+                      f"routability contract: {', '.join(REQUIRED_OPS[finding.backend])}")
 
     failed = bool(findings or empty_backends or version_mismatches or unsafe_members)
     if not failed and checked == 0:
@@ -286,8 +330,7 @@ def main() -> int:
         print("\nERROR: these plugins must not be published:")
         for finding in findings:
             print(f"  - {finding.display}")
-            print(f"      backend '{finding.backend}' does not reference "
-                  f"{', '.join(finding.missing)}")
+            print(f"      backend '{finding.backend}' {finding.reason}")
         for line in empty_backends:
             print(f"  - {line}")
         for line in version_mismatches:


### PR DESCRIPTION
Built and validated on an ASUS Zenbook A14 (Snapdragon X2 Elite, Windows 11 ARM64,
Hexagon v81, QAIRT 2.48.0.260626, VS 2026 / MSVC 19.51).

Six pre-existing Windows defects. No backend and no check is disabled by any of them.

| # | Bug | Symptom | File |
|---|---|---|---|
| 1 | `runtimes/onnxrt` defined its C ABI while inheriting `RAC_USING_SHARED`, making `RAC_API` dllimport | `C2491`/`C2375`, 9 errors | `runtimes/onnxrt/*` |
| 2 | `link_directories` for bundled statics is directory-scoped, so siblings of `core/` never saw it | `LNK1181: cannot open input file 'bz2_bundled.lib'` | `core/CMakeLists.txt` |
| 3 | ONNX + Sherpa op tables lacked dllimport for their thin carriers (data symbols need it, functions don't) | `LNK2001` on `g_onnx_*_ops`, `g_sherpa_*_ops` | `engines/{onnx,sherpa}/*` + 2 new headers |
| 4 | **`LoadLibraryA` never searches the loaded DLL's own directory**, so staged sidecars were invisible | `dlopen failed` err 126 — every backend unavailable at runtime | `core/src/plugin/plugin_loader.cpp` |
| 5 | `node.lib` chosen from `CMAKE_SYSTEM_PROCESSOR` (host) instead of `CMAKE_GENERATOR_PLATFORM` (target) | `LNK4272` + 65 unresolved `__imp_napi_*` when cross-compiling | `bindings/electron/native/CMakeLists.txt` |
| 6 | `rac_logger.h` included only under the desktop-adapter guard while `RAC_LOG_*` is used unconditionally | `C2064` whenever `RAC_DESKTOP_ADAPTER=OFF` (the NPU lane) | `bindings/electron/native/addon.cpp` |

**Fix 4 is the load-bearing one.** No Windows Electron build could ever have loaded a
backend plugin, on any machine. That is why these packages have shipped darwin-only.
Fixes 5 and 6 only bite when cross-compiling and on the ARM64 lane respectively, which
is why nothing caught them earlier: CI builds only
`rac_commons runanywhere_llamacpp runanywhere_native` with `RAC_BACKEND_SHERPA=OFF`,
and llamacpp is the one engine that already had an export macro.

## Non-Windows impact: none

- Fix 4 is entirely inside `#if defined(_WIN32)`.
- `RAC_API` → `RAC_PLUGIN_API` looks cross-platform but is not: `rac_types.h:69` defines
  `RAC_PLUGIN_API` as exactly `RAC_API` on every `__GNUC__`/`__clang__` target, so macOS,
  iOS, Android, Linux and WASM are byte-identical. This matters because
  `rac_onnxrt_probe_webgpu_ep` and `rac_onnxrt_activate_preferred_wasm_ep` are consumed
  by the web build.
- The two new `RAC_{ONNX,SHERPA}_API` headers are no-ops off Windows except for adding
  explicit `visibility("default")` on the backend target — additive, and the same shape
  as the existing `RAC_LLAMACPP_API`.
- Neither `RAC_ONNX_BUILDING` nor `RAC_SHERPA_BUILDING` gates any code; they only select
  export vs import in the new headers.

## Verification

Symbol gate (`scripts/validation/gates/check_plugin_natives.py`) on the produced natives:

```
ok  llamacpp  references all 1 ops tables
ok  onnx      references all 3 ops tables
ok  sherpa    references all 3 ops tables
All 3 backend plugin native(s) are routable.
```

Independently re-verified on the Mac from the shipped binaries with `llvm-readobj`,
confirming every ops table import resolves to a matching export:

| carrier | imports from | symbols |
|---|---|---|
| `runanywhere_llamacpp.dll` | `rac_backend_llamacpp.dll` | `g_llamacpp_{ops,embeddings_ops,rerank_ops,vlm_ops}` |
| `runanywhere_onnx.dll` | `rac_backend_onnx.dll` | `g_onnx_{embeddings,segmentation,diarization}_ops` |
| `runanywhere_sherpa.dll` | `rac_backend_sherpa.dll` | `g_sherpa_{stt,tts,vad}_ops` |

Each carrier exports exactly its `rac_plugin_entry_<id>`. Telemetry is baked in both
lanes (`YOUR_STAGING_BASE_URL` absent from `rac_commons.dll`, the staging URL present) —
the 0.20.19 defect does not recur.

End-to-end, win32-x64, real app over RPC into the utility host, 5/5:

```
backends ["LLAMA_CPP","SHERPA","ONNX"]   unavailable: none
llm   "Colour"                     lfm2.5-230m, 18.3 tok/s
onnx  embedding dims [384, 384]    all-MiniLM-L6-v2
tts   51200 samples @ 22050 Hz     2321 ms, piper-amy
stt   " the Quick Brown Fox."      whisper-tiny, transcribed from that TTS output
```

win32-arm64 (QHexRT on the Hexagon NPU): `{"text":"Blue","model":"lfm2.5-230m-npu","tokensPerSecond":46.72}`.

## Follow-ups, not blockers

- `check_plugin_natives.py` false-negatives QHexRT on Windows: it reports
  `missing: g_qhexrt_llm_ops`, but the engine demonstrably registered and generated
  tokens. QHexRT puts its ops and plugin entry in the *same* DLL, so the symbol is
  internal and stripped from a PE; llamacpp only passes because its symbol is a
  cross-DLL *import* and survives in the import table. The gate needs a Windows-aware
  path for single-DLL engines before it can gate this lane.
- `engines/sherpa/CMakeLists.txt:389` puts `RAC_ONNX_BUILDING` in `SHERPA_COMPILE_DEFS`
  (pre-existing on `main`, unchanged here). Harmless today because nothing under
  `engines/sherpa` includes `rac_onnx_api.h`, but it would wrongly flip that header to
  dllexport if one ever did.
- The ARM64 lane is built without `RAC_DESKTOP_ADAPTER` (no arm64 libcurl), so it has no
  HTTP transport: no downloads, telemetry, or auth. A shippable ARM64 build needs
  `curl:arm64-windows-static` via vcpkg and `-DRAC_DESKTOP_ADAPTER=ON`.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows ARM64 and cross-compilation target detection.
  * Fixed plugin loading with adjacent dependencies on Windows.
  * Enhanced Windows plugin-loading error messages.
  * Improved bundled library resolution and logging in lightweight builds.

* **Compatibility**
  * Improved shared-library compatibility for ONNX Runtime, ONNX, Sherpa, and QHexRT integrations.
  * Improved detection of unavailable or non-routable native capabilities.

* **New Features**
  * Added Windows ARM64 Electron build presets, including QHexRT-only configurations.
  * Updated native bundling to select architecture-specific build configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->