### PR TITLE
feat(electron): add NeuRT (Apple Neural Engine) backend package

### DIFF
--- a/bindings/electron/packages/neurt/LICENSE
+++ b/bindings/electron/packages/neurt/LICENSE
@@ -1,0 +1,15 @@
+RunAnywhere License Notice
+Version 1.0, December 2025
+
+Copyright (c) 2025 RunAnywhere, Inc. All Rights Reserved.
+
+This package is distributed under the RunAnywhere License. The complete
+governing license, including its permitted-user thresholds, commercial-license
+requirement, attribution conditions, and incorporated Apache License 2.0 terms,
+is available at:
+
+https://github.com/RunanywhereAI/runanywhere-sdks/blob/main/LICENSE
+
+By using, copying, modifying, or distributing this package, you agree to be
+bound by that license. This notice is a prominent link to and incorporates the
+complete RunAnywhere License by reference; it is not a replacement license.

--- a/bindings/electron/packages/neurt/README.md
+++ b/bindings/electron/packages/neurt/README.md
@@ -1,0 +1,46 @@
+# `@runanywhere/electron-neurt`
+
+NeuRT backend package for the Electron SDK — text generation on the **Apple
+Neural Engine**, via prebuilt Core ML graphs.
+
+Supported host today: **macOS on Apple Silicon** (`darwin-arm64`). Off-platform
+builds still install and register; the engine reports `BACKEND_UNAVAILABLE` and
+the router can never select it, so a cross-platform app can depend on this
+package unconditionally.
+
+## Usage (main process only)
+
+```ts
+import { NeuRT } from '@runanywhere/electron-neurt';
+NeuRT.register(); // before RunAnywhereMain.connect()
+```
+
+Registration records `prebuilds/<platform>-<arch>/runanywhere_neurt.dylib` in
+the main-process queue; `RunAnywhereMain` copies it into
+`RUNANYWHERE_PLUGIN_PATHS` at utility-host fork. There is no renderer RPC that
+can load a plugin.
+
+## What ships in `prebuilds/darwin-arm64/`
+
+Just the plugin and the shared commons sidecar — Core ML is a system framework,
+not a vendored runtime:
+
+| file | from |
+|---|---|
+| `runanywhere_neurt.dylib` | this repo (`engines/neurt`) |
+| `librac_commons.dylib` | this repo — the thin addon's shared commons |
+
+## Catalog rows
+
+NeuRT-served models declare `framework: 'COREML'` (not `'NEURT'`) — NeuRT is the
+engine's identity, Core ML is the framework it executes, matching every other
+SDK's catalog (iOS registers the same models with `framework: .coreml`). Model
+bundles are Hugging Face folder refs to a `.mlpackage`/`.mlmodelc` tree, resolved
+and downloaded through the SDK's normal model store, never bundled into this
+package.
+
+## Model download
+
+`initialize()` registers the libcurl HTTP transport only when commons was built
+with `-DRAC_DESKTOP_ADAPTER=ON`. Without it, register an already-downloaded
+bundle directory instead of resolving one from Hugging Face.

--- a/bindings/electron/packages/neurt/package-lock.json
+++ b/bindings/electron/packages/neurt/package-lock.json
@@ -1,0 +1,98 @@
+{
+  "name": "@runanywhere/electron-neurt",
+  "version": "0.20.24",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "@runanywhere/electron-neurt",
+      "version": "0.20.24",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "license": "SEE LICENSE IN LICENSE",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "devDependencies": {
+        "@runanywhere/electron": "file:../..",
+        "@types/node": "^22.7.0",
+        "typescript": "^5.6.3"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@runanywhere/electron": "^0.20.15"
+      }
+    },
+    "../..": {
+      "name": "@runanywhere/electron",
+      "version": "0.20.24",
+      "cpu": [
+        "x64",
+        "arm64"
+      ],
+      "dev": true,
+      "license": "SEE LICENSE IN LICENSE",
+      "os": [
+        "darwin",
+        "linux",
+        "win32"
+      ],
+      "dependencies": {
+        "@bufbuild/protobuf": "^2.12.1",
+        "@runanywhere/proto-ts": "file:../proto-ts"
+      },
+      "devDependencies": {
+        "@types/node": "^22.7.0",
+        "electron": "^43.1.1",
+        "typescript": "^5.6.3"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "peerDependencies": {
+        "@runanywhere/proto-ts": "^0.20.24"
+      }
+    },
+    "node_modules/@runanywhere/electron": {
+      "resolved": "../..",
+      "link": true
+    },
+    "node_modules/@types/node": {
+      "version": "22.20.1",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.20.1.tgz",
+      "integrity": "sha512-EANqOCF9QFyra+4pfxUcX9STKJpCLjMbObVzljIJomAWSnuSIEAvyzEU53GaajbXJEgdh0iEcPL+DGvpUd4k1Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    }
+  }
+}

