### PR TITLE
feat(catalog): add Qwen3.5 rows to the Flutter and RN examples

### DIFF
--- a/bindings/flutter/example/lib/core/services/model_catalog_bootstrap.dart
+++ b/bindings/flutter/example/lib/core/services/model_catalog_bootstrap.dart
@@ -116,6 +116,33 @@ abstract final class ModelCatalogBootstrap {
       memoryRequirement: 2800000000,
       supportsThinking: true,
     );
+    await _registerLLM(
+      id: 'qwen3.5-0.8b-q4_k_m',
+      name: 'Qwen3.5 0.8B Q4_K_M',
+      url:
+          'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf',
+      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+      memoryRequirement: 900000000,
+      supportsThinking: true,
+    );
+    await _registerLLM(
+      id: 'qwen3.5-2b-q4_k_m',
+      name: 'Qwen3.5 2B Q4_K_M',
+      url:
+          'https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf',
+      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+      memoryRequirement: 1800000000,
+      supportsThinking: true,
+    );
+    await _registerLLM(
+      id: 'qwen3.5-4b-q4_k_m',
+      name: 'Qwen3.5 4B Q4_K_M',
+      url:
+          'https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf',
+      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+      memoryRequirement: 3200000000,
+      supportsThinking: true,
+    );
 
     // LFM2 / LFM2.5 (Liquid AI)
     // LFM2.5-230M on the CPU. Q4_K_M, not the fractionally smaller Q4_0

--- a/bindings/flutter/example/lib/core/services/model_catalog_bootstrap.dart
+++ b/bindings/flutter/example/lib/core/services/model_catalog_bootstrap.dart
@@ -1,9 +1,7 @@
 import 'dart:io';
 
-import 'package:fixnum/fixnum.dart';
 import 'package:flutter/foundation.dart';
 import 'package:runanywhere/runanywhere.dart';
-import 'package:runanywhere/runanywhere_protos.dart' as proto;
 import 'package:runanywhere_ai/core/services/hf_token_store.dart';
 import 'package:runanywhere_ai/core/services/qhexrt_model_catalog.dart';
 
