### PR TITLE
docs(commons): the VLM vision carriers exist, stop saying they do not

### DIFF
--- a/core/src/infrastructure/telemetry/telemetry_json.cpp
+++ b/core/src/infrastructure/telemetry/telemetry_json.cpp
@@ -330,10 +330,11 @@ rac_result_t rac_telemetry_manager_payload_to_json(const rac_telemetry_payload_t
         json.add_string("voice", payload->voice);
         json.add_double("output_duration_ms", payload->output_duration_ms);
     } else if (strcmp(modality, "vlm") == 0) {
-        // VLM = LLM token fields PLUS vision fields. The token fields are now
-        // populated via the properties carrier (input/total tokens, tps, ttft,
-        // generation_time). The vision-specific fields (vision_tokens,
-        // vision_encode_time_ms, image_resolution) still need carriers.
+        // VLM = LLM token fields PLUS vision fields. Both groups ride the
+        // properties carrier now: vlm_module.cpp writes input/total tokens,
+        // tps, ttft, prompt_eval_time_ms, vision_tokens, vision_encode_time_ms
+        // and image_resolution, and the SDK_COMPONENT_VLM arm of
+        // telemetry_manager.cpp reads every one of them back.
         json.add_int("input_tokens", payload->input_tokens);
         json.add_int("output_tokens", payload->output_tokens);
         json.add_int("total_tokens", payload->total_tokens);


### PR DESCRIPTION
Comment only. Small, but it is wrong in a way that costs someone real work.

## What is wrong

`telemetry_json.cpp` says, immediately above the lines that serialize those very fields:

```cpp
// VLM = LLM token fields PLUS vision fields. The token fields are now
// populated via the properties carrier (input/total tokens, tps, ttft,
// generation_time). The vision-specific fields (vision_tokens,
// vision_encode_time_ms, image_resolution) still need carriers.
```

All three named fields already have carriers, on both sides.

Producer, `core/src/features/vlm/vlm_module.cpp`:

```cpp
:952  (*event.mutable_properties())["vision_tokens"] = std::to_string(vision_tokens);
:955  (*event.mutable_properties())["vision_encode_time_ms"] = std::to_string(vision_encode_ms);
:958  (*event.mutable_properties())["image_resolution"] = image_resolution;
```

Consumer, the `SDK_COMPONENT_VLM` arm of `core/src/infrastructure/telemetry/telemetry_manager.cpp`:

```cpp
:1353  auto vt_it  = ev.properties().find("vision_tokens");
:1358  auto vet_it = ev.properties().find("vision_encode_time_ms");
:1366  auto ir_it  = ev.properties().find("image_resolution");
```

So a reader who trusts the comment goes off to build plumbing that is already there, and the sentence sits directly above `json.add_int("vision_tokens", ...)` which reads the result of that plumbing.

## What this does

States what the code does. I also added `prompt_eval_time_ms` to the list of token fields on the carrier, since it is written at `vlm_module.cpp:940` and read at `telemetry_manager.cpp:1362` and the old text did not mention it.

## How I found it, and what else I checked

I was diffing the property keys each modality writes against the keys the telemetry manager reads back, looking for values that are produced and serialized but dropped in between. VLM was the only mismatch and it turned out to be the comment rather than the code. For completeness, the same diff came back clean elsewhere:

- RAG writes `top_k`, `retrieval_time_ms`, `embedding_model`, `reranker_used`, `query_token_count`, `context_tokens` and the RAG arm reads exactly those.
- LLM writes only `framework` as a property because it uses the typed `GenerationEvent` fields instead, so there is nothing to mismatch.

## Testing

`test_telemetry_extraction` passes: 44 checks, 0 failures. Comment only, so nothing else could move.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated telemetry documentation to clarify how language-model and vision data is provided and consumed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->