--- a/bindings/electron/packages/neurt/package.json
+++ b/bindings/electron/packages/neurt/package.json
@@ -1,0 +1,55 @@
+{
+  "name": "@runanywhere/electron-neurt",
+  "version": "0.20.24",
+  "description": "RunAnywhere Electron SDK — NeuRT backend plugin (Apple Neural Engine via Core ML; macOS only)",
+  "license": "SEE LICENSE IN LICENSE",
+  "type": "commonjs",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    },
+    "./package.json": "./package.json"
+  },
+  "files": [
+    "dist",
+    "prebuilds",
+    "README.md",
+    "LICENSE"
+  ],
+  "os": [
+    "darwin",
+    "linux",
+    "win32"
+  ],
+  "cpu": [
+    "x64",
+    "arm64"
+  ],
+  "engines": {
+    "node": ">=20"
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "clean": "node -e \"require('node:fs').rmSync('dist', { recursive: true, force: true })\""
+  },
+  "peerDependencies": {
+    "@runanywhere/electron": "^0.20.15"
+  },
+  "devDependencies": {
+    "@runanywhere/electron": "file:../..",
+    "@types/node": "^22.7.0",
+    "typescript": "^5.6.3"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/RunanywhereAI/runanywhere-sdks.git",
+    "directory": "bindings/electron/packages/neurt"
+  },
+  "publishConfig": {
+    "access": "public"
+  }
+}

--- a/bindings/electron/packages/neurt/src/NeuRT.ts
+++ b/bindings/electron/packages/neurt/src/NeuRT.ts
@@ -1,0 +1,76 @@
+/**
+ * NeuRT — Electron backend package registration (Apple Neural Engine via Core ML).
+ *
+ * Call from the Electron **main** process before `RunAnywhereMain.connect()`:
+ *
+ * ```ts
+ * import { NeuRT } from '@runanywhere/electron-neurt';
+ * NeuRT.register();
+ * ```
+ *
+ * Records the absolute path to `runanywhere_neurt.dylib` and updates
+ * `RUNANYWHERE_PLUGIN_PATHS` for the utility-host fork. Does **not** load the
+ * plugin over RPC.
+ *
+ * ## What this backend needs, and why
+ *
+ * NeuRT runs prebuilt Core ML graphs on the Apple Neural Engine — macOS only
+ * (`darwin-arm64`; there is no ANE on Intel Macs or any other platform). Unlike
+ * QHexRT, there is no separate vendor runtime to stage beside the plugin: Core ML
+ * is a system framework, and the actual `.mlpackage`/`.mlmodelc` graphs are
+ * downloaded per model through the catalog, never baked into this package. Off
+ * platform, the engine reports `BACKEND_UNAVAILABLE` and the router never
+ * selects it, so a cross-platform app can depend on this package unconditionally.
+ *
+ * The FRAMEWORK a NeuRT catalog row declares is `COREML`, not `NEURT` — NeuRT is
+ * the engine's identity (the codebase it wraps, matching `engines/neurt/`), Core
+ * ML is the framework it executes, and only the framework has a proto ordinal
+ * (`INFERENCE_FRAMEWORK_COREML`). This mirrors iOS, which registers the exact
+ * same models with `framework: .coreml`.
+ */
+
+import * as path from 'node:path';
+
+import {
+  BackendPluginId,
+  isBackendPluginRegistered,
+  recordBackendPlugin,
+  resolvePluginArtifactPath,
+  unregisterBackendPlugin,
+} from '@runanywhere/electron/backend';
+
+export interface NeuRTRegisterOptions {
+  /** Absolute override for the loadable plugin; defaults to this package's prebuild. */
+  pluginPath?: string;
+}
+
+const PACKAGE_ROOT = path.join(__dirname, '..');
+
+export const NeuRT = {
+  get moduleId(): typeof BackendPluginId.NeuRT {
+    return BackendPluginId.NeuRT;
+  },
+
+  get isRegistered(): boolean {
+    return isBackendPluginRegistered(BackendPluginId.NeuRT);
+  },
+
+  /**
+   * Record this package's plugin path for the next utility-host fork.
+   * Idempotent for the same path; a different `pluginPath` replaces the prior entry.
+   */
+  register(options: NeuRTRegisterOptions = {}): void {
+    const pluginPath =
+      options.pluginPath ??
+      resolvePluginArtifactPath({
+        id: BackendPluginId.NeuRT,
+        packageRoot: PACKAGE_ROOT,
+      });
+    recordBackendPlugin({ id: BackendPluginId.NeuRT, pluginPath });
+  },
+
+  /** Remove this backend from the main-process registry (and fork env). */
+  unregister(): void {
+    unregisterBackendPlugin(BackendPluginId.NeuRT);
+  },
+};

