### PR TITLE
docs(electron): Windows ships at 0.20.22, not 0.20.21

### DIFF
--- a/bindings/electron/AGENTS.md
+++ b/bindings/electron/AGENTS.md
@@ -94,7 +94,9 @@ Adapted from `thoughts/shared/plans/BEST_PRACTISES.md` for this package:
 
 - Document what is true today. Do not claim encryption or remote Phase-2 auth unless
   packaging and runtime are wired end-to-end.
-- **Windows ships at 0.20.21.** Prebuilds: `darwin-arm64` (llamacpp / ONNX / Sherpa),
+- **Windows ships at 0.20.22.** 0.20.21 was the first release carrying Windows
+  natives and went out with two staging defects; 0.20.22 is the first one that
+  works. Prebuilds: `darwin-arm64` (llamacpp / ONNX / Sherpa),
   `win32-x64` (llamacpp / ONNX / Sherpa), `win32-arm64` (QHexRT / Hexagon NPU only).
   Linux still has no prebuild. `package.json` keeps `os`/`cpu` permissive on purpose,
   because the TypeScript facade genuinely is cross-platform and narrowing them would


### PR DESCRIPTION
Docs only, so by the fleet's own rule this does not consume a quota slot. Opening it because it points Windows consumers at a release that is known broken.

## What is wrong

`bindings/electron/AGENTS.md:97` says:

> **Windows ships at 0.20.21.**

The 0.20.22 release commit (`963f542d`) says otherwise:

> 0.20.21 is the first release carrying Windows natives and it went out with two defects, both found on the device and both now fixed on main.

and its subject is "fix the Windows staging that 0.20.21 shipped broken". So 0.20.22 is the first Windows release that works, and this line sends a reader to the one that does not.

Two lines above it, the same file states the rule it is breaking:

> Document what is true today. Do not claim encryption or remote Phase-2 auth unless packaging and runtime are wired end-to-end.

## What this does

Updates the version and says in one clause why the previous one is not the answer, so nobody re-derives it from the release log.

I checked the rest of the tree for the same claim: `0.20.21` appears in no other doc or manifest outside changelogs, and the `README.md` and `package.json` statements name platforms without a version, so they are already correct. `CLAUDE.md` in that directory is a symlink to `AGENTS.md`, so it follows automatically.

## Testing

Prose only, no code path touched.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated Electron readiness guidance to identify Windows version 0.20.22 as the first working release.
  - Documented known staging defects in version 0.20.21.
  - Confirmed that Windows and macOS prebuild targets remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->