### PR TITLE
fix(electron): stage each backend vendor runtime beside its own plugin

### DIFF
--- a/bindings/electron/scripts/bundle-native.ts
+++ b/bindings/electron/scripts/bundle-native.ts
@@ -203,20 +203,34 @@ function backendCandidates(id: BundlePackageId): readonly string[] {
 }
 
 /**
- * Vendor runtimes a backend links directly, by platform-correct file name.
- * ONNX Runtime is shared by both engines; sherpa additionally needs its C API.
+ * Vendor runtimes a backend links DYNAMICALLY, by platform-correct file name.
+ *
+ * macOS stages none: the vendor libraries are linked statically into
+ * `librac_backend_<id>.dylib`, which is why the darwin packages ship three files
+ * and no `libonnxruntime`. Windows and Linux link them dynamically.
  */
 function vendorRuntimeNames(id: BundlePackageId): readonly string[] {
+  if (mac) return [];
   const ort = win
     ? ['onnxruntime.dll', 'onnxruntime_providers_shared.dll']
-    : mac
-      ? ['libonnxruntime.dylib']
-      : ['libonnxruntime.so.1', 'libonnxruntime.so'];
+    : ['libonnxruntime.so.1', 'libonnxruntime.so'];
   if (id === BundlePackageId.Sherpa) {
-    return [...ort, win ? 'sherpa-onnx-c-api.dll' : mac ? 'libsherpa-onnx-c-api.dylib' : 'libsherpa-onnx-c-api.so'];
+    return [...ort, win ? 'sherpa-onnx-c-api.dll' : 'libsherpa-onnx-c-api.so'];
   }
   return ort;
 }
+
+/**
+ * Whether a missing vendor runtime should fail the bundle rather than warn.
+ *
+ * Windows is a proven contract: `rac_backend_onnx.dll` and
+ * `rac_backend_sherpa.dll` name these in their PE import tables, so a package
+ * staged without them is guaranteed broken — 0.20.21 shipped exactly that.
+ * Linux stays best-effort because no Linux prebuild is published and its file
+ * set is unverified; failing there would break local staging on a guess rather
+ * than on evidence.
+ */
+const VENDOR_RUNTIME_REQUIRED = win;
 
 /** Everywhere a vendor runtime may have been produced or vendored. */
 function vendorRuntimeCandidates(name: string): readonly string[] {
@@ -224,9 +238,39 @@ function vendorRuntimeCandidates(name: string): readonly string[] {
     path.join(buildDir, name),
     path.join(buildRoot, '_deps', 'onnxruntime-src', 'lib', name),
     path.join(repoRoot, 'core', 'third_party', 'sherpa-onnx-windows', 'lib', name),
-    path.join(repoRoot, 'core', 'third_party', 'sherpa-onnx-macos', 'lib', name),
     path.join(repoRoot, 'core', 'third_party', 'sherpa-onnx-linux', 'lib', name),
   ];
+}
+
+/**
+ * Stage a vendor runtime beside its backend, refusing to plan an unusable
+ * package where the dependency is known to be dynamic.
+ *
+ * Staging this best-effort is what let 0.20.21 publish: the file was absent, the
+ * bundler said nothing, and the defect surfaced on a user's machine as
+ * "Backend not ready" and an access violation with no mention of a missing DLL.
+ */
+function pushVendorRuntime(
+  files: StagedFile[],
+  packageId: BundlePackageId,
+  name: string
+): void {
+  const candidates = vendorRuntimeCandidates(name);
+  const found = findExisting(candidates);
+  if (found) {
+    files.push({ name: path.basename(found), dir: path.dirname(found), packageId });
+    return;
+  }
+  if (!VENDOR_RUNTIME_REQUIRED) {
+    console.error(`  skipped (not built): ${name} for ${packageId}`);
+    return;
+  }
+  console.error(
+    `MISSING vendor runtime '${name}' for backend '${packageId}' on ${platformArch}.\n` +
+      `  ${packageId} links it dynamically, so a package staged without it cannot load.\n` +
+      `  Looked in:\n${candidates.map((c) => `    ${c}`).join('\n')}`
+  );
+  process.exit(1);
 }
 
 /** Stage an optional sidecar into `packageId` when the file exists. */
@@ -370,7 +414,7 @@ function buildStagingPlan(
       // utility host down with an access violation (0xC0000005).
       if (id === BundlePackageId.ONNX || id === BundlePackageId.Sherpa) {
         for (const sidecar of vendorRuntimeNames(id)) {
-          pushOptionalSidecar(files, id, findExisting(vendorRuntimeCandidates(sidecar)));
+          pushVendorRuntime(files, id, sidecar);
         }
       }
     }

--- a/bindings/electron/scripts/bundle-native.ts
+++ b/bindings/electron/scripts/bundle-native.ts
@@ -202,6 +202,33 @@ function backendCandidates(id: BundlePackageId): readonly string[] {
   ];
 }
 
