### PR TITLE
rcli: a chat mode that remembers, and placement flags that reach the engine

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -46,6 +46,11 @@ jobs:
       # if any tracked AGENTS.md is missing its committed CLAUDE.md -> AGENTS.md symlink.
       - name: AGENTS.md / CLAUDE.md symlink check
         run: bash scripts/validation/gates/check_agents_claude_sync.sh
+      # Also bash-only. rcli is built from two hand-maintained source lists
+      # (CMake and SwiftPM); a file added to one and not the other links fine in
+      # whichever build you ran and fails in the other.
+      - name: rcli source lists agree (CMake vs SwiftPM)
+        run: bash scripts/validation/gates/check_rcli_source_lists.sh
       # Also bash-only. Fails the PR if SDK source re-declares a default that
       # idl/sdk_defaults.proto (or a rac_default annotation) already declares.
       # Without it the per-SDK default tables grow back: they had already drifted

--- a/Package.swift
+++ b/Package.swift
@@ -556,6 +556,7 @@ let package = Package(
                 "src/io/output.cpp",
                 "src/progress/progress_bar.cpp",
                 "src/repl/repl.cpp",
+                "src/repl/transcript.cpp",
                 "src/util/term.cpp",
                 "third_party/linenoise/linenoise.c",
             ],

