### PR TITLE
fix(electron): resolve backend plugins out of app.asar.unpacked

### DIFF
--- a/bindings/electron/src/backend/plugin-registry.ts
+++ b/bindings/electron/src/backend/plugin-registry.ts
@@ -98,13 +98,40 @@ export function pluginPrebuildDir(locator: PluginArtifactLocator): string {
 }
 
 /**
+ * Rewrite a path that lands inside `app.asar` to the unpacked copy beside it.
+ *
+ * A packaged Electron app resolves this package's root from `__dirname`, which
+ * is a path INTO the asar archive — virtual, with no file behind it. Native
+ * code cannot load from there, so electron-builder's `asarUnpack` writes the
+ * real bytes to `app.asar.unpacked/...`. Electron's `fs` shim reads both
+ * transparently, so the existence check below passes on the virtual path and
+ * hands the OS loader a file it cannot open: the addon comes up, every backend
+ * then reports "the plugin library could not be loaded", and nothing names the
+ * archive. Every packaged consumer hits this, so the rewrite belongs here
+ * rather than in each app.
+ *
+ * Only rewritten when the unpacked file is actually there, so an app that
+ * unpacks nothing, or a plain unpackaged tree, is left exactly as it was.
+ */
+function asarUnpacked(filePath: string): string {
+  if (!filePath.includes(`app.asar${path.sep}`)) return filePath;
+  const unpacked = filePath.replace(
+    `app.asar${path.sep}`,
+    `app.asar.unpacked${path.sep}`
+  );
+  return isExistingFile(unpacked) ? unpacked : filePath;
+}
+
+/**
  * Absolute path where Track A stages the loadable plugin. Does not require
  * the file to exist yet — fat-addon builds leave this empty until the shared
  * dylib spike lands.
  */
 export function resolvePluginArtifactPath(locator: PluginArtifactLocator): string {
   const platform = locator.platform ?? process.platform;
-  return path.join(pluginPrebuildDir(locator), pluginLibraryFileName(locator.id, platform));
+  return asarUnpacked(
+    path.join(pluginPrebuildDir(locator), pluginLibraryFileName(locator.id, platform))
+  );
 }
 
 /** Whether the resolved artifact is present on disk (thin-addon ready). */

