### PR TITLE
fix(ci): take patchelf from PyPI so auditwheel stops failing python-linux 3.12

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -358,11 +358,19 @@ jobs:
       - uses: ./.github/actions/generate-idl
         with:
           languages: python
+      # patchelf comes from PyPI, not apt. ubuntu-22.04 ships 0.14.3 and current
+      # auditwheel requires >= 0.14.5, so `auditwheel repair` died with
+      # "patchelf 0.14.3 found. auditwheel repair requires patchelf >= 0.14.5".
+      # Only 3.12 failed: 3.9 resolves an older auditwheel that still accepts
+      # 0.14.3, which is why this surfaced as one red cell rather than a red job.
+      # Both tools now come from the same resolver, so they cannot drift apart
+      # again the way an apt package and a pip package silently did.
       - name: Build tools (patchelf is required by auditwheel)
         run: |
           sudo apt-get update -q
-          sudo apt-get install -y -q patchelf ninja-build
-          python -m pip install --upgrade pip build auditwheel pytest
+          sudo apt-get install -y -q ninja-build
+          python -m pip install --upgrade pip build auditwheel patchelf pytest
+          patchelf --version
       - name: Sherpa-ONNX prebuilts
         run: |
           ./core/scripts/linux/download-sherpa-onnx.sh


### PR DESCRIPTION
`python-linux (3.12)` is failing on **every** PR opened today, including ones that touch no Python at all:

```
ValueError: patchelf 0.14.3 found. auditwheel repair requires patchelf >= 0.14.5.
```

## Why it started without anyone changing anything

`ubuntu-22.04`'s apt ships **patchelf 0.14.3**, while `pip install --upgrade auditwheel` takes the newest release — which raised its floor to **0.14.5**. Two halves of an unpinned pair, resolved from two different package managers, drifted apart on their own.

Only 3.12 went red because 3.9 resolves an older `auditwheel` that still accepts 0.14.3. That is why this looked like one odd red cell rather than an obviously environmental break.

## Evidence it is not any PR

| PR | touches | `python-linux (3.12)` |
|---|---|---|
| [#703](https://github.com/RunanywhereAI/runanywhere-sdks/pull/703) | electron TS + docs | fail |
| [#704](https://github.com/RunanywhereAI/runanywhere-sdks/pull/704) | `bundle-native.ts` only | fail |
| [#705](https://github.com/RunanywhereAI/runanywhere-sdks/pull/705) | `plugin-registry.ts` + a test | fail |
| [#702](https://github.com/RunanywhereAI/runanywhere-sdks/pull/702), [#700](https://github.com/RunanywhereAI/runanywhere-sdks/pull/700), [#696](https://github.com/RunanywhereAI/runanywhere-sdks/pull/696) | ran at 07:46 or earlier | pass |

Three unrelated PRs reproduce it identically; the ones that ran before today's runner image are green.

## The change

`patchelf` comes from PyPI alongside `auditwheel`, so a single resolver sees both and they cannot drift apart the same way again. Its version is echoed right after install, so the next mismatch names itself in the log instead of surfacing 12 minutes later inside a wheel repair.

Pinning `auditwheel` instead would freeze a release-tooling dependency and drift again on the next bump; moving to `ubuntu-24.04` would swap the whole toolchain to fix one binary.

**This one should merge first — it is what is currently blocking every other PR in the repo.**

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the Linux wheel build environment to install and verify the required binary-patching tool through Python packaging.
  * Continued installing the build tool through the system package manager.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->