### PR TITLE
fix(react-native): point the podspec source at a tag that exists

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -70,6 +70,11 @@ jobs:
             git fetch --no-tags --depth=1 origin "${PR_BASE_SHA}"
           fi
           bash scripts/validation/gates/check_release_version_coherence.sh
+      - name: Release-train version coherence gate tests
+        # The step above only proves the tree is coherent today. These prove the
+        # gate still rejects the podspec source-tag shapes it was added for, so
+        # it cannot quietly stop catching them.
+        run: python3 scripts/validation/gates/test_release_version_coherence.py
       - name: Swift distribution repo (runanywhere-swift) is cut at this release
         # RunanywhereAI/runanywhere-swift is the lightweight SPM distribution of
         # bindings/swift. Its tags MUST keep pace with this repo's releases or

--- a/bindings/react-native/packages/core/RunAnywhereCore.podspec
+++ b/bindings/react-native/packages/core/RunAnywhereCore.podspec
@@ -13,7 +13,15 @@ Pod::Spec.new do |s|
 
   s.platforms    = { :ios => "17.5" }
   s.swift_version = "6.2"
-  s.source       = { :git => "https://github.com/RunanywhereAI/runanywhere-sdks.git", :tag => "v#{s.version}" }
+  # TEMP: the source tag is pinned to the last release that was actually
+  # tagged, not to s.version. s.version tracks package.json and leads the
+  # published release whenever a release republishes only some packages, and
+  # a tag built from s.version then resolves to one that was never pushed, so
+  # `pod install` fails outright. Mirrors asset_version in the Flutter
+  # podspecs. Bump back in step with the SwiftPM pin once a matching release
+  # exists; check_release_version_coherence.sh enforces that they agree.
+  source_tag_version = '0.20.19'
+  s.source       = { :git => "https://github.com/RunanywhereAI/runanywhere-sdks.git", :tag => "v#{source_tag_version}" }
 
   # =============================================================================
   # Core SDK - RACommons xcframework is bundled in npm package

--- a/bindings/react-native/packages/llamacpp/RunAnywhereLlama.podspec
+++ b/bindings/react-native/packages/llamacpp/RunAnywhereLlama.podspec
@@ -13,7 +13,15 @@ Pod::Spec.new do |s|
 
   s.platforms    = { :ios => "17.5" }
   s.swift_version = "6.2"
-  s.source       = { :git => "https://github.com/RunanywhereAI/runanywhere-sdks.git", :tag => "v#{s.version}" }
+  # TEMP: the source tag is pinned to the last release that was actually
+  # tagged, not to s.version. s.version tracks package.json and leads the
+  # published release whenever a release republishes only some packages, and
+  # a tag built from s.version then resolves to one that was never pushed, so
+  # `pod install` fails outright. Mirrors asset_version in the Flutter
+  # podspecs. Bump back in step with the SwiftPM pin once a matching release
+  # exists; check_release_version_coherence.sh enforces that they agree.
+  source_tag_version = '0.20.19'
+  s.source       = { :git => "https://github.com/RunanywhereAI/runanywhere-sdks.git", :tag => "v#{source_tag_version}" }
 
   # =============================================================================
   # LlamaCPP Backend - xcframework is bundled in npm package

--- a/bindings/react-native/packages/mlx/RunAnywhereMLX.podspec
+++ b/bindings/react-native/packages/mlx/RunAnywhereMLX.podspec
@@ -12,7 +12,15 @@ Pod::Spec.new do |s|
 
   s.platforms     = { :ios => "17.5" }
   s.swift_version = "6.2"
-  s.source        = { :git => "https://github.com/RunanywhereAI/runanywhere-sdks.git", :tag => "v#{s.version}" }
+  # TEMP: the source tag is pinned to the last release that was actually
+  # tagged, not to s.version. s.version tracks package.json and leads the
+  # published release whenever a release republishes only some packages, and
+  # a tag built from s.version then resolves to one that was never pushed, so
+  # `pod install` fails outright. Mirrors asset_version in the Flutter
+  # podspecs. Bump back in step with the SwiftPM pin once a matching release
+  # exists; check_release_version_coherence.sh enforces that they agree.
+  source_tag_version = '0.20.19'
+  s.source        = { :git => "https://github.com/RunanywhereAI/runanywhere-sdks.git", :tag => "v#{source_tag_version}" }
 
   # All three binaries are required. RABackendMLX owns the commons backend
   # plugin, RunAnywhereMLXRuntime owns the static Swift runtime, and the tiny

