### PR TITLE
fix(rag): initialize the LLM service a RAG session creates

### DIFF
--- a/core/src/features/rag/rac_rag_proto_abi.cpp
+++ b/core/src/features/rag/rac_rag_proto_abi.cpp
@@ -785,6 +785,17 @@ rac_result_t rac_rag_session_create_proto(const uint8_t* config_proto_bytes,
             publish_failure(rc, "rag.sessionCreate", rac_error_message(rc));
             return rc;
         }
+        // `create` only builds the session; backends that defer the weight load
+        // (MLX) finish it in `initialize`, so generation would fail here with
+        // "model is not loaded". Same reason HttpServer::loadModel calls this
+        // (#735) and llm_create_service has always called it.
+        rc = rac_llm_initialize(llm_handle, llm_path.c_str());
+        if (rc != RAC_SUCCESS) {
+            rac_llm_destroy(llm_handle);
+            rac_embeddings_destroy(embed_handle);
+            publish_failure(rc, "rag.sessionCreate", rac_error_message(rc));
+            return rc;
+        }
     }
 
     try {


### PR DESCRIPTION
## What is wrong

#735 fixed this in `HttpServer::loadModel` and stated the rule in its comment: `rac_llm_create()` only routes to the plugin's `create` op, and a backend that defers the weight load to `initialize` (MLX) is not loaded when it returns. llama.cpp loads synchronously inside `create`, which is why the omission stays invisible until another backend reaches `generate`.

`rac_rag_session_create_proto` has the same shape. It creates the session's generation model:

```cpp
rc = rac_llm_create(llm_path.c_str(), &llm_handle);
```

and hands that handle straight to `RAGBackend`:

```cpp
session->backend = std::make_unique<RAGBackend>(backend_config, llm_handle, embed_handle, ...);
```

`rac_llm_initialize` does not appear anywhere in `rac_rag_proto_abi.cpp`. The handle is then driven directly through:

- `rag_pipeline_graph.cpp:85` (`rac_llm_generate`)
- `rag_pipeline_graph.cpp:357` (`rac_llm_generate_stream`)
- `rag_rerank.cpp:121` (`rac_llm_generate`)

So a RAG session backed by MLX fails at generation with "model is not loaded", for exactly the reason the server did.

## Why I am confident this is the same defect and not a deliberate difference

I checked every `rac_llm_create` call site in the tree. There are four, and the other three settle the question:

| call site | calls `rac_llm_initialize`? |
|---|---|
| `llm_module.cpp:335` (`llm_create_service`) | yes, and always has |
| `http_server.cpp:309` | yes, as of #735 |
| `rac_rag_proto_abi.cpp:781` | **no** |
| `core/tests/test_advanced_modality_proto_abi.cpp:1149` | test |

## What this does

Adds the `initialize` call, with the same failure handling as the sibling early-out just above it: destroy the LLM handle, release the embedding service created a few lines earlier, and publish the same `rag.sessionCreate` failure the other early-outs publish. 11 lines.

## Verification

Built and ran the full commons suite on this branch:

```
cmake -B build -DRAC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
cmake --build build -j$(sysctl -n hw.logicalcpu)   # clean, 0 errors
ctest --test-dir build -j4                          # 100% tests passed out of 100
```

No test added, and I want to be straight about why: reproducing the failure needs a backend whose `create` defers the load, which in practice means MLX. The commons suite has no such backend, so a test here would either need a fake plugin built for this one case or would pass on llamacpp whether or not the fix is present. #735 added no test for the same reason. What I did instead was enumerate the call sites above, so the claim rests on the invariant the other three already follow rather than on a test that cannot distinguish the two states.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * RAG sessions now correctly initialize the language model service with the resolved model path.
  * Session creation now stops cleanly when model initialization fails.
  * Failed session creation also properly releases associated language model and embedding resources.
  * Clear failure handling prevents partially initialized RAG sessions from being created.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->