+/**
+ * Vendor runtimes a backend links directly, by platform-correct file name.
+ * ONNX Runtime is shared by both engines; sherpa additionally needs its C API.
+ */
+function vendorRuntimeNames(id: BundlePackageId): readonly string[] {
+  const ort = win
+    ? ['onnxruntime.dll', 'onnxruntime_providers_shared.dll']
+    : mac
+      ? ['libonnxruntime.dylib']
+      : ['libonnxruntime.so.1', 'libonnxruntime.so'];
+  if (id === BundlePackageId.Sherpa) {
+    return [...ort, win ? 'sherpa-onnx-c-api.dll' : mac ? 'libsherpa-onnx-c-api.dylib' : 'libsherpa-onnx-c-api.so'];
+  }
+  return ort;
+}
+
+/** Everywhere a vendor runtime may have been produced or vendored. */
+function vendorRuntimeCandidates(name: string): readonly string[] {
+  return [
+    path.join(buildDir, name),
+    path.join(buildRoot, '_deps', 'onnxruntime-src', 'lib', name),
+    path.join(repoRoot, 'core', 'third_party', 'sherpa-onnx-windows', 'lib', name),
+    path.join(repoRoot, 'core', 'third_party', 'sherpa-onnx-macos', 'lib', name),
+    path.join(repoRoot, 'core', 'third_party', 'sherpa-onnx-linux', 'lib', name),
+  ];
+}
+
 /** Stage an optional sidecar into `packageId` when the file exists. */
 function pushOptionalSidecar(
   files: StagedFile[],
@@ -332,6 +359,20 @@ function buildStagingPlan(
       // stage both beside the plugin so dlopen does not need a manual cp step.
       pushOptionalSidecar(files, id, findExisting(backendCandidates(id)));
       pushOptionalSidecar(files, id, commonsPath);
+
+      // The vendor runtime each backend links has to sit beside THAT backend,
+      // not only in core. `rac_backend_onnx` imports onnxruntime and
+      // `rac_backend_sherpa` imports sherpa-onnx-c-api, and commons loads a
+      // plugin with LOAD_WITH_ALTERED_SEARCH_PATH / @loader_path / $ORIGIN —
+      // all of which search the PLUGIN's own directory. Core's copy is not on
+      // that path, so staging it there alone leaves the published package
+      // unusable: onnx reports "Backend not ready" and sherpa takes the
+      // utility host down with an access violation (0xC0000005).
+      if (id === BundlePackageId.ONNX || id === BundlePackageId.Sherpa) {
+        for (const sidecar of vendorRuntimeNames(id)) {
+          pushOptionalSidecar(files, id, findExisting(vendorRuntimeCandidates(sidecar)));
+        }
+      }
     }
   }
 


### PR DESCRIPTION
Found by the Windows agent testing the **published** `0.20.21` packages on `win32-x64`. This is a live defect in what is on npm right now, not a hypothetical.

## What breaks

Against pristine published natives, the inference gate gives **2 passed, 3 failed**:

```
ok  the engines this platform ships are actually loaded
ok  llamacpp generates text        "Colour"  15.9 tok/s
x   onnx embeds text               Error: Backend not ready
x   sherpa synthesises speech      Error: inference host exited unexpectedly (code 3221225477)
x   sherpa transcribes speech      Error: inference host exited unexpectedly (code 3221225477)
```

`3221225477` is `0xC0000005` — an access violation that takes the utility host down.

## Why

`rac_backend_onnx.dll` imports `onnxruntime.dll` and `rac_backend_sherpa.dll` imports `sherpa-onnx-c-api.dll`, but `bundle-native.ts` staged those vendor runtimes into **`@runanywhere/electron` only**. Commons loads a plugin with `LOAD_WITH_ALTERED_SEARCH_PATH`, which searches the *plugin's* own directory — the core package's copy is not on that path. Same story on the other platforms via `@loader_path` / `$ORIGIN`.

Copying the two DLLs beside each plugin and changing nothing else: **5 passed, 1 skipped**, embedding dims `[384, 384]`, tts `47564` samples, stt `" the quick brown fox."`.

## Why nobody caught it

The app's own `scripts/use-sdk.mjs` overlay already stages vendor runtimes **per package** (`if (id === 'onnx') files.push(ort, ortProviders)`). So the dev overlay was more correct than the shipping bundler, and byte-identical natives passed from a local build while failing from the tarball. Every Windows validation to date ran through that overlay.

macOS is unaffected: the vendor libraries are statically linked into `librac_backend_*.dylib` there, which is why the darwin packages ship three files and no `libonnxruntime`.

## The change

Staged file counts move from `[core:5, llamacpp:3, onnx:3, sherpa:3]` to `[core:5, llamacpp:3, onnx:5, sherpa:6]`. Core keeps its copies — the fat/dev path still resolves from beside the addon.

## Note for the release

The natives themselves are correct and unchanged; only staging was wrong. Reaching users needs a republish, since npm is immutable — see the release discussion on the tracking issue.

Reported and fixed by the Windows agent on a Snapdragon X2 Elite; PR opened from the Mac because `gh` is not installed on that box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved desktop application packaging for ONNX and sherpa-based features.
  * Required runtime components are now included more reliably across supported platforms, reducing missing-library errors.
  * Builds remain resilient when optional components are unavailable on Linux and macOS.
  * Windows packaging now reports missing required runtime components early, helping prevent incomplete application bundles.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->