--- a/bindings/react-native/packages/onnx/RunAnywhereONNX.podspec
+++ b/bindings/react-native/packages/onnx/RunAnywhereONNX.podspec
@@ -13,7 +13,15 @@ Pod::Spec.new do |s|
 
   s.platforms    = { :ios => "17.5" }
   s.swift_version = "6.2"
-  s.source       = { :git => "https://github.com/RunanywhereAI/runanywhere-sdks.git", :tag => "v#{s.version}" }
+  # TEMP: the source tag is pinned to the last release that was actually
+  # tagged, not to s.version. s.version tracks package.json and leads the
+  # published release whenever a release republishes only some packages, and
+  # a tag built from s.version then resolves to one that was never pushed, so
+  # `pod install` fails outright. Mirrors asset_version in the Flutter
+  # podspecs. Bump back in step with the SwiftPM pin once a matching release
+  # exists; check_release_version_coherence.sh enforces that they agree.
+  source_tag_version = '0.20.19'
+  s.source       = { :git => "https://github.com/RunanywhereAI/runanywhere-sdks.git", :tag => "v#{source_tag_version}" }
 
   # =============================================================================
   # ONNX Backend - xcframeworks are bundled in npm package

--- a/scripts/validation/gates/check_release_version_coherence.sh
+++ b/scripts/validation/gates/check_release_version_coherence.sh
@@ -395,6 +395,24 @@ for podspec in \
   fi
 done
 
+# The RN podspecs have the same failure in a different shape: they resolve their
+# source from a GIT TAG rather than a release archive. `s.version` comes from
+# package.json, so a tag built from it points at a tag that was never pushed
+# whenever the repo version leads the last tagged release, and `pod install`
+# fails outright rather than degrading. Pin it to the same release the SwiftPM
+# manifests do.
+for podspec in \
+  bindings/react-native/packages/core/RunAnywhereCore.podspec \
+  bindings/react-native/packages/llamacpp/RunAnywhereLlama.podspec \
+  bindings/react-native/packages/mlx/RunAnywhereMLX.podspec \
+  bindings/react-native/packages/onnx/RunAnywhereONNX.podspec; do
+  expect_literal "${podspec}" "source_tag_version = '${SPM_VERSION}'"
+  if grep -qF ':tag => "v#{s.version}"' "${REPO_ROOT}/${podspec}" 2>/dev/null; then
+    echo "[FAIL] ${podspec}: source tag interpolates s.version; it must use source_tag_version so it points at a tag that exists" >&2
+    FAILURES=$((FAILURES + 1))
+  fi
+done
+
 for package_manifest in \
   bindings/flutter/packages/runanywhere/ios/runanywhere/Package.swift \
   bindings/flutter/packages/runanywhere_llamacpp/ios/runanywhere_llamacpp/Package.swift \

