### PR TITLE
feat(react-native): put registry refresh on the models namespace

### DIFF
--- a/bindings/react-native/packages/core/src/Public/Api/Models.ts
+++ b/bindings/react-native/packages/core/src/Public/Api/Models.ts
@@ -24,6 +24,7 @@ import {
   getModel as getModelProto,
   listModels,
   queryModels,
+  refreshModelRegistry,
   registerArchiveModel,
   registerModel as registerUrlModel,
   registerMultiFileModel,
@@ -458,6 +459,25 @@ export const models = {
       storageUsedBytes: Number(storage?.app?.totalBytes ?? 0),
       storageFreeBytes: Number(storage?.device?.freeBytes ?? 0),
     };
+  },
+
+  /**
+   * Rescan managed model directories and reconcile downloaded state.
+   *
+   * Matches `models.refresh` on the Swift, Kotlin, and Flutter namespaces,
+   * including its defaults. Non-throwing like the others: a failed refresh
+   * leaves the current registry contents in place.
+   *
+   * `list()` reads the registry as it stands and never rescans, so this is
+   * the only way to pick up artifacts that changed on disk out from under
+   * the SDK.
+   */
+  refresh(options?: {
+    rescanLocal?: boolean;
+    includeRemoteCatalog?: boolean;
+    pruneOrphans?: boolean;
+  }): Promise<void> {
+    return refreshModelRegistry(options);
   },
 };
 


### PR DESCRIPTION
## What is wrong

React Native has no public way to refresh the model registry.

`#605` aligned the public API across all eight SDKs and gave Swift `models.refresh(rescanLocal:includeRemoteCatalog:pruneOrphans:)` (`ModelsNamespace.swift:389`). Kotlin and Flutter were missed; `#712` closed those two yesterday. RN is the one left.

## Evidence

Every piece of the native path is already there on RN:

- `specs/RunAnywhereCore.nitro.ts:274` declares `refreshModelRegistry(includeRemoteCatalog, rescanLocal, pruneOrphans)`
- `cpp/HybridRunAnywhereCore+Registry.cpp:443` encodes those three flags into a `ModelRegistryRefreshRequest` (fields 1/2/3, matching `idl/model_types.proto:411`) and runs the same discovery pre-pass Swift does
- `Public/Extensions/Models/RunAnywhere+ModelRegistry.ts:1046` wraps it with the same defaults Swift uses, and its own comment says "Matches Swift"

Nothing surfaces it. `src/index.ts:13` exports only the `RunAnywhere` object, that object is namespaces plus `initialize`/`reset`/`capabilities`, and `models` (`Public/Api/Models.ts:194`) has no `refresh`. `storage` (`Public/Api/Platform.ts:25`) has no refresh either, which is where the Web SDK put its equivalent.

So `refreshModelRegistry` is reachable from inside the package and from nowhere else.

This is not a documented omission: `capabilities()` lists the things RN deliberately does not ship (`agents`, `wakeword`, `realtime`) with a reason attached to each. Registry refresh is not among them.

The practical effect is that `models.list()` reads the registry as it stands and never rescans, so an artifact that changed on disk out from under the SDK stays wrong for the life of the process.

## What this does

Adds `models.refresh(options?)`, forwarding to the existing extension function. Forwarding rather than reimplementing keeps the non-throwing best-effort behaviour and the three defaults in one place, and matches how the rest of the namespace delegates.

Placed after `state()` to match Swift's ordering.

## Verification

Ran on this branch:

- `tsc --noEmit` for `@runanywhere/core`: clean
- `tsc -p tsconfig.test.json --noEmit`: clean
- `eslint src/Public/Api/Models.ts --max-warnings 0`: clean
- `jest` for `@runanywhere/core`: 75 passed, 15 suites, 0 failed

The two typechecks needed the full generated proto tree, so I ran `idl/codegen/generate_ts.sh`, `generate_ts_convenience.py`, `generate_defaults_pool.py` and `generate_streams.sh` first. None of that output is committed here; `git status` shows only the one file.

Also compiled a scratch caller against the public entry point to confirm the verb is actually reachable and the option shapes are right:

```ts
import { RunAnywhere } from '../src';
await RunAnywhere.models.refresh();
await RunAnywhere.models.refresh({ rescanLocal: false, pruneOrphans: true });
```

No test added: this is a one-line delegation to a function that already has its behaviour defined elsewhere, and a test here would assert that a forwarder forwards.

I checked the C++ flag ordering against the proto field numbers while I was in there, in case the two adjacent booleans had been swapped across the bridge. They line up correctly.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a model registry refresh capability for React Native applications.
  - Supports optional local model rescanning, remote catalog inclusion, and removal of orphaned entries.
  - Refresh operations return a promise so applications can track completion.
  - If a refresh fails, the existing model registry remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
