### PR TITLE
fix(web): keep a stream failure that lands while nobody is parked on next()

### DIFF
--- a/bindings/web/packages/core/src/Adapters/ProtoAdapterTypes.ts
+++ b/bindings/web/packages/core/src/Adapters/ProtoAdapterTypes.ts
@@ -549,6 +549,7 @@ export function streamCallback<T>(
       let callbackPtr = 0;
       let started = false;
       let finished = false;
+      let failure: unknown = null;
       let callActive = false;
       let emitsSinceYield = 0;
 
@@ -571,6 +572,10 @@ export function streamCallback<T>(
       const fail = (error: unknown): void => {
         if (finished) return;
         finished = true;
+        // Kept for the consumer that is not parked right now (a decode that
+        // throws while earlier events are still buffered, say); without it the
+        // next `next()` would read the stream as a clean end.
+        failure = error;
         while (waiters.length > 0) {
           waiters.shift()!.reject(error);
         }
@@ -699,6 +704,11 @@ export function streamCallback<T>(
           start();
           if (queue.length > 0) {
             return Promise.resolve({ value: queue.shift()!, done: false });
+          }
+          if (failure !== null) {
+            const error = failure;
+            failure = null;
+            return Promise.reject(error);
           }
           if (finished) {
             return Promise.resolve({ value: undefined as T, done: true });

--- a/bindings/web/packages/core/src/Adapters/ProtoAdapterTypes.ts
+++ b/bindings/web/packages/core/src/Adapters/ProtoAdapterTypes.ts
@@ -721,6 +721,11 @@ export function streamCallback<T>(
           try {
             onCancel?.();
           } finally {
+            // An explicit cancel outranks an error the consumer never asked
+            // about: `finish()` is a no-op once `fail()` has set `finished`,
+            // so drop the retained failure here rather than replaying it at
+            // the next `next()`.
+            failure = null;
             finish();
           }
           return Promise.resolve({ value: undefined as T, done: true });

--- a/bindings/web/packages/core/src/Adapters/ProtoAdapterTypes.ts
+++ b/bindings/web/packages/core/src/Adapters/ProtoAdapterTypes.ts
@@ -549,7 +549,9 @@ export function streamCallback<T>(
       let callbackPtr = 0;
       let started = false;
       let finished = false;
-      let failure: unknown = null;
+      // Boxed: a bare `unknown` sentinel cannot tell "rejected with null"
+      // apart from "never failed", and that reason would be dropped.
+      let failure: { reason: unknown } | null = null;
       let callActive = false;
       let emitsSinceYield = 0;
 
@@ -575,7 +577,7 @@ export function streamCallback<T>(
         // Kept for the consumer that is not parked right now (a decode that
         // throws while earlier events are still buffered, say); without it the
         // next `next()` would read the stream as a clean end.
-        failure = error;
+        failure = { reason: error };
         while (waiters.length > 0) {
           waiters.shift()!.reject(error);
         }
@@ -706,7 +708,7 @@ export function streamCallback<T>(
             return Promise.resolve({ value: queue.shift()!, done: false });
           }
           if (failure !== null) {
-            const error = failure;
+            const error = failure.reason;
             failure = null;
             return Promise.reject(error);
           }

--- a/bindings/web/packages/core/src/runtime/BackendWorkerHost.ts
+++ b/bindings/web/packages/core/src/runtime/BackendWorkerHost.ts
@@ -73,6 +73,13 @@ interface StreamPending {
     reject(reason: unknown): void;
   }>;
   finished: boolean;
+  /**
+   * Set by whichever path failed the stream. Rejecting the parked waiters is
+   * not enough on its own: a worker that dies while the consumer is running its
+   * loop body has no waiter to reject, and `next()` would otherwise read
+   * `finished` as a clean end of stream.
+   */
+  failure?: unknown;
 }
 
 type PendingRequest = UnaryPending | StreamPending;
@@ -223,6 +230,7 @@ export class BackendWorkerHost {
     const fail = (error: unknown): void => {
       if (state.finished) return;
       state.finished = true;
+      state.failure = error;
       this.pending.delete(requestId);
       this.activeStreamIds.delete(requestId);
       while (state.waiters.length) state.waiters.shift()!.reject(error);
@@ -244,11 +252,19 @@ export class BackendWorkerHost {
           if (state.events.length) {
             return Promise.resolve({ value: state.events.shift(), done: false });
           }
+          if (state.failure !== undefined) {
+            const error = state.failure;
+            state.failure = undefined;
+            return Promise.reject(error);
+          }
           if (state.finished) return Promise.resolve({ value: undefined, done: true });
           return new Promise((resolve, reject) => state.waiters.push({ resolve, reject }));
         },
         return: (): Promise<IteratorResult<unknown>> => {
           if (started && !state.finished) this.cancel(requestId);
+          // An explicit cancel outranks an error the consumer never asked
+          // about, matching the other two iterators.
+          state.failure = undefined;
           finish();
           return Promise.resolve({ value: undefined, done: true });
         },
@@ -380,6 +396,7 @@ export class BackendWorkerHost {
       return;
     }
     pending.finished = true;
+    pending.failure = error;
     while (pending.waiters.length) pending.waiters.shift()!.reject(error);
   }
 

--- a/bindings/web/packages/core/src/runtime/BackendWorkerHost.ts
+++ b/bindings/web/packages/core/src/runtime/BackendWorkerHost.ts
@@ -79,7 +79,10 @@ interface StreamPending {
    * loop body has no waiter to reject, and `next()` would otherwise read
    * `finished` as a clean end of stream.
    */
-  failure?: unknown;
+  // Boxed so a rejection reason of `undefined` is still a failure. A bare
+  // `failure?: unknown` cannot tell "rejected with undefined" apart from
+  // "never failed", and the undefined case then ends the stream cleanly.
+  failure: { reason: unknown } | null;
 }
 
 type PendingRequest = UnaryPending | StreamPending;
@@ -216,7 +219,13 @@ export class BackendWorkerHost {
   ): AsyncIterable<unknown> {
     const requestId = this.nextRequestId('stream');
     let started = false;
-    const state: StreamPending = { kind: 'stream', events: [], waiters: [], finished: false };
+    const state: StreamPending = {
+      kind: 'stream',
+      events: [],
+      waiters: [],
+      finished: false,
+      failure: null,
+    };
 
     const finish = (): void => {
       if (state.finished) return;
@@ -230,7 +239,7 @@ export class BackendWorkerHost {
     const fail = (error: unknown): void => {
       if (state.finished) return;
       state.finished = true;
-      state.failure = error;
+      state.failure = { reason: error };
       this.pending.delete(requestId);
       this.activeStreamIds.delete(requestId);
       while (state.waiters.length) state.waiters.shift()!.reject(error);
@@ -252,10 +261,10 @@ export class BackendWorkerHost {
           if (state.events.length) {
             return Promise.resolve({ value: state.events.shift(), done: false });
           }
-          if (state.failure !== undefined) {
-            const error = state.failure;
-            state.failure = undefined;
-            return Promise.reject(error);
+          if (state.failure) {
+            const { reason } = state.failure;
+            state.failure = null;
+            return Promise.reject(reason);
           }
           if (state.finished) return Promise.resolve({ value: undefined, done: true });
           return new Promise((resolve, reject) => state.waiters.push({ resolve, reject }));
@@ -264,7 +273,7 @@ export class BackendWorkerHost {
           if (started && !state.finished) this.cancel(requestId);
           // An explicit cancel outranks an error the consumer never asked
           // about, matching the other two iterators.
-          state.failure = undefined;
+          state.failure = null;
           finish();
           return Promise.resolve({ value: undefined, done: true });
         },
@@ -396,7 +405,7 @@ export class BackendWorkerHost {
       return;
     }
     pending.finished = true;
-    pending.failure = error;
+    pending.failure = { reason: error };
     while (pending.waiters.length) pending.waiters.shift()!.reject(error);
   }
 

--- a/bindings/web/packages/core/src/runtime/OffscreenRuntimeBridge.ts
+++ b/bindings/web/packages/core/src/runtime/OffscreenRuntimeBridge.ts
@@ -331,6 +331,11 @@ export class OffscreenRuntimeBridge {
         }> = [];
         let started = false;
         let finished = false;
+        // Rejecting the parked waiters is not enough on its own: a worker that
+        // dies while the consumer is running its loop body has no waiter to
+        // reject, and without this the next `next()` would read the stream as
+        // a clean end.
+        let failure: unknown = null;
 
         const finish = (): void => {
           if (finished) return;
@@ -344,6 +349,7 @@ export class OffscreenRuntimeBridge {
         const fail = (err: unknown): void => {
           if (finished) return;
           finished = true;
+          failure = err;
           this.pending.delete(requestId);
           while (waiters.length > 0) waiters.shift()!.reject(err);
         };
@@ -398,6 +404,11 @@ export class OffscreenRuntimeBridge {
             start();
             if (queue.length > 0) {
               return Promise.resolve({ value: queue.shift()!, done: false });
+            }
+            if (failure !== null) {
+              const err = failure;
+              failure = null;
+              return Promise.reject(err);
             }
             if (finished) {
               return Promise.resolve({ value: undefined as T, done: true });

--- a/bindings/web/packages/core/src/runtime/OffscreenRuntimeBridge.ts
+++ b/bindings/web/packages/core/src/runtime/OffscreenRuntimeBridge.ts
@@ -426,6 +426,11 @@ export class OffscreenRuntimeBridge {
               const cancelMsg: WorkerRequest = { type: 'cancel', requestId };
               this.worker.postMessage(cancelMsg);
             }
+            // An explicit cancel outranks an error the consumer never asked
+            // about: `finish()` is a no-op once `fail()` has set `finished`,
+            // so drop the retained failure here rather than replaying it at
+            // the next `next()`.
+            failure = null;
             finish();
             return Promise.resolve({ value: undefined as T, done: true });
           },

--- a/bindings/web/packages/core/src/runtime/OffscreenRuntimeBridge.ts
+++ b/bindings/web/packages/core/src/runtime/OffscreenRuntimeBridge.ts
@@ -335,7 +335,9 @@ export class OffscreenRuntimeBridge {
         // dies while the consumer is running its loop body has no waiter to
         // reject, and without this the next `next()` would read the stream as
         // a clean end.
-        let failure: unknown = null;
+        // Boxed: a bare `unknown` sentinel cannot tell "rejected with null"
+        // apart from "never failed", and that reason would be dropped.
+        let failure: { reason: unknown } | null = null;
 
         const finish = (): void => {
           if (finished) return;
@@ -349,7 +351,7 @@ export class OffscreenRuntimeBridge {
         const fail = (err: unknown): void => {
           if (finished) return;
           finished = true;
-          failure = err;
+          failure = { reason: err };
           this.pending.delete(requestId);
           while (waiters.length > 0) waiters.shift()!.reject(err);
         };
@@ -406,7 +408,7 @@ export class OffscreenRuntimeBridge {
               return Promise.resolve({ value: queue.shift()!, done: false });
             }
             if (failure !== null) {
-              const err = failure;
+              const err = failure.reason;
               failure = null;
               return Promise.reject(err);
             }

--- a/bindings/web/packages/core/tests/unit/runtime/StreamFailureNotParked.test.ts
+++ b/bindings/web/packages/core/tests/unit/runtime/StreamFailureNotParked.test.ts
@@ -1,0 +1,181 @@
+/**
+ * StreamFailureNotParked.test.ts
+ *
+ * A stream failure has to reach the consumer even when the consumer is not
+ * parked on `next()` at the instant it happens.
+ *
+ * Both hand-rolled iterators here (`OffscreenRuntimeBridge.getStreamIterator`
+ * and `streamCallback` in `ProtoAdapterTypes`) reject the waiters that happen
+ * to be parked. Neither used to keep the error anywhere, so a failure that
+ * arrived while the consumer was between `next()` calls was reported to the
+ * following `next()` as a clean end-of-stream.
+ *
+ * Run from `bindings/web/packages/core`:
+ *
+ *     npx vitest run tests/unit/runtime/StreamFailureNotParked.test.ts
+ */
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  OffscreenRuntimeBridge,
+  setStreamWorkerInit,
+} from '../../../src/runtime/OffscreenRuntimeBridge';
+import { setStreamWorkerFactory } from '../../../src/runtime/StreamWorkerFactoryRegistry';
+import { streamCallback, type ModalityProtoModule } from '../../../src/Adapters/ProtoAdapterTypes';
+import type { ProtoCodec } from '../../../src/runtime/ProtoWasm';
+import type { WorkerRequest, WorkerResponse } from '../../../src/runtime/StreamWorker';
+
+const uint32Codec: ProtoCodec<number> = {
+  encode(_message: number) {
+    return { finish: (): Uint8Array => new Uint8Array(0) };
+  },
+  decode(input: Uint8Array): number {
+    return new DataView(input.buffer, input.byteOffset, input.byteLength).getUint32(0, true);
+  },
+};
+
+function encodeU32(value: number): Uint8Array {
+  const out = new Uint8Array(4);
+  new DataView(out.buffer).setUint32(0, value, true);
+  return out;
+}
+
+/**
+ * Posts one callback for the stream request and then stays quiet until the
+ * test calls {@link crash}. Nothing is timer-driven, so "the consumer is
+ * between `next()` calls" is a fact of the test rather than a race it hopes
+ * to win.
+ */
+class CrashingWorker {
+  onmessage: ((ev: MessageEvent<WorkerResponse>) => void) | null = null;
+  onerror: ((ev: ErrorEvent) => void) | null = null;
+
+  private requestId: string | null = null;
+
+  constructor() {
+    queueMicrotask(() => this.deliver({ type: 'ready' } as WorkerResponse));
+  }
+
+  postMessage(msg: WorkerRequest): void {
+    // The stream request carries its kind in `type`; only `init` and `cancel`
+    // are fixed names.
+    const requestId = (msg as { requestId?: string }).requestId;
+    if (!requestId || msg.type === 'cancel') return;
+    this.requestId = requestId;
+    this.deliver({
+      type: 'callback',
+      requestId,
+      payloadBytes: encodeU32(1),
+    } as unknown as WorkerResponse);
+  }
+
+  /** The worker dies mid-stream, the way a WASM OOM kills it. */
+  crash(message: string): void {
+    this.deliver({
+      type: 'error',
+      requestId: this.requestId,
+      message,
+    } as unknown as WorkerResponse);
+  }
+
+  terminate(): void {}
+
+  private deliver(data: WorkerResponse): void {
+    this.onmessage?.({ data } as MessageEvent<WorkerResponse>);
+  }
+}
+
+interface FakeModule extends ModalityProtoModule {
+  /** Emit a uint32 value through the currently-installed callback. */
+  emitValue: (callbackPtr: number, value: number) => void;
+}
+
+/** Same shape as the fake in `Adapters/StreamLiveDelivery.test.ts`. */
+function makeFakeModule(): FakeModule {
+  const heap = new Uint8Array(4 * 1024);
+  const callbacks = new Map<number, (bytesPtr: number, size: number) => unknown>();
+  let nextPtr = 1;
+  // `streamCallback` treats bytesPtr === 0 as a null sentinel, so start at 1.
+  let heapCursor = 1;
+
+  const mod: Partial<FakeModule> = {
+    HEAPU8: heap,
+    addFunction(fn, _signature) {
+      const id = nextPtr++;
+      callbacks.set(id, fn as (bytesPtr: number, size: number) => unknown);
+      return id;
+    },
+    removeFunction(ptr) {
+      callbacks.delete(ptr);
+    },
+    emitValue(callbackPtr: number, value: number): void {
+      const fn = callbacks.get(callbackPtr);
+      if (!fn) throw new Error(`emitValue: no callback at ptr ${callbackPtr}`);
+      heap.set(encodeU32(value), heapCursor);
+      const ptr = heapCursor;
+      heapCursor += 4;
+      fn(ptr, 4);
+    },
+  };
+  return mod as FakeModule;
+}
+
+describe('a stream failure that lands while the consumer is not parked', () => {
+  let worker: CrashingWorker | null = null;
+
+  beforeEach(() => {
+    OffscreenRuntimeBridge.resetForTesting();
+    setStreamWorkerFactory(null);
+    setStreamWorkerInit(null);
+  });
+
+  afterEach(() => {
+    worker = null;
+    setStreamWorkerFactory(null);
+    setStreamWorkerInit(null);
+    OffscreenRuntimeBridge.resetForTesting();
+  });
+
+  it('is raised by the worker bridge rather than read as end-of-stream', async () => {
+    setStreamWorkerInit({ wasmBytes: new ArrayBuffer(0), moduleFactoryId: 'fake-factory' });
+    setStreamWorkerFactory(() => {
+      worker = new CrashingWorker();
+      return worker as unknown as Worker;
+    });
+
+    const bridge = OffscreenRuntimeBridge.tryGet('worker');
+    expect(bridge).not.toBeNull();
+
+    const stream = bridge!.getStreamIterator(
+      { kind: 'stream.llm.generate', handle: 0, requestBytes: new Uint8Array() },
+      uint32Codec,
+    );
+    const iterator = stream[Symbol.asyncIterator]();
+
+    expect(await iterator.next()).toEqual({ value: 1, done: false });
+
+    // No waiter is parked here, which is the state a consumer is in while it
+    // renders the token it just received.
+    worker!.crash('worker died');
+
+    await expect(iterator.next()).rejects.toThrow('worker died');
+  });
+
+  it('is raised by streamCallback rather than read as end-of-stream', async () => {
+    const fake = makeFakeModule();
+
+    // The first emit wakes the parked consumer; the second is buffered, so
+    // when the call throws there is no waiter left to reject.
+    const iterator = streamCallback(fake, uint32Codec, 'crashing_test_stream', (callbackPtr) => {
+      fake.emitValue(callbackPtr, 1);
+      fake.emitValue(callbackPtr, 2);
+      throw new Error('native call failed');
+    })[Symbol.asyncIterator]();
+
+    expect(await iterator.next()).toEqual({ value: 1, done: false });
+    expect(await iterator.next()).toEqual({ value: 2, done: false });
+
+    await expect(iterator.next()).rejects.toThrow('native call failed');
+  });
+});

--- a/bindings/web/packages/core/tests/unit/runtime/StreamFailureNotParked.test.ts
+++ b/bindings/web/packages/core/tests/unit/runtime/StreamFailureNotParked.test.ts
@@ -54,29 +54,28 @@ class CrashingWorker {
   private requestId: string | null = null;
 
   constructor() {
-    queueMicrotask(() => this.deliver({ type: 'ready' } as WorkerResponse));
+    queueMicrotask(() => this.deliver({ type: 'ready' }));
   }
 
   postMessage(msg: WorkerRequest): void {
-    // The stream request carries its kind in `type`; only `init` and `cancel`
-    // are fixed names.
-    const requestId = (msg as { requestId?: string }).requestId;
-    if (!requestId || msg.type === 'cancel') return;
-    this.requestId = requestId;
+    // Everything that is not `init` or `cancel` is a stream request, and the
+    // union narrows to the variants carrying `requestId`.
+    if (msg.type === 'init' || msg.type === 'cancel') return;
+    this.requestId = msg.requestId;
     this.deliver({
       type: 'callback',
-      requestId,
+      requestId: msg.requestId,
       payloadBytes: encodeU32(1),
-    } as unknown as WorkerResponse);
+    });
   }
 
   /** The worker dies mid-stream, the way a WASM OOM kills it. */
   crash(message: string): void {
     this.deliver({
       type: 'error',
-      requestId: this.requestId,
+      requestId: this.requestId ?? undefined,
       message,
-    } as unknown as WorkerResponse);
+    });
   }
 
   terminate(): void {}
@@ -177,5 +176,27 @@ describe('a stream failure that lands while the consumer is not parked', () => {
     expect(await iterator.next()).toEqual({ value: 2, done: false });
 
     await expect(iterator.next()).rejects.toThrow('native call failed');
+  });
+
+  it('lets an explicit cancel outrank a failure the consumer never read', async () => {
+    setStreamWorkerInit({ wasmBytes: new ArrayBuffer(0), moduleFactoryId: 'fake-factory' });
+    setStreamWorkerFactory(() => {
+      worker = new CrashingWorker();
+      return worker as unknown as Worker;
+    });
+
+    const stream = OffscreenRuntimeBridge.tryGet('worker')!.getStreamIterator(
+      { kind: 'stream.llm.generate', handle: 0, requestBytes: new Uint8Array() },
+      uint32Codec,
+    );
+    const iterator = stream[Symbol.asyncIterator]();
+
+    expect(await iterator.next()).toEqual({ value: 1, done: false });
+    worker!.crash('worker died');
+
+    // The consumer walked away instead of reading the error, so it should not
+    // be handed that error afterwards.
+    await iterator.return?.();
+    expect(await iterator.next()).toEqual({ value: undefined, done: true });
   });
 });

--- a/bindings/web/packages/core/tests/unit/runtime/StreamFailureNotParked.test.ts
+++ b/bindings/web/packages/core/tests/unit/runtime/StreamFailureNotParked.test.ts
@@ -23,6 +23,15 @@ import {
 } from '../../../src/runtime/OffscreenRuntimeBridge';
 import { setStreamWorkerFactory } from '../../../src/runtime/StreamWorkerFactoryRegistry';
 import { streamCallback, type ModalityProtoModule } from '../../../src/Adapters/ProtoAdapterTypes';
+import {
+  BackendWorkerHost,
+  type BackendWorkerLike,
+} from '../../../src/runtime/BackendWorkerHost';
+import { runBackendWorker, type BackendWorkerScope } from '../../../src/runtime/BackendWorker';
+import type {
+  BackendWorkerRequest,
+  BackendWorkerResponse,
+} from '../../../src/runtime/BackendWorkerProtocol';
 import type { ProtoCodec } from '../../../src/runtime/ProtoWasm';
 import type { WorkerRequest, WorkerResponse } from '../../../src/runtime/StreamWorker';
 
@@ -198,5 +207,49 @@ describe('a stream failure that lands while the consumer is not parked', () => {
     // be handed that error afterwards.
     await iterator.return?.();
     expect(await iterator.next()).toEqual({ value: undefined, done: true });
+  });
+
+  it('is raised by the backend worker host rather than read as end-of-stream', async () => {
+    // Emits one event, then keeps the stream open so the crash is what ends it.
+    class OneThenHangWorker implements BackendWorkerLike {
+      onmessage: ((event: MessageEvent<BackendWorkerResponse>) => void) | null = null;
+      onerror: ((event: ErrorEvent) => void) | null = null;
+      private readonly scope: BackendWorkerScope;
+
+      constructor() {
+        this.scope = {
+          onmessage: null,
+          postMessage: (response) =>
+            this.onmessage?.({ data: response } as MessageEvent<BackendWorkerResponse>),
+        };
+        runBackendWorker(this.scope, {
+          init: () => undefined,
+          infer: (_kind, payload) => payload,
+          stream: async function* () {
+            yield 'first';
+            await new Promise<void>(() => {});
+          },
+          cancel: () => undefined,
+        });
+      }
+
+      postMessage(request: BackendWorkerRequest): void {
+        this.scope.onmessage?.({ data: request } as MessageEvent<BackendWorkerRequest>);
+      }
+
+      terminate(): void {}
+    }
+
+    const worker = new OneThenHangWorker();
+    const host = new BackendWorkerHost(() => worker);
+    const iterator = host.stream('tts.synthesize', { text: 'hello' })[Symbol.asyncIterator]();
+
+    expect(await iterator.next()).toEqual({ value: 'first', done: false });
+
+    // The worker dies while the consumer is handling the event it just got.
+    // handleCrash fails every in-flight request, and none of them is parked.
+    worker.onerror?.({ message: 'simulated crash' } as ErrorEvent);
+
+    await expect(iterator.next()).rejects.toThrow();
   });
 });


### PR DESCRIPTION
## What is wrong

`OffscreenRuntimeBridge.getStreamIterator` and `streamCallback` (`ProtoAdapterTypes`) both fail like this:

```ts
const fail = (err: unknown): void => {
  if (finished) return;
  finished = true;
  while (waiters.length > 0) waiters.shift()!.reject(err);
};
```

Only the waiters that are parked at that instant learn about the error, and nothing keeps it afterwards. `next()` drains the queue and then returns `{ done: true }` because `finished` is set. So a failure that arrives while the consumer is between `next()` calls is discarded, and the consumer is told the stream ended normally.

## Why both windows are ordinary

**Worker bridge.** The worker posts `error` whenever it likes, including while the consumer is rendering the token it just received. This is the documented failure here: a WASM OOM in the VLM path kills the worker (see the Web VLM Worker crash-recovery note in AGENTS.md).

**streamCallback.** `start()` defers the native call by a microtask, on purpose, so the consumer's first `next()` parks before native code starts emitting. The first emit wakes it; everything emitted after that is buffered. A call that emits and then throws therefore fails with no waiter left to reject.

The consequence in both cases is the same, and it is the one that costs a user real time: inference dies, and the app renders a truncated answer as a completed one.

## What this changes

Each iterator stores the error and raises it from `next()` on a check placed between the existing queue drain and the `finished` check. Buffered events still arrive first, and only once they are exhausted does the error surface. Cancellation and normal completion are untouched.

+21 lines of source across the two files.

## Verification

Ran in `bindings/web/packages/core`:

- `vitest run`: **57 files, 246 tests, all pass**
- `tsc --noEmit`: clean
- `eslint` on the three changed files with `--max-warnings 0`: clean

The new test is `tests/unit/runtime/StreamFailureNotParked.test.ts`. Both cases are deterministic rather than timing-dependent: the fake worker only crashes when the test tells it to, and the fake module emits a second value so the buffered-events window is a fact of the test rather than a race.

I confirmed both are real regression tests by stashing only the two source files and re-running. Both fail on unfixed source with the same symptom:

```
× is raised by the worker bridge rather than read as end-of-stream
  → promise resolved "{ value: undefined, done: true }" instead of rejecting
× is raised by streamCallback rather than read as end-of-stream
  → promise resolved "{ value: undefined, done: true }" instead of rejecting
```

The suite and typecheck need the generated proto tree, so I ran `idl/codegen/generate_ts.sh`, `generate_ts_convenience.py`, `generate_defaults_pool.py` and `generate_streams.sh` first. None of that output is committed; `git status` shows only the three files.

One note on scope: this is the same failure mode as #721, but a different one of the two races and a disjoint set of files, so I kept them apart rather than growing that diff. #721 loses the error when the consumer **is** parked; this loses it when the consumer **is not**. They can land in either order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Stream errors occurring between successive reads are now correctly reported.
  * Subsequent stream requests reject with the original failure instead of incorrectly signaling the end of the stream.
  * Cancelling a stream clears pending errors and completes normally.
  * Streaming consumers receive consistent failure behavior across supported runtime environments.

* **Tests**
  * Added coverage for deferred stream failures across worker-based and native streaming scenarios, including cancellation behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->