### PR TITLE
fix(jni): clear a pending exception thrown by app-supplied router callbacks

### DIFF
--- a/core/src/jni/rac_hybrid_custom_filter_jni.cpp
+++ b/core/src/jni/rac_hybrid_custom_filter_jni.cpp
@@ -101,6 +101,15 @@ rac_bool_t custom_filter_predicate(const rac_hybrid_routing_context_t* ctx, void
     }
     const jboolean keep = scope.env->CallBooleanMethod(a->predicate, a->mid_evaluate, model_id);
     scope.env->DeleteLocalRef(model_id);
+    // The predicate is app code. A throw leaves `keep` undefined and, worse,
+    // leaves the exception pending on this thread: the next JNI call made by
+    // whoever we return into aborts the process with "JNI called with pending
+    // exception". Clear it and keep the candidate, the same answer this
+    // function already gives when it cannot reach the JVM at all.
+    if (scope.env->ExceptionCheck() == JNI_TRUE) {
+        scope.env->ExceptionClear();
+        return RAC_TRUE;
+    }
     return keep != JNI_FALSE ? RAC_TRUE : RAC_FALSE;
 }
 

--- a/core/src/jni/rac_hybrid_device_state_jni.cpp
+++ b/core/src/jni/rac_hybrid_device_state_jni.cpp
@@ -81,7 +81,16 @@ bool device_state_is_online(void* user_data) {
     if (scope.env == nullptr) {
         return true;
     }
-    return scope.env->CallBooleanMethod(a->provider, a->mid_is_online) != JNI_FALSE;
+    const jboolean online = scope.env->CallBooleanMethod(a->provider, a->mid_is_online);
+    // The provider is app code. A throw leaves the exception pending on this
+    // thread, and the next JNI call aborts the process with "JNI called with
+    // pending exception", so clear it and fall back to the same answer used
+    // when the JVM is unreachable.
+    if (scope.env->ExceptionCheck() == JNI_TRUE) {
+        scope.env->ExceptionClear();
+        return true;
+    }
+    return online != JNI_FALSE;
 }
 
 int32_t device_state_battery_percent(void* user_data) {
@@ -93,7 +102,12 @@ int32_t device_state_battery_percent(void* user_data) {
     if (scope.env == nullptr) {
         return 100;
     }
-    return static_cast<int32_t>(scope.env->CallIntMethod(a->provider, a->mid_battery_percent));
+    const jint percent = scope.env->CallIntMethod(a->provider, a->mid_battery_percent);
+    if (scope.env->ExceptionCheck() == JNI_TRUE) {
+        scope.env->ExceptionClear();
+        return 100;
+    }
+    return static_cast<int32_t>(percent);
 }
 
 bool device_state_is_thermal_throttled(void* user_data) {
@@ -105,7 +119,12 @@ bool device_state_is_thermal_throttled(void* user_data) {
     if (scope.env == nullptr) {
         return false;
     }
-    return scope.env->CallBooleanMethod(a->provider, a->mid_is_thermal_throttled) != JNI_FALSE;
+    const jboolean throttled = scope.env->CallBooleanMethod(a->provider, a->mid_is_thermal_throttled);
+    if (scope.env->ExceptionCheck() == JNI_TRUE) {
+        scope.env->ExceptionClear();
+        return false;
+    }
+    return throttled != JNI_FALSE;
 }
 
 /** Detach commons from the current adapter and free its GlobalRef. */


### PR DESCRIPTION
## What is wrong

Four JNI callbacks invoke app-supplied Java and never check for a pending exception:

| site | call |
|---|---|
| `rac_hybrid_custom_filter_jni.cpp:102` | `predicate.evaluate(modelId)` |
| `rac_hybrid_device_state_jni.cpp:84` | `provider.isOnline()` |
| `rac_hybrid_device_state_jni.cpp:96` | `provider.batteryPercent()` |
| `rac_hybrid_device_state_jni.cpp:108` | `provider.isThermalThrottled()` |

Both objects are registered by the host app: a routing predicate and a device-state provider. For example:

```cpp
return scope.env->CallBooleanMethod(a->provider, a->mid_is_online) != JNI_FALSE;
```

If that method throws, `CallBooleanMethod` returns a default **and the exception stays pending on the thread**. The garbage routing input is the small part. The real cost is that the next JNI call made by whoever we return into aborts the process with `JNI called with pending exception`. The hybrid router invokes these on ordinary routing decisions, so an NPE inside an app's `isOnline()` brings the process down somewhere unrelated to the app code that caused it.

## Why these four and not others

I checked every JNI source that calls into Java. These two files were the only ones with `Call*Method` and zero exception checks:

| file | `Call*Method` | `ExceptionCheck` / `ExceptionOccurred` |
|---|---|---|
| `okhttp_transport_adapter.cpp` | 3 | 13 |
| `runanywhere_commons_jni.cpp` | 40 | 35 |
| `rac_cloud_stt_provider_jni.cpp` | 1 | 1 |
| `rac_hybrid_custom_filter_jni.cpp` | 1 | **0** |
| `rac_hybrid_device_state_jni.cpp` | 3 | **0** |

So this is a gap against the convention the rest of the JNI layer already follows, not a new policy.

## What this does

Checks and clears, using the same idiom as `okhttp_transport_adapter.cpp`:

```cpp
if (scope.env->ExceptionCheck() == JNI_TRUE) {
    scope.env->ExceptionClear();
    return /* documented fallback */;
}
```

The fallback per site is the value the function **already** returns when it cannot reach the JVM at all: keep the candidate, online, 100 percent battery, not throttled. So a throwing provider degrades exactly as far as an unreachable JVM already does, and no further.

## Verification, and one limit I want to be straight about

These files are Android-only and are **not** part of the macOS commons build, so I could not run the usual `cmake`/`ctest` gate over them. What I did run is a real type check rather than a parse, using the JDK's own `jni.h`:

```
clang++ -fsyntax-only -std=c++20 \
  -I$JAVA_HOME/include -I$JAVA_HOME/include/darwin \
  -Icore/include -Icore/src \
  core/src/jni/rac_hybrid_device_state_jni.cpp     # rc=0
  core/src/jni/rac_hybrid_custom_filter_jni.cpp    # rc=0
```

I confirmed that check actually bites by introducing a deliberate typo, which it caught (`error: use of undeclared identifier 'JNI_FALSE_TYPO'`), so rc=0 means the edits type-check and not that the compiler skipped the file. The `kotlin-android` job is the authoritative gate here and will compile them for real.

No test added: reproducing this needs a Java provider that throws, driven through a live JNI attach on a device, which the commons suite cannot host.

One judgement call worth flagging: I clear the exception without logging it, matching the existing okhttp idiom, because neither file currently includes the logger and I did not want to widen the diff into a hot routing path. If you would rather these log once before clearing, say so and I will add it.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved resilience when custom predicates encounter exceptions.
  * Prevented device-state checks from failing when provider callbacks throw errors.
  * Preserved safe fallback values for connectivity, battery level, and thermal throttling status.
  * Ensured normal behavior remains unchanged when predicates and device-state providers complete successfully.
  * Improved application stability when background checks encounter unexpected errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->