### PR TITLE
ci: keep the rcli Homebrew tap current automatically

### DIFF
--- a/.github/workflows/rcli-tap.yml
+++ b/.github/workflows/rcli-tap.yml
@@ -1,0 +1,78 @@
+name: rcli Homebrew tap
+
+# Keeps RunanywhereAI/homebrew-tap's Formula/rcli.rb pointing at the newest
+# release. Nothing did this before, so the tap sat at 0.20.10 from 14 July while
+# releases went on to 0.20.24: `brew install runanywhereai/tap/rcli` handed
+# people a month-old CLI, which is what "brew install rcli doesn't work" was.
+#
+# This is a SEPARATE workflow on purpose. release.yml creates the GitHub Release
+# as a DRAFT, and update-tap.sh reads the published .sha256 sidecars over HTTPS,
+# so it cannot run inside that job — the assets are not downloadable yet. The
+# `release: published` event fires when a human publishes the draft, which is
+# exactly the moment the tarballs become fetchable. Keeping it out of
+# release.yml also means a tap failure can never fail a release.
+on:
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      version:
+        description: "Version to point the tap at, without the leading v (e.g. 0.20.24)"
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  update-tap:
+    name: Point the tap at the published release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
+
+      - name: Resolve version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
+          RELEASE_TAG: ${{ github.event.release.tag_name }}
+        run: |
+          version="${INPUT_VERSION:-${RELEASE_TAG#v}}"
+          if [ -z "${version}" ]; then
+            echo "::error::no version to publish"
+            exit 1
+          fi
+          echo "version=${version}" >> "$GITHUB_OUTPUT"
+
+      # The tap is a different repository, so GITHUB_TOKEN cannot write to it.
+      # Mirrors how the rcli signing step degrades: when the credential is
+      # absent, say so and stop rather than failing the run, so an unconfigured
+      # fork or a release cut before the secret exists stays green.
+      - name: Update the tap
+        env:
+          TAP_TOKEN: ${{ secrets.RCLI_TAP_TOKEN }}
+          VERSION: ${{ steps.version.outputs.version }}
+        run: |
+          if [ -z "${TAP_TOKEN}" ]; then
+            echo "::warning::RCLI_TAP_TOKEN not configured — skipping the Homebrew tap update."
+            echo "Grant a token with push access to RunanywhereAI/homebrew-tap, then re-run"
+            echo "this workflow, or update by hand: ./rcli/scripts/update-tap.sh ${VERSION}"
+            exit 0
+          fi
+          export RCLI_TAP_REPO="https://x-access-token:${TAP_TOKEN}@github.com/RunanywhereAI/homebrew-tap.git"
+          ./rcli/scripts/update-tap.sh "${VERSION}"
+
+      # Proves the formula the tap now serves actually installs and runs, on the
+      # same OS a user would install from. `brew test` runs the formula's own
+      # test block, which checks `rcli version` and `rcli backends`.
+      - name: Verify brew install from the tap
+        if: ${{ secrets.RCLI_TAP_TOKEN != '' }}
+        env:
+          TAP_TOKEN: ${{ secrets.RCLI_TAP_TOKEN }}
+        continue-on-error: true
+        run: |
+          brew tap runanywhereai/tap
+          brew install runanywhereai/tap/rcli
+          brew test runanywhereai/tap/rcli

--- a/.github/workflows/rcli-tap.yml
+++ b/.github/workflows/rcli-tap.yml
@@ -24,10 +24,24 @@ on:
 permissions:
   contents: read
 
+# update-tap.sh clones, commits and pushes with no rebase and no retry, so two
+# runs racing (a release publish alongside a manual dispatch) can have one push
+# rejected and leave the tap pointing at the older release. Queue them instead.
+# cancel-in-progress stays false: a cancelled run here means a tap that never
+# got updated, which is the exact failure this workflow exists to prevent.
+concurrency:
+  group: rcli-homebrew-tap
+  cancel-in-progress: false
+
 jobs:
   update-tap:
     name: Point the tap at the published release
     runs-on: ubuntu-latest
