### PR TITLE
fix(web): stop AsyncQueue.fail from ending a parked consumer normally

### DIFF
--- a/bindings/web/packages/core/src/Foundation/AsyncQueue.ts
+++ b/bindings/web/packages/core/src/Foundation/AsyncQueue.ts
@@ -25,31 +25,34 @@
 /** Async queue with a single producer + single consumer (for-await). */
 export class AsyncQueue<T> implements AsyncIterable<T> {
   private buffer: T[] = [];
-  private resolveNext: ((v: IteratorResult<T>) => void) | null = null;
+  private wake: (() => void) | null = null;
   private done = false;
   private error: Error | null = null;
+
+  /**
+   * Wake a parked consumer. Producers only ever signal; `next()` re-reads the
+   * queue state itself, which is what keeps `fail()` from having to resolve a
+   * waiter it cannot reject. Mirrors `AsyncQueue` in
+   * `@runanywhere/proto-ts/streams/push`.
+   */
+  private signal(): void {
+    const wake = this.wake;
+    this.wake = null;
+    if (wake) wake();
+  }
 
   /** Producer: push the next value. Discarded if the queue is closed. */
   push(value: T): void {
     if (this.done) return;
-    if (this.resolveNext) {
-      const r = this.resolveNext;
-      this.resolveNext = null;
-      r({ value, done: false });
-    } else {
-      this.buffer.push(value);
-    }
+    this.buffer.push(value);
+    this.signal();
   }
 
   /** Producer: signal normal end-of-stream. Idempotent. */
   complete(): void {
     if (this.done) return;
     this.done = true;
-    if (this.resolveNext) {
-      const r = this.resolveNext;
-      this.resolveNext = null;
-      r({ value: undefined as unknown as T, done: true });
-    }
+    this.signal();
   }
 
   /** Producer: signal abnormal termination. Next consumer await throws. */
@@ -57,22 +60,20 @@ export class AsyncQueue<T> implements AsyncIterable<T> {
     if (this.done) return;
     this.done = true;
     this.error = error;
-    if (this.resolveNext) {
-      const r = this.resolveNext;
-      this.resolveNext = null;
-      r({ value: undefined as unknown as T, done: true });
-    }
+    this.signal();
   }
 
   [Symbol.asyncIterator](): AsyncIterator<T> {
     return {
-      next: (): Promise<IteratorResult<T>> => {
-        if (this.buffer.length > 0) {
-          return Promise.resolve({ value: this.buffer.shift()!, done: false });
+      next: async (): Promise<IteratorResult<T>> => {
+        for (;;) {
+          if (this.buffer.length > 0) {
+            return { value: this.buffer.shift()!, done: false };
+          }
+          if (this.error) throw this.error;
+          if (this.done) return { value: undefined as unknown as T, done: true };
+          await new Promise<void>((r) => { this.wake = r; });
         }
-        if (this.error) return Promise.reject(this.error);
-        if (this.done) return Promise.resolve({ value: undefined as unknown as T, done: true });
-        return new Promise((r) => { this.resolveNext = r; });
       },
     };
   }

--- a/bindings/web/packages/core/tests/unit/Foundation/AsyncQueue.test.ts
+++ b/bindings/web/packages/core/tests/unit/Foundation/AsyncQueue.test.ts
@@ -1,0 +1,53 @@
+/**
+ * AsyncQueue.test.ts
+ *
+ * `fail()` has to reach the consumer whether or not it is parked. A streaming
+ * consumer is parked on `next()` almost all the time (it drains tokens faster
+ * than inference produces them), so a failure that only surfaces on a later
+ * `next()` is a failure the caller never sees.
+ */
+
+import { describe, it, expect } from 'vitest';
+
+import { AsyncQueue } from '../../../src/Foundation/AsyncQueue.js';
+
+describe('AsyncQueue.fail', () => {
+  it('rejects a consumer that is already parked on next()', async () => {
+    const queue = new AsyncQueue<string>();
+    const iterator = queue[Symbol.asyncIterator]();
+
+    // Park first, then fail — the order a mid-stream inference error takes.
+    const parked = iterator.next();
+    queue.fail(new Error('inference exploded'));
+
+    await expect(parked).rejects.toThrow('inference exploded');
+  });
+
+  it('rejects a consumer that arrives after the failure', async () => {
+    const queue = new AsyncQueue<string>();
+    queue.fail(new Error('inference exploded'));
+
+    const iterator = queue[Symbol.asyncIterator]();
+    await expect(iterator.next()).rejects.toThrow('inference exploded');
+  });
+
+  it('drains buffered values before reporting the failure', async () => {
+    const queue = new AsyncQueue<string>();
+    queue.push('a');
+    queue.fail(new Error('inference exploded'));
+
+    const iterator = queue[Symbol.asyncIterator]();
+    await expect(iterator.next()).resolves.toEqual({ value: 'a', done: false });
+    await expect(iterator.next()).rejects.toThrow('inference exploded');
+  });
+
+  it('still ends normally on complete()', async () => {
+    const queue = new AsyncQueue<string>();
+    const iterator = queue[Symbol.asyncIterator]();
+
+    const parked = iterator.next();
+    queue.complete();
+
+    await expect(parked).resolves.toEqual({ value: undefined, done: true });
+  });
+});


### PR DESCRIPTION
## What is wrong

`AsyncQueue.fail()` resolved a parked consumer with `{ done: true }` and only stored the error:

```ts
fail(error: Error): void {
  if (this.done) return;
  this.done = true;
  this.error = error;
  if (this.resolveNext) {
    const r = this.resolveNext;
    this.resolveNext = null;
    r({ value: undefined as unknown as T, done: true });   // <- normal end
  }
}
```

The stored `this.error` is only ever read by `next()`. A consumer that was parked has already been handed a normal end-of-stream, its `for await` loop has exited, and it never calls `next()` again. So whether a caller sees the failure or a clean completion depends on whether it happened to be awaiting at that instant.

During streaming it almost always is. The consumer drains tokens faster than inference produces them, so parked is the normal state, and the silent path is the common one rather than the edge case.

## Why it matters

`streamGenerate` fails both queues on a mid-stream error (`RunAnywhere+TextGeneration.ts:183-184`). With the queue swallowing it, iterating `stream` or `events` ends as if generation had completed: the caller keeps a truncated answer and is told nothing went wrong.

The error does survive on the separate `result` promise, but `LLMStreamingResult` exposes `stream`, `events` and `result` independently, and a caller driving the token stream has no obligation to await `result`.

## What this changes

Producers now only signal, and `next()` re-reads the queue state, so a parked consumer raises the error on the same check a late consumer already hit.

That is exactly how `AsyncQueue` in `@runanywhere/proto-ts/streams/push` (the shared implementation used by React Native and Electron) already behaves. This file is a hand-rolled second copy that drifted from it, so this brings the clone back in line rather than inventing a third behaviour.

Buffered values still drain before the error surfaces, and `complete()` still ends the stream normally. Net 25 insertions, 24 deletions.

## Verification

Ran in `bindings/web/packages/core`:

- `vitest run`: **57 files, 248 tests, all pass** (including the 4 new ones)
- `tsc --noEmit`: clean
- `eslint src/Foundation/AsyncQueue.ts tests/unit/Foundation/AsyncQueue.test.ts --max-warnings 0`: clean

The new test is in `tests/unit/Foundation/AsyncQueue.test.ts`. I confirmed it is a real regression test by stashing only `AsyncQueue.ts` and re-running: the parked-consumer case fails on unfixed source with

```
- Error { "message": "rejected promise" }
+ { "done": true, "value": undefined }
```

and the other three pass on unfixed source, so they pin behaviour this change had to preserve rather than describing the fix.

The suite and typecheck need the generated proto tree, so I ran `idl/codegen/generate_ts.sh`, `generate_ts_convenience.py`, `generate_defaults_pool.py` and `generate_streams.sh` first. None of that output is committed; `git status` shows only the two files.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved asynchronous queue handling for waiting consumers.
  * Ensured queued values are delivered before reported failures.
  * Improved behavior for consumers after completion or failure.
  * Reduced the risk of missed notifications when new values, completion, or errors become available.
  * Preserved existing public queue interfaces while improving result delivery consistency.

* **Tests**
  * Added coverage for queue failures, buffered values, parked consumers, and normal completion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->