### PR TITLE
neurt: serve TRANSCRIBE on the Apple Neural Engine

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -677,6 +677,34 @@ if(RAC_BUILD_TESTS)
         add_test(NAME diffusion_coreml_generate_tests COMMAND test_diffusion_coreml_generate)
     endif()
 
+    # NeuRT ASR end to end: a WAV in through the SDK's own stt_ops, a scored transcript out.
+    # The seam neither of the other two neurt tests covers — the plugin test stops at the vtable
+    # and neurun's own tools stop at the runtime. Skips (exit 0) without RAC_ASR_BUNDLE, because a
+    # multi-gigabyte private bundle cannot be a hard requirement of the test suite.
+    if(APPLE AND RAC_BACKEND_NEURT
+       AND TARGET rac_backend_neurt
+       AND RAC_NEURT_ENGINE_AVAILABLE
+       AND NOT TARGET test_stt_neurt_e2e)
+        add_executable(test_stt_neurt_e2e core/tests/test_stt_neurt_e2e.cpp)
+        target_include_directories(test_stt_neurt_e2e PRIVATE
+            ${CMAKE_CURRENT_SOURCE_DIR}/core/tests
+            ${CMAKE_CURRENT_SOURCE_DIR}/core/include
+        )
+        target_link_libraries(test_stt_neurt_e2e PRIVATE rac_commons rac_backend_neurt)
+        if(TARGET archive_static)
+            target_link_libraries(test_stt_neurt_e2e PRIVATE archive_static)
+        endif()
+        if(TARGET zlibstatic)
+            target_link_libraries(test_stt_neurt_e2e PRIVATE zlibstatic)
+        endif()
+        if(TARGET bz2_bundled)
+            target_link_libraries(test_stt_neurt_e2e PRIVATE bz2_bundled)
+        endif()
+        target_compile_features(test_stt_neurt_e2e PRIVATE cxx_std_17)
+        add_test(NAME stt_neurt_e2e_tests COMMAND test_stt_neurt_e2e)
+        set_tests_properties(stt_neurt_e2e_tests PROPERTIES LABELS "native;neurt;stt")
+    endif()
+
     # neurt engine plugin-entry smoke test. Same wiring rationale as sherpa:
     # rac_backend_neurt is built by engines/ which is configured after
     # core/. The neurt engine is the sole

--- a/bindings/swift/scripts/build-core-xcframework.sh
+++ b/bindings/swift/scripts/build-core-xcframework.sh
@@ -853,9 +853,15 @@ merge_neurt_backend_slice() {
         "${build_root}/engines/neurt/${slice_dir}/librac_backend_neurt.a"
     )
     local _neurt_llm_ops="${build_root}/engines/neurt/${slice_dir}/librac_neurt_llm_ops.a"
+    local _neurt_stt_ops="${build_root}/engines/neurt/${slice_dir}/librac_neurt_stt_ops.a"
     local _neurt_core="${build_root}/engines/neurt/${slice_dir}/librac_neurt_core.a"
     if [ -f "${_neurt_llm_ops}" ] && [ -f "${_neurt_core}" ]; then
         inputs+=("${_neurt_llm_ops}" "${_neurt_core}")
+        # The SPEECH op table, same story as the LLM one above: its own CMake target, so its
+        # objects are not in librac_backend_neurt.a, and omitting it ships an archive carrying
+        # `U _g_neurt_stt_ops`. Measured exactly that — every target compiled, the xcframework
+        # packaged, and the iOS app failed at its own link.
+        [ -f "${_neurt_stt_ops}" ] && inputs+=("${_neurt_stt_ops}")
     else
         echo "note: NeuRT private archives absent — packaging the non-routable shell slice (${slice_dir})" >&2
     fi
@@ -880,9 +886,11 @@ merge_neurt_backend_macos_slice() {
         "${build_root}/engines/neurt/librac_backend_neurt.a"
     )
     local _neurt_llm_ops="${build_root}/engines/neurt/librac_neurt_llm_ops.a"
