### PR TITLE
fix(ci): stop the python-linux wheel repair hanging on a symlink loop

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -379,10 +379,14 @@ jobs:
       - name: Sherpa-ONNX prebuilts
         run: |
           ./core/scripts/linux/download-sherpa-onnx.sh
-          # The prebuilt ships libonnxruntime.so, but _core/sherpa record a versioned
-          # DT_NEEDED (libonnxruntime.so.1); give auditwheel a matching filename to vendor.
+          # _core/sherpa record a versioned DT_NEEDED (libonnxruntime.so.1), so that
+          # name has to exist for auditwheel to vendor it. Only create it when the
+          # prebuilt does not already ship it: the RunAnywhere desktop asset ships the
+          # usual libonnxruntime.so -> .so.1 -> .so.1.<ver> chain, and overwriting the
+          # middle link points .so.1 back at .so, which is a symlink loop that leaves
+          # the real library unreachable and hangs auditwheel.
           lib="core/third_party/sherpa-onnx-linux/lib"
-          ln -sf libonnxruntime.so "$lib/libonnxruntime.so.1"
+          [ -e "$lib/libonnxruntime.so.1" ] || ln -sf libonnxruntime.so "$lib/libonnxruntime.so.1"
       - name: Build wheel
         working-directory: bindings/python
         run: python -m build --wheel -o dist

--- a/bindings/python/scripts/test_validate_public_packages.py
+++ b/bindings/python/scripts/test_validate_public_packages.py
@@ -203,6 +203,27 @@ class ValidatePublicPackagesTest(unittest.TestCase):
                 _write_dist(self._tmp(), wheel=_build_wheel(sidecars=partial)), VERSION
             )
 
+    def test_versioned_linux_sidecar_is_accepted(self) -> None:
+        """auditwheel keeps the soname, so the vendored ORT is ``.so.1.28.0``.
+
+        The upstream sherpa tarball shipped a flat ``libonnxruntime.so``, so the
+        relocated copy ended in ``.so`` and the suffix check happened to pass. The
+        RunAnywhere desktop asset ships ``libonnxruntime.so.1.28.0``, and the
+        vendored name keeps that version.
+        """
+        dist = self._tmp() / "dist"
+        dist.mkdir(parents=True)
+        wheel = _build_wheel(
+            sidecars={
+                "runanywhere.libs/libonnxruntime-a1b2c3d4.so.1.28.0": CLEAN_BINARY,
+                "runanywhere.libs/libsherpa-onnx-c-api-e5f6a7b8.so": CLEAN_BINARY,
+            }
+        )
+        linux_wheel = f"runanywhere-{VERSION}-cp39-cp39-manylinux_2_39_x86_64.whl"
+        (dist / linux_wheel).write_bytes(wheel)
+        (dist / SDIST_NAME).write_bytes(_build_sdist())
+        V.validate_public_packages(dist, VERSION)
+
     def test_missing_core_extension_is_rejected(self) -> None:
         with self.assertRaisesRegex(V.PackageValidationError, "_core"):
             V.validate_public_packages(

--- a/bindings/python/scripts/validate_public_packages.py
+++ b/bindings/python/scripts/validate_public_packages.py
@@ -40,6 +40,18 @@ HOST_PATH_MARKERS: tuple[bytes, ...] = (b"/Users/", b"/home/", b"\\Users\\")
 # Compiled-binary suffixes that belong in the wheel but must NEVER appear in the sdist.
 BINARY_SUFFIXES: tuple[str, ...] = (".pyd", ".so", ".dylib", ".dll")
 
+
+def _is_binary_member(name: str) -> bool:
+    """True for compiled artifacts, including ELF names carrying a soname version.
+
+    ``endswith(BINARY_SUFFIXES)`` alone misses ``libonnxruntime-abc123.so.1.28.0``:
+    the ELF convention puts the version *after* the suffix, so a vendored sidecar
+    only ends in ``.so`` when the library it came from was unversioned. That is what
+    ``_basename_stem`` already documents, and both callers below need the same rule.
+    """
+    lowered = name.casefold()
+    return lowered.endswith(BINARY_SUFFIXES) or ".so." in lowered
+
 # The compiled extension is imported as ``runanywhere._native._core``; its file is named
 # ``_core`` with a platform extension suffix (``_core.cp312-win_amd64.pyd`` / ``_core.so`` /
 # ``_core.*.dylib``). Match the stem so the check is interpreter/platform independent.
@@ -152,7 +164,7 @@ def validate_wheel(wheel: Path, expected_version: str, *, gpu: bool = False) -> 
                 for n in names
                 if posixpath.dirname(n) == CORE_DIR
                 and _basename_stem(n) == CORE_STEM
-                and n.casefold().endswith(BINARY_SUFFIXES)
+                and _is_binary_member(n)
             ]
             if not core_members:
                 raise PackageValidationError(
@@ -182,7 +194,7 @@ def validate_wheel(wheel: Path, expected_version: str, *, gpu: bool = False) -> 
                 _basename_stem(n)
                 for n in names
                 if posixpath.dirname(n) == platform.libs_dir
-                and n.casefold().endswith(BINARY_SUFFIXES)
+                and _is_binary_member(n)
             }
             # Repair tools mangle a hash into the name (onnxruntime -> onnxruntime-a1b2c3),
             # so match a stem that equals the expected lib or begins with "<lib>-".
