### PR TITLE
fix(electron): resolve the sidecar dirs out of app.asar.unpacked too

### DIFF
--- a/bindings/electron/src/backend/plugin-registry.ts
+++ b/bindings/electron/src/backend/plugin-registry.ts
@@ -113,7 +113,7 @@ export function pluginPrebuildDir(locator: PluginArtifactLocator): string {
  * Only rewritten when the unpacked file is actually there, so an app that
  * unpacks nothing, or a plain unpackaged tree, is left exactly as it was.
  */
-function asarUnpacked(filePath: string): string {
+export function asarUnpacked(filePath: string): string {
   if (!filePath.includes(`app.asar${path.sep}`)) return filePath;
   const unpacked = filePath.replace(
     `app.asar${path.sep}`,

--- a/bindings/electron/src/bridge.ts
+++ b/bindings/electron/src/bridge.ts
@@ -6,6 +6,7 @@
 import * as fs from 'fs';
 import * as path from 'path';
 
+import { asarUnpacked } from './backend/plugin-registry';
 import { asSDKException } from './errors';
 
 // Re-exported for existing importers (RunAnywhere.ts imports it from here); the
@@ -485,7 +486,12 @@ function commonsLibraryFileName(platform: NodeJS.Platform = process.platform): s
 
 /** Absolute path to shared commons beside a thin addon, or `undefined`. */
 export function resolveCommonsLibrary(addonDir: string): string | undefined {
-  const candidate = path.join(addonDir, commonsLibraryFileName());
+  // Same asar trap resolvePluginArtifactPath guards against: inside a packaged
+  // app this path can point into app.asar, where fs.existsSync succeeds through
+  // Electron's shim but the OS loader sees nothing. The result feeds
+  // addSidecarDirToDllSearch, which is an OS-level call, so it has to be the
+  // real file on disk.
+  const candidate = asarUnpacked(path.join(addonDir, commonsLibraryFileName()));
   return fs.existsSync(candidate) ? candidate : undefined;
 }
 
@@ -547,7 +553,11 @@ function pluginPathCandidatesFromEnv(): string[] {
 }
 
 function prepareNativeLoad(addonPath: string): void {
-  const addonDir = path.dirname(addonPath);
+  // require() can load a .node out of app.asar because Electron patches
+  // process.dlopen to extract it, so addonPath may still be an archive path
+  // here. Everything below hands directories to the OS loader instead, which
+  // cannot look inside the archive, so resolve to the unpacked copy first.
+  const addonDir = path.dirname(asarUnpacked(addonPath));
   addSidecarDirToDllSearch(addonDir);
   const commons = resolveCommonsLibrary(addonDir);
   if (commons) addSidecarDirToDllSearch(path.dirname(commons));

--- a/bindings/electron/test/unit/asar.test.ts
+++ b/bindings/electron/test/unit/asar.test.ts
@@ -1,0 +1,102 @@
+// Unit tests for the app.asar → app.asar.unpacked rewrite that every path
+// handed to the OS loader has to go through.
+//
+// These run under plain Node, without Electron's fs shim. That is the useful
+// half of the packaged-app shape: the archive path has nothing behind it, which
+// is exactly what dlopen and AddDllDirectory see inside a real packaged app.
+// Electron's shim is what makes the bug invisible in JS, not what makes it work.
+import assert from 'node:assert/strict';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { after, test } from 'node:test';
+
+import { asarUnpacked } from '../../dist/backend/plugin-registry';
+import { resolveCommonsLibrary } from '../../dist/bridge';
+
+const roots: string[] = [];
+
+// Every commons filename the three shipping platforms use. The resolver picks
+// by process.platform, so staging all three keeps the fixture host-agnostic
+// without restating the mapping the resolver owns.
+const COMMONS_FILE_NAMES = ['librac_commons.dylib', 'librac_commons.so', 'rac_commons.dll'];
+
+/**
+ * Stage a packaged-app layout and hand back the two sibling directories.
+ * `archive` is inside app.asar and never gets files written under it; whatever
+ * the caller stages goes in `unpacked`.
+ */
+function stagePackagedApp(): { archive: string; unpacked: string } {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rac-asar-'));
+  roots.push(root);
+  const archive = path.join(root, 'app.asar', 'node_modules', 'runanywhere', 'dist');
+  const unpacked = path.join(root, 'app.asar.unpacked', 'node_modules', 'runanywhere', 'dist');
+  fs.mkdirSync(unpacked, { recursive: true });
+  return { archive, unpacked };
+}
+
+after(() => {
+  for (const root of roots) fs.rmSync(root, { recursive: true, force: true });
+});
+
+test('asarUnpacked leaves a path outside app.asar alone', () => {
+  const plain = path.join(os.tmpdir(), 'not-packaged', 'librac_commons.dylib');
+  assert.equal(asarUnpacked(plain), plain);
+});
+
+test('asarUnpacked rewrites to the unpacked sibling when the real file is there', () => {
+  const { archive, unpacked } = stagePackagedApp();
+  fs.writeFileSync(path.join(unpacked, 'runanywhere_llamacpp.dll'), '');
+
+  assert.equal(
+    asarUnpacked(path.join(archive, 'runanywhere_llamacpp.dll')),
+    path.join(unpacked, 'runanywhere_llamacpp.dll')
+  );
+});
+
+test('asarUnpacked returns the input when nothing was unpacked', () => {
+  // An app that sets no asarUnpack rule has no sibling tree at all. Rewriting
+  // blindly would hand the loader a path that is wrong in a second way.
+  const { archive } = stagePackagedApp();
+  const inArchive = path.join(archive, 'runanywhere_llamacpp.dll');
+  assert.equal(asarUnpacked(inArchive), inArchive);
+});
+
+test('asarUnpacked rewrites a directory path, not just a file path', () => {
+  // prepareNativeLoad rewrites the addon path and then takes its dirname, so
+  // the directory that reaches addSidecarDirToDllSearch has to land in the
+  // unpacked tree too — that directory is the whole point of the call.
+  const { archive, unpacked } = stagePackagedApp();
+  fs.writeFileSync(path.join(unpacked, 'runanywhere_native.node'), '');
+
+  const addonDir = path.dirname(asarUnpacked(path.join(archive, 'runanywhere_native.node')));
+  assert.equal(addonDir, unpacked);
+});
+
+test('resolveCommonsLibrary finds commons staged in the unpacked tree', () => {
+  // The regression: the addon loads from the archive because Electron patches
+  // process.dlopen, so addonDir is an archive path. Joining the commons name
+  // onto it and existence-checking that used to be the whole resolver, which
+  // meant the one consumer that needs a real disk path never got one.
+  const { archive, unpacked } = stagePackagedApp();
+  for (const name of COMMONS_FILE_NAMES) fs.writeFileSync(path.join(unpacked, name), '');
+
+  const resolved = resolveCommonsLibrary(archive);
+  assert.ok(resolved, 'commons should resolve out of app.asar.unpacked');
+  assert.equal(path.dirname(resolved), unpacked);
+});
+
+test('resolveCommonsLibrary reports nothing when commons was not staged', () => {
+  const { archive } = stagePackagedApp();
+  assert.equal(resolveCommonsLibrary(archive), undefined);
+});
+
+test('resolveCommonsLibrary still works in an unpackaged tree', () => {
+  const root = fs.mkdtempSync(path.join(os.tmpdir(), 'rac-plain-'));
+  roots.push(root);
+  for (const name of COMMONS_FILE_NAMES) fs.writeFileSync(path.join(root, name), '');
+
+  const resolved = resolveCommonsLibrary(root);
+  assert.ok(resolved, 'commons should resolve from a plain directory');
+  assert.equal(path.dirname(resolved), root);
+});


### PR DESCRIPTION
Follows #705. That PR introduced `asarUnpacked()` and applied it to the plugin library path; the two sibling paths in `bridge.ts` still hand archive paths to the OS loader.

## What is wrong

`resolveCommonsLibrary` accepts a path on `fs.existsSync` and returns it:

```ts
export function resolveCommonsLibrary(addonDir: string): string | undefined {
  const candidate = path.join(addonDir, commonsLibraryFileName());
  return fs.existsSync(candidate) ? candidate : undefined;
}
```

That is the exact trap your own comment on `asarUnpacked` describes: inside a packaged app the candidate can point into `app.asar`, `fs.existsSync` succeeds through Electron's shim, and the file behind it is virtual. The result does not stay in JS, it goes to `addSidecarDirToDllSearch`, which is an OS-level call:

```ts
function prepareNativeLoad(addonPath: string): void {
  const addonDir = path.dirname(addonPath);
  addSidecarDirToDllSearch(addonDir);
  const commons = resolveCommonsLibrary(addonDir);
  if (commons) addSidecarDirToDllSearch(path.dirname(commons));
```

`addonPath` is still an archive path at that point. `resolveAddon` builds the packaged candidate from `__dirname`, and `require()` succeeds on it because Electron patches `process.dlopen` to extract a `.node` out of asar. The addon therefore loads, and every directory registered for the loader afterwards points inside the archive, so `rac_commons` and the vendor runtimes staged next to it by #704 are not on the search path.

## Why the plugin fix did not cover it

The distinction is which loader sees the path. The plugin library is `dlopen`ed from C++, so it never passes through Electron's patched `process.dlopen` and #705 had to rewrite it. The addon does pass through that patch, which is why it loads from the archive and hides the problem, while the sidecar directories derived from it silently do not work.

## What this does

Sends both paths through the existing `asarUnpacked`, exported for the purpose rather than duplicated. It already returns the input unchanged when the path is not inside `app.asar` and when the unpacked file is not present, so unpackaged trees and apps that unpack nothing are untouched.

## Testing, and what I could not verify

`npm install` in `bindings/electron` succeeds, but `tsc -p tsconfig.json --noEmit` cannot resolve `@runanywhere/proto-ts/*` on this machine: that package's `exports` map to `./dist/*`, and building it needs `@bufbuild/protobuf/wire`, which `npm install` inside `bindings/proto-ts` will not install here because it resolves against the monorepo root and hits an ERESOLVE conflict.

So I checked the diff does not add errors rather than claiming a green typecheck:

- clean tree: 118 `error TS` lines, all `TS2307` proto-ts resolution
- with this diff: 118, identical
- errors in `bridge.ts` or `backend/plugin-registry.ts`: none in either run

I also have not run this in a packaged Windows app, which is where it matters. The reasoning above is from the code and from the mechanism your #705 comment documents, so it is worth a packaged smoke test before trusting it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved native component loading in packaged desktop applications.
  * Ensured required libraries and add-ons are correctly located when running from packaged installations.
  * Fixed path handling for components stored outside the application archive.
  * Improved compatibility across packaged and unpackaged installations, including cases where optional libraries are unavailable.
  * Added coverage for packaged path resolution and native library loading scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->