--- a/bindings/electron/packages/neurt/src/index.ts
+++ b/bindings/electron/packages/neurt/src/index.ts
@@ -1,0 +1,11 @@
+/**
+ * `@runanywhere/electron-neurt` — NeuRT (Apple Neural Engine via Core ML) backend
+ * for the Electron SDK.
+ *
+ * Peer-depends on `@runanywhere/electron`. Registers the ANE engine; it does not
+ * replace a CPU backend, so an app that also wants GGUF inference declares
+ * `@runanywhere/electron-llamacpp` alongside it.
+ */
+
+export { NeuRT } from './NeuRT';
+export type { NeuRTRegisterOptions } from './NeuRT';

--- a/bindings/electron/packages/neurt/tsconfig.json
+++ b/bindings/electron/packages/neurt/tsconfig.json
@@ -1,0 +1,16 @@
+{
+  "compilerOptions": {
+    "target": "ES2021",
+    "module": "node16",
+    "moduleResolution": "node16",
+    "lib": ["ES2021"],
+    "declaration": true,
+    "outDir": "dist",
+    "rootDir": "src",
+    "strict": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "skipLibCheck": true
+  },
+  "include": ["src/**/*"]
+}

--- a/bindings/electron/scripts/bundle-native.ts
+++ b/bindings/electron/scripts/bundle-native.ts
@@ -24,6 +24,7 @@ const BundlePackageId = {
   ONNX: 'onnx',
   Sherpa: 'sherpa',
   QHexRT: 'qhexrt',
+  NeuRT: 'neurt',
 } as const;
 type BundlePackageId = (typeof BundlePackageId)[keyof typeof BundlePackageId];
 
