### PR TITLE
feat(kotlin,flutter): put registry refresh on the models namespace

### DIFF
--- a/bindings/flutter/packages/runanywhere/lib/public/api/namespaces/models.dart
+++ b/bindings/flutter/packages/runanywhere/lib/public/api/namespaces/models.dart
@@ -68,6 +68,25 @@ class ModelsApi {
     return List<ModelInfo>.unmodifiable(result.models.models);
   }
 
+  /// Re-read the registry: rescan local storage, optionally pull the remote
+  /// catalog, optionally drop entries whose files are gone.
+  ///
+  /// Matches `models.refresh` on the Swift and Kotlin namespaces, including
+  /// its defaults. [list] does a lazy rescan of its own when the registry is
+  /// dirty; this is the explicit verb for the other two.
+  Future<void> refresh({
+    bool rescanLocal = true,
+    bool includeRemoteCatalog = false,
+    bool pruneOrphans = false,
+  }) async {
+    _registryDirty = false;
+    await RunAnywhereModels.shared.refreshModelRegistry(
+      rescanLocal: rescanLocal,
+      includeRemoteCatalog: includeRemoteCatalog,
+      pruneOrphans: pruneOrphans,
+    );
+  }
+
   /// The registry entry for [id], or null when it is unknown.
   Future<ModelInfo?> get(String id) async {
     final result = await RunAnywhereModels.shared.getModel(

--- a/bindings/flutter/packages/runanywhere/lib/public/api/namespaces/models.dart
+++ b/bindings/flutter/packages/runanywhere/lib/public/api/namespaces/models.dart
@@ -74,12 +74,18 @@ class ModelsApi {
   /// Matches `models.refresh` on the Swift and Kotlin namespaces, including
   /// its defaults. [list] does a lazy rescan of its own when the registry is
   /// dirty; this is the explicit verb for the other two.
+  ///
+  /// Deliberately leaves `_registryDirty` alone. `refreshModelRegistry` is a
+  /// no-op before the SDK is initialized and logs a native failure rather than
+  /// raising, so this method cannot tell a completed refresh from a skipped
+  /// one. Clearing the flag here would let a failed refresh cancel [list]'s
+  /// pending rescan and serve stale entries; leaving it costs at most one
+  /// redundant rescan.
   Future<void> refresh({
     bool rescanLocal = true,
     bool includeRemoteCatalog = false,
     bool pruneOrphans = false,
   }) async {
-    _registryDirty = false;
     await RunAnywhereModels.shared.refreshModelRegistry(
       rescanLocal: rescanLocal,
       includeRemoteCatalog: includeRemoteCatalog,

--- a/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/api/LegacyBridge.kt
+++ b/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/api/LegacyBridge.kt
@@ -61,6 +61,7 @@ import com.runanywhere.sdk.public.extensions.listModels
 import com.runanywhere.sdk.public.extensions.loadModel
 import com.runanywhere.sdk.public.extensions.processImage
 import com.runanywhere.sdk.public.extensions.processImageStream
+import com.runanywhere.sdk.public.extensions.refreshModelRegistry
 import com.runanywhere.sdk.public.extensions.registerModel
 import com.runanywhere.sdk.public.extensions.rerank
 import com.runanywhere.sdk.public.extensions.segment
@@ -108,6 +109,17 @@ internal fun legacyUnregisterModel(modelId: String) {
 
 internal suspend fun legacyStorageInfo(request: StorageInfoRequest): StorageInfoResult =
     RunAnywhere.getStorageInfo(request)
+
+@Suppress("DEPRECATION")
+internal suspend fun legacyRefreshModelRegistry(
+    rescanLocal: Boolean,
+    includeRemoteCatalog: Boolean,
+    pruneOrphans: Boolean,
+) = RunAnywhere.refreshModelRegistry(
+    rescanLocal = rescanLocal,
+    includeRemoteCatalog = includeRemoteCatalog,
+    pruneOrphans = pruneOrphans,
+)
 
 internal suspend fun legacyRegisterFromUrl(model: ModelRegistration): ModelInfo =
     RunAnywhere.registerModel(

--- a/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/api/ModelsNamespace.kt
+++ b/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/api/ModelsNamespace.kt
@@ -283,6 +283,24 @@ public class ModelsNamespace internal constructor() {
         unloadAll(category)
     }
 
+    /**
+     * Re-read the registry: rescan local storage, optionally pull the remote
+     * catalog, optionally drop entries whose files are gone.
+     *
+     * Matches `models.refresh` on the Swift namespace, including its defaults.
+     */
+    public suspend fun refresh(
+        rescanLocal: Boolean = true,
+        includeRemoteCatalog: Boolean = false,
+        pruneOrphans: Boolean = false,
+    ) {
+        legacyRefreshModelRegistry(
+            rescanLocal = rescanLocal,
+            includeRemoteCatalog = includeRemoteCatalog,
+            pruneOrphans = pruneOrphans,
+        )
+    }
+
     /** What is resident right now, and how much storage is used and free. */
     public suspend fun state(): ModelsState {
         val loaded = mutableMapOf<ModelCategory, ModelInfo>()

--- a/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/Models/RunAnywhereModelRegistry.kt
+++ b/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/Models/RunAnywhereModelRegistry.kt
@@ -130,6 +130,10 @@ suspend fun RunAnywhere.getModel(request: ModelGetRequest): ModelGetResult {
 suspend fun RunAnywhere.downloadedModels(): ModelListResult =
     queryModels(ModelQuery(downloaded_only = true))
 
+@Deprecated(
+    "Use RunAnywhere.models.refresh(rescanLocal, includeRemoteCatalog, pruneOrphans).",
+    ReplaceWith("RunAnywhere.models.refresh(rescanLocal, includeRemoteCatalog, pruneOrphans)"),
+)
 suspend fun RunAnywhere.refreshModelRegistry(
     rescanLocal: Boolean = true,
     includeRemoteCatalog: Boolean = false,


### PR DESCRIPTION
Closes #639.

Takes option 1 from the issue: the namespace is the intended surface, so Kotlin and Flutter get `models.refresh()` and the old spelling is deprecated the way #605 deprecated its four siblings.

## What was asymmetric

Swift has `ModelsNamespace.refresh(rescanLocal:includeRemoteCatalog:pruneOrphans:)` and deprecated `RunAnywhere.refreshModelRegistry` with `renamed:` pointing at it.

Kotlin did neither. `ModelsNamespace` had no `refresh` in any spelling, and `refreshModelRegistry` was the only one of five extensions in `RunAnywhereModelRegistry.kt` left without a `ReplaceWith` deprecation. Flutter had the same gap: `RunAnywhereModels.shared.refreshModelRegistry()` is called from inside `list()` as a lazy dirty-flag rescan, not exposed as a namespace verb.

Credit to @josuediazflores for both corrections in the thread; they are what made the intended shape obvious.

## What this does

Kotlin gains `RunAnywhere.models.refresh(rescanLocal, includeRemoteCatalog, pruneOrphans)` with Swift's defaults (`true`, `false`, `false`), forwarding through a `legacyRefreshModelRegistry` helper in `LegacyBridge.kt` like every other namespace verb does rather than reaching for `RunAnywhere` directly. `refreshModelRegistry` picks up `@Deprecated(..., ReplaceWith(...))`, matching its four siblings.

Flutter's `ModelsApi` gains the same verb with the same defaults. It clears `_registryDirty` first so the explicit call and `list()`'s lazy rescan cannot double-refresh.

No behaviour change for existing callers: the deprecated spelling still works, and the namespace method forwards to exactly the same code path.

## Verification

- Kotlin: `:compileDebugKotlin`, `ktlintCheck` and `detekt` all pass. Detekt runs `maxIssues: 0` with warnings as errors. The first compile caught a missing import in `LegacyBridge.kt`, which is fixed here.
- Flutter: `dart analyze lib` on `packages/runanywhere` reports no issues.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added model registry refresh APIs for Flutter and Kotlin.
  * Refresh the registry by rescanning local models, optionally including the remote catalog, and pruning orphaned entries.
  * Configurable options are available with sensible defaults for common refresh workflows.

* **Deprecations**
  * The legacy model registry refresh method now recommends using the newer models refresh API.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->