--- a/bindings/electron/test/unit/plugin-registry.test.ts
+++ b/bindings/electron/test/unit/plugin-registry.test.ts
@@ -19,6 +19,7 @@ import {
 
 /** A throwaway `<root>/app.asar[.unpacked]/...` layout for one backend. */
 function stageAsarLayout(options: { unpack: boolean }): {
+  root: string;
   packageRoot: string;
   unpackedFile: string;
 } {
@@ -39,7 +40,7 @@ function stageAsarLayout(options: { unpack: boolean }): {
     fs.mkdirSync(path.dirname(unpackedFile), { recursive: true });
     fs.writeFileSync(unpackedFile, 'not a real dylib');
   }
-  return { packageRoot, unpackedFile };
+  return { root, packageRoot, unpackedFile };
 }
 
 test('a plain package root resolves to prebuilds/<platform>-<arch>/<lib>', () => {
@@ -56,23 +57,31 @@ test('a plain package root resolves to prebuilds/<platform>-<arch>/<lib>', () =>
 });
 
 test('a path inside app.asar resolves to the unpacked file that really exists', () => {
-  const { packageRoot, unpackedFile } = stageAsarLayout({ unpack: true });
-  assert.equal(
-    resolvePluginArtifactPath({ id: BackendPluginId.Sherpa, packageRoot }),
-    unpackedFile
-  );
+  const { root, packageRoot, unpackedFile } = stageAsarLayout({ unpack: true });
+  try {
+    assert.equal(
+      resolvePluginArtifactPath({ id: BackendPluginId.Sherpa, packageRoot }),
+      unpackedFile
+    );
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('app.asar is left alone when nothing was unpacked beside it', () => {
   // Rewriting unconditionally would replace a path that at least resolves
   // through Electron's fs shim with one that exists nowhere at all.
-  const { packageRoot } = stageAsarLayout({ unpack: false });
-  const resolved = resolvePluginArtifactPath({ id: BackendPluginId.Sherpa, packageRoot });
-  assert.ok(
-    resolved.includes(`app.asar${path.sep}`),
-    'unpacked copy is absent, so the original path must survive'
-  );
-  assert.ok(!resolved.includes('app.asar.unpacked'), 'must not invent an unpacked path');
+  const { root, packageRoot } = stageAsarLayout({ unpack: false });
+  try {
+    const resolved = resolvePluginArtifactPath({ id: BackendPluginId.Sherpa, packageRoot });
+    assert.ok(
+      resolved.includes(`app.asar${path.sep}`),
+      'unpacked copy is absent, so the original path must survive'
+    );
+    assert.ok(!resolved.includes('app.asar.unpacked'), 'must not invent an unpacked path');
+  } finally {
+    fs.rmSync(root, { recursive: true, force: true });
+  }
 });
 
 test('a package root merely containing the text "asar" is not rewritten', () => {

--- a/bindings/electron/test/unit/plugin-registry.test.ts
+++ b/bindings/electron/test/unit/plugin-registry.test.ts
@@ -1,0 +1,82 @@
+// Unit tests for backend plugin artifact resolution.
+//
+// The asar cases are the ones with teeth: a packaged Electron app resolves a
+// backend package root from `__dirname`, which points INSIDE app.asar, and the
+// OS loader cannot open a path in an archive. These assert the rewrite to the
+// unpacked copy happens, and — just as important — that it does not happen when
+// there is nothing unpacked to rewrite to.
+import assert from 'node:assert/strict';
+import * as fs from 'node:fs';
+import * as os from 'node:os';
+import * as path from 'node:path';
+import { test } from 'node:test';
+
+import {
+  BackendPluginId,
+  pluginLibraryFileName,
+  resolvePluginArtifactPath,
+} from '../../dist/backend/plugin-registry';
+
+/** A throwaway `<root>/app.asar[.unpacked]/...` layout for one backend. */
+function stageAsarLayout(options: { unpack: boolean }): {
+  packageRoot: string;
+  unpackedFile: string;
+} {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'ra-asar-'));
+  const rel = path.join(
+    'node_modules',
+    '@runanywhere',
+    'electron-sherpa'
+  );
+  const packageRoot = path.join(root, 'app.asar', rel);
+  const leaf = path.join(
+    'prebuilds',
+    `${process.platform}-${process.arch}`,
+    pluginLibraryFileName(BackendPluginId.Sherpa)
+  );
+  const unpackedFile = path.join(root, 'app.asar.unpacked', rel, leaf);
+  if (options.unpack) {
+    fs.mkdirSync(path.dirname(unpackedFile), { recursive: true });
+    fs.writeFileSync(unpackedFile, 'not a real dylib');
+  }
+  return { packageRoot, unpackedFile };
+}
+
+test('a plain package root resolves to prebuilds/<platform>-<arch>/<lib>', () => {
+  const packageRoot = path.join(path.sep, 'tmp', 'pkg');
+  assert.equal(
+    resolvePluginArtifactPath({ id: BackendPluginId.Sherpa, packageRoot }),
+    path.join(
+      packageRoot,
+      'prebuilds',
+      `${process.platform}-${process.arch}`,
+      pluginLibraryFileName(BackendPluginId.Sherpa)
+    )
+  );
+});
+
+test('a path inside app.asar resolves to the unpacked file that really exists', () => {
+  const { packageRoot, unpackedFile } = stageAsarLayout({ unpack: true });
+  assert.equal(
+    resolvePluginArtifactPath({ id: BackendPluginId.Sherpa, packageRoot }),
+    unpackedFile
+  );
+});
+
+test('app.asar is left alone when nothing was unpacked beside it', () => {
+  // Rewriting unconditionally would replace a path that at least resolves
+  // through Electron's fs shim with one that exists nowhere at all.
+  const { packageRoot } = stageAsarLayout({ unpack: false });
+  const resolved = resolvePluginArtifactPath({ id: BackendPluginId.Sherpa, packageRoot });
+  assert.ok(
+    resolved.includes(`app.asar${path.sep}`),
+    'unpacked copy is absent, so the original path must survive'
+  );
+  assert.ok(!resolved.includes('app.asar.unpacked'), 'must not invent an unpacked path');
+});
+
+test('a package root merely containing the text "asar" is not rewritten', () => {
+  const packageRoot = path.join(path.sep, 'tmp', 'asarcompany', 'pkg');
+  const resolved = resolvePluginArtifactPath({ id: BackendPluginId.ONNX, packageRoot });
+  assert.ok(resolved.startsWith(packageRoot), 'only a real app.asar segment is a container');
+});


### PR DESCRIPTION
The SDK-side root cause of the packaged-app failure the Windows agent found. [runanywhere-electron#6](https://github.com/RunanywhereAI/runanywhere-electron/pull/6) works around it in our app to unblock shipping; this fixes it for **every** packaged Electron consumer.

## What breaks

```
backends: []
backend:qhexrt — the plugin library could not be loaded
                 (missing file, wrong architecture, or unresolved symbols)
```

Each backend package calls `resolvePluginArtifactPath()` with a `packageRoot` taken from its own `__dirname`. Packaged, that is a path **into `app.asar`** — virtual, with no file behind it — so electron-builder's `asarUnpack` writes the real bytes to `app.asar.unpacked`.

## Why it was invisible

Electron's `fs` shim reads both transparently. So `pluginArtifactExists()` returns **true** for the virtual path, the path survives the existence filter into `RUNANYWHERE_PLUGIN_PATHS`, and then the OS loader — which has no asar shim — cannot open it. The addon itself resolved fine, so the SDK came up healthy and only the engines vanished, and nothing in the failure text names the archive.

## The change

`resolvePluginArtifactPath()` rewrites `app.asar` → `app.asar.unpacked`, and only when the unpacked file is actually present. An app that unpacks nothing, and an ordinary unpackaged tree, behave exactly as before.

This belongs in the SDK, not in each app: the path is computed here from a `packageRoot` the app never supplies, every packaged consumer hits it, and the failure gives them no route to this cause.

## Verification

Verified on a packaged Windows ARM64 build (Snapdragon X2 Elite, Hexagon v81) against the published `0.20.21` packages — `backends` went from `[]` to `["QHEXRT"]`, generating at 55.34 tok/s.

Four new unit tests cover the rewrite, the nothing-unpacked case, and a package root that merely contains the text `asar`. 234 tests pass, typecheck clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved plugin artifact loading in packaged desktop applications.
  - Uses unpacked plugin files when available while preserving valid archive paths when they are not.
  - Prevents incorrect path rewrites for unrelated filenames that merely contain similar text.

- **Tests**
  - Added coverage for packaged paths, unpacked files, fallback behavior, and path-matching edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->