### PR TITLE
fix(electron): tell the truth about Windows, and unstick bundle:native

### DIFF
--- a/bindings/electron/AGENTS.md
+++ b/bindings/electron/AGENTS.md
@@ -94,27 +94,20 @@ Adapted from `thoughts/shared/plans/BEST_PRACTISES.md` for this package:
 
 - Document what is true today. Do not claim encryption or remote Phase-2 auth unless
   packaging and runtime are wired end-to-end.
-- **Windows QHexRT/NPU is NOT wired, and neither is Windows.** As of 0.20.18 this SDK
-  ships prebuilds for **`darwin-arm64` only** — the addon at `prebuilds/darwin-arm64/`
-  plus one directory each in the llamacpp / onnx / sherpa packages. There is nothing
-  for linux, win32, or x64. `package.json` keeps `os`/`cpu` permissive on purpose,
+- **Windows ships at 0.20.21.** Prebuilds: `darwin-arm64` (llamacpp / ONNX / Sherpa),
+  `win32-x64` (llamacpp / ONNX / Sherpa), `win32-arm64` (QHexRT / Hexagon NPU only).
+  Linux still has no prebuild. `package.json` keeps `os`/`cpu` permissive on purpose,
   because the TypeScript facade genuinely is cross-platform and narrowing them would
   also block TS-only consumers and our own Linux CI; `resolveAddon()` in
-  `src/bridge.ts` instead names the gap explicitly against `PREBUILT_PLATFORMS`.
-- **`@runanywhere/electron-qhexrt` ships no native plugin on any platform.** It is
-  pinned at 0.20.17 and npm-deprecated saying so. `register()` records a path with no
-  binary behind it, so the plugin never loads and the app must degrade gracefully.
-  Windows ARM64 (Snapdragon X / X2 Elite, Hexagon v81) is the only host where it could
-  ever work, and that build does not exist: every payload under
-  `engines/qhexrt/prebuilt/` is Android `arm64-v8a` only, and a win-arm64 runner
-  hard-fails at configure on the "Partial QHexRT prebuilt" FATAL_ERROR. Do not
-  describe this package as NPU-accelerated until a real win-arm64 DLL passes
-  `check_plugin_natives.py`; a shell build exports `rac_plugin_entry_qhexrt` and looks
-  healthy by size and export count, so gate on `g_qhexrt_llm_ops` via `nm -a`.
-- What is separately true on that host once it lands: llama.cpp, ONNX and Sherpa do not
-  build for win-arm64 (ggml rejects MSVC for ARM; `FetchONNXRuntime.cmake` has no
-  win-arm64 URL — see the `windows-arm64-release` preset comments), so the NPU would be
-  the only engine there with no CPU fallback to hide behind.
+  `src/bridge.ts` names remaining gaps against `PREBUILT_PLATFORMS`.
+- **`@runanywhere/electron-qhexrt` ships a real `win32-arm64` plugin** (routable
+  `qhexrt:engine-available`, QAIRT 2.48 flat runtime bundled beside it). A shell
+  build still exports `rac_plugin_entry_qhexrt` and looks healthy by size, so gate
+  on the `qhexrt:engine-available` marker via `check_plugin_natives.py` — `g_qhexrt_llm_ops`
+  is internal on PE and is not evidence.
+- llama.cpp, ONNX and Sherpa do not build for win-arm64 (ggml rejects MSVC for ARM;
+  `FetchONNXRuntime.cmake` has no win-arm64 URL), so the NPU is the only engine on
+  that host with no CPU fallback to hide behind.
 - Win32 secure store is DPAPI; do not label it "plaintext M0" in headers/docs.
 - Phase-2 `completeServicesInitialization` is a local lifecycle seam unless real auth
   lands.

--- a/bindings/electron/README.md
+++ b/bindings/electron/README.md
@@ -2,7 +2,7 @@
 
 On-device **LLM, VLM, STT, TTS, and embeddings** for Electron and Node. The SDK is a native N-API addon over the RunAnywhere `rac_*` C ABI and llama.cpp / ONNX Runtime / Sherpa-ONNX. Inference runs in an isolated Electron **utility process**, streaming results to the renderer over a `MessagePort`.
 