--- a/scripts/validation/gates/test_release_version_coherence.py
+++ b/scripts/validation/gates/test_release_version_coherence.py
@@ -1,0 +1,144 @@
+"""Tests for the podspec source-tag half of check_release_version_coherence.sh.
+
+The gate is the only thing standing between a podspec and a `:tag` that was
+never pushed, which fails `pod install` outright rather than degrading. It reads
+~40 files under REPO_ROOT, so the tests run it against a sandbox that mirrors
+the real tree with symlinks and materializes only the podspecs a case mutates.
+That keeps every other assertion in the gate satisfied by the real repo, so a
+failure means the mutation caused it.
+"""
+
+import os
+from pathlib import Path
+import shutil
+import subprocess
+import sys
+import tempfile
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+GATE = "scripts/validation/gates/check_release_version_coherence.sh"
+
+RN_PODSPECS = (
+    "bindings/react-native/packages/core/RunAnywhereCore.podspec",
+    "bindings/react-native/packages/llamacpp/RunAnywhereLlama.podspec",
+    "bindings/react-native/packages/mlx/RunAnywhereMLX.podspec",
+    "bindings/react-native/packages/onnx/RunAnywhereONNX.podspec",
+)
+
+
+def _mirror(tmp_path, writable, case="case"):
+    """Symlink-mirror REPO_ROOT into a fresh sandbox, copying `writable` for real.
+
+    Only the directories on the path to a writable file become real; every
+    other entry is a symlink to the original, so the mirror costs nothing.
+    Returns the sandbox root, which is what the gate sees as REPO_ROOT.
+    """
+    sandbox = tmp_path / case
+    real_dirs = set()
+    for relative in writable:
+        parent = os.path.dirname(relative)
+        while parent:
+            real_dirs.add(parent)
+            parent = os.path.dirname(parent)
+
+    def build(relative):
+        source = REPO_ROOT / relative if relative else REPO_ROOT
+        target = sandbox / relative if relative else sandbox
+        target.mkdir(parents=True, exist_ok=True)
+        for child in source.iterdir():
+            child_relative = f"{relative}/{child.name}" if relative else child.name
+            if child_relative in writable:
+                shutil.copy2(child, target / child.name)
+            elif child_relative in real_dirs:
+                build(child_relative)
+            else:
+                (target / child.name).symlink_to(child)
+
+    build("")
+    return sandbox
+
+
+def _run(sandbox):
+    return subprocess.run(
+        ["bash", os.fspath(sandbox / GATE)],
+        capture_output=True,
+        text=True,
+        # PR_BASE_SHA would pull the gate into its release-label branch, which
+        # needs a real git base and is not what these cases are about.
+        env={k: v for k, v in os.environ.items() if k != "PR_BASE_SHA"},
+    )
+
+
+def _spm_version():
+    for line in (REPO_ROOT / "Package.swift").read_text(encoding="utf-8").splitlines():
+        if line.startswith('let sdkVersion = "'):
+            return line.split('"')[1]
+    raise AssertionError("Package.swift has no sdkVersion pin")
+
+
+def test_unmodified_tree_passes(tmp_path):
+    # Establishes the baseline the other cases lean on: whatever they trip, it
+    # is not one of the gate's other forty assertions.
+    sandbox = _mirror(tmp_path, writable=set())
+    result = _run(sandbox)
+    assert result.returncode == 0, result.stdout + result.stderr
+    assert "[OK] release version coherence" in result.stdout
+
+
+def test_source_tag_built_from_s_version_is_rejected(tmp_path):
+    # The original defect. s.version tracks package.json, which leads the last
+    # tagged release whenever a release republishes only some packages, so a tag
+    # interpolated from it resolves to one that was never pushed.
+    for index, podspec in enumerate(RN_PODSPECS):
+        sandbox = _mirror(tmp_path, writable={podspec}, case=f"case{index}")
+        text = (sandbox / podspec).read_text(encoding="utf-8")
+        (sandbox / podspec).write_text(
+            text.replace('"v#{source_tag_version}"', '"v#{s.version}"'), encoding="utf-8"
+        )
+        result = _run(sandbox)
+        assert result.returncode == 1, podspec
+        assert "source tag interpolates s.version" in result.stderr, podspec
+
+
+def test_source_tag_pinned_to_the_wrong_release_is_rejected(tmp_path):
+    # Pinning is not enough on its own: the pin has to be the same release the
+    # SwiftPM manifests resolve their XCFrameworks from, or the podspec points
+    # at a tag whose assets belong to a different build.
+    podspec = RN_PODSPECS[0]
+    sandbox = _mirror(tmp_path, writable={podspec})
+    text = (sandbox / podspec).read_text(encoding="utf-8")
+    assert f"source_tag_version = '{_spm_version()}'" in text
+    (sandbox / podspec).write_text(
+        text.replace(f"source_tag_version = '{_spm_version()}'", "source_tag_version = '0.0.1'"),
+        encoding="utf-8",
+    )
+    result = _run(sandbox)
+    assert result.returncode == 1
+    assert f"expected 'source_tag_version = '{_spm_version()}''" in result.stderr
+
+
+def test_every_rn_podspec_is_covered(tmp_path):
+    # The Flutter podspecs were already gated when this drifted; RN was simply
+    # not in the loop. A podspec added later and left out of the gate's list is
+    # the same failure again, so assert the list is the directory.
+    gate = (REPO_ROOT / GATE).read_text(encoding="utf-8")
+    on_disk = sorted(
+        str(p.relative_to(REPO_ROOT))
+        for p in (REPO_ROOT / "bindings/react-native/packages").glob("*/*.podspec")
+    )
+    assert on_disk == sorted(RN_PODSPECS)
+    for podspec in on_disk:
+        assert podspec in gate, f"{podspec} is not covered by {GATE}"
+
+
+if __name__ == "__main__":
+    tests = sorted(
+        (name, value)
+        for name, value in globals().items()
+        if name.startswith("test_") and callable(value)
+    )
+    for name, test in tests:
+        with tempfile.TemporaryDirectory(prefix=f"{name}-") as temporary:
+            test(Path(temporary))
+    print(f"{len(tests)} release version coherence tests passed", file=sys.stderr)


