### PR TITLE
Fix WebGPU release build on emsdk 6 Linux

### DIFF
--- a/bindings/flutter/scripts/package-sdk.sh
+++ b/bindings/flutter/scripts/package-sdk.sh
@@ -455,7 +455,7 @@ validate_mlx_local_payload() {
 validate_public_remote_binary_contract() {
     local pkg component pkg_dir build_gradle binary_config podspec package_manifest
     local file relative expected_target expected_targets expected_count actual_count
-    local actual_pubignore expected_pubignore
+    local actual_pubignore expected_pubignore podspec_version asset_version
     for pkg in runanywhere runanywhere_llamacpp runanywhere_mlx runanywhere_onnx; do
         case "$pkg" in
             runanywhere)
@@ -524,7 +524,14 @@ validate_public_remote_binary_contract() {
         grep -Fq 'RUNANYWHERE_FLUTTER_IOS_RELEASE_BASE_URL' "$podspec" || { echo "ERROR: $pkg podspec is missing the test-only release URL override" >&2; exit 1; }
         grep -Fq "shasum -a 256" "$podspec" || { echo "ERROR: $pkg podspec is missing Apple archive checksum verification" >&2; exit 1; }
         grep -Fq -- "--proto '=https,file'" "$podspec" || { echo "ERROR: $pkg podspec does not restrict download protocols" >&2; exit 1; }
-        grep -Fq -- '-ios-v#{s.version}.zip' "$podspec" || { echo "ERROR: $pkg podspec is missing versioned Apple release archive URLs" >&2; exit 1; }
+        podspec_version="$(sed -nE "s/^[[:space:]]*s\.version[[:space:]]*=[[:space:]]*'([^']+)'$/\1/p" "$podspec")"
+        asset_version="$(sed -nE "s/^[[:space:]]*asset_version[[:space:]]*=[[:space:]]*'([^']+)'$/\1/p" "$podspec")"
+        [ -n "$podspec_version" ] || { echo "ERROR: $pkg podspec is missing s.version" >&2; exit 1; }
+        [ "$asset_version" = "$podspec_version" ] || { echo "ERROR: $pkg podspec asset_version must match s.version ($podspec_version)" >&2; exit 1; }
+        apple_archive_name_variable='$name'
+        [ "$pkg" != "runanywhere_mlx" ] || apple_archive_name_variable='$asset_name'
+        apple_archive_template="v#{asset_version}/${apple_archive_name_variable}-ios-v#{asset_version}.zip"
+        grep -Fq -- "$apple_archive_template" "$podspec" || { echo "ERROR: $pkg podspec must use asset_version in the Apple release URL path and filename" >&2; exit 1; }
 
         if [ "$pkg" = "runanywhere_mlx" ]; then
             [ ! -e "$package_manifest" ] || { echo "ERROR: runanywhere_mlx must remain CocoaPods-only; remove its SwiftPM manifest" >&2; exit 1; }

--- a/bindings/kotlin/docs/KOTLIN_MAVEN_CENTRAL_PUBLISHING.md
+++ b/bindings/kotlin/docs/KOTLIN_MAVEN_CENTRAL_PUBLISHING.md
@@ -67,10 +67,13 @@ runanywhere-sdk AAR                  runanywhere-llamacpp AAR             runany
 Publishing uses the **Sonatype OSSRH Staging API**. Three explicit phases:
 
 ```
-Upload (Gradle) --> Close (validation) --> Release (promotes to Maven Central)
+Upload (Gradle) --> Transfer to Portal --> Validate + publish to Maven Central
 ```
 
-The Gradle `maven-publish` plugin only does the upload. Close and release must be done separately.
+The Gradle `maven-publish` plugin only writes files to Sonatype's OSSRH
+compatibility service. The deployment must then be transferred to the Central
+Publisher Portal. Using `publishing_type=automatic` validates and publishes it
+without a separate Portal click.
 
 ---
 
@@ -190,33 +193,62 @@ cd bindings/kotlin
   --no-daemon
 ```
 
-### 4. Close and Release Staging Repo
+### 4. Transfer the deployment to Central Portal
 
 ```bash