@@ -205,7 +217,7 @@ def validate_wheel(wheel: Path, expected_version: str, *, gpu: bool = False) -> 
                 # and CI runner workspaces themselves live under /home/ or /Users/ — so scanning
                 # binaries yields only false positives. A host path in a TEXT / metadata member
                 # (our .py sources, METADATA, RECORD, WHEEL) IS an avoidable leak and is rejected.
-                if member_name.casefold().endswith(BINARY_SUFFIXES):
+                if _is_binary_member(member_name):
                     continue
                 payload = archive.read(member_name)
                 if any(marker in payload for marker in HOST_PATH_MARKERS):
@@ -262,7 +274,7 @@ def validate_sdist(sdist: Path, expected_version: str) -> None:
                     )
 
             for relative in relative_paths:
-                if relative.casefold().endswith(BINARY_SUFFIXES):
+                if _is_binary_member(relative):
                     raise PackageValidationError(
                         f"{label}: sdist must not contain compiled binaries: {relative}"
                     )


### PR DESCRIPTION
## What is wrong

`python-linux (3.9)` and `(3.12)` are red on **main**, not just on PRs. Run [32011099890](https://github.com/RunanywhereAI/runanywhere-sdks/actions/runs/32011099890) at `b2d2ff6d`:

> The job has exceeded the maximum execution time of 1h30m0s

The log stops dead at the start of the repair step and never prints again:

```
08:47:58 INFO:auditwheel.main_repair:Repairing runanywhere-0.20.24-cp39-cp39-linux_x86_64.whl
10:05:51 ##[error]The operation was canceled.
10:05:52 Terminate orphan process: pid (13128) (auditwheel)
```

The same job took about **11 minutes** on 2026-08-16 (see #720's run, `python-linux (3.12)` in 10m16s). Every PR opened since inherits the red cell.

## Root cause

`pr-build.yml` did not change in that window, so the input did. #718 moved the Linux prebuilt off k2-fsa's upstream tarball and onto the RunAnywhere desktop asset, and the two lay ONNX Runtime out differently:

```
upstream v1.13.2       libonnxruntime.so                          real file, 25,008,897 bytes

rac-desktop.4          libonnxruntime.so   -> libonnxruntime.so.1
                       libonnxruntime.so.1 -> libonnxruntime.so.1.28.0
                       libonnxruntime.so.1.28.0                   real file, 24,268,848 bytes
```

The prep step runs:

```sh
ln -sf libonnxruntime.so "$lib/libonnxruntime.so.1"
```

On the old flat layout that created the versioned name `_core`/sherpa record as `DT_NEEDED`, exactly as the comment says. On the new layout it **overwrites the middle link of an existing chain**, leaving:

```
libonnxruntime.so   -> libonnxruntime.so.1
libonnxruntime.so.1 -> libonnxruntime.so
```

That is a cycle. The real 23 MB library is no longer reachable through either name, and auditwheel sits on it until the runner's 1h30m limit kills the job.

## What this changes

Create the versioned name only when the prebuilt does not already ship it. Both layouts then work, and the comment now records why overwriting is not safe.

## Verification

I downloaded both assets and ran the current command and the new one against each, then checked whether `libonnxruntime.so.1` still resolves to a real file:

| command | rac-desktop.4 asset | upstream v1.13.2 asset |
|---|---|---|
| `ln -sf ...` (main today) | **BROKEN: Too many levels of symbolic links** | OK, 25,008,897 bytes |
| `[ -e ... ] \|\| ln -sf ...` (this PR) | OK, 24,268,848 bytes | OK, 25,008,897 bytes |

So the failure is real and asset-dependent, and the guard fixes the new layout while leaving the old behaviour byte-identical.

`yaml.safe_load` parses the workflow (22 jobs).

I could not run `auditwheel` itself here, since this is a macOS host and the hang is Linux-only. The ELOOP above is the mechanism, and this PR's own `python-linux` cells are the real test: if they go green while main stays red, that confirms it end to end.

One caveat worth stating: this unblocks the job, it does not claim the vendored result is otherwise unchanged. auditwheel will now vendor `libonnxruntime.so.1.28.0` through the intact chain, which is what it did before #718 changed the asset.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Linux package builds by preserving existing shared-library links when compatible prebuilt files are already available.
  * Prevented unnecessary replacement of library symlink chains during wheel creation.
  * Improved package validation to correctly recognize versioned Linux shared libraries and compatible sidecar libraries.
  * Added validation coverage for wheels containing versioned runtime libraries, ensuring these packages are accepted correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->