@@ -33,6 +34,7 @@ const ALL_PACKAGES: readonly BundlePackageId[] = [
   BundlePackageId.ONNX,
   BundlePackageId.Sherpa,
   BundlePackageId.QHexRT,
+  BundlePackageId.NeuRT,
 ];
 
 const BACKEND_PACKAGES: readonly BundlePackageId[] = [
@@ -40,6 +42,7 @@ const BACKEND_PACKAGES: readonly BundlePackageId[] = [
   BundlePackageId.ONNX,
   BundlePackageId.Sherpa,
   BundlePackageId.QHexRT,
+  BundlePackageId.NeuRT,
 ];
 
 /** Detected packaging posture for this build tree. */

--- a/bindings/electron/src/api/facade.ts
+++ b/bindings/electron/src/api/facade.ts
@@ -333,6 +333,12 @@ function modalitiesForBackends(backends: readonly InferenceFramework[]): string[
         mods.add('stt');
         mods.add('tts');
         break;
+      case InferenceFramework.COREML:
+        // NeuRT serves LLM + STT + DIFFUSION; diffusion has no Electron facade
+        // (no browser/desktop engine publishes RAC_PRIMITIVE_DIFFUSION here).
+        mods.add('llm');
+        mods.add('stt');
+        break;
       default: {
         const _exhaustive: never = framework;
         void _exhaustive;

--- a/bindings/electron/src/api/model-abi.ts
+++ b/bindings/electron/src/api/model-abi.ts
@@ -70,6 +70,7 @@ const FRAMEWORK_TO_PROTO: Record<InferenceFramework, ProtoFramework> = {
   [InferenceFramework.ONNX]: ProtoFramework.INFERENCE_FRAMEWORK_ONNX,
   [InferenceFramework.SHERPA]: ProtoFramework.INFERENCE_FRAMEWORK_SHERPA,
   [InferenceFramework.QHEXRT]: ProtoFramework.INFERENCE_FRAMEWORK_QHEXRT,
+  [InferenceFramework.COREML]: ProtoFramework.INFERENCE_FRAMEWORK_COREML,
 };
 
 const FRAMEWORK_FROM_PROTO = new Map<ProtoFramework, InferenceFramework>(

--- a/bindings/electron/src/api/types.ts
+++ b/bindings/electron/src/api/types.ts
@@ -128,6 +128,14 @@ export const InferenceFramework = {
    * with a single engine built in, the router picks it without this.
    */
   QHEXRT: 'QHEXRT',
+  /**
+   * COREML — the engine name is `neurt` (prebuilt Core ML graphs on the Apple
+   * Neural Engine), but the FRAMEWORK is Core ML, matching iOS's `.coreml` and
+   * every other SDK's catalog rows for the same ANE bundles. Never rename this
+   * to NEURT: the proto's `InferenceFramework` enum has no such value, only
+   * `INFERENCE_FRAMEWORK_COREML`.
+   */
+  COREML: 'COREML',
 } as const;
 export type InferenceFramework =
   (typeof InferenceFramework)[keyof typeof InferenceFramework];

--- a/bindings/electron/src/backend/engines.ts
+++ b/bindings/electron/src/backend/engines.ts
@@ -41,7 +41,7 @@ export interface EngineRegistrySnapshot extends RegisteredEngines {
 
 /**
  * Map registry / package ids to {@link InferenceFramework} values.
- * Unknown names are ignored (cloud/mlx/neurt shells, test plugins, …).
+ * Unknown names are ignored (cloud/mlx shells, test plugins, …).
  */
 export function frameworksFromPluginNames(
   names: readonly string[]
@@ -83,6 +83,12 @@ function frameworkForPluginId(id: string): InferenceFramework | undefined {
     case BackendPluginId.QHexRT:
     case 'rac_backend_qhexrt':
       return InferenceFramework.QHEXRT;
+    // The engine's identity is `neurt`; the FRAMEWORK it executes is Core ML
+    // (see `@runanywhere/electron-neurt`'s README) — same distinction as
+    // qhexrt's target-stem alias above.
+    case BackendPluginId.NeuRT:
+    case 'rac_backend_neurt':
+      return InferenceFramework.COREML;
     default:
       return undefined;
   }

--- a/bindings/electron/src/backend/plugin-registry.ts
+++ b/bindings/electron/src/backend/plugin-registry.ts
@@ -22,6 +22,7 @@ export const BackendPluginId = {
   ONNX: 'onnx',
   Sherpa: 'sherpa',
   QHexRT: 'qhexrt',
+  NeuRT: 'neurt',
 } as const;
 
 export type BackendPluginId = (typeof BackendPluginId)[keyof typeof BackendPluginId];
@@ -57,16 +58,17 @@ const ENV_PLUGIN_PATHS = 'RUNANYWHERE_PLUGIN_PATHS' as const;
 /**
  * Canonical id order used when no insertion history is needed.
  *
- * QHexRT is last so a host that loads every registered plugin brings the CPU/GPU
- * engines up first. Ordering does not decide routing — the router picks by
- * primitive and model format — but a plugin that fails to load should not be the
- * one holding up the engines that would have worked.
+ * QHexRT and NeuRT are last so a host that loads every registered plugin brings
+ * the CPU/GPU engines up first. Ordering does not decide routing — the router
+ * picks by primitive and model format — but a plugin that fails to load should
+ * not be the one holding up the engines that would have worked.
  */
 const CANONICAL_ORDER: readonly BackendPluginId[] = [
   BackendPluginId.LlamaCPP,
   BackendPluginId.ONNX,
   BackendPluginId.Sherpa,
   BackendPluginId.QHexRT,
+  BackendPluginId.NeuRT,
 ];
 
 /** Insertion-ordered queue (id → registration). Replace keeps position. */


### PR DESCRIPTION
## Summary
- New `@runanywhere/electron-neurt` package — text generation on the Apple Neural Engine via prebuilt Core ML graphs, mirroring the existing `@runanywhere/electron-qhexrt` packaging pattern.
- Unlike QHexRT, NeuRT needs no vendor runtime staging (Core ML is an OS framework, not a bundled third-party SDK) and already compiles by default under the `electron-macos` CMake preset (`RAC_BACKEND_NEURT` defaults ON on Apple) — this PR is packaging/registration wiring only, no new native code.
- `InferenceFramework.COREML` added to the Electron SDK's public type (matches the existing proto `INFERENCE_FRAMEWORK_COREML`, already used by every other SDK for these same ANE bundles — NeuRT is the engine's identity, Core ML is the framework it executes, same distinction QHexRT/Hexagon already draws).
- `BackendPluginId.NeuRT` added to the plugin registry; `bundle-native.ts` gains `neurt` in its package set (no new candidate-path logic needed — the generic filename derivation already covers it since `engines/neurt/` matches the expected directory convention).
- `backend/engines.ts`'s plugin-name → framework mapping gains a `neurt` → `COREML` case. This was previously explicitly absent (the comment said "cloud/mlx/neurt shells" are ignored, from when neurt was always a build-time stub) — without this, `capabilities()` silently omits a backend that is genuinely loaded and serving.

## Verification
Reproduced and verified end-to-end on real Apple Silicon hardware (macOS, native `electron-macos` build):
- `capabilities()` reports `COREML` in `backends` after the plugin registers (`rac_plugin_register: 'neurt' ok`, confirmed via the native log subscription).
- Added a real Playwright test, `neurt generates text on the Apple Neural Engine`, in the `runanywhere-electron` consumer app (separate PR there) — downloads a public HF-hosted Core ML bundle via the SDK's existing `models.register({ url })` folder-ref resolution (the same mechanism used for ad hoc "add model from URL"), loads it, and generates real text: `{"text":"Blue","model":"lfm2.5-230m-ane","tokensPerSecond":116.7}`.
- Full existing Electron inference suite re-run clean alongside it (llamacpp/onnx/sherpa all still pass; qhexrt correctly skips on non-Windows-ARM64).

## Test plan
- [x] `npm run build && npm run typecheck && npm test` all pass in `bindings/electron` (241/241 unit tests).
- [x] New `@runanywhere/electron-neurt` package builds and typechecks standalone.
- [x] Real end-to-end Apple Neural Engine text generation verified on device (not simulated/mocked).
- [x] No behavior change for other platforms — QHexRT (Windows-only) and llamacpp/onnx/sherpa (cross-platform) are unaffected.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vtg9MWU3nMYbsCEcmc4nUv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added NeuRT backend support for Electron on Apple Silicon macOS.
  * Added Core ML/Neural Engine as a supported inference framework.
  * Added support for large language and speech-to-text modalities through Core ML.
  * Added backend registration, plugin loading, model bundle resolution, and package publishing support.

* **Documentation**
  * Added package documentation covering platform support, setup, model downloads, and availability.
  * Added licensing information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->