--- a/bindings/swift/scripts/build-core-xcframework.sh
+++ b/bindings/swift/scripts/build-core-xcframework.sh
@@ -1087,6 +1087,14 @@ macos_cmake_args=(
     "-DRAC_BACKEND_NEURT=${RAC_BACKEND_NEURT}"
     "-DRAC_BACKEND_MLX=${RAC_BACKEND_MLX}"
     "-DGGML_NATIVE=OFF"
+    # Metal, the same way the iOS slices get it from RAC_PLATFORM_IOS. The
+    # macos-release preset pins GGML_METAL=OFF, so without this the macOS slice
+    # shipped a CPU-only llama.cpp while both iOS slices carried Metal: the
+    # backend logged "no GPU backend active" and every GGUF model ran on the CPU
+    # no matter what placement the caller asked for. EMBED_LIBRARY keeps the
+    # shaders inside the archive so consumers need no sidecar metallib.
+    "-DGGML_METAL=ON"
+    "-DGGML_METAL_EMBED_LIBRARY=ON"
     "-DCMAKE_DISABLE_FIND_PACKAGE_Protobuf=TRUE"
     "-DCMAKE_DISABLE_FIND_PACKAGE_absl=TRUE"
     "-DCMAKE_OSX_ARCHITECTURES=arm64"

--- a/core/include/rac/backends/rac_llm_llamacpp.h
+++ b/core/include/rac/backends/rac_llm_llamacpp.h
@@ -11,6 +11,8 @@
 #ifndef RAC_LLM_LLAMACPP_H
 #define RAC_LLM_LLAMACPP_H
 
+#include <stdint.h>
+
 #include "rac/core/rac_benchmark.h"
 #include "rac/core/rac_error.h"
 #include "rac/core/rac_types.h"
@@ -52,6 +54,9 @@ extern "C" {
  *
  * Mirrors Swift's LlamaCPPGenerationConfig.
  */
+/** `gpu_layers` value meaning "let llama.cpp decide" (see the field docs). */
+#define RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO INT32_MIN
+
 typedef struct rac_llm_llamacpp_config {
     /** Context size (0 = auto-detect from model) */
     int32_t context_size;
@@ -59,7 +64,15 @@ typedef struct rac_llm_llamacpp_config {
     /** Number of threads (0 = auto-detect) */
     int32_t num_threads;
 
-    /** Number of layers to offload to GPU (Metal on iOS/macOS) */
+    /**
+     * Number of layers to offload to GPU (Metal on iOS/macOS).
+     *
+     * `RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO` leaves the decision to llama.cpp's own
+     * fitting pass; `-1` offloads every layer; `0` pins the model to the CPU.
+     * Zero used to double as "unspecified", which made pinning to CPU
+     * impossible to express: the value was indistinguishable from a caller who
+     * had simply left the field alone.
+     */
     int32_t gpu_layers;
 
     /** Batch size for prompt processing */

--- a/core/include/rac/server/rac_server.h
+++ b/core/include/rac/server/rac_server.h
@@ -29,6 +29,7 @@
 #ifndef RAC_SERVER_H
 #define RAC_SERVER_H
 
+#include "rac/backends/rac_llm_llamacpp.h"
 #include "rac/core/rac_types.h"
 
 #ifdef __cplusplus
@@ -91,7 +92,7 @@ static const rac_server_config_t RAC_SERVER_CONFIG_DEFAULT = {.host = "127.0.0.1
                                                               .model_id = RAC_NULL,
                                                               .context_size = 8192,
                                                               .threads = 4,
-                                                              .gpu_layers = 0,
+                                                              .gpu_layers = RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO,
                                                               .enable_cors = RAC_TRUE,
                                                               .cors_origins = "*",
                                                               .request_timeout_seconds = 300,

--- a/core/tools/runanywhere-server.cpp
+++ b/core/tools/runanywhere-server.cpp
@@ -68,7 +68,7 @@ struct ServerOptions {
     uint16_t port = 8080;
     int32_t threads = 4;
     int32_t contextSize = 8192;
-    int32_t gpuLayers = 0;
+    int32_t gpuLayers = RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO;  // -1 all, 0 CPU
     bool enableCors = true;
     bool verbose = false;
     bool showHelp = false;

--- a/engines/llamacpp/rac_backend_llamacpp_register.cpp
+++ b/engines/llamacpp/rac_backend_llamacpp_register.cpp
@@ -49,6 +49,50 @@ rac_handle_t legacy_handle(void* impl) {
     return runtime_impl ? runtime_impl->legacy_handle : nullptr;
 }
 
+// AcceleratorPolicy wire values (idl/public_api_v4.proto), mirrored the same way
+// core/src/core/model_lifecycle.cpp mirrors them rather than pulling the
+// generated enum in for three integers.
+constexpr int kAcceleratorPolicyCpu = 2;
+constexpr int kAcceleratorPolicyGpu = 3;
+
+// Translate commons' advisory load JSON into llama.cpp's own knobs. Returns
+// false when there was nothing to say, so the caller can keep passing nullptr
+// and leave today's behaviour exactly as it was.
+bool parse_load_options(const char* options_json, rac_llm_llamacpp_config_t* config) {
+    if (options_json == nullptr || options_json[0] == '\0' || config == nullptr) {
+        return false;
+    }
+    nlohmann::json parsed = nlohmann::json::parse(options_json, nullptr, /*allow_exceptions=*/false);
+    if (parsed.is_discarded() || !parsed.is_object()) {
+        RAC_LOG_WARNING(LOG_CAT, "ignoring unparseable load options: %s", options_json);
+        return false;
+    }
+
+    bool any = false;
+    if (parsed.contains("context_length") && parsed["context_length"].is_number_integer()) {
+        config->context_size = parsed["context_length"].get<int32_t>();
+        any = true;
+    }
+    // accelerator_policy wins over the deprecated use_gpu when both are present,
+    // matching the proto comment that calls use_gpu an adapter onto it.
+    int policy = 0;
+    if (parsed.contains("accelerator_policy") && parsed["accelerator_policy"].is_number_integer()) {
+        policy = parsed["accelerator_policy"].get<int>();
+    } else if (parsed.contains("use_gpu") && parsed["use_gpu"].is_boolean()) {
+        policy = parsed["use_gpu"].get<bool>() ? kAcceleratorPolicyGpu : kAcceleratorPolicyCpu;
+    }
+    if (policy == kAcceleratorPolicyCpu) {
+        config->gpu_layers = 0;  // every layer stays on the CPU
+        any = true;
+    } else if (policy == kAcceleratorPolicyGpu) {
+        config->gpu_layers = -1;  // offload all of them
+        any = true;
+    }
+    // AUTO and NPU are left alone: AUTO is llama.cpp's own fitting pass, and
+    // llama.cpp has no NPU path, which commons already warns about separately.
+    return any;
+}
+
 rac_result_t llamacpp_cpu_provider_create_session(const rac_runtime_session_desc_t* desc,
                                                   rac_runtime_session_t** out) {
     if (desc == nullptr || out == nullptr)
@@ -58,8 +102,18 @@ rac_result_t llamacpp_cpu_provider_create_session(const rac_runtime_session_desc
         return RAC_ERROR_INVALID_PATH;
     }
 
+    // Commons hands the v4 load knobs down as advisory JSON
+    // ({"context_length":N,"use_gpu":bool,"accelerator_policy":int}, see
+    // model_lifecycle_translation.cpp). Translating them here is what makes
+    // `--accelerator cpu|gpu` and `--context-length` actually reach llama.cpp;
+    // passing nullptr meant every one of them was dropped on the floor.
+    rac_llm_llamacpp_config_t config = RAC_LLM_LLAMACPP_CONFIG_DEFAULT;
+    config.gpu_layers = RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO;
+    const bool have_config = parse_load_options(desc->options_json, &config);
+
     rac_handle_t backend_handle = nullptr;
-    rac_result_t rc = rac_llm_llamacpp_create(desc->model_path, nullptr, &backend_handle);
+    rac_result_t rc = rac_llm_llamacpp_create(desc->model_path,
+                                              have_config ? &config : nullptr, &backend_handle);
     if (rc != RAC_SUCCESS)
         return rc;
     *out = reinterpret_cast<rac_runtime_session_t*>(backend_handle);
@@ -290,10 +344,10 @@ static rac_result_t llamacpp_vtable_get_stream_token_counts(void* impl,
 // limited to the backend library via symbol hiding (the struct is `const`).
 // The `create` adapter called by commons rac_llm_create() after
 // rac_plugin_find picks this plugin. Replaces the legacy factory that was
-// registered via rac_service_provider_t::create. The config_json parameter is
-// reserved for future engine-specific tuning (num_threads, gpu_layers, etc.);
-// today we pass nullptr to rac_llm_llamacpp_create to use defaults.
-rac_result_t llamacpp_llm_create_impl(const char* model_id, const char* /*config_json*/,
+// registered via rac_service_provider_t::create. config_json carries commons'
+// advisory load knobs and rides on the session descriptor to the provider,
+// which translates it into rac_llm_llamacpp_config_t.
+rac_result_t llamacpp_llm_create_impl(const char* model_id, const char* config_json,
                                       void** out_impl) {
     if (!model_id || !out_impl) {
         return RAC_ERROR_NULL_POINTER;
@@ -313,6 +367,9 @@ rac_result_t llamacpp_llm_create_impl(const char* model_id, const char* /*config
     desc.primitive = RAC_PRIMITIVE_GENERATE_TEXT;
     desc.model_format = RAC_MODEL_FORMAT_ID_GGUF;
     desc.model_path = model_id;
+    // The CPU runtime forwards the descriptor untouched, so this is how the
+    // load knobs reach llamacpp_cpu_provider_create_session.
+    desc.options_json = config_json;
 
     rac_runtime_session_t* runtime_session = nullptr;
     rc = runtime->create_session(&desc, &runtime_session);

--- a/engines/llamacpp/rac_llm_llamacpp.cpp
+++ b/engines/llamacpp/rac_llm_llamacpp.cpp
@@ -180,7 +180,10 @@ rac_result_t rac_llm_llamacpp_create(const char* model_path,
         if (config->context_size > 0) {
             model_config["context_size"] = config->context_size;
         }
-        if (config->gpu_layers != 0) {
+        // AUTO means "no opinion"; every other value, INCLUDING 0, is an
+        // explicit placement request and must reach the backend. Gating on
+        // `!= 0` here is what silently swallowed a CPU pin.
+        if (config->gpu_layers != RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO) {
             model_config["gpu_layers"] = config->gpu_layers;
         }
         if (config->batch_size > 0) {

--- a/rcli/AGENTS.md
+++ b/rcli/AGENTS.md
@@ -71,8 +71,23 @@ cmake --preset rcli-macos-release && cmake --build build/rcli-macos-release -j 2
 Always `-j 2` (repo resource discipline). One heavy build at a time.
 
 macOS release CLI keeps **both** `RAC_BACKEND_LLAMACPP=ON` and `RAC_BACKEND_MLX=ON`.
-MLX inference needs the Swift host (`RunAnywhereMLXCLI` / `build-mlx-cli.sh`);
-the CMake `rcli` binary still links the MLX bridge and ships both catalogs.
+
+**There is one shipped binary, `rcli`, and on macOS it is the Swift-hosted one.**
+`RunAnywhereMLXCLI` is not a second CLI: it is a Swift `@main` that registers the
+MLX and ONNX Swift callbacks and then calls `rcli_run_main()`, the same C++ host.
+`package-rcli.sh` stages it as `bin/rcli`, and `build-mlx-cli.sh` symlinks it as
+`rcli` in the Swift bin dir so the dev name matches the ship name.
+
+The CMake `rcli` links the MLX bridge but **cannot run MLX**: registration needs
+Swift callbacks on the MainActor, which a C++ `main` cannot provide. It says so
+at startup (`warning: mlx backend requires MLX runtime callbacks`). The catalog
+still offers MLX models on purpose, because the models directory is shared
+between RunAnywhere binaries, so pulling with one and running with another is
+valid; `test_rcli_unit.cpp::mlx_catalog_registration` locks that. Do not "fix" it
+by hiding those entries.
+
+So on macOS, build with `build-mlx-cli.sh` when you need MLX, and expect the
+CMake `rcli` to be llama.cpp-only.
 
 ## Vendored third_party
 

--- a/rcli/CMakeLists.txt
+++ b/rcli/CMakeLists.txt
@@ -71,6 +71,7 @@ set(RCLI_SOURCES
     src/io/output.cpp
     src/progress/progress_bar.cpp
     src/repl/repl.cpp
+    src/repl/transcript.cpp
     src/util/term.cpp
 )
 

--- a/rcli/README.md
+++ b/rcli/README.md
@@ -113,7 +113,13 @@ rcli chat qwen3
 
 Features line editing and history (`~/.local/state/runanywhere/history`; disable with `RUNANYWHERE_NOHISTORY=1`).
 
-Slash commands: `/set system <text>`, `/set temperature <f>`, `/set max-output-tokens <n>`, `/show`, `/bye` (or Ctrl-D). One Ctrl-C cancels the current generation.
+The conversation is remembered: every turn sends the whole transcript, and the oldest turns are dropped once it outgrows the window. `/context` shows how much is held, `/clear` forgets it.
+
+Slash commands: `/set system <text>`, `/set temperature <f>`, `/set max-output-tokens <n>`, `/show`, `/context`, `/clear`, `/bye` (or Ctrl-D). One Ctrl-C cancels the current generation.
+
+Other modalities join the same conversation: `/image <path> [question]` asks a vision model about a picture, `/audio <file.wav>` transcribes speech and answers it as if you had typed it, and `/say [text]` speaks the last reply into a WAV. `/model <name>`, `/engine <name>` and `/accelerator <policy>` reload without losing the conversation, and `/save <file.md>` writes it out. Pick the models these use with `--vlm-model`, `--stt-model` and `--tts-voice`.
+
+`/image` asks a single-turn question: commons does not read `VLMGenerationRequest.messages`, so the vision model does not see the prior conversation. Its answer still joins the transcript, so later text turns can refer to the picture.
 
 Thinking models (qwen3 family): thought tokens stream dimmed to **stderr**, answers to **stdout**. `--hide-thinking` keeps the thoughts off your terminal while the model still thinks; `--reasoning off` stops it thinking at all.
 
@@ -180,13 +186,12 @@ bash core/tests/scripts/run-cli-e2e-linux.sh
 ## Known limitations
 
 - `serve` is LLM-only and single-model.
-- REPL turns are independent (no conversation memory yet).
 - `rcli voice` with thinking models may speak reasoning text — use a non-thinking LLM (`--llm lfm2`) until voice-agent thinking control lands.
 - macOS x86_64, Linux ARM64, and Windows ARM64 binaries are not published yet.
 - Spec verbs with no standalone command yet: `tts speak` (commons synthesizes to a buffer and has no playback path), and `rag open` / `rag ingest` (RAG indexes are in-memory per process). `rcli rag query` and `rcli rag search` open, ingest, then ask or retrieve in one invocation instead.
 - `VLMGenerationOptions` was deleted; `vlm generate` (and `run --image`) now share the exact `LLMGenerationOptions` the text path uses, so `--seed`, `--frequency-penalty`, and `--presence-penalty` all apply to VLM generation too.
 - `rcli lora import` was removed: `idl/lora_options.proto` deleted `LoraAdapterImportRequest`/`Result` outright, and commons permanently stubs `rac_lora_adapter_import_proto` to `RAC_ERROR_NOT_IMPLEMENTED`. No replacement verb exists in this namespace yet.
-- `models load` takes `--engine` and `--category` only. `ModelLoadRequest` carries no context length, thread count or GPU switch; `rcli serve` has `--context`, `--threads` and `--gpu-layers` for the server it runs.
+- `models load` takes `--engine` and `--category` only. The generation commands (`llm`, `vlm`, `chat`, `run`) additionally take `--accelerator auto|cpu|gpu|npu` and `--context-length`, which ride on `ModelLoadRequest.accelerator_policy` / `.context_length`. Placement is advisory: commons forwards it to the engine and prints what it forwarded, and an engine is free to ignore it. llama.cpp honours both. `rcli serve` keeps its own `--context`, `--threads` and `--gpu-layers` for the server it runs.
 - `vad detect` exposes `--activation-threshold`. The spec's `minSpeechMs`, `minSilenceMs` and `prefixPaddingMs` are stream-level knobs that the per-frame `rac_vad_component_process` call does not accept.
 - `stt transcribe` has no `--translate-to-english`: `rac_stt_options_t` has no field for it.
 

--- a/rcli/scripts/build-mlx-cli.sh
+++ b/rcli/scripts/build-mlx-cli.sh
@@ -75,5 +75,11 @@ fi
 echo "linking mlx.metallib (${#airs[@]} kernels)"
 xcrun -sdk macosx metallib "${airs[@]}" -o "$BIN_DIR/mlx.metallib"
 
-echo "ready: $EXE"
+# Ship name and dev name are the same thing. package-rcli.sh stages this binary
+# as bin/rcli, so a developer running the macOS build should get `rcli` too;
+# otherwise the binary you test is not the binary users run, and the CMake-built
+# `rcli` next to it is the one WITHOUT an MLX runtime.
+ln -sf "$PRODUCT" "$BIN_DIR/rcli"
+
+echo "ready: $BIN_DIR/rcli -> $PRODUCT"
 echo "metallib: $BIN_DIR/mlx.metallib"

--- a/rcli/src/commands/cmd_run.cpp
+++ b/rcli/src/commands/cmd_run.cpp
@@ -15,8 +15,9 @@
  *   VLM: rac_vlm_generate_proto (unary) returns a VLMResult.
  *   Ctrl-C: rac_llm_cancel_proto from the token callback thread.
  *
- * REPL turns are independent generations (no cross-turn memory yet — that
- * needs a commons chat-session API; tracked in the rcli plan doc).
+ * The REPL remembers the conversation: each turn sends the whole transcript as
+ * LLMGenerateRequest.messages, which is what that field is for. Commons
+ * flattens it to the engine's history array.
  */
 
 #include "commands/commands.h"
@@ -24,9 +25,12 @@
 #include <csignal>
 #include <chrono>
 #include <condition_variable>
+#include <filesystem>
+#include <fstream>
 #include <memory>
 #include <mutex>
 #include <string>
+#include <utility>
 #include <vector>
 
 #include "chat.pb.h"
@@ -48,6 +52,7 @@
 #include "io/proto.h"
 #include "progress/progress_bar.h"
 #include "repl/repl.h"
+#include "repl/transcript.h"
 #include "util/term.h"
 
 namespace rcli::commands {
@@ -63,6 +68,13 @@ namespace v1 = runanywhere::v1;
 struct RunParams {
     std::string model;
     std::string image;
+    // Models the chat slash commands reach for. Empty means the built-in
+    // default for that modality, the same one `rcli vlm` / `rcli stt` use.
+    std::string vlm_model;
+    std::string stt_model;
+    std::string tts_voice;
+    std::string accelerator;       // auto | cpu | gpu | npu ("" = engine decides)
+    int32_t context_length = 0;    // 0 = engine default
     std::string system_prompt;
     std::string engine;
     std::string lora;            // optional LoRA adapter (.gguf) to attach before generating
@@ -225,12 +237,13 @@ void llm_stream_callback(const uint8_t* event_bytes, size_t event_size, void* /*
 }
 
 // One blocking streaming generation; returns 0 ok, 1 error, 130 user-cancel.
+// `history` carries the prior conversation (null = single turn); `out_answer`
+// receives the assistant text so a caller can append it to the transcript.
 int stream_once(const GlobalOptions& options, const std::string& model_id,
-                const std::string& prompt, const RunParams& params) {
+                const std::string& prompt, const RunParams& params,
+                const repl::Transcript* history = nullptr, std::string* out_answer = nullptr) {
     v1::LLMGenerateRequest request;
-    v1::ChatMessage* message = request.add_messages();
-    message->set_role(v1::MESSAGE_ROLE_USER);
-    message->set_content(prompt);
+    fill_messages(&request, history, prompt);
     apply_options(params, request.mutable_options());
     (void)model_id;  // lifecycle-owned state knows the loaded model
 
@@ -278,6 +291,9 @@ int stream_once(const GlobalOptions& options, const std::string& model_id,
             out::result_line(json.str());
         } else if (options.verbose) {
             out::status_line("(" + std::to_string(elapsed) + " ms)");
+        }
+        if (exit_code == 0 && out_answer != nullptr) {
+            *out_answer = state.answer;
         }
     }
 
@@ -336,8 +352,27 @@ int generate_once(const GlobalOptions& options, const std::string& model_id,
     return 0;
 }
 
+// Placement and sizing knobs ModelLoadRequest has always carried. Before these
+// were wired the CLI sent neither, so every load went out as
+// ACCELERATOR_POLICY_UNSPECIFIED and the engine chose alone.
+struct LoadTuning {
+    v1::AcceleratorPolicy accelerator = v1::ACCELERATOR_POLICY_UNSPECIFIED;
+    int32_t context_length = 0;  // 0 = engine default
+};
+
+LoadTuning tuning_from(const RunParams& params) {
+    LoadTuning tuning;
+    tuning.context_length = params.context_length;
+    std::string error;
+    if (!parse_accelerator(params.accelerator, &tuning.accelerator, &error)) {
+        out::error_line(error);
+    }
+    return tuning;
+}
+
 bool load_model(const GlobalOptions& options, const std::string& model_id,
-                v1::InferenceFramework framework, bool is_vlm) {
+                v1::InferenceFramework framework, bool is_vlm,
+                const LoadTuning& tuning = LoadTuning{}) {
     // Auto-pull (validate_availability) + resolve + engine load, one call.
     progress::DownloadProgressScope progress_scope(model_id,
                                                    !options.no_progress && !options.json);
@@ -349,6 +384,12 @@ bool load_model(const GlobalOptions& options, const std::string& model_id,
     }
     if (is_vlm) {
         request.set_category(v1::MODEL_CATEGORY_MULTIMODAL);
+    }
+    if (tuning.accelerator != v1::ACCELERATOR_POLICY_UNSPECIFIED) {
+        request.set_accelerator_policy(tuning.accelerator);
+    }
+    if (tuning.context_length > 0) {
+        request.set_context_length(tuning.context_length);
     }
     const std::string bytes = proto::serialize(request);
 
@@ -369,6 +410,13 @@ bool load_model(const GlobalOptions& options, const std::string& model_id,
                                                      : result.error().message()));
         return false;
     }
+    // Commons reports here when a load knob was forwarded to an engine that may
+    // not honour it (accelerator_policy and friends travel as advisory
+    // config_json). Dropping these made `--accelerator gpu` look like it worked
+    // on llama.cpp when nothing had changed.
+    for (const std::string& warning : result.warnings()) {
+        out::status_line("note: " + warning);
+    }
     if (options.verbose) {
         out::status_line("loaded " + result.resolved_path());
     }
@@ -376,7 +424,8 @@ bool load_model(const GlobalOptions& options, const std::string& model_id,
 }
 
 int run_vlm(const GlobalOptions& options, const std::string& model_id,
-            const std::string& image_path, const std::string& prompt, const RunParams& params) {
+            const std::string& image_path, const std::string& prompt, const RunParams& params,
+            std::string* out_answer = nullptr) {
     v1::VLMGenerationRequest request;
     request.set_model_id(model_id);
     v1::VLMImage* image = request.add_images();
@@ -457,7 +506,27 @@ int run_vlm(const GlobalOptions& options, const std::string& model_id,
                              " tok/s)");
         }
     }
+    if (out_answer != nullptr) {
+        *out_answer = result.text();
+    }
     return 0;
+}
+
+// `/image` inside a chat: resolve and load a vision model, then ask it.
+int run_vlm_turn(const GlobalOptions& options, const RunParams& params,
+                 const std::string& image_path, const std::string& question,
+                 std::string* out_answer) {
+    model_ref::Resolved resolved;
+    std::string error;
+    if (model_ref::resolve(params.model, &resolved, &error) != RAC_SUCCESS) {
+        out::error_line(error);
+        return 1;
+    }
+    if (!load_model(options, resolved.model_id, v1::INFERENCE_FRAMEWORK_UNSPECIFIED,
+                    /*is_vlm=*/true, tuning_from(params))) {
+        return 1;
+    }
+    return run_vlm(options, resolved.model_id, image_path, question, params, out_answer);
 }
 
 void print_repl_help() {
@@ -466,15 +535,30 @@ void print_repl_help() {
     out::status_line("  /set temperature <float>    set sampling temperature");
     out::status_line("  /set max-output-tokens <n>  set the generation budget");
     out::status_line("  /show                       show current settings");
+    out::status_line("  /image <path> [question]    ask a vision model about a picture");
+    out::status_line("  /audio <file.wav>           transcribe speech and answer it");
+    out::status_line("  /engine <name>              reload on another engine, keeping the chat");
+    out::status_line("      llamacpp  GGUF on CPU, and GPU when built with Metal");
+    out::status_line("      mlx       Apple Silicon; needs the Swift-hosted rcli");
+    out::status_line("      neurt     Apple Neural Engine (aliases: coreml, ane)");
+    out::status_line("      onnx      embeddings and segmentation");
+    out::status_line("      sherpa    speech models");
+    out::status_line("  /accelerator <policy>       auto | cpu | gpu | npu, keeping the chat");
+    out::status_line("      advisory: an engine may ignore it and will say so");
+    out::status_line("  /say [text]                 speak the last reply, or given text, to a WAV");
+    out::status_line("  /model <name>               switch model, keeping the chat");
+    out::status_line("  /save <file.md>             write the conversation to a file");
+    out::status_line("  /context                    show how much conversation is remembered");
+    out::status_line("  /clear                      forget the conversation, keep settings");
     out::status_line("  /bye                        exit (also Ctrl-D)");
-    out::status_line("note: turns are independent — no conversation memory yet");
 }
 
-int run_repl(const GlobalOptions& options, const std::string& model_id, RunParams params) {
+int run_repl(const GlobalOptions& options, std::string model_id, RunParams params) {
     out::status_line("loaded " + model_id + " — type a prompt, /? for help, /bye to exit");
     repl::LineEditor editor(std::getenv("RUNANYWHERE_NOHISTORY")
                                 ? std::string()
                                 : paths::state_dir() + "/history");
+    repl::Transcript transcript;
 
     std::string line;
     while (editor.read_line("» ", &line)) {
@@ -499,6 +583,190 @@ int run_repl(const GlobalOptions& options, const std::string& model_id, RunParam
                                                          : "(engine default)"));
             out::status_line("max-output-tokens  " + std::to_string(params.max_output_tokens));
             out::status_line("reasoning          " + params.reasoning);
+            out::status_line("engine             " +
+                             (params.engine.empty() ? "(model default)" : params.engine));
+            out::status_line("accelerator        " +
+                             (params.accelerator.empty() ? "(engine decides)" : params.accelerator));
+            continue;
+        }
+        if (line == "/context") {
+            out::status_line("turns remembered   " + std::to_string(transcript.size()) + " of " +
+                             std::to_string(transcript.max_turns()));
+            if (transcript.trimmed()) {
+                out::status_line("note: oldest turns were dropped to stay under the cap");
+            }
+            continue;
+        }
+        if (line == "/clear" || line == "/reset") {
+            transcript.clear();
+            out::status_line("conversation cleared");
+            continue;
+        }
+        if (line.starts_with("/say")) {
+            const auto [first, rest] = repl::split_first_word(line.substr(4));
+            std::string spoken = first.empty() ? std::string() : first + (rest.empty() ? "" : " " + rest);
+            if (spoken.empty()) {
+                // No text given: voice the model's last reply, which is what
+                // "say that back to me" means in a conversation.
+                for (auto it = transcript.turns().rbegin(); it != transcript.turns().rend(); ++it) {
+                    if (it->role == repl::Role::Assistant) {
+                        spoken = it->content;
+                        break;
+                    }
+                }
+            }
+            if (spoken.empty()) {
+                out::status_line("nothing to say yet — usage: /say [text]");
+                continue;
+            }
+            const std::string wav = paths::state_dir() + "/say.wav";
+            if (synthesize_to_file(options, params.tts_voice, spoken, wav) == 0) {
+                out::status_line("wrote " + wav);
+            }
+            continue;
+        }
+        if (line.starts_with("/save")) {
+            const auto [path, ignored] = repl::split_first_word(line.substr(5));
+            (void)ignored;
+            if (path.empty()) {
+                out::status_line("usage: /save <file.md>");
+                continue;
+            }
+            std::ofstream file(path);
+            if (!file) {
+                out::status_line("cannot write " + path);
+                continue;
+            }
+            for (const repl::Turn& turn : transcript.turns()) {
+                file << (turn.role == repl::Role::User ? "## you\n\n" : "## " + model_id + "\n\n")
+                     << turn.content << "\n\n";
+            }
+            if (!file) {
+                out::status_line("failed while writing " + path);
+                continue;
+            }
+            out::status_line("saved " + std::to_string(transcript.size()) + " turns to " + path);
+            continue;
+        }
+        if (line.starts_with("/model ")) {
+            const auto [name, ignored] = repl::split_first_word(line.substr(7));
+            (void)ignored;
+            if (name.empty()) {
+                out::status_line("usage: /model <name>");
+                continue;
+            }
+            model_ref::Resolved resolved;
+            std::string resolve_error;
+            if (model_ref::resolve(name, &resolved, &resolve_error) != RAC_SUCCESS) {
+                out::status_line(resolve_error);
+                continue;
+            }
+            v1::InferenceFramework framework = v1::INFERENCE_FRAMEWORK_UNSPECIFIED;
+            std::string hint_error;
+            if (!parse_engine_hint(params.engine, &framework, &hint_error)) {
+                out::status_line(hint_error);
+                continue;
+            }
+            if (!load_model(options, resolved.model_id, framework, /*is_vlm=*/false,
+                            tuning_from(params))) {
+                out::status_line("keeping " + model_id + "; the conversation is intact");
+                continue;
+            }
+            // The transcript deliberately survives: comparing two models on the
+            // same conversation is the reason to switch mid-session.
+            model_id = resolved.model_id;
+            params.model = resolved.model_id;
+            out::status_line("now " + model_id + "; " + std::to_string(transcript.size()) +
+                             " turns still remembered");
+            continue;
+        }
+        if (line.starts_with("/engine ") || line.starts_with("/accelerator ")) {
+            const bool is_engine = line.starts_with("/engine ");
+            const auto [value, ignored_rest] =
+                repl::split_first_word(line.substr(is_engine ? 7 : 13));
+            (void)ignored_rest;
+            if (value.empty()) {
+                out::status_line(is_engine ? "usage: /engine <mlx|llamacpp|neurt|onnx|sherpa>"
+                                           : "usage: /accelerator <auto|cpu|gpu|npu>");
+                continue;
+            }
+            // Validate before touching the loaded model, so a typo cannot leave
+            // the session with nothing loaded.
+            RunParams next = params;
+            (is_engine ? next.engine : next.accelerator) = value;
+            v1::InferenceFramework framework = v1::INFERENCE_FRAMEWORK_UNSPECIFIED;
+            v1::AcceleratorPolicy policy = v1::ACCELERATOR_POLICY_UNSPECIFIED;
+            std::string parse_error;
+            if (!parse_engine_hint(next.engine, &framework, &parse_error) ||
+                !parse_accelerator(next.accelerator, &policy, &parse_error)) {
+                out::status_line(parse_error);
+                continue;
+            }
+            LoadTuning tuning;
+            tuning.accelerator = policy;
+            tuning.context_length = next.context_length;
+            if (!load_model(options, model_id, framework, /*is_vlm=*/false, tuning)) {
+                out::status_line("keeping the previous placement; the conversation is intact");
+                continue;
+            }
+            params = next;  // only after the reload actually succeeded
+            out::status_line(std::string(is_engine ? "engine" : "accelerator") + " set to " +
+                             value + "; " + std::to_string(transcript.size()) +
+                             " turns still remembered");
+            continue;
+        }
+        if (line.starts_with("/image")) {
+            const auto [path, question] = repl::split_first_word(line.substr(6));
+            if (path.empty()) {
+                out::status_line("usage: /image <path> [question]");
+                continue;
+            }
+            if (!std::filesystem::exists(path)) {
+                out::status_line("no such file: " + path);
+                continue;
+            }
+            RunParams vlm_params = params;
+            vlm_params.model = params.vlm_model;
+            std::string answer;
+            if (run_vlm_turn(options, vlm_params, path, question, &answer) == 0 &&
+                !answer.empty()) {
+                // The VLM call itself is single-turn: commons does not read
+                // VLMGenerationRequest.messages. Recording the exchange here is
+                // what lets the following TEXT turns refer back to the picture.
+                transcript.add(repl::Role::User,
+                               (question.empty() ? std::string("Describe this image.") : question) +
+                                   "\n[image: " + path + "]");
+                transcript.add(repl::Role::Assistant, answer);
+            }
+            continue;
+        }
+        if (line.starts_with("/audio")) {
+            const auto [path, ignored] = repl::split_first_word(line.substr(6));
+            (void)ignored;
+            if (path.empty()) {
+                out::status_line("usage: /audio <file.wav>");
+                continue;
+            }
+            if (!std::filesystem::exists(path)) {
+                out::status_line("no such file: " + path);
+                continue;
+            }
+            std::string spoken;
+            if (transcribe_to_text(options, params.stt_model, path, &spoken) != 0) {
+                continue;
+            }
+            if (spoken.empty()) {
+                out::status_line("nothing was transcribed from " + path);
+                continue;
+            }
+            // Speaking is typing: the transcript becomes an ordinary user turn.
+            out::status_line("heard: " + spoken);
+            std::string answer;
+            if (stream_once(options, model_id, spoken, params, &transcript, &answer) == 0 &&
+                !answer.empty()) {
+                transcript.add(repl::Role::User, spoken);
+                transcript.add(repl::Role::Assistant, answer);
+            }
             continue;
         }
         if (line.starts_with("/set ")) {
@@ -531,9 +799,17 @@ int run_repl(const GlobalOptions& options, const std::string& model_id, RunParam
             continue;
         }
 
-        const int code = stream_once(options, model_id, line, params);
+        std::string answer;
+        const int code = stream_once(options, model_id, line, params, &transcript, &answer);
         if (code == 1) {
             return 1;  // hard error; cancel (130) just returns to the prompt
+        }
+        // A cancelled turn is deliberately not remembered: the answer is a
+        // fragment, and feeding half a reply back as context makes the next
+        // turn worse in a way the user cannot see.
+        if (code == 0 && !answer.empty()) {
+            transcript.add(repl::Role::User, line);
+            transcript.add(repl::Role::Assistant, answer);
         }
     }
     return 0;
@@ -591,6 +867,14 @@ int run_llm(const GlobalOptions& options, LlmVerb verb, const std::string& promp
         out::error_line("--model is required (a catalog id, alias, hf.co/... ref or URL)");
         return 2;
     }
+    // Reject an unusable --accelerator here rather than loading without it. A
+    // flag the load call then ignores is worse than no flag at all.
+    v1::AcceleratorPolicy unused_policy = v1::ACCELERATOR_POLICY_UNSPECIFIED;
+    std::string accelerator_error;
+    if (!parse_accelerator(params.accelerator, &unused_policy, &accelerator_error)) {
+        out::error_line(accelerator_error);
+        return 2;
+    }
 
     EngineHintResolution engine_hint;
     std::string engine_error;
@@ -621,7 +905,8 @@ int run_llm(const GlobalOptions& options, LlmVerb verb, const std::string& promp
     // catalog entries still fall back to their own declared framework exactly as
     // before; the only behaviour that changes is that asking now works. Mirrors
     // cmd_embed.cpp.
-    if (!load_model(options, resolved.model_id, engine_hint.framework, is_vlm)) {
+    if (!load_model(options, resolved.model_id, engine_hint.framework, is_vlm,
+                    tuning_from(params))) {
         return 1;
     }
     if (!params.lora.empty() && !apply_lora_adapter(params.lora, params.lora_scale)) {
@@ -675,6 +960,10 @@ void add_generation_options(CLI::App* cmd, const std::shared_ptr<RunParams>& par
     cmd->add_option("--engine", params->engine,
                     "Engine hint (neurt|coreml|ane, mlx, llamacpp, onnx, sherpa). Honoured for "
                     "catalog models too, not just URL/HF refs.");
+    cmd->add_option("--accelerator", params->accelerator,
+                    "Where the model runs: auto, cpu, gpu or npu");
+    cmd->add_option("--context-length", params->context_length,
+                    "Context window to load the model with (0 = engine default)");
     cmd->add_option("--temperature,--temp", params->temperature,
                     "Raise for more random sampling (0 = engine default)");
     cmd->add_option("--top-p", params->top_p, "Keep the smallest token set above this probability");
@@ -715,6 +1004,12 @@ void configure_llm(CLI::App* cmd, GlobalOptions& options, LlmVerb verb, ModelArg
         // the documented alias of `vlm generate`.
         cmd->add_option("--image", params->image, "Describe this image instead (VLM models)")
             ->check(CLI::ExistingFile);
+        cmd->add_option("--vlm-model", params->vlm_model,
+                        "Vision model the chat /image command uses");
+        cmd->add_option("--stt-model", params->stt_model,
+                        "Speech model the chat /audio command uses");
+        cmd->add_option("--tts-voice", params->tts_voice,
+                        "Voice the chat /say command speaks with");
     }
     cmd->callback([&options, verb, params, prompt]() {
         const int exit_code = run_llm(options, verb, *prompt, *params);

--- a/rcli/src/commands/cmd_stt.cpp
+++ b/rcli/src/commands/cmd_stt.cpp
@@ -134,6 +134,60 @@ int run_stt(const GlobalOptions& options, const SttParams& params) {
 
 }  // namespace
 
+int transcribe_to_text(const GlobalOptions& options, const std::string& model_ref,
+                       const std::string& audio_path, std::string* out_text) {
+    ResolvedModelPaths model;
+    const int setup =
+        ensure_model_ready(options, model_ref.empty() ? kDefaultSttModel : model_ref, &model);
+    if (setup != 0) {
+        return setup;
+    }
+
+    wav::WavData audio;
+    std::string error;
+    if (!wav::read_wav(audio_path, &audio, &error)) {
+        out::error_line(error);
+        return 1;
+    }
+    const std::vector<int16_t> pcm16 =
+        wav::resample(audio.samples, audio.sample_rate, kSttSampleRate);
+
+    rac_handle_t stt = nullptr;
+    if (rac_stt_component_create(&stt) != RAC_SUCCESS) {
+        out::error_line("failed to create STT component");
+        return 1;
+    }
+    rac_result_t rc =
+        rac_stt_component_load_model(stt, model.primary_path.c_str(), model.model_id.c_str(),
+                                     model.display_name.c_str());
+    if (rc != RAC_SUCCESS) {
+        out::error_line("failed to load STT model: " + out::describe_result(rc));
+        rac_stt_component_destroy(stt);
+        return 1;
+    }
+
+    rac_stt_options_t stt_options = RAC_STT_OPTIONS_DEFAULT;
+    stt_options.detect_language = RAC_TRUE;
+    stt_options.enable_punctuation = RAC_TRUE;
+    stt_options.sample_rate = kSttSampleRate;
+
+    rac_stt_result_t result = {};
+    rc = rac_stt_component_transcribe(stt, pcm16.data(), pcm16.size() * sizeof(int16_t),
+                                      &stt_options, &result);
+    int exit_code = 0;
+    if (rc != RAC_SUCCESS) {
+        out::error_line("transcription failed: " + out::describe_result(rc));
+        exit_code = 1;
+    } else {
+        if (out_text != nullptr) {
+            *out_text = result.text ? result.text : "";
+        }
+        rac_stt_result_free(&result);
+    }
+    rac_stt_component_destroy(stt);
+    return exit_code;
+}
+
 void register_stt(CLI::App& app, GlobalOptions& options) {
     CLI::App* cmd = app.add_subcommand("stt", "Turn recorded speech into text");
     cmd->require_subcommand(0, 1);

--- a/rcli/src/commands/cmd_tts.cpp
+++ b/rcli/src/commands/cmd_tts.cpp
@@ -132,6 +132,51 @@ int run_tts(const GlobalOptions& options, const TtsParams& params) {
 
 }  // namespace
 
+int synthesize_to_file(const GlobalOptions& options, const std::string& voice_ref,
+                       const std::string& text, const std::string& output_path) {
+    ResolvedModelPaths voice;
+    const int setup =
+        ensure_model_ready(options, voice_ref.empty() ? kDefaultVoice : voice_ref, &voice);
+    if (setup != 0) {
+        return setup;
+    }
+
+    rac_handle_t tts = nullptr;
+    if (rac_tts_component_create(&tts) != RAC_SUCCESS) {
+        out::error_line("failed to create TTS component");
+        return 1;
+    }
+    rac_result_t rc = rac_tts_component_load_voice(
+        tts, voice.primary_path.c_str(), voice.model_id.c_str(), voice.display_name.c_str());
+    if (rc != RAC_SUCCESS) {
+        out::error_line("failed to load voice: " + out::describe_result(rc));
+        rac_tts_component_destroy(tts);
+        return 1;
+    }
+
+    rac_tts_options_t tts_options = RAC_TTS_OPTIONS_DEFAULT;
+    rac_tts_result_t result = {};
+    rc = rac_tts_component_synthesize(tts, text.c_str(), &tts_options, &result);
+
+    int exit_code = 0;
+    if (rc != RAC_SUCCESS || !result.audio_data || result.audio_size == 0) {
+        out::error_line("synthesis failed: " + out::describe_result(rc));
+        exit_code = 1;
+    } else {
+        const auto* float_samples = static_cast<const float*>(result.audio_data);
+        const size_t sample_count = result.audio_size / sizeof(float);
+        std::string error;
+        if (!wav::write_wav_f32(output_path, float_samples, sample_count, result.sample_rate,
+                                &error)) {
+            out::error_line(error);
+            exit_code = 1;
+        }
+        rac_tts_result_free(&result);
+    }
+    rac_tts_component_destroy(tts);
+    return exit_code;
+}
+
 void register_tts(CLI::App& app, GlobalOptions& options) {
     CLI::App* cmd = app.add_subcommand("tts", "Speak text with an on-device voice");
     cmd->require_subcommand(0, 1);

--- a/rcli/src/commands/commands.h
+++ b/rcli/src/commands/commands.h
@@ -88,6 +88,22 @@ void configure_models_delete(CLI::App* cmd, GlobalOptions& options);
 int pull_model_flow(const GlobalOptions& options, const std::string& model_id);
 
 /**
+ * Transcribe an audio file and hand back the text instead of rendering it, so
+ * the chat REPL can turn `/audio <file>` into an ordinary user turn. Downloads
+ * and loads the STT model if needed. Returns 0 / 1 / 2 like a command callback.
+ */
+int transcribe_to_text(const GlobalOptions& options, const std::string& model_ref,
+                       const std::string& audio_path, std::string* out_text);
+
+/**
+ * Speak `text` into a WAV file, so the chat REPL's `/say` can voice a reply.
+ * Commons has no playback path (`tts speak` is unimplemented), so the file is
+ * the deliverable and the caller prints where it landed.
+ */
+int synthesize_to_file(const GlobalOptions& options, const std::string& voice_ref,
+                       const std::string& text, const std::string& output_path);
+
+/**
  * Attach the spec verb name to a namespace whose options live on the namespace
  * itself (`rcli stt transcribe --input a.wav` and `rcli stt --input a.wav` are
  * the same command). The verb is a grammar marker: CLI11 fallthrough hands its

--- a/rcli/src/commands/engine_options.cpp
+++ b/rcli/src/commands/engine_options.cpp
@@ -70,4 +70,39 @@ bool resolve_engine_hint(const std::string& engine, EngineHintResolution* out_re
     return true;
 }
 
+
+bool parse_accelerator(const std::string& accelerator,
+                       runanywhere::v1::AcceleratorPolicy* out_policy, std::string* error) {
+    if (!out_policy) {
+        return false;
+    }
+    *out_policy = runanywhere::v1::ACCELERATOR_POLICY_UNSPECIFIED;
+    std::string normalized = accelerator;
+    std::transform(normalized.begin(), normalized.end(), normalized.begin(),
+                   [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+    if (normalized.empty()) {
+        return true;
+    }
+    if (normalized == "auto") {
+        *out_policy = runanywhere::v1::ACCELERATOR_POLICY_AUTO;
+        return true;
+    }
+    if (normalized == "cpu") {
+        *out_policy = runanywhere::v1::ACCELERATOR_POLICY_CPU;
+        return true;
+    }
+    if (normalized == "gpu" || normalized == "metal") {
+        *out_policy = runanywhere::v1::ACCELERATOR_POLICY_GPU;
+        return true;
+    }
+    if (normalized == "npu" || normalized == "ane" || normalized == "neural-engine") {
+        *out_policy = runanywhere::v1::ACCELERATOR_POLICY_NPU;
+        return true;
+    }
+    if (error) {
+        *error = "unknown accelerator '" + accelerator + "' (expected auto, cpu, gpu or npu)";
+    }
+    return false;
+}
+
 }  // namespace rcli::commands

--- a/rcli/src/commands/engine_options.h
+++ b/rcli/src/commands/engine_options.h
@@ -23,6 +23,17 @@ bool parse_engine_hint(const std::string& engine,
                        runanywhere::v1::InferenceFramework* out_framework,
                        std::string* error);
 
+/**
+ * Parse `--accelerator auto|cpu|gpu|npu` into ModelLoadRequest.accelerator_policy.
+ * An empty string is valid and leaves the policy UNSPECIFIED, which is what the
+ * CLI sent unconditionally before this option existed: the engine decides.
+ *
+ * `ane` and `neural-engine` are accepted spellings of `npu`, because on Apple
+ * hardware that is the same request and it is the word people use.
+ */
+bool parse_accelerator(const std::string& accelerator,
+                       runanywhere::v1::AcceleratorPolicy* out_policy, std::string* error);
+
 bool resolve_engine_hint(const std::string& engine, EngineHintResolution* out_resolution,
                          std::string* error);
 

--- a/rcli/src/repl/repl.cpp
+++ b/rcli/src/repl/repl.cpp
@@ -70,4 +70,19 @@ void LineEditor::add_history(const std::string& line) {
     }
 }
 
+
+std::pair<std::string, std::string> split_first_word(const std::string& text) {
+    const size_t begin = text.find_first_not_of(" \t");
+    if (begin == std::string::npos) {
+        return {};
+    }
+    const size_t end = text.find_first_of(" \t", begin);
+    if (end == std::string::npos) {
+        return {text.substr(begin), std::string()};
+    }
+    const size_t rest = text.find_first_not_of(" \t", end);
+    return {text.substr(begin, end - begin),
+            rest == std::string::npos ? std::string() : text.substr(rest)};
+}
+
 }  // namespace rcli::repl

--- a/rcli/src/repl/repl.h
+++ b/rcli/src/repl/repl.h
@@ -7,8 +7,17 @@
 #define RCLI_REPL_REPL_H
 
 #include <string>
+#include <utility>
 
 namespace rcli::repl {
+
+/**
+ * Split a slash-command argument string into its first word and the remainder,
+ * e.g. "  shot.png what is this" -> {"shot.png", "what is this"}. Both halves
+ * are empty when there is nothing but whitespace, which is how the REPL detects
+ * a command invoked without its required argument.
+ */
+std::pair<std::string, std::string> split_first_word(const std::string& text);
 
 class LineEditor {
    public:

--- a/rcli/src/repl/transcript.cpp
+++ b/rcli/src/repl/transcript.cpp
@@ -1,0 +1,57 @@
+#include "repl/transcript.h"
+
+#include <utility>
+
+#include "chat.pb.h"
+#include "llm_service.pb.h"
+
+namespace rcli::repl {
+
+Transcript::Transcript(std::size_t max_turns)
+    : max_turns_(max_turns > 0 ? max_turns : kDefaultMaxTurns) {}
+
+void Transcript::add(Role role, std::string content) {
+    if (content.empty()) {
+        return;
+    }
+    turns_.push_back(Turn{role, std::move(content)});
+    trim();
+}
+
+void Transcript::clear() {
+    turns_.clear();
+    trimmed_ = false;
+}
+
+void Transcript::trim() {
+    if (turns_.size() > max_turns_) {
+        turns_.erase(turns_.begin(),
+                     turns_.begin() + static_cast<std::ptrdiff_t>(turns_.size() - max_turns_));
+        trimmed_ = true;
+    }
+    // Commons skips a leading assistant turn when it flattens the array
+    // (llm_module.cpp), so a window starting on one would report a turn the
+    // model never sees. Drop it here instead, and keep the two counts equal.
+    if (!turns_.empty() && turns_.front().role == Role::Assistant) {
+        turns_.erase(turns_.begin());
+        trimmed_ = true;
+    }
+}
+
+void fill_messages(runanywhere::v1::LLMGenerateRequest* request, const Transcript* history,
+                   const std::string& prompt) {
+    namespace v1 = runanywhere::v1;
+    if (history != nullptr) {
+        for (const Turn& turn : history->turns()) {
+            v1::ChatMessage* prior = request->add_messages();
+            prior->set_role(turn.role == Role::User ? v1::MESSAGE_ROLE_USER
+                                                    : v1::MESSAGE_ROLE_ASSISTANT);
+            prior->set_content(turn.content);
+        }
+    }
+    v1::ChatMessage* current = request->add_messages();
+    current->set_role(v1::MESSAGE_ROLE_USER);
+    current->set_content(prompt);
+}
+
+}  // namespace rcli::repl

--- a/rcli/src/repl/transcript.h
+++ b/rcli/src/repl/transcript.h
@@ -1,0 +1,83 @@
+/**
+ * @file transcript.h
+ * @brief The conversation a chat session remembers.
+ *
+ * Commons takes the whole conversation per request: LLMGenerateRequest carries
+ * `repeated ChatMessage messages`, oldest first, ending with the turn the model
+ * must answer (idl/llm_service.proto). The single `prompt` and `history` fields
+ * are reserved. So a chat session's only state is the ordered list of turns,
+ * and this owns it.
+ *
+ * The system prompt is NOT a turn. It rides in LLMGenerationOptions and commons
+ * drops system messages when it flattens the array for engines
+ * (llm_module.cpp), so keeping it here would send it twice.
+ */
+
+#ifndef RCLI_REPL_TRANSCRIPT_H
+#define RCLI_REPL_TRANSCRIPT_H
+
+#include <cstddef>
+#include <string>
+#include <vector>
+
+namespace runanywhere::v1 {
+class LLMGenerateRequest;
+}
+
+namespace rcli::repl {
+
+enum class Role { User, Assistant };
+
+struct Turn {
+    Role role;
+    std::string content;
+};
+
+/**
+ * Ordered conversation turns, capped so a long session cannot outgrow the
+ * model's context window.
+ *
+ * The cap mirrors the voice agent's policy (voice_agent_d7_abi.cpp), which
+ * erases oldest-first once the history exceeds its bound. Turns are counted
+ * rather than tokens because no engine reports a window size through the ABI;
+ * `/context` therefore shows turns, not a percentage.
+ */
+class Transcript {
+   public:
+    static constexpr std::size_t kDefaultMaxTurns = 40;
+
+    explicit Transcript(std::size_t max_turns = kDefaultMaxTurns);
+
+    void add(Role role, std::string content);
+    void clear();
+
+    const std::vector<Turn>& turns() const { return turns_; }
+    std::size_t size() const { return turns_.size(); }
+    bool empty() const { return turns_.empty(); }
+    std::size_t max_turns() const { return max_turns_; }
+
+    /** True once a turn has been dropped, so `/context` can say so. */
+    bool trimmed() const { return trimmed_; }
+
+   private:
+    void trim();
+
+    std::vector<Turn> turns_;
+    std::size_t max_turns_;
+    bool trimmed_ = false;
+};
+
+/**
+ * Fill the request's message array: prior turns oldest first, then the turn the
+ * model must answer. `history` may be null for a single-turn generation.
+ *
+ * The system prompt is deliberately absent; it belongs in
+ * LLMGenerationOptions.system_prompt, and commons drops system messages when it
+ * flattens this array.
+ */
+void fill_messages(runanywhere::v1::LLMGenerateRequest* request, const Transcript* history,
+                   const std::string& prompt);
+
+}  // namespace rcli::repl
+
+#endif  // RCLI_REPL_TRANSCRIPT_H

--- a/rcli/tests/test_rcli_unit.cpp
+++ b/rcli/tests/test_rcli_unit.cpp
@@ -21,7 +21,9 @@
 #include <system_error>
 #include <vector>
 
+#include "chat.pb.h"
 #include "llm_options.pb.h"
+#include "llm_service.pb.h"
 #include "model_types.pb.h"
 #include "vlm_options.pb.h"
 #include "rac/core/rac_core.h"
@@ -37,6 +39,8 @@
 #include "io/image_io.h"
 #include "io/output.h"
 #include "io/proto.h"
+#include "repl/repl.h"
+#include "repl/transcript.h"
 
 namespace {
 
@@ -2114,10 +2118,200 @@ TestResult test_bench_metrics_consume_only() {
     return result;
 }
 
+// ---------------------------------------------------------------------------
+// Chat transcript — what the REPL remembers, and what it puts on the wire.
+// ---------------------------------------------------------------------------
+
+TestResult test_transcript_builds_conversation() {
+  TestResult result;
+  result.test_name = "transcript_builds_conversation";
+
+  rcli::repl::Transcript transcript;
+  transcript.add(rcli::repl::Role::User, "my favourite colour is vermilion");
+  transcript.add(rcli::repl::Role::Assistant, "ok");
+
+  runanywhere::v1::LLMGenerateRequest request;
+  rcli::repl::fill_messages(&request, &transcript, "what is my favourite colour?");
+
+  // Prior turns oldest first, then the turn the model must answer.
+  if (request.messages_size() != 3) {
+    result.expected = "3 messages";
+    result.actual = std::to_string(request.messages_size()) + " messages";
+    return result;
+  }
+  const bool shape_ok =
+      request.messages(0).role() == runanywhere::v1::MESSAGE_ROLE_USER &&
+      request.messages(0).content() == "my favourite colour is vermilion" &&
+      request.messages(1).role() == runanywhere::v1::MESSAGE_ROLE_ASSISTANT &&
+      request.messages(1).content() == "ok" &&
+      request.messages(2).role() == runanywhere::v1::MESSAGE_ROLE_USER &&
+      request.messages(2).content() == "what is my favourite colour?";
+  if (!shape_ok) {
+    result.expected = "user/assistant/user in chronological order";
+    result.actual = "roles or content out of order";
+    return result;
+  }
+  result.passed = true;
+  return result;
+}
+
+TestResult test_transcript_single_turn() {
+  TestResult result;
+  result.test_name = "transcript_single_turn";
+
+  // A one-shot generation passes no history at all.
+  runanywhere::v1::LLMGenerateRequest request;
+  rcli::repl::fill_messages(&request, nullptr, "hello");
+  if (request.messages_size() != 1 || request.messages(0).content() != "hello") {
+    result.expected = "1 message carrying the prompt";
+    result.actual = std::to_string(request.messages_size()) + " messages";
+    return result;
+  }
+  result.passed = true;
+  return result;
+}
+
+TestResult test_transcript_trims_oldest_first() {
+  TestResult result;
+  result.test_name = "transcript_trims_oldest_first";
+
+  rcli::repl::Transcript transcript(4);
+  for (int i = 0; i < 5; ++i) {
+    transcript.add(rcli::repl::Role::User, "u" + std::to_string(i));
+    transcript.add(rcli::repl::Role::Assistant, "a" + std::to_string(i));
+  }
+
+  if (transcript.size() > 4) {
+    result.expected = "at most 4 turns";
+    result.actual = std::to_string(transcript.size()) + " turns";
+    return result;
+  }
+  if (!transcript.trimmed()) {
+    result.expected = "trimmed() true after dropping turns";
+    result.actual = "trimmed() false";
+    return result;
+  }
+  // The newest turn survives and the oldest is gone.
+  if (transcript.turns().back().content != "a4") {
+    result.expected = "newest turn a4 retained";
+    result.actual = transcript.turns().back().content;
+    return result;
+  }
+  // Commons skips a leading assistant turn, so the window must not start on one
+  // or the reported count would overstate what the model sees.
+  if (transcript.turns().front().role != rcli::repl::Role::User) {
+    result.expected = "window starts on a user turn";
+    result.actual = "window starts on an assistant turn";
+    return result;
+  }
+  result.passed = true;
+  return result;
+}
+
+TestResult test_transcript_clear_and_empty() {
+  TestResult result;
+  result.test_name = "transcript_clear_and_empty";
+
+  rcli::repl::Transcript transcript;
+  transcript.add(rcli::repl::Role::User, "remember this");
+  transcript.add(rcli::repl::Role::Assistant, "");  // empty answers are not turns
+  if (transcript.size() != 1) {
+    result.expected = "1 turn (empty content ignored)";
+    result.actual = std::to_string(transcript.size()) + " turns";
+    return result;
+  }
+  transcript.clear();
+  if (!transcript.empty() || transcript.trimmed()) {
+    result.expected = "cleared and not marked trimmed";
+    result.actual = std::to_string(transcript.size()) + " turns";
+    return result;
+  }
+  result.passed = true;
+  return result;
+}
+
+TestResult test_accelerator_parsing() {
+  TestResult result;
+  result.test_name = "accelerator_parsing";
+
+  struct Case {
+    std::string in;
+    bool ok;
+    runanywhere::v1::AcceleratorPolicy expected;
+  };
+  const Case cases[] = {
+      {"", true, runanywhere::v1::ACCELERATOR_POLICY_UNSPECIFIED},
+      {"auto", true, runanywhere::v1::ACCELERATOR_POLICY_AUTO},
+      {"cpu", true, runanywhere::v1::ACCELERATOR_POLICY_CPU},
+      {"GPU", true, runanywhere::v1::ACCELERATOR_POLICY_GPU},
+      {"metal", true, runanywhere::v1::ACCELERATOR_POLICY_GPU},
+      {"npu", true, runanywhere::v1::ACCELERATOR_POLICY_NPU},
+      {"ane", true, runanywhere::v1::ACCELERATOR_POLICY_NPU},
+      {"quantum", false, runanywhere::v1::ACCELERATOR_POLICY_UNSPECIFIED},
+  };
+  for (const Case &c : cases) {
+    runanywhere::v1::AcceleratorPolicy policy =
+        runanywhere::v1::ACCELERATOR_POLICY_NPU;  // poisoned, must be overwritten
+    std::string error;
+    const bool ok = rcli::commands::parse_accelerator(c.in, &policy, &error);
+    if (ok != c.ok || policy != c.expected) {
+      result.expected = std::string(c.ok ? "ok " : "rejected ") + std::to_string(c.expected);
+      result.actual = std::string(ok ? "ok " : "rejected ") + std::to_string(policy);
+      return result;
+    }
+    // A rejection must explain itself; a silent false would strand the caller.
+    if (!ok && error.empty()) {
+      result.expected = "an error message on rejection";
+      result.actual = "empty error";
+      return result;
+    }
+  }
+  result.passed = true;
+  return result;
+}
+
+TestResult test_slash_argument_splitting() {
+  TestResult result;
+  result.test_name = "slash_argument_splitting";
+
+  struct Case {
+    std::string in;
+    std::string first;
+    std::string rest;
+  };
+  // The REPL calls this on everything after the command word, so the empty
+  // cases are how `/image` with no path is detected and reported rather than
+  // ending the session.
+  const Case cases[] = {
+      {" shot.png what is this", "shot.png", "what is this"},
+      {"shot.png", "shot.png", ""},
+      {"   ", "", ""},
+      {"", "", ""},
+      {"  a.wav   ", "a.wav", ""},
+      {" /abs/path with spaces.png describe", "/abs/path", "with spaces.png describe"},
+  };
+  for (const Case &c : cases) {
+    const auto [first, rest] = rcli::repl::split_first_word(c.in);
+    if (first != c.first || rest != c.rest) {
+      result.expected = "{'" + c.first + "','" + c.rest + "'}";
+      result.actual = "{'" + first + "','" + rest + "'}";
+      return result;
+    }
+  }
+  result.passed = true;
+  return result;
+}
+
 }  // namespace
 
 int main(int argc, char **argv) {
   TestSuite suite("rcli_unit");
+  suite.add("accelerator_parsing", test_accelerator_parsing);
+  suite.add("slash_argument_splitting", test_slash_argument_splitting);
+  suite.add("transcript_builds_conversation", test_transcript_builds_conversation);
+  suite.add("transcript_single_turn", test_transcript_single_turn);
+  suite.add("transcript_trims_oldest_first", test_transcript_trims_oldest_first);
+  suite.add("transcript_clear_and_empty", test_transcript_clear_and_empty);
   suite.add("json_escape", test_json_escape);
   suite.add("json_writer_shape", test_json_writer_shape);
   suite.add("human_bytes", test_human_bytes);

--- a/scripts/validation/gates/check_rcli_source_lists.sh
+++ b/scripts/validation/gates/check_rcli_source_lists.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+#
+# rcli is compiled by two build systems from two hand-maintained source lists:
+# rcli/CMakeLists.txt (RCLI_SOURCES) builds the Linux/Windows/dev binary, and
+# Package.swift (the RCLIHost target) builds the Swift-hosted macOS binary that
+# actually ships. Nothing links them, so adding a .cpp to one and not the other
+# compiles fine and then fails at link, in whichever build you happen not to run.
+#
+# That is not hypothetical: src/repl/transcript.cpp was added to CMake only, and
+# the Swift build died with "undefined symbol rcli::repl::Transcript::Transcript"
+# after six minutes of compiling. This gate compares the two lists directly.
+#
+# linenoise is excluded: CMake drops it on Windows (POSIX-only) while SwiftPM,
+# which only ever builds Apple targets, always includes it.
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../../.." && pwd)"
+CMAKE_FILE="${REPO_ROOT}/rcli/CMakeLists.txt"
+PACKAGE_FILE="${REPO_ROOT}/Package.swift"
+
+for f in "${CMAKE_FILE}" "${PACKAGE_FILE}"; do
+    [ -f "$f" ] || { echo "ERROR: missing ${f}" >&2; exit 1; }
+done
+
+# RCLI_SOURCES( ... ) up to the closing paren.
+cmake_sources="$(awk '/^set\(RCLI_SOURCES/{flag=1; next} /^\)/{flag=0} flag' "${CMAKE_FILE}" \
+    | tr -d ' \t' | grep -E '^src/.*\.(cpp|c)$' | sort -u)"
+
+# The RCLIHost target's sources: [ ... ] block.
+swift_sources="$(awk '/name: "RCLIHost"/{flag=1} flag && /sources: \[/{collect=1; next} collect && /\],/{collect=0; flag=0} collect' "${PACKAGE_FILE}" \
+    | tr -d ' \t"' | sed 's/,$//' | grep -E '^src/.*\.(cpp|c)$' | sort -u)"
+
+if [ -z "${cmake_sources}" ] || [ -z "${swift_sources}" ]; then
+    echo "ERROR: parsed an empty source list (CMake: $(echo "${cmake_sources}" | grep -c . || true), SwiftPM: $(echo "${swift_sources}" | grep -c . || true))." >&2
+    echo "       The gate cannot pass vacuously; fix the parser before trusting it." >&2
+    exit 1
+fi
+
+only_cmake="$(comm -23 <(echo "${cmake_sources}") <(echo "${swift_sources}"))"
+only_swift="$(comm -13 <(echo "${cmake_sources}") <(echo "${swift_sources}"))"
+
+status=0
+if [ -n "${only_cmake}" ]; then
+    echo "In rcli/CMakeLists.txt but NOT in Package.swift RCLIHost:" >&2
+    echo "${only_cmake}" | sed 's/^/  /' >&2
+    echo "  -> the macOS binary will fail to link these symbols." >&2
+    status=1
+fi
+if [ -n "${only_swift}" ]; then
+    echo "In Package.swift RCLIHost but NOT in rcli/CMakeLists.txt:" >&2
+    echo "${only_swift}" | sed 's/^/  /' >&2
+    echo "  -> the CMake binary will fail to link these symbols." >&2
+    status=1
+fi
+
+if [ "${status}" -eq 0 ]; then
+    echo "rcli source lists agree ($(echo "${cmake_sources}" | grep -c .) files)"
+fi
+exit "${status}"


### PR DESCRIPTION
`rcli chat` becomes a place you can actually sit: it remembers the conversation, and slash
commands reach the other modalities without leaving it.

```
» my favourite colour is vermilion
» /image ~/shot.png what is in this picture?
» /audio ~/question.wav
» /accelerator cpu
» /save chat.md
```

## The conversation

The README said "REPL turns are independent (no conversation memory yet)". That was a CLI
omission, not a missing capability. `LLMGenerateRequest` already carries
`repeated ChatMessage messages` — "the whole conversation, oldest first" — with `prompt` and
`history` retired to `reserved`, and `cmd_run.cpp` already built that request. It put exactly one
message in it and threw the rest away. Commons already flattens the array into each engine's
history (`llm_module.cpp:1700`).

So the transcript is the only new state. It caps at 40 turns and drops oldest-first, copying the
voice agent's policy, and never leaves a window starting on an assistant turn, because commons
skips a leading assistant turn and the reported count would otherwise overstate what the model
sees. `/context` shows the state, `/clear` forgets it.

## Placement knobs that were sitting unused

`ModelLoadRequest` has carried `accelerator_policy` (a first-class `auto|cpu|gpu|npu` enum),
`context_length` and `backend_preferences` for some time. `load_model()` set `model_id`,
`validate_availability`, `framework` and `category` and nothing else, so every load went out as
`UNSPECIFIED`. There are now `--accelerator` and `--context-length` flags, plus `/engine` and
`/accelerator` in chat which reload the model and keep the conversation.

Two things had to be fixed underneath before those flags meant anything.

**llama.cpp was ignoring them.** `llamacpp_llm_create_impl` took `config_json` with the parameter
name commented out and never put it on the session descriptor; the provider then passed `nullptr`
as the config. The CPU runtime forwards the descriptor untouched, so only those two ends were
broken. Proven end to end — with `--context-length 2048 --accelerator cpu` the log now reads
`common_fit_params SUCCESS: n_gpu_layers=-1` (llama.cpp's own choice) followed by
`Loading model with n_gpu_layers=0` (ours). With no flags the behaviour is unchanged.

**"Pin to CPU" was inexpressible.** `rac_llm_llamacpp_config_t::gpu_layers` used `0` as both
"unspecified" and "no layers on GPU", so a CPU pin was indistinguishable from an unset field. There
is now an explicit `RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO`; `-1` still means all layers, `0` now means
CPU. The two callers that meant "auto" by passing 0 say so explicitly.

**Commons already warned and rcli was swallowing it.** `ModelLoadResult.warnings` says when a knob
was forwarded to an engine that may not honour it. Those are printed now. That warning alone would
have shown that `--accelerator gpu` was doing nothing.

## Metal on macOS

The macOS slice of the llama.cpp xcframework shipped with **no Metal at all**, while both iOS
slices had it: 0 symbols versus 91. `build-core-xcframework.sh` configures macOS with
`--preset macos-release`, which pins `GGML_METAL=OFF`; iOS gets Metal from `RAC_PLATFORM_IOS` and
macOS falls through that branch. The macOS slice now builds with `GGML_METAL=ON` and embedded
shaders, and carries the same 91 symbols.

Careful reading this if you go looking: it presents as a linker problem and is not one. Nothing was
dropped at link time; Metal was never compiled in.

## A CI gate for a seam that has now bitten twice

rcli is built from two hand-maintained source lists, `RCLI_SOURCES` in CMake and the `RCLIHost`
target in `Package.swift`. Adding `transcript.cpp` to the first and not the second compiled fine
and then failed to link the macOS binary after six minutes:
`undefined symbol rcli::repl::Transcript::Transcript`. Same seam that produced the
`librac_neurt_stt_ops.a` bug on the ASR work.

`scripts/validation/gates/check_rcli_source_lists.sh` diffs the two lists and runs in the
`centralization` job. It was tested by reintroducing the real drift, and it refuses to pass
vacuously: an empty parse is a hard error, so a refactor that breaks the parser fails loudly
instead of going green.

## Tests

32 passing in `test_rcli_unit`, five of them new: transcript assembly produces a correctly ordered
`messages` array, trimming drops oldest first and never starts on an assistant turn, `/image` and
friends handle a missing argument without ending the session, and `--accelerator` parsing covers
the aliases and proves a rejection carries a message.

Worth saying plainly: the REPL itself is not covered end to end. Piped stdin never reaches it (it
becomes a single prompt) and a pty harness kept racing linenoise's redraw, so the logic was moved
into unit-testable units instead of trusted to a flaky terminal test.

## Things this does not do

- **`/image` is single-turn.** `vlm_options.proto` declares `repeated ChatMessage messages`, but
  nothing in `core/src/features/vlm/` reads it, so the vision model never sees prior conversation.
  Its answer still joins the transcript so later text turns can refer to the picture.
- **`/vad`, `/diarize`, `/draw`, `/doc`, `/ask` are not implemented.** Each needs its own reusable
  entry point, and RAG needs a decision about index lifetime inside a session. The RAG pair is
  worth doing: the README says `rag open`/`rag ingest` have no command because indexes are
  in-memory per process, and a chat session is one long-lived process, so the constraint that
  blocked them disappears there.
- **The CMake `rcli` cannot run MLX**, and says so at startup. Registration needs Swift callbacks
  on the MainActor, which a C++ `main` cannot provide. `build-mlx-cli.sh` now symlinks its output
  as `rcli` so the name you build matches the name that ships. The MLX catalog entries stay
  registered in both builds on purpose (`test_rcli_unit::mlx_catalog_registration` locks that),
  because the models directory is shared between RunAnywhere binaries.

## Question for review

`RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO` changes what `gpu_layers = 0` means: previously "leave it
alone", now "CPU only". Both in-tree callers were updated, and `runanywhere-server`'s
`--gpu-layers 0` now pins to CPU rather than meaning auto — which matches llama.cpp's own
convention, but it is a behaviour change in a public header. Shout if you would rather it stayed
where it was.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added conversation history with context limits, clearing, saving, and multi-turn streaming.
  - Added `/image`, `/audio`, `/say`, model switching, and engine/accelerator controls.
  - Added speech-to-text transcription and text-to-speech WAV export.
  - Added accelerator options including automatic, CPU, GPU/Metal, and Neural Engine selection.
  - Added context-length and vision model controls.

- **Bug Fixes**
  - Explicit CPU-only inference settings are now preserved correctly.
  - macOS builds automatically enable Metal support when available.

- **Documentation**
  - Expanded CLI guidance, supported commands, model behavior, and known limitations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->