### PR TITLE
fix(rcli): fail when `voice --output` cannot be written

### DIFF
--- a/rcli/src/commands/cmd_voice.cpp
+++ b/rcli/src/commands/cmd_voice.cpp
@@ -118,7 +118,13 @@ int run_voice(const GlobalOptions& options, const std::string& input, const std:
             if (file.good()) {
                 reply_path = output;
             } else {
-                out::status_line("warning: cannot write " + output);
+                // A requested --output that cannot be written is a runtime error,
+                // not a warning: `rcli tts --output` already exits 1 for exactly
+                // this (cmd_tts.cpp), and a caller doing
+                // `rcli voice --output reply.wav && play reply.wav` otherwise
+                // proceeds against a file that is not there.
+                out::error_line("cannot write " + output);
+                exit_code = 1;
             }
         }
 

--- a/rcli/src/commands/cmd_voice.cpp
+++ b/rcli/src/commands/cmd_voice.cpp
@@ -128,19 +128,27 @@ int run_voice(const GlobalOptions& options, const std::string& input, const std:
             }
         }
 
-        if (options.json) {
-            out::JsonWriter json;
-            json.begin_object()
-                .field("transcription", result.transcription())
-                .field("response", result.assistant_response())
-                .field("reply_audio", reply_path)
-                .end_object();
-            out::result_line(json.str());
-        } else {
-            out::result_line("you   " + result.transcription());
-            out::result_line("agent " + result.assistant_response());
-            if (!reply_path.empty()) {
-                out::result_line("audio " + reply_path);
+        // Only a turn that fully succeeded prints a result. cmd_tts.cpp emits
+        // its result in the `else if` branch of the same write check, so a
+        // failed --output write there produces an error and nothing else; a
+        // success-shaped line next to exit 1 would let
+        // `rcli voice --json -o reply.wav | jq -r .reply_audio` read an empty
+        // path as if the turn had produced no audio.
+        if (exit_code == 0) {
+            if (options.json) {
+                out::JsonWriter json;
+                json.begin_object()
+                    .field("transcription", result.transcription())
+                    .field("response", result.assistant_response())
+                    .field("reply_audio", reply_path)
+                    .end_object();
+                out::result_line(json.str());
+            } else {
+                out::result_line("you   " + result.transcription());
+                out::result_line("agent " + result.assistant_response());
+                if (!reply_path.empty()) {
+                    out::result_line("audio " + reply_path);
+                }
             }
         }
     }


### PR DESCRIPTION
## What is wrong

`rcli voice --output reply.wav` exits 0 when it cannot write the file.

`cmd_voice.cpp:115-121`:

```cpp
std::ofstream file(output, std::ios::binary);
file.write(result.synthesized_audio().data(), ...);
if (file.good()) {
    reply_path = output;
} else {
    out::status_line("warning: cannot write " + output);
}
```

`exit_code` is never touched, so the command returns 0. In `--json` mode the object then reports `"reply_audio": ""`, which a consumer cannot distinguish from a turn that produced no audio at all. A caller doing

```sh
rcli voice --output reply.wav && play reply.wav
```

proceeds against a file that is not there, with only a line on stderr that a script capturing stdout never sees.

## Why this is the outlier and not a policy

`main.cpp` states the contract in its header comment:

> Exit codes: 0 success, 1 runtime/SDK error, 2 usage error.

Both sibling commands that write a user-requested output file already follow it:

| command | write failure | exit |
|---|---|---|
| `tts` (`cmd_tts.cpp:105`) | `out::error_line(error)` | **1** |
| `image` (`cmd_image.cpp:156`) | returns false with `"cannot write " + out_path` | **1** |
| `voice` (`cmd_voice.cpp:119`) | `out::status_line("warning: ...")` | **0** |

`tts` is the closest analogue: synthesis succeeded, only the file write failed, and it still exits 1. There is no comment anywhere justifying the difference, so this reads as an oversight rather than an intentional split.

## What this does

Reports the failure through `error_line` and sets `exit_code = 1`, matching `tts`. Seven lines, one of them the actual change.

The turn's text output is unaffected: transcription and response still print, so a user running interactively loses nothing and a script now learns that the file it asked for does not exist.

If you would rather keep exit 0 because the voice turn itself succeeded, the alternative fix is to leave the code and make the JSON distinguishable instead (a `reply_audio_error` field). I went with matching `tts` because the exit-code contract is documented and two of three commands already implement it that way.

## Verification

Built with the CLI enabled and ran the whole suite:

```
cmake -B build-cli -DRAC_BUILD_CLI=ON -DRAC_DESKTOP_ADAPTER=ON -DRAC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
cmake --build build-cli -j$(sysctl -n hw.logicalcpu)   # 0 errors; cmd_voice.cpp.o rebuilt, rcli linked
ctest --test-dir build-cli                            # 100% tests passed out of 107
```

(`RAC_BUILD_CLI` defaults to OFF, so a plain `cmake -B build -DRAC_BUILD_TESTS=ON` does not compile this file at all. I mention it because I initially built without it and had to redo the gate; `-DRAC_DESKTOP_ADAPTER=ON` is also required or rcli's CMakeLists fails outright.)

No test added: exercising this needs a loaded voice-agent model plus an unwritable destination, which the rcli suite does not set up. The change is a one-line contract alignment with `cmd_tts`, and the enumeration above is what the claim rests on.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Voice commands now clearly report output-write failures.
  * The command exits with a failure status and suppresses result output when voice output cannot be written.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->