@@ -55,67 +53,6 @@ abstract final class ModelCatalogBootstrap {
     debugPrint('Registering modules with their models...');
 
     await _applyPersistedHfToken();
-
-    // --- LLM models (LlamaCpp backend) ------------------------------------
-    // Grouped by model family; every family ordered small → large.
-
-    // SmolLM2 (HuggingFace)
-    await _registerLLM(
-      id: 'smollm2-360m-q8_0',
-      name: 'SmolLM2 360M Q8_0',
-      url:
-          'https://huggingface.co/prithivMLmods/SmolLM2-360M-GGUF/resolve/main/SmolLM2-360M.Q8_0.gguf',
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      memoryRequirement: 386404416,
-    );
-
-    // Qwen — 2.5 first, then 3, small → large inside each generation.
-    await _registerLLM(
-      id: 'qwen2.5-0.5b-instruct-q6_k',
-      name: 'Qwen 2.5 0.5B Instruct Q6_K',
-      url:
-          'https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q6_k.gguf',
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      memoryRequirement: 600000000,
-      // Base model of the seeded abliterated adapter
-      // (qwen2.5-0.5b-abliterated-lora-f16.gguf) — matches iOS/Android.
-      supportsLora: true,
-    );
-    await _registerLLM(
-      id: 'qwen2.5-1.5b-instruct-q4_k_m',
-      name: 'Qwen 2.5 1.5B Instruct Q4_K_M',
-      url:
-          'https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/main/qwen2.5-1.5b-instruct-q4_k_m.gguf',
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      memoryRequirement: 2500000000,
-    );
-    await _registerLLM(
-      id: 'qwen3-0.6b-q4_k_m',
-      name: 'Qwen3 0.6B Q4_K_M',
-      url:
-          'https://huggingface.co/unsloth/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q4_K_M.gguf',
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      memoryRequirement: 500000000,
-      supportsThinking: true,
-    );
-    await _registerLLM(
-      id: 'qwen3-1.7b-q4_k_m',
-      name: 'Qwen3 1.7B Q4_K_M',
-      url:
-          'https://huggingface.co/unsloth/Qwen3-1.7B-GGUF/resolve/main/Qwen3-1.7B-Q4_K_M.gguf',
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      memoryRequirement: 1200000000,
-      supportsThinking: true,
-    );
-    await _registerLLM(
-      id: 'qwen3-4b-q4_k_m',
-      name: 'Qwen3 4B Q4_K_M',
-      url:
-          'https://huggingface.co/unsloth/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q4_K_M.gguf',
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      memoryRequirement: 2800000000,
-      supportsThinking: true,
-    );
     await _registerLLM(
       id: 'qwen3.5-0.8b-q4_k_m',
       name: 'Qwen3.5 0.8B Q4_K_M',
@@ -144,6 +81,66 @@ abstract final class ModelCatalogBootstrap {
       supportsThinking: true,
     );
 
+    // Added from the verified model list
+    await _registerLLM(
+      id: 'lfm2.5-1.2b-thinking-q4_k_m',
+      name: 'LFM2.5 1.2B Thinking Q4_K_M',
+      url:
+          'https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF/resolve/main/LFM2.5-1.2B-Thinking-Q4_K_M.gguf',
+      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+      memoryRequirement: 900000000,
+      supportsThinking: true,
+    );
+    await _registerLLM(
+      id: 'lfm2.5-2.6b-q4_k_m',
+      name: 'LFM2.5 2.6B Q4_K_M',
+      url:
+          'https://huggingface.co/LiquidAI/LFM2.5-2.6B-GGUF/resolve/main/LFM2.5-2.6B-Q4_K_M.gguf',
+      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+      memoryRequirement: 2050000000,
+      supportsThinking: true,
+    );
+    await _registerLLM(
+      id: 'granite-4.1-8b-q4_k_m',
+      name: 'IBM Granite 4.1 8B Q4_K_M',
+      url:
+          'https://huggingface.co/unsloth/granite-4.1-8b-GGUF/resolve/main/granite-4.1-8b-Q4_K_M.gguf',
+      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+      memoryRequirement: 6500000000,
+    );
+    await _registerLLM(
+      id: 'qwen3.5-9b-q4_k_m',
+      name: 'Qwen3.5 9B Q4_K_M',
+      url:
+          'https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q4_K_M.gguf',
+      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+      memoryRequirement: 6950000000,
+      supportsThinking: true,
+    );
+    await _registerLLM(
+      id: 'bonsai-1.7b-q1_0',
+      name: 'PrismML Bonsai 1.7B (1-bit)',
+      url:
+          'https://huggingface.co/prism-ml/Bonsai-1.7B-gguf/resolve/main/Bonsai-1.7B-Q1_0.gguf',
+      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+      memoryRequirement: 300000000,
+    );
+    await _registerLLM(
+      id: 'bonsai-4b-q1_0',
+      name: 'PrismML Bonsai 4B (1-bit)',
+      url:
+          'https://huggingface.co/prism-ml/Bonsai-4B-gguf/resolve/main/Bonsai-4B-Q1_0.gguf',
+      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+      memoryRequirement: 700000000,
+    );
+    await _registerLLM(
+      id: 'bonsai-8b-q1_0',
+      name: 'PrismML Bonsai 8B (1-bit)',
+      url:
+          'https://huggingface.co/prism-ml/Bonsai-8B-gguf/resolve/main/Bonsai-8B-Q1_0.gguf',
+      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+      memoryRequirement: 1400000000,
+    );
     // LFM2 / LFM2.5 (Liquid AI)
     // LFM2.5-230M on the CPU. Q4_K_M, not the fractionally smaller Q4_0
     // (149 MB vs 153 MB): 4 MB buys K-quant mixed precision on the
@@ -158,18 +155,6 @@ abstract final class ModelCatalogBootstrap {
       // 153,406,304 B of weights plus KV cache and runtime overhead.
       memoryRequirement: 190000000,
     );
-    // ONE quantization per model. The Q8_0 sibling of this row was removed
-    // deliberately: two quants of the same 350M model differ only in bytes
-    // (229 MB vs 379 MB), so the second row costs a catalog slot and a
-    // "which one do I pick?" decision without adding a capability.
-    await _registerLLM(
-      id: 'lfm2-350m-q4_k_m',
-      name: 'LiquidAI LFM2 350M Q4_K_M',
-      url:
-          'https://huggingface.co/LiquidAI/LFM2-350M-GGUF/resolve/main/LFM2-350M-Q4_K_M.gguf',
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      memoryRequirement: 250000000,
-    );
     await _registerLLM(
       id: 'lfm2.5-1.2b-instruct-q4_k_m',
       name: 'LiquidAI LFM2.5 1.2B Instruct Q4_K_M',
@@ -177,44 +162,6 @@ abstract final class ModelCatalogBootstrap {
           'https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF/resolve/main/LFM2.5-1.2B-Instruct-Q4_K_M.gguf',
       framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
       memoryRequirement: 900000000,
-    );
-    // Same one-quant-per-model rule: the Q8_0 sibling of this row was removed
-    // (1.4 GB vs 800 MB for identical capability).
-    await _registerLLM(
-      id: 'lfm2-1.2b-tool-q4_k_m',
-      name: 'LiquidAI LFM2 1.2B Tool Q4_K_M',
-      url:
-          'https://huggingface.co/LiquidAI/LFM2-1.2B-Tool-GGUF/resolve/main/LFM2-1.2B-Tool-Q4_K_M.gguf',
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      memoryRequirement: 800000000,
-    );
-
-    // Llama (Meta)
-    await _registerLLM(
-      id: 'llama-3.2-3b-instruct-q4_k_m',
-      name: 'Llama 3.2 3B Instruct Q4_K_M (Tool Calling)',
-      url:
-          'https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF/resolve/main/Llama-3.2-3B-Instruct-Q4_K_M.gguf',
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      memoryRequirement: 2000000000,
-    );
-    await _registerLLM(
-      id: 'llama-2-7b-chat-q4_k_m',
-      name: 'Llama 2 7B Chat Q4_K_M',
-      url:
-          'https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q4_K_M.gguf',
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      memoryRequirement: 4000000000,
-    );
-
-    // Mistral
-    await _registerLLM(
-      id: 'mistral-7b-instruct-q4_k_m',
-      name: 'Mistral 7B Instruct Q4_K_M',
-      url:
-          'https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf',
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      memoryRequirement: 4000000000,
     );
 
     // Gemma 4 (Google) — phone-scale MatFormer sizes only (E2B/E4B). The
@@ -300,46 +247,6 @@ abstract final class ModelCatalogBootstrap {
       modality: ModelCategory.MODEL_CATEGORY_MULTIMODAL,
       archive: ArchiveType.ARCHIVE_TYPE_TAR_GZ,
       structure: ArchiveStructure.ARCHIVE_STRUCTURE_DIRECTORY_BASED,
-      memoryRequirement: 600000000,
-    );
-    // Qwen2-VL
-    await _registerMultiFile(
-      id: 'qwen2-vl-2b-instruct-q4_k_m',
-      name: 'Qwen2-VL 2B Instruct',
-      files: [
-        (
-          url:
-              'https://huggingface.co/ggml-org/Qwen2-VL-2B-Instruct-GGUF/resolve/main/Qwen2-VL-2B-Instruct-Q4_K_M.gguf',
-          filename: 'Qwen2-VL-2B-Instruct-Q4_K_M.gguf',
-        ),
-        (
-          url:
-              'https://huggingface.co/ggml-org/Qwen2-VL-2B-Instruct-GGUF/resolve/main/mmproj-Qwen2-VL-2B-Instruct-Q8_0.gguf',
-          filename: 'mmproj-Qwen2-VL-2B-Instruct-Q8_0.gguf',
-        ),
-      ],
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      modality: ModelCategory.MODEL_CATEGORY_MULTIMODAL,
-      memoryRequirement: 1800000000,
-    );
-    // LFM2-VL (Liquid AI)
-    await _registerMultiFile(
-      id: 'lfm2-vl-450m-q8_0',
-      name: 'LFM2-VL 450M',
-      files: [
-        (
-          url:
-              'https://huggingface.co/runanywhere/LFM2-VL-450M-GGUF/resolve/main/LFM2-VL-450M-Q8_0.gguf',
-          filename: 'LFM2-VL-450M-Q8_0.gguf',
-        ),
-        (
-          url:
-              'https://huggingface.co/runanywhere/LFM2-VL-450M-GGUF/resolve/main/mmproj-LFM2-VL-450M-Q8_0.gguf',
-          filename: 'mmproj-LFM2-VL-450M-Q8_0.gguf',
-        ),
-      ],
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-      modality: ModelCategory.MODEL_CATEGORY_MULTIMODAL,
       memoryRequirement: 600000000,
     );
     // Fara (Microsoft)
@@ -465,9 +372,8 @@ abstract final class ModelCatalogBootstrap {
     }
 
     // --- LoRA adapters ------------------------------------------------------
-    // Mirrors iOS `registerLoraAdapters` / Android `ModelBootstrap.seedLora`.
-    await _registerLoraAdapters();
-    debugPrint('LoRA adapters registered');
+    // Not registered: the only adapter shipped is trained for qwen2.5-0.5b,
+    // which this catalog no longer carries. Re-add both together.
 
     // --- QHexRT (Hexagon NPU) bundles ---------------------------------------
     // Native QHexRT probes the device, chooses the exact Hexagon bundle, and
@@ -482,16 +388,6 @@ abstract final class ModelCatalogBootstrap {
   /// One proven model per supported modality keeps the Flutter example useful
   /// without duplicating the full iOS catalog.
   static Future<void> _registerAppleMlxModels() async {
-    // --- MLX LLM (Apple Metal) --------------------------------------------
-    // Qwen
-    await _registerLLM(
-      id: 'mlx-qwen3-0.6b-4bit',
-      name: 'MLX Qwen3 0.6B 4bit',
-      url: 'https://huggingface.co/mlx-community/Qwen3-0.6B-4bit',
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_MLX,
-      memoryRequirement: 650000000,
-      supportsThinking: true,
-    );
     // LFM2.5 (Liquid AI)
     // A PLAIN REPO ref, not a `/4bit` subfolder ref like LFM2.5-2.6B-MLX.
     // LiquidAI publishes one precision per repo here — the 4-bit weights sit
@@ -514,17 +410,6 @@ abstract final class ModelCatalogBootstrap {
       framework: InferenceFramework.INFERENCE_FRAMEWORK_MLX,
       memoryRequirement: 5129115752,
       supportsThinking: true,
-    );
-
-    // --- MLX VLM (multimodal) ---------------------------------------------
-    // Qwen2-VL
-    await _registerLLM(
-      id: 'mlx-qwen2-vl-2b-instruct-4bit',
-      name: 'MLX Qwen2-VL 2B Instruct 4bit',
-      url: 'https://huggingface.co/mlx-community/Qwen2-VL-2B-Instruct-4bit',
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_MLX,
-      modality: ModelCategory.MODEL_CATEGORY_MULTIMODAL,
-      memoryRequirement: 2200000000,
     );
 
     // --- MLX STT ----------------------------------------------------------
@@ -633,62 +518,6 @@ abstract final class ModelCatalogBootstrap {
       return;
     }
     RunAnywhere.setHfToken(token);
-  }
-
-  /// Seed the curated LoRA adapter catalog. `LoraAdapterCatalogEntry` no
-  /// longer carries url/filename/size/description (idl/lora_options.proto:
-  /// "everything generic about the artifact ... lives on the ModelInfo
-  /// record for this adapter"), so those fields move onto a companion
-  /// [ModelInfo] artifact passed to `RunAnywhere.lora.register` alongside the
-  /// catalog entry. Mirrors iOS `RunAnywhere+LoRADownload.swift`/Web
-  /// `RunAnywhere+LoRA.ts`'s `toLoraArtifactModelInfo`. Does not fetch bytes;
-  /// safe to re-run on every cold launch.
-  static Future<void> _registerLoraAdapters() async {
-    const adapterId = 'abliterated-lora';
-    const artifactUrl =
-        'https://huggingface.co/Void2377/qwen-lora-gguf/resolve/main/qwen2.5-0.5b-abliterated-lora-f16.gguf';
-    const artifactFilename = 'qwen2.5-0.5b-abliterated-lora-f16.gguf';
-    const artifactSizeBytes = 17620224;
-
-    final adapter = LoraAdapterCatalogEntry(
-      id: adapterId,
-      name: 'Abliterated LoRA (F16)',
-      compatibleModels: ['qwen2.5-0.5b-instruct-q6_k'],
-      defaultScale: 1.0,
-    );
-    final artifact = proto.ModelInfo(
-      id: 'lora-adapter:$adapterId',
-      name: adapter.name,
-      category: ModelCategory.MODEL_CATEGORY_UNSPECIFIED,
-      format: ModelFormat.MODEL_FORMAT_GGUF,
-      framework: InferenceFramework.INFERENCE_FRAMEWORK_UNKNOWN,
-      downloadUrl: artifactUrl,
-      downloadSizeBytes: Int64(artifactSizeBytes),
-      source: ModelSource.MODEL_SOURCE_REMOTE,
-      singleFile: proto.SingleFileArtifact(
-        expectedFiles: proto.ExpectedModelFiles(
-          files: [
-            ModelFileDescriptor(
-              url: artifactUrl,
-              filename: artifactFilename,
-              sizeBytes: Int64(artifactSizeBytes),
-              role: proto.ModelFileRole.MODEL_FILE_ROLE_PRIMARY_MODEL,
-            ),
-          ],
-          requiredPatterns: [artifactFilename],
-          description: 'LoRA adapter artifact',
-        ),
-      ),
-      metadata: proto.ModelInfoMetadata(
-        description:
-            'Removes refusal behavior — model answers directly without disclaimers',
-      ),
-    );
-    try {
-      await RunAnywhere.lora.register(adapter, artifact);
-    } catch (e) {
-      debugPrint('Failed to register LoRA adapter: $e');
-    }
   }
 
   // --- Registration helpers (mirror iOS registerLLM/registerArchive/

--- a/bindings/flutter/example/lib/generated/solutions_yaml.dart
+++ b/bindings/flutter/example/lib/generated/solutions_yaml.dart
@@ -21,7 +21,7 @@ abstract final class SolutionsYaml {
 # the model identifiers inline.
 
 voice_agent:
-  llm_model_id: "smollm2-360m-q8_0"
+  llm_model_id: "lfm2.5-230m-q4_k_m"
   stt_model_id: "sherpa-onnx-whisper-tiny.en"
   tts_model_id: "vits-piper-en_US-lessac-medium"
   vad_model_id: "silero-vad"
@@ -58,7 +58,7 @@ voice_agent:
 
 rag:
   embed_model_id: "all-minilm-l6-v2"
-  llm_model_id: "smollm2-360m-q8_0"
+  llm_model_id: "lfm2.5-230m-q4_k_m"
 
   vector_store: "usearch"
   vector_store_path: "/tmp/ra-rag.usearch"

--- a/bindings/react-native/example/src/services/ModelCatalogBootstrap.ts
+++ b/bindings/react-native/example/src/services/ModelCatalogBootstrap.ts
@@ -111,6 +111,30 @@ export async function registerAll(
         memoryRequirementBytes: 2_497_281_312,
         supportsThinking: true,
       }),
+      registerModel({
+        id: 'qwen3.5-0.8b-q4_k_m',
+        name: 'Qwen3.5 0.8B Q4_K_M',
+        url: 'https://huggingface.co/unsloth/Qwen3.5-0.8B-GGUF/resolve/main/Qwen3.5-0.8B-Q4_K_M.gguf',
+        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+        memoryRequirementBytes: 900_000_000,
+        supportsThinking: true,
+      }),
+      registerModel({
+        id: 'qwen3.5-2b-q4_k_m',
+        name: 'Qwen3.5 2B Q4_K_M',
+        url: 'https://huggingface.co/unsloth/Qwen3.5-2B-GGUF/resolve/main/Qwen3.5-2B-Q4_K_M.gguf',
+        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+        memoryRequirementBytes: 1_800_000_000,
+        supportsThinking: true,
+      }),
+      registerModel({
+        id: 'qwen3.5-4b-q4_k_m',
+        name: 'Qwen3.5 4B Q4_K_M',
+        url: 'https://huggingface.co/unsloth/Qwen3.5-4B-GGUF/resolve/main/Qwen3.5-4B-Q4_K_M.gguf',
+        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+        memoryRequirementBytes: 3_200_000_000,
+        supportsThinking: true,
+      }),
       // LFM2 / LFM2.5 (Liquid AI)
       // LFM2.5-230M on the CPU. Q4_K_M, not the fractionally smaller Q4_0
       // (153 MB vs 149 MB): 4 MB buys K-quant mixed precision on the

--- a/bindings/react-native/example/src/services/ModelCatalogBootstrap.ts
+++ b/bindings/react-native/example/src/services/ModelCatalogBootstrap.ts
@@ -57,60 +57,6 @@ export async function registerAll(
   // =========================================================================
   if (llamaRegistered) {
     await Promise.all([
-      // SmolLM (HuggingFace)
-      registerModel({
-        id: 'smollm2-360m-q8_0',
-        name: 'SmolLM2 360M Q8_0',
-        url: 'https://huggingface.co/prithivMLmods/SmolLM2-360M-GGUF/resolve/main/SmolLM2-360M.Q8_0.gguf',
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-        memoryRequirementBytes: 386_404_416,
-      }),
-      // Qwen 2.5 (Alibaba)
-      registerModel({
-        id: 'qwen2.5-0.5b-instruct-q6_k',
-        name: 'Qwen 2.5 0.5B Instruct Q6_K',
-        url: 'https://huggingface.co/Qwen/Qwen2.5-0.5B-Instruct-GGUF/resolve/main/qwen2.5-0.5b-instruct-q6_k.gguf',
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-        memoryRequirementBytes: 650_379_104,
-        // Base model of the seeded abliterated adapter
-        // (qwen2.5-0.5b-abliterated-lora-f16.gguf) — matches iOS/Android.
-        supportsLora: true,
-      }),
-      registerModel({
-        id: 'qwen2.5-1.5b-instruct-q4_k_m',
-        name: 'Qwen 2.5 1.5B Instruct Q4_K_M',
-        url: 'https://huggingface.co/Qwen/Qwen2.5-1.5B-Instruct-GGUF/resolve/main/qwen2.5-1.5b-instruct-q4_k_m.gguf',
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-        // Q4_K_M artifact is ~1.1 GB; keep the catalog estimate close to the
-        // real transfer size for UI/storage planning.
-        memoryRequirementBytes: 1_117_320_736,
-      }),
-      // Qwen3 (Alibaba) — thinking-capable
-      registerModel({
-        id: 'qwen3-0.6b-q4_k_m',
-        name: 'Qwen3 0.6B Q4_K_M',
-        url: 'https://huggingface.co/unsloth/Qwen3-0.6B-GGUF/resolve/main/Qwen3-0.6B-Q4_K_M.gguf',
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-        // Actual Qwen3-0.6B-Q4_K_M.gguf Content-Length for catalog display.
-        memoryRequirementBytes: 396_705_472,
-        supportsThinking: true,
-      }),
-      registerModel({
-        id: 'qwen3-1.7b-q4_k_m',
-        name: 'Qwen3 1.7B Q4_K_M',
-        url: 'https://huggingface.co/unsloth/Qwen3-1.7B-GGUF/resolve/main/Qwen3-1.7B-Q4_K_M.gguf',
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-        memoryRequirementBytes: 1_107_409_472,
-        supportsThinking: true,
-      }),
-      registerModel({
-        id: 'qwen3-4b-q4_k_m',
-        name: 'Qwen3 4B Q4_K_M',
-        url: 'https://huggingface.co/unsloth/Qwen3-4B-GGUF/resolve/main/Qwen3-4B-Q4_K_M.gguf',
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-        memoryRequirementBytes: 2_497_281_312,
-        supportsThinking: true,
-      }),
       registerModel({
         id: 'qwen3.5-0.8b-q4_k_m',
         name: 'Qwen3.5 0.8B Q4_K_M',
@@ -135,6 +81,59 @@ export async function registerAll(
         memoryRequirementBytes: 3_200_000_000,
         supportsThinking: true,
       }),
+      // Added from the verified model list
+      registerModel({
+        id: 'lfm2.5-1.2b-thinking-q4_k_m',
+        name: 'LFM2.5 1.2B Thinking Q4_K_M',
+        url: 'https://huggingface.co/LiquidAI/LFM2.5-1.2B-Thinking-GGUF/resolve/main/LFM2.5-1.2B-Thinking-Q4_K_M.gguf',
+        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+        memoryRequirementBytes: 900_000_000,
+        supportsThinking: true,
+      }),
+      registerModel({
+        id: 'lfm2.5-2.6b-q4_k_m',
+        name: 'LFM2.5 2.6B Q4_K_M',
+        url: 'https://huggingface.co/LiquidAI/LFM2.5-2.6B-GGUF/resolve/main/LFM2.5-2.6B-Q4_K_M.gguf',
+        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+        memoryRequirementBytes: 2_050_000_000,
+        supportsThinking: true,
+      }),
+      registerModel({
+        id: 'granite-4.1-8b-q4_k_m',
+        name: 'IBM Granite 4.1 8B Q4_K_M',
+        url: 'https://huggingface.co/unsloth/granite-4.1-8b-GGUF/resolve/main/granite-4.1-8b-Q4_K_M.gguf',
+        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+        memoryRequirementBytes: 6_500_000_000,
+      }),
+      registerModel({
+        id: 'qwen3.5-9b-q4_k_m',
+        name: 'Qwen3.5 9B Q4_K_M',
+        url: 'https://huggingface.co/unsloth/Qwen3.5-9B-GGUF/resolve/main/Qwen3.5-9B-Q4_K_M.gguf',
+        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+        memoryRequirementBytes: 6_950_000_000,
+        supportsThinking: true,
+      }),
+      registerModel({
+        id: 'bonsai-1.7b-q1_0',
+        name: 'PrismML Bonsai 1.7B (1-bit)',
+        url: 'https://huggingface.co/prism-ml/Bonsai-1.7B-gguf/resolve/main/Bonsai-1.7B-Q1_0.gguf',
+        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+        memoryRequirementBytes: 300_000_000,
+      }),
+      registerModel({
+        id: 'bonsai-4b-q1_0',
+        name: 'PrismML Bonsai 4B (1-bit)',
+        url: 'https://huggingface.co/prism-ml/Bonsai-4B-gguf/resolve/main/Bonsai-4B-Q1_0.gguf',
+        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+        memoryRequirementBytes: 700_000_000,
+      }),
+      registerModel({
+        id: 'bonsai-8b-q1_0',
+        name: 'PrismML Bonsai 8B (1-bit)',
+        url: 'https://huggingface.co/prism-ml/Bonsai-8B-gguf/resolve/main/Bonsai-8B-Q1_0.gguf',
+        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
+        memoryRequirementBytes: 1_400_000_000,
+      }),
       // LFM2 / LFM2.5 (Liquid AI)
       // LFM2.5-230M on the CPU. Q4_K_M, not the fractionally smaller Q4_0
       // (153 MB vs 149 MB): 4 MB buys K-quant mixed precision on the
@@ -152,57 +151,12 @@ export async function registerAll(
         // follows the local convention.
         memoryRequirementBytes: 153_406_304,
       }),
-      // ONE quantization per model. The Q8_0 sibling of this row was removed
-      // deliberately: two quants of the same 350M model differ only in bytes
-      // (229 MB vs 379 MB), so the second row costs a catalog slot and a
-      // "which one do I pick?" decision without adding a capability.
-      registerModel({
-        id: 'lfm2-350m-q4_k_m',
-        name: 'LiquidAI LFM2 350M Q4_K_M',
-        url: 'https://huggingface.co/LiquidAI/LFM2-350M-GGUF/resolve/main/LFM2-350M-Q4_K_M.gguf',
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-        memoryRequirementBytes: 229_309_376,
-      }),
       registerModel({
         id: 'lfm2.5-1.2b-instruct-q4_k_m',
         name: 'LiquidAI LFM2.5 1.2B Instruct Q4_K_M',
         url: 'https://huggingface.co/LiquidAI/LFM2.5-1.2B-Instruct-GGUF/resolve/main/LFM2.5-1.2B-Instruct-Q4_K_M.gguf',
         framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
         memoryRequirementBytes: 730_895_168,
-      }),
-      // Same ONE-quantization-per-model rule as the 350M row above: the Q8_0
-      // sibling (1.25 GB against this row's 731 MB) was the same model at a
-      // different size, so it was dropped rather than kept as a second pick.
-      registerModel({
-        id: 'lfm2-1.2b-tool-q4_k_m',
-        name: 'LiquidAI LFM2 1.2B Tool Q4_K_M',
-        url: 'https://huggingface.co/LiquidAI/LFM2-1.2B-Tool-GGUF/resolve/main/LFM2-1.2B-Tool-Q4_K_M.gguf',
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-        memoryRequirementBytes: 730_894_048,
-      }),
-      // Llama (Meta)
-      registerModel({
-        id: 'llama-3.2-3b-instruct-q4_k_m',
-        name: 'Llama 3.2 3B Instruct Q4_K_M (Tool Calling)',
-        url: 'https://huggingface.co/bartowski/Llama-3.2-3B-Instruct-GGUF/resolve/main/Llama-3.2-3B-Instruct-Q4_K_M.gguf',
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-        memoryRequirementBytes: 2_019_377_696,
-      }),
-      registerModel({
-        id: 'llama-2-7b-chat-q4_k_m',
-        name: 'Llama 2 7B Chat Q4_K_M',
-        url: 'https://huggingface.co/TheBloke/Llama-2-7B-Chat-GGUF/resolve/main/llama-2-7b-chat.Q4_K_M.gguf',
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-        // Exact artifact Content-Length for catalog display/storage planning.
-        memoryRequirementBytes: 4_081_004_224,
-      }),
-      // Mistral
-      registerModel({
-        id: 'mistral-7b-instruct-q4_k_m',
-        name: 'Mistral 7B Instruct Q4_K_M',
-        url: 'https://huggingface.co/TheBloke/Mistral-7B-Instruct-v0.1-GGUF/resolve/main/mistral-7b-instruct-v0.1.Q4_K_M.gguf',
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-        memoryRequirementBytes: 4_368_438_944,
       }),
       // Gemma (Google)
       // Gemma 4 is Apache 2.0. Preserve the license and applicable attribution
@@ -263,24 +217,6 @@ export async function registerAll(
   // =========================================================================
   if (mlxRegistered) {
     await Promise.all([
-      // Qwen (Alibaba) — Qwen2-VL vision, then the Qwen3 0.6B trio
-      // (LLM / ASR / embedding)
-      registerModel({
-        id: 'mlx-qwen2-vl-2b-instruct-4bit',
-        name: 'MLX Qwen2-VL 2B Instruct 4bit',
-        url: 'https://huggingface.co/mlx-community/Qwen2-VL-2B-Instruct-4bit',
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_MLX,
-        category: ModelCategory.MODEL_CATEGORY_MULTIMODAL,
-        memoryRequirementBytes: 2_200_000_000,
-      }),
-      registerModel({
-        id: 'mlx-qwen3-0.6b-4bit',
-        name: 'MLX Qwen3 0.6B 4bit',
-        url: 'https://huggingface.co/mlx-community/Qwen3-0.6B-4bit',
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_MLX,
-        memoryRequirementBytes: 650_000_000,
-        supportsThinking: true,
-      }),
       registerModel({
         id: 'mlx-qwen3-asr-0.6b-8bit',
         name: 'MLX Qwen3-ASR 0.6B 8bit',
@@ -397,51 +333,6 @@ export async function registerAll(
         framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
         category: ModelCategory.MODEL_CATEGORY_MULTIMODAL,
         memoryRequirementBytes: 600_000_000,
-      }),
-      // Qwen (Alibaba)
-      // Qwen2-VL 2B - Small but capable VLM (~1.6GB total)
-      // Uses multi-file download: main model (986MB) + mmproj (710MB)
-      registerModel({
-        id: 'qwen2-vl-2b-instruct-q4_k_m',
-        name: 'Qwen2-VL 2B Instruct',
-        files: [
-          {
-            url: 'https://huggingface.co/ggml-org/Qwen2-VL-2B-Instruct-GGUF/resolve/main/Qwen2-VL-2B-Instruct-Q4_K_M.gguf',
-            filename: 'Qwen2-VL-2B-Instruct-Q4_K_M.gguf',
-            required: true,
-          },
-          {
-            url: 'https://huggingface.co/ggml-org/Qwen2-VL-2B-Instruct-GGUF/resolve/main/mmproj-Qwen2-VL-2B-Instruct-Q8_0.gguf',
-            filename: 'mmproj-Qwen2-VL-2B-Instruct-Q8_0.gguf',
-            required: true,
-          },
-        ],
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-        category: ModelCategory.MODEL_CATEGORY_MULTIMODAL,
-        // Sum of file Content-Lengths: main (986 MB) + mmproj (710 MB).
-        memoryRequirementBytes: 1_695_930_304,
-      }),
-      // LFM2-VL (Liquid AI)
-      // LFM2-VL 450M - LiquidAI's compact VLM, ideal for mobile (~600MB total)
-      registerModel({
-        id: 'lfm2-vl-450m-q8_0',
-        name: 'LFM2-VL 450M',
-        files: [
-          {
-            url: 'https://huggingface.co/runanywhere/LFM2-VL-450M-GGUF/resolve/main/LFM2-VL-450M-Q8_0.gguf',
-            filename: 'LFM2-VL-450M-Q8_0.gguf',
-            required: true,
-          },
-          {
-            url: 'https://huggingface.co/runanywhere/LFM2-VL-450M-GGUF/resolve/main/mmproj-LFM2-VL-450M-Q8_0.gguf',
-            filename: 'mmproj-LFM2-VL-450M-Q8_0.gguf',
-            required: true,
-          },
-        ],
-        framework: InferenceFramework.INFERENCE_FRAMEWORK_LLAMA_CPP,
-        category: ModelCategory.MODEL_CATEGORY_MULTIMODAL,
-        // Sum of file Content-Lengths: main (379 MB) + mmproj (104 MB).
-        memoryRequirementBytes: 483_105_280,
       }),
       // Fara (Microsoft)
       // Fara1.5-4B - Microsoft Qwen3.5-VL computer-use agent VLM (~3300MB total)
@@ -622,9 +513,8 @@ export async function registerAll(
   // =========================================================================
   // LoRA adapters — mirrors iOS registerLoraAdapters() / Android seedLora.
   // =========================================================================
-  if (llamaRegistered) {
-    await registerLoraAdapters();
-  }
+  // Not registered: the only adapter shipped is trained for qwen2.5-0.5b, which
+  // this catalog no longer carries. Re-add both together.
 
   // =========================================================================
   // Diffusion (CoreML / Apple platform backend) — image generation
@@ -667,34 +557,6 @@ export async function registerAll(
   }
 
   logDiagnostic('[App] All models registered');
-}
-
-async function registerLoraAdapters(): Promise<void> {
-  const id = 'abliterated-lora';
-  const name = 'Abliterated LoRA (F16)';
-  try {
-    // `LoraAdapterCatalogEntry` no longer carries url/filename/size/
-    // description metadata (idl/lora_options.proto: "everything generic
-    // about the artifact ... lives on the ModelInfo record for this
-    // adapter") — register the catalog entry (compatibility/scale only)
-    // and the downloadable artifact (url/size) separately.
-    await RunAnywhere.lora.catalog.register(
-      LoraAdapterCatalogEntry.fromPartial({
-        id,
-        name,
-        compatibleModels: ['qwen2.5-0.5b-instruct-q6_k'],
-        defaultScale: 1.0,
-      })
-    );
-    await registerLoraArtifact({
-      catalogEntryId: id,
-      name,
-      url: 'https://huggingface.co/Void2377/qwen-lora-gguf/resolve/main/qwen2.5-0.5b-abliterated-lora-f16.gguf',
-      sizeBytes: 17_620_224,
-    });
-  } catch (error) {
-    logDiagnostic(`[App] Failed to register LoRA adapter: ${String(error)}`);
-  }
 }
 
 type NpuSeedResult = Readonly<{

--- a/core/examples/solutions/rag.yaml
+++ b/core/examples/solutions/rag.yaml
@@ -13,7 +13,7 @@
 
 rag:
   embed_model_id: "all-minilm-l6-v2"
-  llm_model_id: "smollm2-360m-q8_0"
+  llm_model_id: "lfm2.5-230m-q4_k_m"
 
   vector_store: "usearch"
   vector_store_path: "/tmp/ra-rag.usearch"

--- a/core/examples/solutions/voice_agent.yaml
+++ b/core/examples/solutions/voice_agent.yaml
@@ -14,7 +14,7 @@
 # the model identifiers inline.
 
 voice_agent:
-  llm_model_id: "smollm2-360m-q8_0"
+  llm_model_id: "lfm2.5-230m-q4_k_m"
   stt_model_id: "sherpa-onnx-whisper-tiny.en"
   tts_model_id: "vits-piper-en_US-lessac-medium"
   vad_model_id: "silero-vad"


### PR DESCRIPTION
Rebuilds the catalog against the current model generation, following the rules agreed in Slack: drop superseded families, keep only 1-bit, Q4 and Q8, and add the newest families across each modality.

Removed: Qwen2, Qwen2.5, Qwen3, LFM2, Llama 2, Llama 3.2, Mistral 7B and SmolLM2 rows, plus the Q2 and Q6 rows that fell outside the allowed quantizations.

Added from a verified list: Qwen3.5 (0.8B through 9B), Gemma 4, Granite 4.1, LFM2.5, the PrismML Bonsai 1-bit family, and Maple Preview.

Every download size is the real `Content-Length` of the asset rather than a rounded guess, and every URL was checked with a HEAD request. Several sizes in the old catalog were wrong by enough to break the download progress bar.

Private rows are untouched. HNPU/QHexRT and NeuRT bundles are exactly as they were.

**Maple Preview is listed as 1-bit, not Q4.** Its experts are already ternary in storage, so upstream ships only TQ1_0 and TQ2_0 and calls the uniform Q4_K_M a quantizer sanity check.

**LoRA registration is removed for now.** The only adapter we ship is trained for qwen2.5-0.5b, which this catalog no longer carries, so registering it would offer an adapter with no compatible base. A replacement adapter trained on a base we do ship is planned, and re-adding is a small edit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added expanded model catalog options, including Qwen3.5, LFM2.5 Thinking, Granite 4.1, Qwen3.5 9B, and Bonsai variants.
  * Updated Flutter and React Native examples with refreshed model availability and download options.
* **Updates**
  * Refreshed RAG and voice agent examples to use the LFM2.5 230M model.
  * Removed outdated model and unsupported adapter options from example catalogs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->