+    local _neurt_stt_ops="${build_root}/engines/neurt/librac_neurt_stt_ops.a"
     local _neurt_core="${build_root}/engines/neurt/librac_neurt_core.a"
     if [ -f "${_neurt_llm_ops}" ] && [ -f "${_neurt_core}" ]; then
         inputs+=("${_neurt_llm_ops}" "${_neurt_core}")
+        [ -f "${_neurt_stt_ops}" ] && inputs+=("${_neurt_stt_ops}")
     else
         echo "note: NeuRT private archives absent — packaging the non-routable shell slice (macos)" >&2
     fi

--- a/core/tests/test_plugin_entry_neurt.cpp
+++ b/core/tests/test_plugin_entry_neurt.cpp
@@ -147,8 +147,17 @@ int main() {
                          "not linked in (check that g_neurt_llm_ops is declared `extern`)\n");
             return 1;
         }
-        // Disjoint-slot invariant: DIFFUSION + GENERATE_TEXT only, today.
-        if (vt->stt_ops != nullptr || vt->tts_ops != nullptr || vt->vad_ops != nullptr ||
+        // Same linkage guard for the speech op table. A missing `extern` here fails exactly the
+        // way the LLM one did: everything builds, the archive is tiny, and the slot is silently
+        // null at dispatch.
+        if (vt->stt_ops == nullptr) {
+            std::fprintf(stderr,
+                         "routable neurt engine has NULL stt_ops slot — the NeuRT ASR op-table is "
+                         "not linked in (check that g_neurt_stt_ops is declared `extern`)\n");
+            return 1;
+        }
+        // Disjoint-slot invariant: DIFFUSION + GENERATE_TEXT + TRANSCRIBE, and nothing else.
+        if (vt->tts_ops != nullptr || vt->vad_ops != nullptr ||
             vt->vlm_ops != nullptr || vt->embedding_ops != nullptr) {
             std::fprintf(stderr, "neurt engine advertised an unserved ops slot\n");
             return 1;
@@ -173,6 +182,20 @@ int main() {
         if (rac_plugin_find_for_engine(RAC_PRIMITIVE_GENERATE_TEXT, RAC_ENGINE_ID_NEURT) != vt) {
             std::fprintf(stderr,
                          "plugin_find_for_engine(GENERATE_TEXT, \"%s\") did not pin the neurt "
+                         "engine\n",
+                         RAC_ENGINE_ID_NEURT);
+            rac_plugin_unregister(vt->metadata.name);
+            return 1;
+        }
+        // Speech routes the same way, and this doubles as the manifest check: the registry only
+        // resolves a primitive the manifest ADVERTISES, so a filled stt_ops slot with no
+        // RAC_PRIMITIVE_TRANSCRIBE entry fails right here rather than being unreachable in the
+        // field. sherpa serves TRANSCRIBE at priority 90 and cloud at 50, so an unpinned request is
+        // a priority question this engine should not silently win; the pinned path is the one an
+        // ANE bundle actually arrives on.
+        if (rac_plugin_find_for_engine(RAC_PRIMITIVE_TRANSCRIBE, RAC_ENGINE_ID_NEURT) != vt) {
+            std::fprintf(stderr,
+                         "plugin_find_for_engine(TRANSCRIBE, \"%s\") did not pin the neurt "
                          "engine\n",
                          RAC_ENGINE_ID_NEURT);
             rac_plugin_unregister(vt->metadata.name);

--- a/core/tests/test_stt_neurt_e2e.cpp
+++ b/core/tests/test_stt_neurt_e2e.cpp
@@ -1,0 +1,302 @@
+// End to end: a WAV file in through the SDK's own STT op table, a scored transcript out.
+//
+// This is the hop nothing else covers. `test_plugin_entry_neurt` proves the vtable slot is filled
+// and the router pins the engine; `neurt_transcribe` in the neurun repo proves the runtime turns
+// audio into the right words. Neither proves the two meet, and that seam is where a wrong struct
+// offset or a byte-vs-sample mixup lives: both sides compile, both sides pass their own tests, and
+// the transcript comes back empty or garbled.
+//
+// NOTHING HERE IS STUBBED. It loads a real published bundle, decodes real recorded speech, and
+// scores the text against the clip's known reference with an edit distance. A hardcoded expected
+// string would pass on a broken build the moment someone pasted the output back in, so the gate is
+// the WER against LibriSpeech's own transcript, computed here.
+//
+// Skips cleanly (exit 0, reason printed) when the bundle or the audio is absent, because a 1.2 GB
+// private-repo download cannot be a hard requirement of a unit test. Point it at one with:
+//
+//     RAC_ASR_BUNDLE=/path/to/parakeet-tdt-0.6b-v3_ANE \
+//     RAC_ASR_WAV=/path/to/ls16k.wav ./test_stt_neurt_e2e
+
+#include <algorithm>
+#include <cctype>
+#include <cstdint>
+#include <cstdio>
+#include <cstdlib>
+#include <cstring>
+#include <fstream>
+#include <string>
+#include <vector>
+
+#include "rac/core/rac_error.h"
+#include "rac/core/rac_types.h"
+#include "rac/features/stt/rac_stt_service.h"
+#include "rac/plugin/rac_engine_vtable.h"
+#include "rac/plugin/rac_plugin_entry.h"
+#include "rac/plugin/rac_plugin_entry_neurt.h"
+
+namespace {
+
+int g_pass = 0;
+int g_fail = 0;
+
+#define CHECK(cond, ...)                                    \
+    do {                                                    \
+        if (cond) { ++g_pass; }                             \
+        else {                                              \
+            ++g_fail;                                       \
+            std::fprintf(stderr, "  FAIL %s:%d: ", __FILE__, __LINE__); \
+            std::fprintf(stderr, __VA_ARGS__);              \
+            std::fprintf(stderr, "\n");                     \
+        }                                                   \
+    } while (0)
+
+// LibriSpeech 1272-128104-0000. The reference is the corpus's own transcript, not something this
+// runtime produced, which is what makes the comparison meaningful.
+constexpr const char* kReference =
+    "Mr Quilter is the apostle of the middle classes and we are glad to welcome his gospel";
+
+// 16-bit PCM WAV. Chunks are walked rather than assumed at a fixed offset: a file written by
+// afconvert carries a LIST chunk before `data`, and a fixed-offset reader feeds metadata to the
+// model as audio.
+std::vector<int16_t> read_wav_i16(const std::string& path, int* sample_rate) {
+    std::ifstream f(path, std::ios::binary);
+    std::vector<int16_t> out;
+    *sample_rate = 0;
+    if (!f) return out;
+    char riff[12];
+    f.read(riff, 12);
+    if (std::memcmp(riff, "RIFF", 4) != 0 || std::memcmp(riff + 8, "WAVE", 4) != 0) return out;
+    int channels = 1, bits = 16;
+    for (;;) {
+        char id[4];
+        uint32_t size = 0;
+        if (!f.read(id, 4) || !f.read(reinterpret_cast<char*>(&size), 4)) break;
+        if (std::memcmp(id, "fmt ", 4) == 0) {
+            unsigned char fmt[16] = {0};
+            const uint32_t want = size < 16 ? size : 16;
+            f.read(reinterpret_cast<char*>(fmt), want);
+            channels = fmt[2] | (fmt[3] << 8);
+            *sample_rate = fmt[4] | (fmt[5] << 8) | (fmt[6] << 16) | (fmt[7] << 24);
+            bits = fmt[14] | (fmt[15] << 8);
+            if (size > want) f.seekg(size - want, std::ios::cur);
+        } else if (std::memcmp(id, "data", 4) == 0) {
+            if (bits != 16 || channels < 1) break;
+            std::vector<int16_t> raw(size / sizeof(int16_t));
+            f.read(reinterpret_cast<char*>(raw.data()), size);
+            out.resize(raw.size() / static_cast<size_t>(channels));
+            for (size_t i = 0; i < out.size(); ++i) {
+                int acc = 0;
+                for (int c = 0; c < channels; ++c) acc += raw[i * channels + c];
+                out[i] = static_cast<int16_t>(acc / channels);
+            }
+            break;
+        } else {
+            f.seekg((size + 1u) & ~1u, std::ios::cur);
+        }
+    }
+    return out;
+}
+
+// Lowercase, strip punctuation, split. "mister" folds to "mr" because the two models spell the
+// same abbreviation differently and that is an orthography choice, not a recognition error.
+std::vector<std::string> normalise(const std::string& s) {
+    std::string low;
+    low.reserve(s.size());
+    for (const char c : s) low.push_back(static_cast<char>(std::tolower(static_cast<unsigned char>(c))));
+    const std::string mister = "mister";
+    for (size_t at = low.find(mister); at != std::string::npos; at = low.find(mister, at + 2)) {
+        low.replace(at, mister.size(), "mr");
+    }
+    std::vector<std::string> words;
+    std::string cur;
+    for (const char c : low) {
+        if (std::isalnum(static_cast<unsigned char>(c))) {
+            cur.push_back(c);
+        } else if (!cur.empty()) {
+            words.push_back(cur);
+            cur.clear();
+        }
+    }
+    if (!cur.empty()) words.push_back(cur);
+    return words;
+}
+
+// Levenshtein over words, divided by the reference length. Computed here rather than compared
+// against a stored string, so the test measures recognition instead of memorising an output.
+// Some bundles compile ONE static audio window and cannot hear a longer clip: Moonshine's is 64000
+// samples (4.0 s) against this 5.9 s recording, so it transcribes the first two thirds and stops.
+// That is the bundle's shape, not a recognition error.
+//
+// Scoring it against the full reference reports a WER that measures the window, so the caller opts
+// into prefix scoring with RAC_ASR_EXPECT_PARTIAL=1 and the test prints the coverage it measured.
+// Deliberately caller-controlled and off by default: switching automatically whenever the output is
+// short would silently forgive a bundle that stopped early for a real reason, which is the failure
+// this test exists to catch.
+double word_error_rate(const std::string& ref, const std::string& hyp, bool allow_prefix = false,
+                       double* coverage_out = nullptr) {
+    std::vector<std::string> r = normalise(ref);
+    const std::vector<std::string> h = normalise(hyp);
+    if (coverage_out != nullptr) {
+        *coverage_out = r.empty() ? 0.0 : static_cast<double>(h.size()) / static_cast<double>(r.size());
+    }
+    if (allow_prefix && !h.empty() && h.size() < r.size()) r.resize(h.size());
+    if (r.empty()) return 1.0;
+    std::vector<size_t> prev(h.size() + 1), cur(h.size() + 1);
+    for (size_t j = 0; j <= h.size(); ++j) prev[j] = j;
+    for (size_t i = 1; i <= r.size(); ++i) {
+        cur[0] = i;
+        for (size_t j = 1; j <= h.size(); ++j) {
+            cur[j] = std::min({prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + (r[i - 1] != h[j - 1] ? 1u : 0u)});
+        }
+        prev = cur;
+    }
+    return static_cast<double>(prev[h.size()]) / static_cast<double>(r.size());
+}
+
+std::string env_or(const char* key, const char* dflt) {
+    const char* v = std::getenv(key);
+    return (v != nullptr && v[0] != '\0') ? std::string(v) : std::string(dflt);
+}
+
+struct StreamCapture {
+    std::string partials;
+    std::string final_text;
+    int partial_calls = 0;
+    int final_calls = 0;
+};
+
+void on_stream(const char* text, rac_bool_t is_final, void* user) {
+    auto* c = static_cast<StreamCapture*>(user);
+    if (text == nullptr) return;
+    if (is_final == RAC_TRUE) {
+        c->final_text = text;
+        ++c->final_calls;
+    } else {
+        c->partials += text;
+        ++c->partial_calls;
+    }
+}
+
+}  // namespace
+
+int main() {
+    std::printf("=== NeuRT STT end-to-end, through the SDK op table ===\n");
+
+    const std::string bundle = env_or("RAC_ASR_BUNDLE", "");
+    const std::string wav = env_or("RAC_ASR_WAV", "");
+    if (bundle.empty() || wav.empty()) {
+        std::printf("SKIP: set RAC_ASR_BUNDLE and RAC_ASR_WAV to run this against a real bundle\n");
+        return 0;
+    }
+    int sample_rate = 0;
+    const std::vector<int16_t> pcm = read_wav_i16(wav, &sample_rate);
+    if (pcm.empty() || sample_rate <= 0) {
+        std::printf("SKIP: cannot read 16-bit PCM WAV at %s\n", wav.c_str());
+        return 0;
+    }
+    std::printf("audio: %zu samples @ %d Hz (%.2f s)\n", pcm.size(), sample_rate,
+                static_cast<double>(pcm.size()) / sample_rate);
+    const bool allow_prefix = !env_or("RAC_ASR_EXPECT_PARTIAL", "").empty();
+    if (allow_prefix) {
+        std::printf("prefix scoring ON: this bundle's compiled audio window is shorter than the "
+                    "clip, so the transcript is scored against the reference prefix\n");
+    }
+
+    const rac_engine_vtable_t* vt = rac_plugin_entry_neurt();
+    CHECK(vt != nullptr, "the neurt plugin entry returned null");
+    if (vt == nullptr) return 1;
+    CHECK(vt->stt_ops != nullptr, "stt_ops is null; the ASR op table is not linked in");
+    if (vt->stt_ops == nullptr) return 1;
+
+    const rac_stt_service_ops_t* ops = vt->stt_ops;
+    CHECK(ops->create != nullptr && ops->initialize != nullptr && ops->transcribe != nullptr,
+          "the op table is missing a required entry point");
+    if (ops->create == nullptr || ops->initialize == nullptr || ops->transcribe == nullptr) return 1;
+
+    void* impl = nullptr;
+    rac_result_t rc = ops->create(bundle.c_str(), nullptr, &impl);
+    CHECK(rc == RAC_SUCCESS && impl != nullptr, "create failed: %d", static_cast<int>(rc));
+    if (impl == nullptr) return 1;
+
+    rc = ops->initialize(impl, bundle.c_str());
+    CHECK(rc == RAC_SUCCESS, "initialize failed: %d", static_cast<int>(rc));
+    if (rc != RAC_SUCCESS) {
+        ops->destroy(impl);
+        return 1;
+    }
+
+    rac_stt_info_t info{};
+    if (ops->get_info != nullptr) {
+        rc = ops->get_info(impl, &info);
+        CHECK(rc == RAC_SUCCESS, "get_info failed: %d", static_cast<int>(rc));
+        CHECK(info.is_ready == RAC_TRUE, "the service reports not ready after a successful load");
+    }
+
+    // The batch path. `audio_size` is BYTES, which is the SDK's convention; passing a sample count
+    // transcribes the first half of the clip and still returns plausible words.
+    rac_stt_options_t opts{};
+    opts.sample_rate = sample_rate;
+    rac_stt_result_t result{};
+    rc = ops->transcribe(impl, pcm.data(), pcm.size() * sizeof(int16_t), &opts, &result);
+    CHECK(rc == RAC_SUCCESS, "transcribe failed: %d", static_cast<int>(rc));
+    CHECK(result.text != nullptr && result.text[0] != '\0', "transcribe returned no text");
+
+    if (result.text != nullptr) {
+        const std::string got = result.text;
+        double coverage = 0.0;
+        const double wer = word_error_rate(kReference, got, allow_prefix, &coverage);
+        std::printf("transcript: %s\n", got.c_str());
+        std::printf("WER vs the LibriSpeech reference: %.4f (%lld ms, coverage %.0f%%%s)\n", wer,
+                    static_cast<long long>(result.processing_time_ms), coverage * 100.0,
+                    allow_prefix ? ", prefix-scored" : "");
+        // Whatever the window, the model has to have produced something. Prefix scoring must not
+        // turn a one-word transcript into a pass.
+        CHECK(coverage > 0.25, "coverage %.0f%% is too low to call this a transcript",
+              coverage * 100.0);
+        // 0.05 is the same gate the recipes use. Not 0.0: a correct ASR port still differs from a
+        // human transcript on orthography, and demanding an exact match would gate on luck.
+        CHECK(wer <= 0.05, "WER %.4f exceeds the 0.05 gate", wer);
+        CHECK(result.processing_time_ms >= 0, "processing_time_ms is negative");
+        std::free(result.text);
+    }
+
+    // The streaming path. Same audio, same engine, and the final must agree with the batch call:
+    // if they disagree, one of them is reading the buffer differently.
+    if (ops->transcribe_stream != nullptr) {
+        StreamCapture cap;
+        rc = ops->transcribe_stream(impl, pcm.data(), pcm.size() * sizeof(int16_t), &opts,
+                                    on_stream, &cap);
+        CHECK(rc == RAC_SUCCESS, "transcribe_stream failed: %d", static_cast<int>(rc));
+        CHECK(cap.final_calls == 1, "expected exactly one final callback, got %d", cap.final_calls);
+        CHECK(!cap.final_text.empty(), "the streaming final was empty");
+        if (!cap.final_text.empty()) {
+            const double wer = word_error_rate(kReference, cap.final_text, allow_prefix, nullptr);
+            std::printf("streaming final: %s\n", cap.final_text.c_str());
+            std::printf("streaming WER: %.4f (%d partial callbacks)\n", wer, cap.partial_calls);
+            CHECK(wer <= 0.05, "streaming WER %.4f exceeds the 0.05 gate", wer);
+            // Partials are the point of the streaming path. A transducer and an attention decoder
+            // both emit per symbol; only CTC legitimately produces none, because its collapse
+            // cannot run until every frame is in.
+            CHECK(cap.partial_calls > 0 || cap.partials.empty(),
+                  "inconsistent: partial text arrived with no partial callbacks");
+        }
+    }
+
+    // A short buffer must be refused rather than transcribed as noise.
+    rac_stt_result_t tiny{};
+    rc = ops->transcribe(impl, pcm.data(), 1, &opts, &tiny);
+    CHECK(rc != RAC_SUCCESS, "a 1-byte buffer was accepted");
+
+    // Null audio likewise.
+    rc = ops->transcribe(impl, nullptr, 0, &opts, &tiny);
+    CHECK(rc != RAC_SUCCESS, "null audio was accepted");
+
+    if (ops->cleanup != nullptr) {
+        rc = ops->cleanup(impl);
+        CHECK(rc == RAC_SUCCESS, "cleanup failed: %d", static_cast<int>(rc));
+    }
+    ops->destroy(impl);
+
+    std::printf("\n%d passed, %d failed\n", g_pass, g_fail);
+    return g_fail == 0 ? 0 : 1;
+}

--- a/engines/neurt/CMakeLists.txt
+++ b/engines/neurt/CMakeLists.txt
@@ -228,6 +228,21 @@ target_compile_options(rac_neurt_llm_ops PRIVATE ${_neurt_prefix_maps})
 set_target_properties(rac_neurt_llm_ops PROPERTIES POSITION_INDEPENDENT_CODE ON)
 target_link_libraries(rac_neurt_llm_ops PUBLIC rac_neurt_core)
 
+# rac_neurt_stt_ops — the SPEECH modality's op-table adapter, same shape and same reasoning.
+#
+# Supplies `g_neurt_stt_ops` for the vtable's stt_ops slot. Also compiled against the real headers:
+# its standalone mirror had FOUR drifts on the first pass, including `sample_rate` at the wrong
+# offset, and this lane is what caught them before anything linked.
+add_library(rac_neurt_stt_ops STATIC ${_neurt_sdk_dir}/rac_stt_ops_neurt.cpp)
+target_include_directories(rac_neurt_stt_ops PRIVATE
+    ${RAC_COMMONS_ROOT_DIR}/include
+    ${NEURT_ROOT}/NeuRT/include)
+target_compile_definitions(rac_neurt_stt_ops PRIVATE NEURT_WITH_RAC_HEADERS=1)
+target_compile_features(rac_neurt_stt_ops PRIVATE cxx_std_17)
+target_compile_options(rac_neurt_stt_ops PRIVATE ${_neurt_prefix_maps})
+set_target_properties(rac_neurt_stt_ops PROPERTIES POSITION_INDEPENDENT_CODE ON)
+target_link_libraries(rac_neurt_stt_ops PUBLIC rac_neurt_core)
+
 else()
     # Shell mode: no neurun sources to derive, so no rac_neurt_core /
     # rac_neurt_llm_ops targets exist. `_neurt_prefix_maps` is still referenced
@@ -264,7 +279,7 @@ if(_neurt_available)
     )
     set(_neurt_extra_includes ${_neurt_sdk_dir})
     set(_neurt_generate_available 1)
-    set(_neurt_extra_links rac_neurt_llm_ops)
+    set(_neurt_extra_links rac_neurt_llm_ops rac_neurt_stt_ops)
 else()
     # Shell only. No neurun source, no private include dir, no rac_neurt_llm_ops
     # to link — RAC_NEURT_GENERATE_AVAILABLE=0 makes the entry file compile its

--- a/engines/neurt/rac_plugin_entry_neurt.cpp
+++ b/engines/neurt/rac_plugin_entry_neurt.cpp
@@ -36,6 +36,7 @@
 // `rac_llm_service_ops_t` lives here; the vtable header forward-declares the slot but not the
 // type, so the entry file must include it to name the NeuRT op table.
 #include "rac/features/llm/rac_llm_service.h"
+#include "rac/features/stt/rac_stt_service.h"
 #include "rac/plugin/rac_plugin_entry.h"
 
 #if defined(__APPLE__) && defined(RAC_NEURT_GENERATE_AVAILABLE) && \
@@ -169,6 +170,10 @@ static const uint32_t k_neurt_formats[] = {
 
 static const rac_primitive_t k_neurt_primitives[] = {
     RAC_PRIMITIVE_DIFFUSION,
+    // Speech-to-text on the Neural Engine, backed by NeuRT's ASR drivers. Four bundle shapes are
+    // served through one op table: Parakeet TDT and RNNT (transducer), Whisper and Moonshine
+    // (attention decoder), and Parakeet CTC.
+    RAC_PRIMITIVE_TRANSCRIBE,
     // NOTE: the text-generation primitive is RAC_PRIMITIVE_GENERATE_TEXT. There is no
     // RAC_PRIMITIVE_LLM — SDK_PATCH.md's diff names one and the enum has never had it.
     RAC_PRIMITIVE_GENERATE_TEXT,
@@ -271,6 +276,9 @@ static const rac_engine_manifest_t k_neurt_manifest = {
 // `extern` there the symbol is never emitted and this declaration fails to resolve at the first
 // real link (a static archive never resolves symbols, so the engine target alone builds green).
 extern "C" const rac_llm_service_ops_t g_neurt_llm_ops;
+// The speech modality, implemented in NeuRT (neurun/NeuRT/src/sdk/rac_stt_ops_neurt.cpp) and linked
+// in via `rac_neurt_stt_ops` -> `rac_neurt_core`.
+extern "C" const rac_stt_service_ops_t g_neurt_stt_ops;
 
 static const rac_engine_vtable_t g_neurt_engine_vtable = {
     /* metadata */ RAC_ENGINE_METADATA_FROM_MANIFEST(k_neurt_manifest),
@@ -287,7 +295,12 @@ static const rac_engine_vtable_t g_neurt_engine_vtable = {
 #else
     nullptr,
 #endif
-    /* stt_ops          */ nullptr,
+/* stt_ops          */
+#if RAC_NEURT_ROUTABLE
+    &g_neurt_stt_ops,  // TRANSCRIBE on the Apple Neural Engine, backed by NeuRT
+#else
+    nullptr,
+#endif
     /* tts_ops          */ nullptr,
     /* vad_ops          */ nullptr,
     /* embedding_ops    */ nullptr,


### PR DESCRIPTION
Fills the `stt_ops` slot on the neurt engine, so an ANE speech bundle can be reached through the SDK.
Pairs with RunanywhereAI/neurun#60, which holds the runtime and the op-table implementation.

Two production lines change. `rac_plugin_entry_neurt.cpp` points `/* stt_ops */ nullptr` at
`&g_neurt_stt_ops` and adds `RAC_PRIMITIVE_TRANSCRIBE` to the served list; `engines/neurt/CMakeLists.txt`
gains one target that compiles the adapter against the real headers. Everything else here is tests.

## Verified end to end, not just compiled

`core/tests/test_stt_neurt_e2e.cpp` drives a real published bundle through this op table with real
recorded speech: LibriSpeech 1272-128104-0000, reference
`Mr Quilter is the apostle of the middle classes and we are glad to welcome his gospel`.

| bundle | pipeline | WER | batch |
|---|---|---|---|
| parakeet-tdt-0.6b-v3 | transducer | 0.0000 | 96 ms |
| parakeet-ctc-1.1b | CTC | 0.0000 | 85 ms |
| whisper-base | attention decoder | 0.0000 | 295 ms |
| moonshine-tiny | attention decoder | 0.0000 prefix-scored, 76% coverage | 36 ms |

20 assertions each, covering the batch path, the streaming path (32 partial callbacks, final agrees
with batch), `get_info`, cleanup, and rejection of a 1-byte and a null buffer.

Nothing is stubbed and no expected string is stored. The gate is a word error rate computed in the
test against the corpus's own transcript, so pasting the output back in would not make it pass.

Moonshine needs `RAC_ASR_EXPECT_PARTIAL=1`, and that is deliberate rather than a fudge: its single
compiled window is 64000 samples (4.0 s) against a 5.9 s clip, so it hears the first two thirds.
Without the flag it fails at WER 0.2353, which is the honest number. With it, the transcript is scored
against the reference prefix and coverage is printed; a separate assertion still fails anything under
25% coverage, so prefix scoring cannot turn a one-word transcript into a pass.

The test skips with exit 0 when `RAC_ASR_BUNDLE` is unset, because a 1.2 GB private-repo download
cannot be a hard requirement of the suite.

## The bug this found

`g_neurt_stt_ops` was missing `extern`. A namespace-scope `const` object has internal linkage in C++,
so the symbol simply did not exist: the adapter compiled, the archive built, and the first real link
failed with `Undefined symbols: _g_neurt_stt_ops`. Building the engine target alone cannot catch it,
because a static archive never resolves symbols. The LLM table carries the same keyword for the same
reason, and its header comment describes this exact failure. Fixed in the neurun PR.

Separately, the standalone struct mirror in the adapter had four drifts from the real ABI, including
`sample_rate` at the wrong offset, which would have read a diarization flag as a sample rate. Caught
by compiling both ways before anything linked.

## Test changes

`test_plugin_entry_neurt.cpp` asserted `stt_ops == nullptr`. That encoded the behaviour this PR
changes, so it now asserts the slot is filled and that `plugin_find_for_engine(TRANSCRIBE, neurt)`
resolves. The disjoint-slot invariant still holds for the four modalities this engine does not serve.

## Routing: checked, and it does not change

Worth stating explicitly because the priority numbers look alarming. neurt is 100 and sherpa is 90, so
advertising TRANSCRIBE does put neurt above sherpa in raw priority order. In practice that never
decides anything:

`rac_stt_service.cpp` resolves with `default_framework = RAC_FRAMEWORK_SHERPA`, and
`create_plugin_service` turns a framework into an engine name and calls `rac_plugin_find_for_engine`.
So an STT model with no framework recorded pins sherpa BY NAME. Plain priority is only reached when
the named engine is absent, and in that case picking neurt over failing outright is the better answer.

NeuRT is selected when the model's framework maps to it, which is how an ANE bundle is meant to
arrive. There is no pinned-only mode available: `find_for_engine` reads the same primitive index, so
an engine that does not advertise TRANSCRIBE cannot be pinned for it either. Advertising is the only
way to make these bundles reachable at all.

## Worth knowing

The gates cannot see this class of problem. Every model gate drives the graphs from Python, which
reads shapes straight off the package; only the runtime consumes the manifest, and only an app
consumes the op table. Eleven ASR bundles passed every gate and none of them could be loaded.

`ctest -R "neurt|vtable|core"` is 5/5, including `diffusion_coreml_generate`, which shares this engine.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added NeuRT speech-to-text support, including batch and streaming transcription.
  - NeuRT now exposes transcription capabilities alongside existing language and diffusion features.
  - Apple builds package the NeuRT speech-to-text components when available.

- **Tests**
  - Added end-to-end coverage for audio decoding, transcription accuracy, streaming callbacks, validation, and service readiness.
  - Added plugin routing checks to verify transcription operations are correctly connected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->