### PR TITLE
Add Gemma 4 E2B/E4B + Granite 4.1 3B to Flutter example catalog

### DIFF
--- a/bindings/flutter/example/lib/core/services/model_catalog_bootstrap.dart
+++ b/bindings/flutter/example/lib/core/services/model_catalog_bootstrap.dart
@@ -193,15 +193,16 @@ abstract final class ModelCatalogBootstrap {
     // Gemma 4 (Google) — phone-scale MatFormer sizes only (E2B/E4B). The
     // 12B/26B-A4B/31B siblings are desktop-scale and this app ships mobile
     // (iOS/Android) targets only, no Flutter desktop build. License is the
-    // Gemma Terms of Use, not Apache — noted since every other row here is
-    // Apache/MIT-licensed upstream.
+    // Apache 2.0. Preserve the license and applicable attribution notices if
+    // downloaded artifacts are redistributed.
     await _registerLLM(
       id: 'gemma-4-e2b-it-q4_k_m',
       name: 'Gemma 4 E2B IT Q4_K_M',
       url:
           'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf',
       framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      memoryRequirement: 3106738272,
+      // 3,106,738,272 B of weights plus a 4K-context KV/runtime allowance.
+      memoryRequirement: 3400000000,
     );
     await _registerLLM(
       id: 'gemma-4-e4b-it-q4_k_m',
@@ -209,7 +210,8 @@ abstract final class ModelCatalogBootstrap {
       url:
           'https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf',
       framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      memoryRequirement: 4977171584,
+      // 4,977,171,584 B of weights plus a 4K-context KV/runtime allowance.
+      memoryRequirement: 5700000000,
     );
 
     // Granite 4.1 (IBM) — only the 3B row is phone-scale; the 8B/30B
@@ -221,7 +223,8 @@ abstract final class ModelCatalogBootstrap {
       url:
           'https://huggingface.co/unsloth/granite-4.1-3b-GGUF/resolve/main/granite-4.1-3b-Q4_K_M.gguf',
       framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      memoryRequirement: 2099502400,
+      // 2,099,502,400 B of weights plus a 4K-context KV/runtime allowance.
+      memoryRequirement: 2400000000,
     );
 
     // Nemotron (NVIDIA) — portable embedding GGUFs on the llama.cpp backend.

--- a/bindings/flutter/example/lib/core/services/model_catalog_bootstrap.dart
+++ b/bindings/flutter/example/lib/core/services/model_catalog_bootstrap.dart
@@ -190,6 +190,40 @@ abstract final class ModelCatalogBootstrap {
       memoryRequirement: 4000000000,
     );
 
+    // Gemma 4 (Google) — phone-scale MatFormer sizes only (E2B/E4B). The
+    // 12B/26B-A4B/31B siblings are desktop-scale and this app ships mobile
+    // (iOS/Android) targets only, no Flutter desktop build. License is the
+    // Gemma Terms of Use, not Apache — noted since every other row here is
+    // Apache/MIT-licensed upstream.
+    await _registerLLM(
+      id: 'gemma-4-e2b-it-q4_k_m',
+      name: 'Gemma 4 E2B IT Q4_K_M',
+      url:
+          'https://huggingface.co/unsloth/gemma-4-E2B-it-GGUF/resolve/main/gemma-4-E2B-it-Q4_K_M.gguf',
+      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+      memoryRequirement: 3106738272,
+    );
+    await _registerLLM(
+      id: 'gemma-4-e4b-it-q4_k_m',
+      name: 'Gemma 4 E4B IT Q4_K_M',
+      url:
+          'https://huggingface.co/unsloth/gemma-4-E4B-it-GGUF/resolve/main/gemma-4-E4B-it-Q4_K_M.gguf',
+      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+      memoryRequirement: 4977171584,
+    );
+
+    // Granite 4.1 (IBM) — only the 3B row is phone-scale; the 8B/30B
+    // siblings are desktop-scale and skipped for the same reason as the
+    // larger Gemma 4 rows above. Apache 2.0 licensed.
+    await _registerLLM(
+      id: 'granite-4.1-3b-q4_k_m',
+      name: 'IBM Granite 4.1 3B Q4_K_M',
+      url:
+          'https://huggingface.co/unsloth/granite-4.1-3b-GGUF/resolve/main/granite-4.1-3b-Q4_K_M.gguf',
+      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+      memoryRequirement: 2099502400,
+    );
+
     // Nemotron (NVIDIA) — portable embedding GGUFs on the llama.cpp backend.
     for (final model in portableNvidiaEmbeddingCatalog) {
       await _registerLLM(


### PR DESCRIPTION
## Summary

Catalog-only change to `bindings/flutter/example/` — brings its general model catalog in line with the new models just added to the four standalone starter-app repos (iOS, Android, Electron, Web), so "phone" catalogs stay consistent across every RunAnywhere sample app.

### What applied (added to `lib/core/services/model_catalog_bootstrap.dart`, mobile section)

This file is confirmed to be the general llama.cpp/MLX/ONNX catalog (mirrors iOS `ModelCatalogBootstrap.swift` / Android `ModelBootstrap.seedCuratedCatalog`, per its own doc comment), registered via `RunAnywhere.models.register(ModelRegistration.url(...))` on the llama.cpp backend, same pattern as every existing row.

- **Gemma 4 E2B IT Q4_K_M** (`unsloth/gemma-4-E2B-it-GGUF`, ~3.1 GB)
- **Gemma 4 E4B IT Q4_K_M** (`unsloth/gemma-4-E4B-it-GGUF`, ~5.0 GB)
- **IBM Granite 4.1 3B Q4_K_M** (`unsloth/granite-4.1-3b-GGUF`, ~2.1 GB) — the one Granite 4.1 size that is phone-scale

### What was skipped, and why

- **Gemma 4 12B / 26B-A4B (MoE) / 31B, Qwen3.6-35B-A3B, Qwen3.8-27B, Muse-Glimmer-30B (VLM), Granite 4.1 8B/30B, Nemotron-3-Nano-Omni-30B** — all desktop-scale. Verified this Flutter example ships **mobile-only** targets: `bindings/flutter/example/` has `android/` and `ios/` directories only, no `macos/`, `windows/`, or `linux/` Flutter build directories, and `pubspec.yaml`/`AGENTS.md` confirm iOS + Android as the only supported platforms. No desktop Flutter target exists to gate these behind, so — unlike a sibling app with a desktop build — there is no "desktop-only" section to add them to here; they're left out entirely, matching the phone-scale discipline the task specified.
- **Supertone Supertonic v3 TTS / NVIDIA Nemotron-3.5-ASR-Streaming STT** — not added. This app's Sherpa-ONNX STT/TTS rows are all pre-packaged directory-structure archives hosted via `RunanywhereAI/sherpa-onnx` GitHub Releases (see the Whisper/Piper rows), not raw per-file HF URLs; there is no equivalent pre-packaged archive for either new model, and creating one is a packaging/build task outside a catalog-only change. Additionally, per `core/VERSIONS`, this app's vendored sherpa-onnx is pinned to **1.13.2** on both iOS and Android — that meets Supertonic's `>=1.13.2` floor but is below Nemotron ASR's `>=1.13.4/1.13.5` floor, so Nemotron ASR is blocked regardless. Flagging both as follow-ups rather than forcing a broken row.
- **`qhexrt_model_catalog.dart` (the QHexRT/Hexagon-NPU catalog)** — untouched. Confirmed via full read: this is a completely separate catalog/format (HNPU JSON manifests from the `forge/` compile pipeline, native-registered through `QHexRT.registerModelForDevice`), explicitly "kept in lockstep with Android's `ModelCatalog.npuCatalog`". None of Qwen3.6/Qwen3.8/Muse-Glimmer/Granite-4.1/Nemotron-Omni have an HNPU bundle. Gemma 4 E2B/E4B actually **already have** `gemma4_e2b`/`gemma4_e4b` (+ VLM variant) HNPU rows in this file pointing at `huggingface.co/runanywhere/gemma4_{e2b,e4b}_HNPU` — pre-existing, already in lockstep with Android, so no edit was needed there.

### Confirmation

- Catalog-only: no SDK/engine/native code touched. Single file changed: `bindings/flutter/example/lib/core/services/model_catalog_bootstrap.dart` (+34 lines, 2 new family blocks, existing `_registerLLM` helper/pattern only).

## Test plan

- [x] `fvm flutter pub get` — resolves clean (this app requires Flutter 3.44.6/Dart 3.12.2+; pinned via `.fvmrc`)
- [x] `fvm flutter analyze` — "No issues found!"
- [x] `fvm flutter test` — all 8 existing tests pass (incl. `qhexrt_model_catalog_test.dart`, unaffected since that file wasn't touched)
- [ ] `flutter build apk --debug` — not run in this environment (Android SDK licenses not accepted here); no native/build-affecting change was made, so analyze + test are the meaningful gates for this catalog-only PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DxGfpsMbkNzoQT559b2tXz

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added three Llama.cpp language models to the curated model catalog:
    * Gemma 4 E2B IT
    * Gemma 4 E4B IT
    * IBM Granite 4.1 3B
  * Included download sources and memory requirements for each model.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->