-# Drop any stale staging repo first (if previous publish failed)
-curl -s -X POST -u "$MAVEN_CENTRAL_USERNAME:$MAVEN_CENTRAL_PASSWORD" \
-  "https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/drop" \
-  -H "Content-Type: application/json" \
-  -d '{"data":{"stagedRepositoryIds":["io.github.sanchitmonga22--default-repository"],"description":"Clean","autoDropAfterRelease":true}}'
+# Run this from the same host/IP that performed the Gradle upload. Sonatype's
+# compatibility service groups Maven-like PUT requests by source IP.
+CENTRAL_BEARER="$(printf '%s:%s' \
+  "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" |
+  base64 | tr -d '\r\n')"
 
-# ... then re-run the publish command above if needed ...
+curl --fail --request POST \
+  -H "Authorization: Bearer $CENTRAL_BEARER" \
+  'https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/io.github.sanchitmonga22?publishing_type=automatic'
 
-# Close (triggers validation)
-curl -X POST -u "$MAVEN_CENTRAL_USERNAME:$MAVEN_CENTRAL_PASSWORD" \
-  "https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/close" \
-  -H "Content-Type: application/json" \
-  -d '{"data":{"stagedRepositoryIds":["io.github.sanchitmonga22--default-repository"],"description":"Release","autoDropAfterRelease":true}}'
+# This flow assumes the compatibility service was clean before the Gradle
+# upload. Require exactly one repository for this client IP and namespace so a
+# stale or concurrent deployment can never be selected by accident.
+REPOSITORIES_JSON="$(curl --fail --silent \
+  -H "Authorization: Bearer $CENTRAL_BEARER" \
+  'https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?ip=client&profile_id=io.github.sanchitmonga22')"
+REPOSITORY_COUNT="$(jq '[.repositories[] | select(.portal_deployment_id != null)] | length' <<<"$REPOSITORIES_JSON")"
+[ "$REPOSITORY_COUNT" = 1 ] || {
+  echo "Expected exactly one transferred repository; found $REPOSITORY_COUNT" >&2
+  exit 1
+}
+DEPLOYMENT_ID="$(jq -r '.repositories[] | select(.portal_deployment_id != null) | .portal_deployment_id' <<<"$REPOSITORIES_JSON")"
+[ -n "$DEPLOYMENT_ID" ] && [ "$DEPLOYMENT_ID" != null ]
 
-# Wait ~30s, verify "type": "closed"
-curl -s -u "$MAVEN_CENTRAL_USERNAME:$MAVEN_CENTRAL_PASSWORD" \
-  "https://ossrh-staging-api.central.sonatype.com/service/local/staging/profile_repositories/io.github.sanchitmonga22" \
-  -H "Accept: application/json"
-
-# Release (promote to Maven Central)
-curl -X POST -u "$MAVEN_CENTRAL_USERNAME:$MAVEN_CENTRAL_PASSWORD" \
-  "https://ossrh-staging-api.central.sonatype.com/service/local/staging/bulk/promote" \
-  -H "Content-Type: application/json" \
-  -d '{"data":{"stagedRepositoryIds":["io.github.sanchitmonga22--default-repository"],"description":"Release","autoDropAfterRelease":true}}'
+# Poll for at most 15 minutes. Automatic deployments normally pass through
+# PENDING -> VALIDATING -> PUBLISHING -> PUBLISHED.
+DEPLOYMENT_STATE=
+for attempt in $(seq 1 90); do
+  STATUS_JSON="$(curl --fail --silent --request POST \
+    -H "Authorization: Bearer $CENTRAL_BEARER" \
+    "https://central.sonatype.com/api/v1/publisher/status?id=$DEPLOYMENT_ID")"
+  DEPLOYMENT_STATE="$(jq -r '.deploymentState' <<<"$STATUS_JSON")"
+  case "$DEPLOYMENT_STATE" in
+    PUBLISHED) break ;;
+    FAILED)
+      jq '.errors' <<<"$STATUS_JSON" >&2
+      exit 1
+      ;;
+    PENDING|VALIDATING|PUBLISHING) sleep 10 ;;
+    VALIDATED)
+      echo "Deployment is waiting for manual publication instead of automatic release; publish it in Central Portal or use the Portal publish endpoint, then resume status polling." >&2
+      exit 1
+      ;;
+    *)
+      echo "Unexpected Central Portal state: $DEPLOYMENT_STATE" >&2
+      exit 1
+      ;;
+  esac
+done
+[ "$DEPLOYMENT_STATE" = PUBLISHED ] || {
+  echo "Timed out waiting for Central Portal deployment $DEPLOYMENT_ID" >&2
+  exit 1
+}
 ```
 
 ### 5. Verify
@@ -238,8 +270,9 @@ Check: [Central Portal Deployments](https://central.sonatype.com/publishing/depl
 
 Maven Central publishing is **manual** (not automated in GitHub Actions).
 `.github/workflows/release.yml` only attaches a local Maven repository zip to
-the GitHub Release. Use the local release steps above to upload to OSSRH, then
-close/promote via the staging API.
+the GitHub Release. Use the local release steps above to upload to the OSSRH
+compatibility service, then transfer it to Central Portal with automatic
+publishing.
 
 ---
 
@@ -269,8 +302,8 @@ cd bindings/kotlin
   --no-daemon
 ```
 
