### PR TITLE
fix(web): restore surviving capability owners after backend teardown

### DIFF
--- a/bindings/web/packages/core/src/runtime/EmscriptenModule.ts
+++ b/bindings/web/packages/core/src/runtime/EmscriptenModule.ts
@@ -912,6 +912,8 @@ export type WasmModuleReadiness = 'registering' | 'ready' | 'unregistered';
 export interface WasmModuleRecord {
   readonly module: EmscriptenRunanywhereModule;
   readonly capabilities: readonly WasmCapability[];
+  /** Last registration generation for each capability claimed by this module. */
+  readonly capabilityGenerations: ReadonlyMap<WasmCapability, number>;
   readonly frameworks: readonly string[];
   readonly backend: WasmBackendKind;
   readonly acceleration: string | null;
@@ -1005,14 +1007,22 @@ export function registerWasmModule(
     ...(prior?.frameworks ?? []),
     ...frameworks.filter(Boolean).map((framework) => framework.toLowerCase()),
   ]);
+  const generation = ++_registrationGeneration;
+  const capabilityGenerations = new Map<WasmCapability, number>(
+    prior?.capabilityGenerations,
+  );
+  for (const capability of capabilities) {
+    capabilityGenerations.set(capability, generation);
+  }
   const record: WasmModuleRecord = {
     module: mod,
     capabilities: [...mergedCapabilities],
+    capabilityGenerations,
     frameworks: [...mergedFrameworks],
     backend: registration.backend ?? prior?.backend ?? 'custom',
     acceleration: registration.acceleration ?? prior?.acceleration ?? null,
     readiness: registration.readiness ?? 'ready',
-    generation: ++_registrationGeneration,
+    generation,
     lifecycleGeneration: prior?.lifecycleGeneration ?? 0,
   };
   _recordByModule.set(mod, record);
@@ -1110,7 +1120,8 @@ export function recordModelLifecycle(
  * Drop a single module from the registry. All capability slots that
  * point at this module are removed, and downstream adapters are cleared
  * if they were tracking it. Use this on backend teardown / acceleration
- * switch — it lets siblings keep their slots intact.
+ * switch — any sibling that still claims a released capability regains
+ * ownership of that slot.
  */
 export function unregisterWasmModule(mod: EmscriptenRunanywhereModule): void {
   for (const [fw, current] of Array.from(_moduleByFramework.entries())) {
@@ -1124,6 +1135,30 @@ export function unregisterWasmModule(mod: EmscriptenRunanywhereModule): void {
     }
   }
   _recordByModule.delete(mod);
+
+  // Re-elect a surviving owner for every released capability. Registration
+  // is last-writer-wins, so among the modules still registered the one that
+  // claimed this capability most recently (highest per-capability generation)
+  // regains the slot. This is what lets siblings keep their slots intact across
+  // a single-backend teardown / acceleration switch.
+  const restoredByModule = new Map<EmscriptenRunanywhereModule, WasmCapability[]>();
+  for (const cap of releasedCapabilities) {
+    let survivor: WasmModuleRecord | null = null;
+    let survivorGeneration = -1;
+    for (const record of _recordByModule.values()) {
+      const capabilityGeneration = record.capabilityGenerations.get(cap);
+      if (capabilityGeneration !== undefined && capabilityGeneration > survivorGeneration) {
+        survivor = record;
+        survivorGeneration = capabilityGeneration;
+      }
+    }
+    if (survivor) {
+      _recordByCapability.set(cap, survivor);
+      const restored = restoredByModule.get(survivor.module) ?? [];
+      restored.push(cap);
+      restoredByModule.set(survivor.module, restored);
+    }
+  }
   for (const [modelId, owner] of Array.from(_moduleByModelId.entries())) {
     if (owner === mod) _moduleByModelId.delete(modelId);
   }
@@ -1139,6 +1174,12 @@ export function unregisterWasmModule(mod: EmscriptenRunanywhereModule): void {
     SDKEventStreamAdapter.clearDefaultModule();
   }
   ModalityProtoAdapter.unregisterModuleCapabilities(releasedCapabilities, mod);
+  // Restore the modality dispatch slots for re-elected survivors so
+  // per-modality routing and the aggregate `defaultModule` keep pointing at a
+  // live module rather than going null.
+  for (const [module, restoredCapabilities] of restoredByModule) {
+    ModalityProtoAdapter.registerModuleCapabilities(restoredCapabilities, module);
+  }
   reelectLifecycleAndRegistryPrimary();
 }
 


### PR DESCRIPTION
## Description
`unregisterWasmModule()` in `EmscriptenModule.ts` removed every `_recordByCapability` slot owned by a torn-down backend. Because registration is last-writer-wins, unregistering a later module deleted the mapping even when an earlier sibling still claimed the same capability ? `getModuleForCapability('llm')` returned `null` and facade verbs reported no backend, contradicting the function's own contract that teardown lets siblings keep their slots.

The fix re-elects the most recently registered surviving sibling (highest registration generation for that capability) for each released capability, restores it in the capability registry, and re-registers it with `ModalityProtoAdapter` so per-modality dispatch slots and the aggregate `defaultModule` keep pointing at a live module. `reelectLifecycleAndRegistryPrimary()` then correctly re-pins the lifecycle/model-registry adapters to the survivor instead of falling back to commons.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Lint passes locally
- [ ] Added/updated tests for changes (existing suite re-run; no new tests per repo guidance)

Local (from `bindings/web/packages/core`): `npm run typecheck` (exit 0, 0 errors), `npm run lint` (exit 0, 0 findings), `npx vitest run tests/unit/runtime/EmscriptenModule.test.ts` (9/9 passed), `npm run test:unit` (56 files / 244 tests passed). `git diff --check` clean.

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop) ? not run on this host (requires Emscripten WASM + browser; CI covers)
- [ ] Tested in Firefox ? not run on this host
- [ ] Tested in Safari ? not run on this host
- [ ] WASM backends load (LlamaCpp + ONNX) ? not run on this host; CI covers
- [ ] OPFS storage persistence verified (survives page refresh) ? not run on this host
- [ ] Settings persistence verified (localStorage) ? not run on this host

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`bindings/swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`bindings/kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`bindings/flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`bindings/react-native`)
- [x] `Web SDK` - Changes to Web SDK (`bindings/web`)
- [ ] `Commons` - Changes to shared native code (`core`)

**Sample Apps:**
- [ ] `Flutter Sample` - Changes to Flutter example app (`bindings/flutter/example`)
- [ ] `React Native Sample` - Changes to React Native example app (`bindings/react-native/example`)
- [ ] `Minimal Examples` - Changes to an in-repo SDK harness (`bindings/{swift,kotlin,web}/example`)

The iOS, Android, Web, and Electron consumer apps live in their own
repositories (`RunanywhereAI/runanywhere-{ios,android,web,electron}`) ? open
those PRs there.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed) ? behavior restored to the documented contract; no doc change required

## Screenshots
Attach relevant UI screenshots for changes (if applicable):
- Mobile (Phone)
- Tablet / iPad
- Desktop / Mac


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved WebAssembly module capability management for more predictable ownership when modules are registered or removed.
  * Restored surviving capability handlers automatically when the current provider is unregistered.
  * Ensured capability dispatch consistently follows the most recently registered provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->