### PR DESCRIPTION
Follows #697, which fixed this for Flutter. The RN podspecs have the same defect in a different shape and were not covered.

## What is wrong

The four RN podspecs resolve their source from a git tag built from `s.version`:

```ruby
s.version      = package["version"]
s.source       = { :git => "https://github.com/RunanywhereAI/runanywhere-sdks.git", :tag => "v#{s.version}" }
```

`package.json` is at `0.20.20`. The newest tag upstream is `v0.20.19`:

```
$ gh api repos/RunanywhereAI/runanywhere-sdks/tags --jq '.[].name' | head -3
yaprun-v0.1-mac
voice-assistant-v0.1.0
v0.20.19
```

So `pod install` resolves `v0.20.20`, which was never pushed, and fails. Unlike the Flutter case this does not degrade quietly, it stops the install.

## Why it happens

Exactly the reason #697 gives for Flutter. `s.version` tracks the repo version, which leads the last published release whenever a release republishes only some packages, and 0.20.20 did precisely that (it republished Electron). #697 handled the Flutter side by decoupling `asset_version` from `s.version`, and its own comment says to bump back "once a matching release exists". The RN side kept deriving from `s.version`.

## What this does

Pins the source tag to the release the SwiftPM manifests already pin, using the same shape as Flutter's `asset_version`, and extends `check_release_version_coherence.sh` to cover the RN podspecs.

The gate is the part that matters. It already asserted `asset_version == SPM_VERSION` for the four Flutter podspecs, and RN was simply not in the loop, which is why this side drifted while the Flutter side was being fixed.

`s.version` is untouched, so the published CocoaPods version still tracks `package.json`. Only the source reference moves.

## Verification

The gate fails on the unfixed state and passes on the fixed one. Reverting one podspec to `origin/main` and re-running:

```
[FAIL] bindings/react-native/packages/core/RunAnywhereCore.podspec: expected 'source_tag_version = '0.20.19''
[FAIL] bindings/react-native/packages/core/RunAnywhereCore.podspec: source tag interpolates s.version; it must use source_tag_version so it points at a tag that exists
[FAIL] release version coherence: 2 mismatch(es)
```

With all four fixed:

```
[OK] SwiftPM manifests temporarily pin 0.20.19 until v0.20.20 assets are published
[OK] release version coherence: 0.20.20
exit 0
```

`bash -n` on the gate is clean.

I did not run `pod install`, so I have shown the tag does not exist and that the gate now enforces the pin, not that CocoaPods resolves end to end. That needs macOS with CocoaPods and a published pod.

One follow-up I did not fold in: when v0.20.20 is tagged, both `asset_version` and this `source_tag_version` need bumping together. `sync-versions.sh` deliberately leaves `asset_version` alone, so the same applies here, and the gate will fail loudly if only one moves.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Chores**
  - Improved React Native package release consistency by pinning package sources to the intended release tag.
  - Added automated checks to detect mismatched or incorrectly derived release tags before publication.
  - Added validation coverage to ensure all React Native packages are included in release-coherence checks.
  - Reduced the risk of installation or integration issues caused by packages referencing inconsistent release versions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->