### PR TITLE
fix(qhexrt): resolve QNN runtime DLLs from the plugin's own directory on Windows

### DIFF
--- a/engines/qhexrt/qhexrt_session.cpp
+++ b/engines/qhexrt/qhexrt_session.cpp
@@ -28,6 +28,10 @@
 #include <cstdlib>
 #endif
 
+#if defined(_WIN32)
+#include <windows.h>
+#endif
+
 #include "qhexrt_bundle_policy.h"
 
 #include "rac/core/rac_logger.h"
@@ -193,14 +197,51 @@ rac_qhexrt_set_skel_directory(const char* path) {
 }
 #endif
 
+#if defined(_WIN32)
+// QnnHtp.dll / QnnSystem.dll are not load-time imports of this DLL, so the
+// LOAD_WITH_ALTERED_SEARCH_PATH the plugin loader uses to load *us* (see
+// core/src/plugin/plugin_loader.cpp) never applies to them: that flag only
+// widens the search for the DLL being loaded by that specific call, not for
+// LoadLibrary calls made later by code already running inside it. Passing
+// nullptr here leaves qhx_runtime_create() to fall back to the OS's default
+// search order, which does not include this plugin's own directory — a
+// sibling next to a dynamically-loaded plugin DLL is otherwise invisible.
+// Resolve our own module directory instead and hand qhx_runtime_create
+// explicit paths there.
+std::string this_module_directory() {
+    HMODULE module = nullptr;
+    if (!GetModuleHandleExA(
+            GET_MODULE_HANDLE_EX_FLAG_FROM_ADDRESS | GET_MODULE_HANDLE_EX_FLAG_UNCHANGED_REFCOUNT,
+            reinterpret_cast<LPCSTR>(&this_module_directory), &module)) {
+        return {};
+    }
+    char buf[MAX_PATH];
+    DWORD len = GetModuleFileNameA(module, buf, sizeof(buf));
+    if (len == 0 || len >= sizeof(buf)) {
+        return {};
+    }
+    std::string path(buf, len);
+    auto slash = path.find_last_of("\\/");
+    return slash == std::string::npos ? std::string() : path.substr(0, slash);
+}
+#endif
+
 qhx_runtime* runtime_acquire() {
     std::lock_guard<std::mutex> lock(g_rt_mutex);
     if (g_rt == nullptr) {
 #if defined(__ANDROID__)
         static std::once_flag adsp_once;
         std::call_once(adsp_once, configure_adsp_library_path);
-#endif
         g_rt = qhx_runtime_create(nullptr, nullptr);  // default libQnnHtp.so / libQnnSystem.so
+#elif defined(_WIN32)
+        std::string dir = this_module_directory();
+        std::string qnn_htp = dir.empty() ? std::string() : dir + "\\QnnHtp.dll";
+        std::string qnn_system = dir.empty() ? std::string() : dir + "\\QnnSystem.dll";
+        g_rt = qhx_runtime_create(qnn_htp.empty() ? nullptr : qnn_htp.c_str(),
+                                   qnn_system.empty() ? nullptr : qnn_system.c_str());
+#else
+        g_rt = qhx_runtime_create(nullptr, nullptr);  // default libQnnHtp.so / libQnnSystem.so
+#endif
         if (g_rt == nullptr) {
             RAC_LOG_ERROR(LOG_CAT, "qhx_runtime_create failed (QNN libs unavailable?)");
             return nullptr;


### PR DESCRIPTION
## Summary
- `runtime_acquire()` in `engines/qhexrt/qhexrt_session.cpp` called `qhx_runtime_create(nullptr, nullptr)` unconditionally on every non-Android platform, relying on the OS default DLL search order to find `QnnHtp.dll`/`QnnSystem.dll`.
- On Windows that default search order never includes the directory of a dynamically-loaded sibling plugin DLL: `LOAD_WITH_ALTERED_SEARCH_PATH` (used by `core/src/plugin/plugin_loader.cpp` to load `runanywhere_qhexrt.dll` itself) only widens the search for *that* `LoadLibrary` call, not for later `LoadLibrary` calls made by code already running inside the loaded DLL.
- Every Windows load of the qhexrt engine therefore failed inside `qhx_runtime_create`, surfaced up through `session_open()` → `qhexrt_llm_create()` as the generic `RAC_ERROR_BACKEND_INIT_FAILED` ("Backend initialization failed"), even with the correct QNN runtime DLLs physically present right next to the plugin.
- Fix resolves the plugin's own module directory (`GetModuleHandleExA` + `GetModuleFileNameA`) and hands `qhx_runtime_create` explicit paths there — the Windows equivalent of the `ADSP_LIBRARY_PATH` resolution Android already does in the same file for the identical underlying problem (a dynamically-loaded plugin's sibling native deps being invisible to the default search path).

## Verification
Reproduced and fixed on a real Snapdragon X2 Elite (Hexagon v81) Windows ARM64 box:
- Before: `runanywhere-electron`'s Playwright NPU test (`qhexrt generates text on the Hexagon NPU`) failed 100% of the time with `Error: Backend initialization failed`, confirmed via the native log subscription (`[QHexRT] qhx_runtime_create failed (QNN libs unavailable?)`).
- After: the same test passes with real generated output, e.g. `{"text":"Blue","model":"lfm2.5-230m-npu","tokensPerSecond":58.8}`.

Separately (not part of this PR's diff, an operational/packaging issue on that box): the QNN runtime DLLs staged into `@runanywhere/electron-qhexrt`'s `prebuilds/win32-arm64` were a stale QAIRT ~2.45.x vintage build vs. the QAIRT 2.48.0.260626 the engine was actually linked against — `bindings/electron/scripts/bundle-native.ts`'s `stageQnnRuntime()` faithfully mirrors whatever `RA_QNN_RUNTIME_DIR` points at with no version check, so this was a stale-source-directory problem, not a script bug. Both issues had to be fixed together to get a real pass; only the source fix is in this diff.

## Test plan
- [x] `qhexrt generates text on the Hexagon NPU` Playwright test passes on real Snapdragon X2 Elite / Hexagon v81 hardware.
- [x] `the engines this platform ships are actually loaded` capabilities test still passes (QHEXRT backend registers cleanly).
- [x] No behavior change on Android/other platforms (change is `#if defined(_WIN32)` gated, alongside the existing `#if defined(__ANDROID__)` branch).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vtg9MWU3nMYbsCEcmc4nUv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Windows support for locating required runtime libraries automatically.
  * Android and other platforms continue using their existing default library resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->