-Then close/promote the staging repo with the same API commands as the core
-artifacts. Consumers depend on:
+Then transfer the staging repository with the same manual upload command as the
+core artifacts. Consumers depend on:
 
 ```kotlin
 implementation("io.github.sanchitmonga22:runanywhere-sdk:0.20.11")
@@ -328,8 +361,8 @@ No `pickFirsts` or workarounds needed. Each AAR bundles only its own native libs
 | Missing native libs in AAR | Clean all `jniLibs/` dirs and rebuild. Check each module has its own libs. |
 | `UnsatisfiedLinkError: nativeRegisterVlm` | Native libs are stale (pre-VLM). Rebuild from source with `build-android.sh`. |
 | Duplicate `.so` across AARs | Stale files in module `jniLibs/`. Delete and rebuild. Check `.gitignore` covers `src/main/jniLibs/`. |
-| Staging repo "No objects found" | Drop the stale repo and re-upload |
-| OSSRH staging never auto-closes | Manually close/release via staging API |
+| Compatibility repository is stale or closed | Treat the compatibility repository and its Portal deployment as separate resources. Find the repository with `GET /manual/search/repositories?ip=any&profile_id=io.github.sanchitmonga22`. If `portal_deployment_id` is present, query `/api/v1/publisher/status` first: for `PUBLISHED`, verify the released artifacts and stop; for active states, wait; for `FAILED`, preserve the deployment when requesting support; for a retryable `VALIDATED` or `FAILED` deployment, explicitly delete it through `/api/v1/publisher/deployment/{id}`. Only when retrying a non-published deployment should you delete the compatibility repository with `DELETE /manual/drop/repository/{repository_key}` before re-uploading. |
+| Deployment never appears in Central Portal | Call `POST /manual/upload/defaultRepository/io.github.sanchitmonga22` from the same IP as the Gradle upload. |
 
 ---
 
@@ -359,3 +392,4 @@ No `pickFirsts` or workarounds needed. Each AAR bundles only its own native libs
 - **GPG Keyserver**: https://keys.openpgp.org
 - **GitHub Releases**: https://github.com/RunanywhereAI/runanywhere-sdks/releases
 - **OSSRH Staging API**: https://ossrh-staging-api.central.sonatype.com
+- **OSSRH compatibility-service guide**: https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/

--- a/bindings/web/wasm/scripts/vendor-onnxruntime-wasm-webgpu.sh
+++ b/bindings/web/wasm/scripts/vendor-onnxruntime-wasm-webgpu.sh
@@ -406,7 +406,30 @@ export PATH
 source "${EMSDK}/emsdk_env.sh"
 export EMSCRIPTEN="${EMSDK}/upstream/emscripten"
 export EM_CONFIG="${EMSDK}/.emscripten"
-: "${EMSDK_PYTHON:?emsdk_env.sh did not provide EMSDK_PYTHON}"
+# emsdk 6.x deliberately omits its bundled Python dependency on Linux and
+# therefore does not export EMSDK_PYTHON there. macOS/Windows still provide it.
+# Resolve a host interpreter on Linux, but keep the explicit >=3.10 gate from
+# Emscripten 6 so an older Anaconda/system Python cannot silently win CMake's
+# discovery and fail much later in the Dawn build.
+if [ -z "${EMSDK_PYTHON:-}" ]; then
+  _emsdk_python_candidate="$(command -v python3 || true)"
+  if [ -n "${_emsdk_python_candidate}" ] && \
+      "${_emsdk_python_candidate}" -c 'import sys; raise SystemExit(sys.version_info < (3, 10))'; then
+    EMSDK_PYTHON="${_emsdk_python_candidate}"
+  elif [ -x /usr/bin/python3 ] && \
+      /usr/bin/python3 -c 'import sys; raise SystemExit(sys.version_info < (3, 10))'; then
+    EMSDK_PYTHON=/usr/bin/python3
+  else
+    echo "ERROR: Emscripten ${EMSCRIPTEN_VERSION} requires Python 3.10 or newer." >&2
+    echo "       emsdk_env.sh did not export EMSDK_PYTHON and no compatible python3 was found." >&2
+    exit 1
+  fi
+fi
+if ! "${EMSDK_PYTHON}" -c 'import sys; raise SystemExit(sys.version_info < (3, 10))'; then
+  echo "ERROR: EMSDK_PYTHON must point to Python 3.10 or newer: ${EMSDK_PYTHON}" >&2
+  exit 1
+fi
+export EMSDK_PYTHON
 # Dawn launches Emscripten's Python helpers through CMake's discovered
 # interpreter. A host Anaconda installation can otherwise win discovery and
 # select Python 3.9, which Emscripten 6 rejects. Pin every spelling used by ORT


### PR DESCRIPTION
## Description

Fix the 0.20.23 release path after emsdk 6.x stopped exporting `EMSDK_PYTHON` on Linux, strengthen Flutter Apple archive version validation, and update Kotlin Maven Central guidance to the current Sonatype compatibility-service and Portal workflow.

No Windows jobs are removed or changed.

## Type of Change

- [x] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring

## Testing

- [x] Lint/syntax checks pass locally
- [x] Added/updated validation coverage for changes

### Platform-Specific Testing (check all that apply)

**Swift SDK / iOS Sample:**

- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**

- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**

- [x] Flutter packaging dry-run passed for all four public packages with zero warnings
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**

- [ ] Tested on iOS
- [ ] Tested on Android

**Web SDK / Web Sample:**

- [x] WebGPU vendoring script syntax and Python 3.10+ fallback/rejection paths validated
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels

- [x] `Kotlin SDK`
- [x] `Flutter SDK`
- [x] `Web SDK`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated
- [x] `bash -n` passes for both modified shell scripts
- [x] Python fallback resolves Python 3.10+ and rejects Python 3.9
- [x] Release-version coherence gate passes
- [x] Full Flutter package validation passes for all four public packages
- [x] Archive URL positive and mismatched-path negative cases pass
- [x] `git diff --check` passes
- [x] All CodeRabbit inline findings addressed and resolved

## Screenshots

Not applicable; this PR changes release scripts, validation, and publishing documentation only.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated Maven Central publishing instructions for the current transfer and automatic publication workflow.
  * Added guidance for monitoring publication status, validating repositories, and troubleshooting deployment issues.

* **Build & Packaging**
  * Improved WebAssembly setup by automatically selecting and validating a compatible Python 3.10+ interpreter, with clearer errors when requirements are not met.
  * Strengthened SDK package validation to ensure version metadata and archive URLs remain consistent before publishing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->