+    # Job level, not step level: a step's `if` cannot read the `secrets` context
+    # at all, and cannot read env declared on that same step either. Hoisting it
+    # here is what makes the token-presence check below actually evaluate.
+    env:
+      TAP_TOKEN: ${{ secrets.RCLI_TAP_TOKEN }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -52,7 +66,6 @@ jobs:
       # fork or a release cut before the secret exists stays green.
       - name: Update the tap
         env:
-          TAP_TOKEN: ${{ secrets.RCLI_TAP_TOKEN }}
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           if [ -z "${TAP_TOKEN}" ]; then
@@ -67,11 +80,11 @@ jobs:
       # Proves the formula the tap now serves actually installs and runs, on the
       # same OS a user would install from. `brew test` runs the formula's own
       # test block, which checks `rcli version` and `rcli backends`.
+      # No continue-on-error: this step exists to catch a formula that does not
+      # install, and a check that cannot fail would report a broken tap as
+      # healthy — which is how the tap sat broken for a month in the first place.
       - name: Verify brew install from the tap
-        if: ${{ secrets.RCLI_TAP_TOKEN != '' }}
-        env:
-          TAP_TOKEN: ${{ secrets.RCLI_TAP_TOKEN }}
-        continue-on-error: true
+        if: ${{ env.TAP_TOKEN != '' }}
         run: |
           brew tap runanywhereai/tap
           brew install runanywhereai/tap/rcli


### PR DESCRIPTION
The tap served **rcli 0.20.10 from 14 July** while releases went on to 0.20.24, so `brew install runanywhereai/tap/rcli` handed people a month-old CLI. Nothing was wrong with the release: `release.yml` simply never calls `rcli/scripts/update-tap.sh`, so the formula only moved when somebody ran it by hand, and nobody had since July.

The formula itself is already fixed and merged (RunanywhereAI/homebrew-tap#1, now at 0.20.24). This is the part that stops it going stale again.

## Why a separate workflow and not a step in release.yml

`release.yml` creates the GitHub Release as a **draft**. `update-tap.sh` reads the published `.sha256` sidecars over HTTPS, so it cannot run inside that job — the assets are not downloadable yet. That is exactly why the script's own header says to run it manually after the draft is published.

`release: published` fires when a human publishes the draft, which is the first moment the tarballs are fetchable. Keeping it out of `release.yml` also means a tap failure can never fail a release.

## Degrades instead of failing

The tap is a different repository, so `GITHUB_TOKEN` cannot write to it. When `RCLI_TAP_TOKEN` is absent the job prints a warning naming the manual command and exits 0, mirroring how the rcli signing step degrades when the Developer ID secrets are missing. An unconfigured fork, or a release cut before the secret exists, stays green.

`workflow_dispatch` takes a version, so the tap can be re-pointed at any published release without cutting a new one.

## Verification

The install path in this PR is the one I exercised by hand before opening the tap PR: tapped the branch locally, `brew install runanywhereai/tap/rcli`, `brew test` green, and the installed binary reported `rcli 0.20.24 (commons 0.20.24)` with all five backends registering. The workflow's last step repeats that on a runner so a bad formula is caught where someone will see it.

## Needs one secret

`RCLI_TAP_TOKEN` — a token with `Contents: read and write` on `RunanywhereAI/homebrew-tap`. Until it exists this workflow no-ops with a warning, and the tap is updated by hand:

```bash
./rcli/scripts/update-tap.sh <version>
```

## Unrelated but worth knowing

The macOS rcli tarball is **ad-hoc signed and not notarized** — `Signature=adhoc`, `TeamIdentifier=not set`, `spctl` rejects it, no stapled ticket. `release.yml` has the whole signing path but it is gated on `RCLI_DEVELOPER_ID_CERT_P12_BASE64`, which is not configured; only the three `RCLI_NOTARY_*` secrets exist, so it takes the ad-hoc fallback. This does not affect `brew install` (Homebrew downloads are not quarantined, which is why the install above worked), but a browser download from the releases page is refused by Gatekeeper. Fixing it needs a Developer ID Application certificate from the existing Apple team, which only an Account Holder or Admin can create.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Automation**
  * Added automated Homebrew tap updates when a release is published.
  * Added support for manually triggering tap updates with a specified version.
  * Added optional Homebrew installation and formula verification when credentials are configured.
  * Verification failures now clearly report as workflow failures, while unavailable credentials allow the workflow to complete without verification.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->