### PR TITLE
fix(kotlin): stop deprecations pointing at deprecated replacements

### DIFF
--- a/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/Models/RunAnywhereModelLifecycle.kt
+++ b/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/Models/RunAnywhereModelLifecycle.kt
@@ -97,7 +97,7 @@ suspend fun RunAnywhere.loadModel(model: RAModelInfo): RAModelLoadResult =
         ),
     )
 
-@Deprecated("Use RunAnywhere.models.unload(category).")
+@Deprecated("Use RunAnywhere.models.unloadAll(category).")
 suspend fun RunAnywhere.unloadModel(request: ModelUnloadRequest): ModelUnloadResult {
     if (!isInitialized) {
         return ModelUnloadResult(

--- a/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/STT/RunAnywhereSTT.kt
+++ b/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/STT/RunAnywhereSTT.kt
@@ -85,7 +85,7 @@ suspend fun RunAnywhere.transcribe(
     return result
 }
 
-@Deprecated("Use RunAnywhere.stt.transcribeStream(audio, options).")
+@Deprecated("Use RunAnywhere.stt.openStream(format, options).")
 fun RunAnywhere.transcribeStream(
     audio: Flow<ByteArray>,
     options: RASTTOptions = RASTTOptions.defaults(),

--- a/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/TTS/RunAnywhereTTS.kt
+++ b/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/TTS/RunAnywhereTTS.kt
@@ -177,7 +177,7 @@ fun RunAnywhere.synthesizeStream(
         }
     }
 
-@Deprecated("Use RunAnywhere.tts.stop().")
+@Deprecated("Use interrupt() on the SpeechHandle returned by RunAnywhere.tts.speak().")
 suspend fun RunAnywhere.stopSynthesis() {
     CppBridgeTTS.stop()
 }
@@ -241,7 +241,7 @@ private fun convertPcmToWav(pcmData: ByteArray, sampleRate: Int): ByteArray {
         ?: throw SDKException.tts("Failed to convert PCM to WAV")
 }
 
-@Deprecated("Use RunAnywhere.tts.stop().")
+@Deprecated("Use interrupt() on the SpeechHandle returned by RunAnywhere.tts.speak().")
 suspend fun RunAnywhere.stopSpeaking() {
     ttsAudioPlayback.stop()
     stopSynthesis()

--- a/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/VAD/RunAnywhereVAD.kt
+++ b/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/VAD/RunAnywhereVAD.kt
@@ -93,7 +93,7 @@ suspend fun RunAnywhere.detectVoiceActivity(
  * `error_code`) and the flow finishes so callers do not silently keep
  * pumping audio into a dead detector.
  */
-@Deprecated("Use RunAnywhere.vad.detectStream(audio, options).")
+@Deprecated("Use RunAnywhere.vad.openStream(format, options).")
 fun RunAnywhere.streamVAD(
     audio: Flow<ByteArray>,
     options: RAVADOptions? = null,
@@ -115,7 +115,7 @@ fun RunAnywhere.streamVAD(
             )
         }
 
-@Deprecated("Cancel the Flow returned by RunAnywhere.vad.detectStream instead.")
+@Deprecated("Close the VadStream returned by RunAnywhere.vad.openStream instead.")
 suspend fun RunAnywhere.resetVAD() {
     if (!isInitialized) {
         throw notInitializedException()


### PR DESCRIPTION
## What is wrong

Six `@Deprecated` messages on the legacy extension surface tell the caller to move to a namespace method that is itself deprecated, so following the advice lands them on a second deprecation:

| legacy extension | current advice | that target's own annotation |
|---|---|---|
| `unloadModel` | `models.unload(category)` | `@Deprecated("Use unloadAll(category).")` |
| `stopSynthesis` | `tts.stop()` | `@Deprecated("Use the SpeechHandle returned by speak().")` |
| `stopSpeaking` | `tts.stop()` | same |
| `streamVAD` | `vad.detectStream(audio, options)` | `@Deprecated("Use vad.openStream(format, options).")` |
| `resetVAD` | `vad.detectStream` | same |
| `transcribeStream` | `stt.transcribeStream(audio, options)` | `@Deprecated("Use stt.openStream(format, options).")` |

The IDE shows the strikethrough and the message, the caller migrates, and gets struck through again. `ReplaceWith` is not involved in any of these, so nothing auto-applies, but the written guidance is a dead end and no gate covers it. `check_deprecated_surfaces.sh` tracks which deprecated surfaces exist against an allowlist; it does not check that a deprecation's target is supported.

## What this changes

Each message now names the replacement the namespace's own annotation points at, so one hop reaches a supported API:

- `models.unloadAll(category)`
- `interrupt()` on the `SpeechHandle` returned by `tts.speak()`
- `vad.openStream(format, options)`, and `close()` on the `VadStream` it returns for the reset case
- `stt.openStream(format, options)`

I took each target from the deprecated namespace method's own annotation rather than picking one, and confirmed the members exist: `ModelsNamespace.unloadAll` (`:266`), `TtsNamespace.speak` (`:60`) returning `SpeechHandle` with `interrupt()` (`Results.kt:252`), `SttNamespace.openStream` (`:189`), and `VadStream.close()` (`Results.kt:315`).

Message strings only. No signature, body, or `ReplaceWith` target changes, so this cannot alter behaviour.

## How I found them

Collected the deprecated methods declared inside `public/api/*Namespace.kt`, then looked for any `@Deprecated` message elsewhere naming `<namespace>.<method>` for that set. Six hits, four files. After the change the same scan reports zero.

Worth noting the scan produced 31 raw hits at first and 25 were false positives, because a deprecated extension and the live namespace method often share a simple name (`generate`, `rerank`, `diarize`). Those messages are correct and I left them alone; only the six above name a target that really is deprecated.

## Verification

- `./gradlew :compileDebugKotlin --rerun-tasks -x :buildLocalJniLibs -x :downloadJniLibs -x :syncAndroidRuntimeLibs -Prunanywhere.useLocalNatives=false`: **BUILD SUCCESSFUL**
- `./gradlew ktlintMainSourceSetCheck`: clean
- `git status` shows only the four source files; the codegen the Gradle build runs left nothing behind

No test added: these are annotation strings, and a test asserting the text of a deprecation message would pin prose rather than behaviour.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deprecation guidance for model unloading, speech-to-text streaming, text-to-speech controls, and voice activity detection.
  * Deprecated APIs now point to recommended replacement workflows, including stream handles and lifecycle methods.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->