### PR TITLE
fix(android): reject incomplete OkHttp request marshaling

### DIFF
--- a/core/src/jni/okhttp_transport_adapter.cpp
+++ b/core/src/jni/okhttp_transport_adapter.cpp
@@ -367,6 +367,16 @@ rac_result_t okhttp_request_send(void* /*user_data*/, const rac_http_request_t* 
     // can do a plain `headersFlat.size` check.
     jstring j_method = env->NewStringUTF(req->method);
     jstring j_url = env->NewStringUTF(req->url);
+    if (j_method == nullptr || j_url == nullptr) {
+        if (env->ExceptionCheck() == JNI_TRUE) {
+            env->ExceptionClear();
+        }
+        if (j_method)
+            env->DeleteLocalRef(j_method);
+        if (j_url)
+            env->DeleteLocalRef(j_url);
+        return RAC_ERROR_OUT_OF_MEMORY;
+    }
     jobjectArray j_headers = build_headers_flat(env, req->headers, req->header_count);
     rac_result_t headers_rc = ensure_headers_array(env, &j_headers);
     if (headers_rc != RAC_SUCCESS) {
@@ -380,10 +390,17 @@ rac_result_t okhttp_request_send(void* /*user_data*/, const rac_http_request_t* 
     jbyteArray j_body = nullptr;
     if (req->body_bytes != nullptr && req->body_len > 0) {
         j_body = env->NewByteArray(static_cast<jsize>(req->body_len));
-        if (j_body != nullptr) {
-            env->SetByteArrayRegion(j_body, 0, static_cast<jsize>(req->body_len),
-                                    reinterpret_cast<const jbyte*>(req->body_bytes));
+        if (j_body == nullptr) {
+            if (env->ExceptionCheck() == JNI_TRUE) {
+                env->ExceptionClear();
+            }
+            env->DeleteLocalRef(j_method);
+            env->DeleteLocalRef(j_url);
+            env->DeleteLocalRef(j_headers);
+            return RAC_ERROR_OUT_OF_MEMORY;
         }
+        env->SetByteArrayRegion(j_body, 0, static_cast<jsize>(req->body_len),
+                                reinterpret_cast<const jbyte*>(req->body_bytes));
     }
 
     jlong j_timeout_ms = static_cast<jlong>(req->timeout_ms);
@@ -527,6 +544,16 @@ rac_result_t okhttp_request_stream(void* /*user_data*/, const rac_http_request_t
 
     jstring j_method = env->NewStringUTF(req->method);
     jstring j_url = env->NewStringUTF(req->url);
+    if (j_method == nullptr || j_url == nullptr) {
+        if (env->ExceptionCheck() == JNI_TRUE) {
+            env->ExceptionClear();
+        }
+        if (j_method)
+            env->DeleteLocalRef(j_method);
+        if (j_url)
+            env->DeleteLocalRef(j_url);
+        return RAC_ERROR_OUT_OF_MEMORY;
+    }
     jobjectArray j_headers = build_headers_flat(env, req->headers, req->header_count);
     rac_result_t headers_rc = ensure_headers_array(env, &j_headers);
     if (headers_rc != RAC_SUCCESS) {
@@ -540,10 +567,17 @@ rac_result_t okhttp_request_stream(void* /*user_data*/, const rac_http_request_t
     jbyteArray j_body = nullptr;
     if (req->body_bytes != nullptr && req->body_len > 0) {
         j_body = env->NewByteArray(static_cast<jsize>(req->body_len));
-        if (j_body != nullptr) {
-            env->SetByteArrayRegion(j_body, 0, static_cast<jsize>(req->body_len),
-                                    reinterpret_cast<const jbyte*>(req->body_bytes));
+        if (j_body == nullptr) {
+            if (env->ExceptionCheck() == JNI_TRUE) {
+                env->ExceptionClear();
+            }
+            env->DeleteLocalRef(j_method);
+            env->DeleteLocalRef(j_url);
+            env->DeleteLocalRef(j_headers);
+            return RAC_ERROR_OUT_OF_MEMORY;
         }
+        env->SetByteArrayRegion(j_body, 0, static_cast<jsize>(req->body_len),
+                                reinterpret_cast<const jbyte*>(req->body_bytes));
     }
 
     jlong j_timeout_ms = static_cast<jlong>(req->timeout_ms);
@@ -672,6 +706,16 @@ rac_result_t okhttp_request_resume(void* /*user_data*/, const rac_http_request_t
 
     jstring j_method = env->NewStringUTF(req->method);
     jstring j_url = env->NewStringUTF(req->url);
+    if (j_method == nullptr || j_url == nullptr) {
+        if (env->ExceptionCheck() == JNI_TRUE) {
+            env->ExceptionClear();
+        }
+        if (j_method)
+            env->DeleteLocalRef(j_method);
+        if (j_url)
+            env->DeleteLocalRef(j_url);
+        return RAC_ERROR_OUT_OF_MEMORY;
+    }
     jobjectArray j_headers = build_headers_flat(env, req->headers, req->header_count);
     rac_result_t headers_rc = ensure_headers_array(env, &j_headers);
     if (headers_rc != RAC_SUCCESS) {
@@ -685,10 +729,17 @@ rac_result_t okhttp_request_resume(void* /*user_data*/, const rac_http_request_t
     jbyteArray j_body = nullptr;
     if (req->body_bytes != nullptr && req->body_len > 0) {
         j_body = env->NewByteArray(static_cast<jsize>(req->body_len));
-        if (j_body != nullptr) {
-            env->SetByteArrayRegion(j_body, 0, static_cast<jsize>(req->body_len),
-                                    reinterpret_cast<const jbyte*>(req->body_bytes));
+        if (j_body == nullptr) {
+            if (env->ExceptionCheck() == JNI_TRUE) {
+                env->ExceptionClear();
+            }
+            env->DeleteLocalRef(j_method);
+            env->DeleteLocalRef(j_url);
+            env->DeleteLocalRef(j_headers);
+            return RAC_ERROR_OUT_OF_MEMORY;
         }
+        env->SetByteArrayRegion(j_body, 0, static_cast<jsize>(req->body_len),
+                                reinterpret_cast<const jbyte*>(req->body_bytes));
     }
 
     jlong j_timeout_ms = static_cast<jlong>(req->timeout_ms);

--- a/core/src/jni/okhttp_transport_adapter.cpp
+++ b/core/src/jni/okhttp_transport_adapter.cpp
@@ -39,6 +39,7 @@
 #include <cstdint>
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <mutex>
 #include <string>
 #include <vector>
@@ -182,38 +183,20 @@ class ScopedJniEnv {
     bool did_attach_ = false;
 };
 
-// Helper: turn a std::string pair list into a jobjectArray<String> for
+// Helper: turn a string pair list into a jobjectArray<String> for
 // `OkHttpTransport.executeRequest(headersFlat=[k1,v1,...])`.
-jobjectArray build_headers_flat(JNIEnv* env, const rac_http_header_kv_t* headers,
-                                size_t header_count) {
-    jclass strCls = env->FindClass("java/lang/String");
-    if (strCls == nullptr)
-        return nullptr;
-
-    jsize total = static_cast<jsize>(header_count * 2);
-    jobjectArray arr = env->NewObjectArray(total, strCls, nullptr);
-    if (arr == nullptr) {
-        env->DeleteLocalRef(strCls);
-        return nullptr;
+rac_result_t build_headers_flat(JNIEnv* env, const rac_http_header_kv_t* headers,
+                                size_t header_count, jobjectArray* out_headers) {
+    if (env == nullptr || out_headers == nullptr || (header_count > 0 && headers == nullptr)) {
+        return RAC_ERROR_INVALID_ARGUMENT;
     }
-    for (size_t i = 0; i < header_count; ++i) {
-        jstring k = env->NewStringUTF(headers[i].name ? headers[i].name : "");
-        jstring v = env->NewStringUTF(headers[i].value ? headers[i].value : "");
-        env->SetObjectArrayElement(arr, static_cast<jsize>(i * 2), k);
-        env->SetObjectArrayElement(arr, static_cast<jsize>(i * 2 + 1), v);
-        env->DeleteLocalRef(k);
-        env->DeleteLocalRef(v);
-    }
-    env->DeleteLocalRef(strCls);
-    return arr;
-}
+    *out_headers = nullptr;
 
-// Guard the empty-headers fallback. FindClass can fail under
-// JVM shutdown / classloader pressure, so never hand a null class to
-// NewObjectArray (which throws NPE and would ship a malformed request).
-rac_result_t ensure_headers_array(JNIEnv* env, jobjectArray* headers) {
-    if (*headers != nullptr)
-        return RAC_SUCCESS;
+    constexpr size_t kMaxHeaderCount =
+        static_cast<size_t>(std::numeric_limits<jsize>::max()) / 2;
+    if (header_count > kMaxHeaderCount) {
+        return RAC_ERROR_INVALID_ARGUMENT;
+    }
 
     jclass strCls = env->FindClass("java/lang/String");
     if (strCls == nullptr) {
@@ -222,14 +205,84 @@ rac_result_t ensure_headers_array(JNIEnv* env, jobjectArray* headers) {
         return RAC_ERROR_INTERNAL;
     }
 
-    *headers = env->NewObjectArray(0, strCls, nullptr);
+    const jsize total = static_cast<jsize>(header_count * 2);
+    jobjectArray arr = env->NewObjectArray(total, strCls, nullptr);
+    if (arr == nullptr) {
+        if (env->ExceptionCheck() == JNI_TRUE)
+            env->ExceptionClear();
+        env->DeleteLocalRef(strCls);
+        return RAC_ERROR_OUT_OF_MEMORY;
+    }
+    for (size_t i = 0; i < header_count; ++i) {
+        jstring k = env->NewStringUTF(headers[i].name ? headers[i].name : "");
+        if (k == nullptr) {
+            if (env->ExceptionCheck() == JNI_TRUE)
+                env->ExceptionClear();
+            env->DeleteLocalRef(arr);
+            env->DeleteLocalRef(strCls);
+            return RAC_ERROR_OUT_OF_MEMORY;
+        }
+        jstring v = env->NewStringUTF(headers[i].value ? headers[i].value : "");
+        if (v == nullptr) {
+            if (env->ExceptionCheck() == JNI_TRUE)
+                env->ExceptionClear();
+            env->DeleteLocalRef(k);
+            env->DeleteLocalRef(arr);
+            env->DeleteLocalRef(strCls);
+            return RAC_ERROR_OUT_OF_MEMORY;
+        }
+
+        const jsize key_index = static_cast<jsize>(i * 2);
+        env->SetObjectArrayElement(arr, key_index, k);
+        env->SetObjectArrayElement(arr, key_index + 1, v);
+        if (env->ExceptionCheck() == JNI_TRUE) {
+            env->ExceptionClear();
+            env->DeleteLocalRef(k);
+            env->DeleteLocalRef(v);
+            env->DeleteLocalRef(arr);
+            env->DeleteLocalRef(strCls);
+            return RAC_ERROR_INTERNAL;
+        }
+        env->DeleteLocalRef(k);
+        env->DeleteLocalRef(v);
+    }
     env->DeleteLocalRef(strCls);
-    if (*headers == nullptr) {
+    *out_headers = arr;
+    return RAC_SUCCESS;
+}
+
+rac_result_t build_request_body(JNIEnv* env, const rac_http_request_t* req,
+                                jbyteArray* out_body) {
+    if (env == nullptr || req == nullptr || out_body == nullptr) {
+        return RAC_ERROR_INVALID_ARGUMENT;
+    }
+    *out_body = nullptr;
+
+    if (req->body_len == 0) {
+        return RAC_SUCCESS;
+    }
+    if (req->body_bytes == nullptr ||
+        req->body_len > static_cast<size_t>(std::numeric_limits<jsize>::max())) {
+        return RAC_ERROR_INVALID_ARGUMENT;
+    }
+
+    const jsize body_len = static_cast<jsize>(req->body_len);
+    jbyteArray body = env->NewByteArray(body_len);
+    if (body == nullptr) {
         if (env->ExceptionCheck() == JNI_TRUE)
             env->ExceptionClear();
         return RAC_ERROR_OUT_OF_MEMORY;
     }
 
+    env->SetByteArrayRegion(body, 0, body_len,
+                            reinterpret_cast<const jbyte*>(req->body_bytes));
+    if (env->ExceptionCheck() == JNI_TRUE) {
+        env->ExceptionClear();
+        env->DeleteLocalRef(body);
+        return RAC_ERROR_INTERNAL;
+    }
+
+    *out_body = body;
     return RAC_SUCCESS;
 }
 
@@ -377,8 +430,9 @@ rac_result_t okhttp_request_send(void* /*user_data*/, const rac_http_request_t* 
             env->DeleteLocalRef(j_url);
         return RAC_ERROR_OUT_OF_MEMORY;
     }
-    jobjectArray j_headers = build_headers_flat(env, req->headers, req->header_count);
-    rac_result_t headers_rc = ensure_headers_array(env, &j_headers);
+    jobjectArray j_headers = nullptr;
+    rac_result_t headers_rc =
+        build_headers_flat(env, req->headers, req->header_count, &j_headers);
     if (headers_rc != RAC_SUCCESS) {
         if (j_method)
             env->DeleteLocalRef(j_method);
@@ -388,19 +442,12 @@ rac_result_t okhttp_request_send(void* /*user_data*/, const rac_http_request_t* 
     }
 
     jbyteArray j_body = nullptr;
-    if (req->body_bytes != nullptr && req->body_len > 0) {
-        j_body = env->NewByteArray(static_cast<jsize>(req->body_len));
-        if (j_body == nullptr) {
-            if (env->ExceptionCheck() == JNI_TRUE) {
-                env->ExceptionClear();
-            }
-            env->DeleteLocalRef(j_method);
-            env->DeleteLocalRef(j_url);
-            env->DeleteLocalRef(j_headers);
-            return RAC_ERROR_OUT_OF_MEMORY;
-        }
-        env->SetByteArrayRegion(j_body, 0, static_cast<jsize>(req->body_len),
-                                reinterpret_cast<const jbyte*>(req->body_bytes));
+    rac_result_t body_rc = build_request_body(env, req, &j_body);
+    if (body_rc != RAC_SUCCESS) {
+        env->DeleteLocalRef(j_method);
+        env->DeleteLocalRef(j_url);
+        env->DeleteLocalRef(j_headers);
+        return body_rc;
     }
 
     jlong j_timeout_ms = static_cast<jlong>(req->timeout_ms);
@@ -554,8 +601,9 @@ rac_result_t okhttp_request_stream(void* /*user_data*/, const rac_http_request_t
             env->DeleteLocalRef(j_url);
         return RAC_ERROR_OUT_OF_MEMORY;
     }
-    jobjectArray j_headers = build_headers_flat(env, req->headers, req->header_count);
-    rac_result_t headers_rc = ensure_headers_array(env, &j_headers);
+    jobjectArray j_headers = nullptr;
+    rac_result_t headers_rc =
+        build_headers_flat(env, req->headers, req->header_count, &j_headers);
     if (headers_rc != RAC_SUCCESS) {
         if (j_method)
             env->DeleteLocalRef(j_method);
@@ -565,19 +613,12 @@ rac_result_t okhttp_request_stream(void* /*user_data*/, const rac_http_request_t
     }
 
     jbyteArray j_body = nullptr;
-    if (req->body_bytes != nullptr && req->body_len > 0) {
-        j_body = env->NewByteArray(static_cast<jsize>(req->body_len));
-        if (j_body == nullptr) {
-            if (env->ExceptionCheck() == JNI_TRUE) {
-                env->ExceptionClear();
-            }
-            env->DeleteLocalRef(j_method);
-            env->DeleteLocalRef(j_url);
-            env->DeleteLocalRef(j_headers);
-            return RAC_ERROR_OUT_OF_MEMORY;
-        }
-        env->SetByteArrayRegion(j_body, 0, static_cast<jsize>(req->body_len),
-                                reinterpret_cast<const jbyte*>(req->body_bytes));
+    rac_result_t body_rc = build_request_body(env, req, &j_body);
+    if (body_rc != RAC_SUCCESS) {
+        env->DeleteLocalRef(j_method);
+        env->DeleteLocalRef(j_url);
+        env->DeleteLocalRef(j_headers);
+        return body_rc;
     }
 
     jlong j_timeout_ms = static_cast<jlong>(req->timeout_ms);
@@ -716,8 +757,9 @@ rac_result_t okhttp_request_resume(void* /*user_data*/, const rac_http_request_t
             env->DeleteLocalRef(j_url);
         return RAC_ERROR_OUT_OF_MEMORY;
     }
-    jobjectArray j_headers = build_headers_flat(env, req->headers, req->header_count);
-    rac_result_t headers_rc = ensure_headers_array(env, &j_headers);
+    jobjectArray j_headers = nullptr;
+    rac_result_t headers_rc =
+        build_headers_flat(env, req->headers, req->header_count, &j_headers);
     if (headers_rc != RAC_SUCCESS) {
         if (j_method)
             env->DeleteLocalRef(j_method);
@@ -727,19 +769,12 @@ rac_result_t okhttp_request_resume(void* /*user_data*/, const rac_http_request_t
     }
 
     jbyteArray j_body = nullptr;
-    if (req->body_bytes != nullptr && req->body_len > 0) {
-        j_body = env->NewByteArray(static_cast<jsize>(req->body_len));
-        if (j_body == nullptr) {
-            if (env->ExceptionCheck() == JNI_TRUE) {
-                env->ExceptionClear();
-            }
-            env->DeleteLocalRef(j_method);
-            env->DeleteLocalRef(j_url);
-            env->DeleteLocalRef(j_headers);
-            return RAC_ERROR_OUT_OF_MEMORY;
-        }
-        env->SetByteArrayRegion(j_body, 0, static_cast<jsize>(req->body_len),
-                                reinterpret_cast<const jbyte*>(req->body_bytes));
+    rac_result_t body_rc = build_request_body(env, req, &j_body);
+    if (body_rc != RAC_SUCCESS) {
+        env->DeleteLocalRef(j_method);
+        env->DeleteLocalRef(j_url);
+        env->DeleteLocalRef(j_headers);
+        return body_rc;
     }
 
     jlong j_timeout_ms = static_cast<jlong>(req->timeout_ms);

--- a/core/src/jni/okhttp_transport_adapter.cpp
+++ b/core/src/jni/okhttp_transport_adapter.cpp
@@ -183,6 +183,37 @@ class ScopedJniEnv {
     bool did_attach_ = false;
 };
 
+rac_result_t build_request_strings(JNIEnv* env, const rac_http_request_t* req,
+                                   jstring* out_method, jstring* out_url) {
+    if (env == nullptr || req == nullptr || req->method == nullptr || req->url == nullptr ||
+        out_method == nullptr || out_url == nullptr) {
+        return RAC_ERROR_INVALID_ARGUMENT;
+    }
+    *out_method = nullptr;
+    *out_url = nullptr;
+
+    jstring method = env->NewStringUTF(req->method);
+    if (method == nullptr || env->ExceptionCheck() == JNI_TRUE) {
+        env->ExceptionClear();
+        if (method != nullptr)
+            env->DeleteLocalRef(method);
+        return RAC_ERROR_OUT_OF_MEMORY;
+    }
+
+    jstring url = env->NewStringUTF(req->url);
+    if (url == nullptr || env->ExceptionCheck() == JNI_TRUE) {
+        env->ExceptionClear();
+        env->DeleteLocalRef(method);
+        if (url != nullptr)
+            env->DeleteLocalRef(url);
+        return RAC_ERROR_OUT_OF_MEMORY;
+    }
+
+    *out_method = method;
+    *out_url = url;
+    return RAC_SUCCESS;
+}
+
 // Helper: turn a string pair list into a jobjectArray<String> for
 // `OkHttpTransport.executeRequest(headersFlat=[k1,v1,...])`.
 rac_result_t build_headers_flat(JNIEnv* env, const rac_http_header_kv_t* headers,
@@ -418,18 +449,11 @@ rac_result_t okhttp_request_send(void* /*user_data*/, const rac_http_request_t* 
     // Build jstring / jobjectArray / jbyteArray args. Always pass a
     // non-null headers array so Kotlin's executeRequest(headersFlat) loop
     // can do a plain `headersFlat.size` check.
-    jstring j_method = env->NewStringUTF(req->method);
-    jstring j_url = env->NewStringUTF(req->url);
-    if (j_method == nullptr || j_url == nullptr) {
-        if (env->ExceptionCheck() == JNI_TRUE) {
-            env->ExceptionClear();
-        }
-        if (j_method)
-            env->DeleteLocalRef(j_method);
-        if (j_url)
-            env->DeleteLocalRef(j_url);
-        return RAC_ERROR_OUT_OF_MEMORY;
-    }
+    jstring j_method = nullptr;
+    jstring j_url = nullptr;
+    rac_result_t strings_rc = build_request_strings(env, req, &j_method, &j_url);
+    if (strings_rc != RAC_SUCCESS)
+        return strings_rc;
     jobjectArray j_headers = nullptr;
     rac_result_t headers_rc =
         build_headers_flat(env, req->headers, req->header_count, &j_headers);
@@ -589,18 +613,11 @@ rac_result_t okhttp_request_stream(void* /*user_data*/, const rac_http_request_t
         return RAC_ERROR_INTERNAL;
     }
 
-    jstring j_method = env->NewStringUTF(req->method);
-    jstring j_url = env->NewStringUTF(req->url);
-    if (j_method == nullptr || j_url == nullptr) {
-        if (env->ExceptionCheck() == JNI_TRUE) {
-            env->ExceptionClear();
-        }
-        if (j_method)
-            env->DeleteLocalRef(j_method);
-        if (j_url)
-            env->DeleteLocalRef(j_url);
-        return RAC_ERROR_OUT_OF_MEMORY;
-    }
+    jstring j_method = nullptr;
+    jstring j_url = nullptr;
+    rac_result_t strings_rc = build_request_strings(env, req, &j_method, &j_url);
+    if (strings_rc != RAC_SUCCESS)
+        return strings_rc;
     jobjectArray j_headers = nullptr;
     rac_result_t headers_rc =
         build_headers_flat(env, req->headers, req->header_count, &j_headers);
@@ -745,18 +762,11 @@ rac_result_t okhttp_request_resume(void* /*user_data*/, const rac_http_request_t
         return RAC_ERROR_INTERNAL;
     }
 
-    jstring j_method = env->NewStringUTF(req->method);
-    jstring j_url = env->NewStringUTF(req->url);
-    if (j_method == nullptr || j_url == nullptr) {
-        if (env->ExceptionCheck() == JNI_TRUE) {
-            env->ExceptionClear();
-        }
-        if (j_method)
-            env->DeleteLocalRef(j_method);
-        if (j_url)
-            env->DeleteLocalRef(j_url);
-        return RAC_ERROR_OUT_OF_MEMORY;
-    }
+    jstring j_method = nullptr;
+    jstring j_url = nullptr;
+    rac_result_t strings_rc = build_request_strings(env, req, &j_method, &j_url);
+    if (strings_rc != RAC_SUCCESS)
+        return strings_rc;
     jobjectArray j_headers = nullptr;
     rac_result_t headers_rc =
         build_headers_flat(env, req->headers, req->header_count, &j_headers);


### PR DESCRIPTION
## Description
The OkHttp transport adapter's request entry points (`okhttp_request_send`, `okhttp_request_stream`, `okhttp_request_resume`) marshaled the method, URL, and body into JVM objects without checking the results:

- `NewStringUTF(req->method)` / `NewStringUTF(req->url)` returning `NULL` were passed straight into `CallStaticObjectMethod`, so a failed allocation surfaced later as a thrown exception translated into a generic `RAC_ERROR_NETWORK_ERROR`.
- For a non-empty request body, a failed `NewByteArray()` left `j_body == nullptr` and execution **continued**, invoking the transport without the body that commons supplied (a POST/PUT can ship bodyless) — or, if the OOM exception was still pending, producing a generic network error.

All three entry points now reject incomplete marshaling consistently: if either the method or URL string cannot be created, or `NewByteArray` fails while a non-empty body is required, the pending JNI exception is cleared, the created local references are released, and `RAC_ERROR_OUT_OF_MEMORY` is returned before the Kotlin side is invoked. The `SetByteArrayRegion` fill and all other behavior are unchanged.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Lint passes locally
- [ ] Added/updated tests for changes (no new tests per repo guidance)

Local:
- `git diff --check` — clean.
- `g++ -std=c++20 -fsyntax-only` of the edited marshaling block against a minimal local `JNIEnv` stand-in — exit 0.
- Full Android compile cannot run on this Windows host (no NDK `jni.h`/`android/log.h`); the `pr-build.yml` Android build is the authoritative gate.

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device) — not run (no macOS host)
- [ ] Tested on iPad / Tablet — not run
- [ ] Tested on Mac (macOS target) — not run

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device) — not run (no Android toolchain on this host)
- [ ] Tested on Android Tablet — not run

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS — not run
- [ ] Tested on Android — not run

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS — not run
- [ ] Tested on Android — not run

**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop) — not run
- [ ] Tested in Firefox — not run
- [ ] Tested in Safari — not run
- [ ] WASM backends load (LlamaCpp + ONNX) — not run
- [ ] OPFS storage persistence verified (survives page refresh) — not run
- [ ] Settings persistence verified (localStorage) — not run

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`bindings/swift`)
- [x] `Kotlin SDK` - Changes to Kotlin SDK (`bindings/kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`bindings/flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`bindings/react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`bindings/web`)
- [ ] `Commons` - Changes to shared native code (`core`)

**Sample Apps:**
- [ ] `Flutter Sample` - Changes to Flutter example app (`bindings/flutter/example`)
- [ ] `React Native Sample` - Changes to React Native example app (`bindings/react-native/example`)
- [ ] `Minimal Examples` - Changes to an in-repo SDK harness (`bindings/{swift,kotlin,web}/example`)

The iOS, Android, Web, and Electron consumer apps live in their own
repositories (`RunanywhereAI/runanywhere-{ios,android,web,electron}`) — open
those PRs there.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed) — no public API contract change

## Screenshots
Attach relevant UI screenshots for changes (if applicable):
- Mobile (Phone)
- Tablet / iPad
- Desktop / Mac


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when creating network requests with headers or request bodies.
  * Prevented incomplete requests when request data is invalid, too large, or cannot be allocated.
  * Added clearer error handling for request-construction failures.
  * Ensured temporary resources are released when requests cannot be created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->