-> **Status:** Unpublished preview (`private: true`, version `0.1.0`), not on npm. Windows x64 and Linux x64 build and run; build from source in this repository.
+> **Status:** Published on npm. Native prebuilds ship for `darwin-arm64` and `win32-x64` (llama.cpp / ONNX / Sherpa) and for `win32-arm64` (QHexRT on the Qualcomm Hexagon NPU, via `@runanywhere/electron-qhexrt`). Linux builds from source.
 
 ## Capabilities
 
@@ -13,19 +13,39 @@ On-device **LLM, VLM, STT, TTS, and embeddings** for Electron and Node. The SDK 
 - Encrypted secure store (Windows DPAPI)
 - Built-in energy VAD
 
+## Install
+
+```bash
+npm install @runanywhere/electron
+npm install @runanywhere/electron-llamacpp @runanywhere/electron-onnx @runanywhere/electron-sherpa
+npm install @runanywhere/electron-qhexrt   # Hexagon NPU, win32-arm64
+```
+
+Every backend package can be declared unconditionally. One with no payload for the
+running platform records a path that does not exist, and the existence filter drops
+it before the utility host forks, so it never loads and never appears in
+`capabilities().backends`.
+
 ## Build from source
 
-This package is not published to npm. Clone the repository and build the native addon on Windows:
+Only needed for Linux, or to run against local native changes:
 
 ```bash
 git clone https://github.com/RunanywhereAI/runanywhere-sdks.git
 cd runanywhere-sdks/bindings/electron
 npm install
 npm run build
-npm run bundle:native   # copies .node + DLLs into prebuilds/win32-x64/
+npm run bundle:native   # stages the built .node + libs into prebuilds/<platform>-<arch>/
 ```
 
-Prerequisites: MSVC, Node.js, and a `windows-release` build of `runanywhere-commons` with backends enabled. See [docs/DEVELOPMENT.md](./docs/DEVELOPMENT.md) for CUDA builds, integration tests, and contributor details.
+`bundle:native` compiles only itself (`tsconfig.bundle.json`), so it runs on a machine
+that builds natives and never builds the SDK's TypeScript. Point it at a specific CMake
+tree with `RA_NATIVE_DIR`, and stage the QAIRT runtime into the qhexrt package with
+`RA_QNN_RUNTIME_DIR`.
+
+Prerequisites: a C++ toolchain (MSVC on Windows), Node.js, and a `runanywhere-commons`
+build with backends enabled. See [docs/DEVELOPMENT.md](./docs/DEVELOPMENT.md) for CUDA
+builds, integration tests, and contributor details.
 
 ## Quick start (Node)
 

--- a/bindings/electron/package.json
+++ b/bindings/electron/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@runanywhere/electron",
   "version": "0.20.21",
-  "description": "RunAnywhere Electron SDK — on-device LLM/VLM/STT/TTS/embeddings for Electron & Node (ships macOS arm64 prebuilds only today; QHexRT NPU seam open, not claimed).",
+  "description": "RunAnywhere Electron SDK — on-device LLM/VLM/STT/TTS/embeddings for Electron & Node (prebuilds: darwin-arm64, win32-x64; win32-arm64 QHexRT/Hexagon NPU).",
   "publishConfig": {
     "access": "public"
   },
@@ -59,7 +59,7 @@
     "build:test": "tsc -p tsconfig.test.json",
     "build:scripts": "tsc -p tsconfig.scripts.json",
     "build:native-smoke": "tsc -p tsconfig.native.json",
-    "bundle:native": "npm run build:scripts && node dist-scripts/bundle-native.js",
+    "bundle:native": "tsc -p tsconfig.bundle.json && node dist-scripts/bundle-native.js",
     "pretest": "npm run build && npm run build:test",
     "test": "node --enable-source-maps --test \"dist-test/unit/**/*.test.js\"",
     "pretest:feature": "npm run build && npm run build:test",

