### PR TITLE
fix(server): call rac_llm_initialize() after rac_llm_create() in HttpServer::loadModel

### DIFF
--- a/core/src/server/http_server.cpp
+++ b/core/src/server/http_server.cpp
@@ -312,6 +312,21 @@ rac_result_t HttpServer::loadModel(const std::string& modelPath) {
         return RAC_ERROR_SERVER_MODEL_LOAD_FAILED;
     }
 
+    // rac_llm_create() only routes to the plugin and calls its `create` op
+    // (session/impl construction). Some backends (e.g. MLX, whose `create`
+    // just registers a session and defers the actual weight load to
+    // `initialize`) do not finish loading until `rac_llm_initialize()` is
+    // called explicitly. llama.cpp's `create` happens to load synchronously,
+    // which made this omission invisible until an MLX model hit `generate`
+    // here and failed with "model is not loaded".
+    rc = rac_llm_initialize(llmHandle_, modelPath.c_str());
+    if (RAC_FAILED(rc)) {
+        RAC_LOG_ERROR("Server", "Failed to initialize LLM handle: %d", rc);
+        rac_llm_destroy(llmHandle_);
+        llmHandle_ = nullptr;
+        return RAC_ERROR_SERVER_MODEL_LOAD_FAILED;
+    }
+
     RAC_LOG_INFO("Server", "Model loaded successfully");
     return RAC_SUCCESS;
 }


### PR DESCRIPTION
## Summary
`HttpServer::loadModel()` called `rac_llm_create()` but never `rac_llm_initialize()`. Per `core/src/features/common/rac_service_factory_internal.h`, the generic `rac_llm_create()` only invokes the plugin's `.create` op (session/impl construction) — actual weight loading is a separate `.initialize` step. llama.cpp's `.create` happens to load synchronously, which masked this omission; MLX's `.create` just registers a session and defers the real load to `.initialize` (Swift's `MLX.swift` `load(modelPath:)`), so every MLX-served request through `rac_server` failed with a "model is not loaded" error.

Found while verifying `rcli serve` against a real MLX model — `RAC_BUILD_SERVER` defaults OFF everywhere in CI, so this code path was never previously exercised with a backend whose create/initialize are genuinely split.

## Fix
Call `rac_llm_initialize(llmHandle_, modelPath.c_str())` right after `rac_llm_create()` succeeds, with cleanup (`rac_llm_destroy` + null out the handle) on failure, matching the existing error-handling shape in the same function.

## Test plan
- [x] `cmake --build build/rcli-macos-release --target rac_server` compiles clean.
- [x] Verified end-to-end: `RunAnywhereMLXCLI serve <mlx-model> --port <p>` now successfully serves a real MLX model over the OpenAI-compatible HTTP API — `POST /v1/chat/completions` returns genuine generated text (previously failed on every request with "model is not loaded").
- [x] No behavior change for llama.cpp-served models (already loads synchronously in `.create`; the added `.initialize` call is a correct no-op/idempotent completion of the same lifecycle for backends that need it).

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Vtg9MWU3nMYbsCEcmc4nUv

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model loading reliability by validating initialization before use.
  * Added clearer failure handling when model initialization cannot be completed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->