--- a/bindings/electron/src/bridge.ts
+++ b/bindings/electron/src/bridge.ts
@@ -558,7 +558,7 @@ function prepareNativeLoad(addonPath: string): void {
 
 // Platforms this release actually ships a prebuilt addon for. Kept next to the
 // resolver so it cannot drift from what bundle-native staged.
-const PREBUILT_PLATFORMS: readonly string[] = ['darwin-arm64'];
+const PREBUILT_PLATFORMS: readonly string[] = ['darwin-arm64', 'win32-x64', 'win32-arm64'];
 
 function resolveAddon(): NativeAddon {
   const candidates = [

--- a/bindings/electron/tsconfig.bundle.json
+++ b/bindings/electron/tsconfig.bundle.json
@@ -1,0 +1,19 @@
+{
+  // Native staging only. `bundle:native` runs on machines that build the addon
+  // and never build the SDK's TypeScript — a Windows box producing prebuilds,
+  // for instance. tsconfig.scripts.json compiles every scripts/**/*.ts, which
+  // drags in manual-resolve.ts and its `../dist/download` import, so staging
+  // natives failed there with TS2307 on a module that has nothing to do with
+  // staging. bundle-native.ts imports only `fs` and `path`; compile just it.
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "rootDir": "scripts",
+    "outDir": "dist-scripts",
+    "declaration": false,
+    "sourceMap": true,
+    "noEmitOnError": true,
+    "lib": ["ES2021"],
+    "types": ["node"]
+  },
+  "include": ["scripts/bundle-native.ts"]
+}


### PR DESCRIPTION
`0.20.21` published `win32-x64` (llamacpp / ONNX / Sherpa) and `win32-arm64` (QHexRT on the Hexagon NPU) natives, but the tree still described a darwin-only release. Nothing here changes behaviour for an existing consumer — it makes the repo say what the published packages already contain, and removes a coupling that blocks the machine producing those natives.

## 1. `resolveAddon()` denied a prebuild it ships

`PREBUILT_PLATFORMS` was `['darwin-arm64']`, so a Windows user whose addon failed to load for any reason got:

> No prebuild ships for `win32-x64`. This release carries `darwin-arm64` only.

That message is the first thing anyone reads when a load fails, and it pointed away from the truth — the payload was sitting right there. Now `['darwin-arm64', 'win32-x64', 'win32-arm64']`, which is exactly what `bundle-native` stages and what the six published tarballs contain.

## 2. The package README was the npm page for "not on npm"

`README.md` opened with *"Unpublished preview (`private: true`, version `0.1.0`), not on npm"* and sent readers to build from source. It is listed in `files[]`, so it ships **inside** the tarball and has been the package page on npm for several releases. It now documents installing from the registry, states which platform gets which engines, and keeps build-from-source where it is still the answer (Linux, or working against local native changes).

## 3. `bundle:native` needed an unrelated module to compile

`bundle:native` ran `build:scripts`, which compiles every `scripts/**/*.ts` — including `manual-resolve.ts` and its `import { resolveModel } from '../dist/download'`. So staging natives required the SDK's TypeScript to be built first, which is not true on a box whose only job is producing prebuilds. Reproduced on this branch by parking `dist/`:

```
scripts/manual-resolve.ts(12,46): error TS2307: Cannot find module '../dist/download'
scripts/manual-resolve.ts(13,39): error TS2307: Cannot find module '../dist/download'
```

`bundle-native.ts` imports only `fs` and `path`. It now compiles through its own `tsconfig.bundle.json`, which succeeds on that same `dist`-less tree. `build:scripts` and `typecheck` keep their current coverage, so CI is unaffected and `manual-resolve.ts` is still type-checked.

This is the concrete blocker hit while building the `0.20.21` Windows natives: the operator had to hand-compile `bundle-native.ts` to stage a release.

## Verification

`npm run typecheck` clean, 230 unit tests pass, and the `dist`-less compile above was run both ways on this branch.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added Electron native prebuilt support for macOS ARM64, Windows x64, and Windows ARM64.
  - Added Windows ARM64 support using the QHexRT engine with Hexagon NPU acceleration.
  - Improved platform-specific backend selection during installation.

- **Documentation**
  - Updated Electron SDK installation and source-build guidance.
  - Clarified supported platforms, available engines, and Windows ARM64 limitations.
  - Documented configuration options for local native builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->