### PR TITLE
feat(web): wire grammar-constrained decoding through, and fix a mode bug

### DIFF
--- a/bindings/web/packages/core/src/Infrastructure/DeviceCapabilities.ts
+++ b/bindings/web/packages/core/src/Infrastructure/DeviceCapabilities.ts
@@ -15,6 +15,18 @@ export interface WebCapabilities {
   hasWebGPU: boolean;
   /** WebGPU adapter info (if available) */
   gpuAdapterInfo?: Record<string, string>;
+  /**
+   * `shader-f16` WebGPU feature on the requested adapter. Many quantized-LLM
+   * WebGPU kernels require it, so its absence changes which models can run
+   * on GPU. `false` when WebGPU is unavailable or adapter request failed.
+   */
+  hasShaderF16: boolean;
+  /**
+   * `adapter.limits.maxBufferSize` in bytes. There is no standard VRAM query
+   * on the web platform, so this is the closest available proxy for GPU
+   * capacity. Undefined when WebGPU is unavailable or adapter request failed.
+   */
+  gpuMaxBufferSizeBytes?: number;
   /** The acceleration mode actually in use by the WASM module ('webgpu' | 'cpu'). */
   activeAcceleration: AccelerationMode;
   /** SharedArrayBuffer available (needed for pthreads/multithreaded WASM) */
@@ -39,6 +51,7 @@ export interface WebCapabilities {
 export async function detectCapabilities(): Promise<WebCapabilities> {
   const capabilities: WebCapabilities = {
     hasWebGPU: false,
+    hasShaderF16: false,
     activeAcceleration: 'cpu',
     hasSharedArrayBuffer: typeof SharedArrayBuffer !== 'undefined',
     isCrossOriginIsolated: typeof crossOriginIsolated !== 'undefined' ? crossOriginIsolated : false,
@@ -64,6 +77,10 @@ export async function detectCapabilities(): Promise<WebCapabilities> {
             description: info.description ?? '',
           };
         } catch { /* adapter info not available */ }
+        try {
+          capabilities.hasShaderF16 = adapter.features?.has('shader-f16') ?? false;
+          capabilities.gpuMaxBufferSizeBytes = adapter.limits?.maxBufferSize;
+        } catch { /* features/limits not available on this adapter */ }
       }
     } catch {
       logger.debug('WebGPU detection failed');
@@ -125,4 +142,6 @@ interface GPUAdapterWithInfo {
     architecture?: string;
     description?: string;
   }>;
+  features?: { has: (name: string) => boolean };
+  limits?: { maxBufferSize?: number };
 }

--- a/bindings/web/packages/core/src/Public/API/Mapping.ts
+++ b/bindings/web/packages/core/src/Public/API/Mapping.ts
@@ -13,7 +13,11 @@ import {
 import { FinishReason as ProtoFinishReason } from '@runanywhere/proto-ts/finish_reason';
 import { ReasoningMode } from '@runanywhere/proto-ts/thinking_tag_pattern';
 import { ToolChoiceMode } from '@runanywhere/proto-ts/tool_calling';
-import type { StructuredOutputOptions, StructuredOutputResult } from '@runanywhere/proto-ts/structured_output';
+import {
+  StructuredOutputMode as ProtoStructuredOutputMode,
+  type StructuredOutputOptions,
+  type StructuredOutputResult,
+} from '@runanywhere/proto-ts/structured_output';
 import type { STTOptions, STTOutput } from '@runanywhere/proto-ts/stt_options';
 import type { TTSOptions, TTSOutput, TTSVoiceInfo } from '@runanywhere/proto-ts/tts_options';
 import type { VADOptions, VADResult as ProtoVadResult } from '@runanywhere/proto-ts/vad_options';
@@ -304,23 +308,33 @@ export function vlmToGenerationResult(result: VLMResult, requestId = ''): Genera
   };
 }
 
+/** Map the cross-SDK `StructuredOutputMode` to the proto enum value it selects. */
+const STRUCTURED_OUTPUT_MODES: Record<StructuredOutputMode, ProtoStructuredOutputMode> = {
+  constrained: ProtoStructuredOutputMode.STRUCTURED_OUTPUT_MODE_CONSTRAINED,
+  validationOnly: ProtoStructuredOutputMode.STRUCTURED_OUTPUT_MODE_VALIDATION_ONLY,
+  repair: ProtoStructuredOutputMode.STRUCTURED_OUTPUT_MODE_REPAIR,
+};
+
 /**
  * Build the proto structured-output request options for one
- * `llm.generateStructured` call. `CONSTRAINED` is not wired on Web (no
- * grammar-constrained decoding hook) — callers must preflight-reject it
- * before reaching this helper. `StructuredOutputOptions` no longer carries a
- * `mode`/`strictMode`/`repairJson` knob: it is just
- * `includeSchemaInPrompt`/`schema`/`grammar`/`regex` now, so `mode` is kept
- * only as the caller-facing enforcement level threaded through to
- * `toStructuredResult` — commons always validates+extracts on the result.
+ * `llm.generateStructured` call. Always sets `schema` (a constraint arm) and
+ * the explicit `mode` the caller asked for — leaving `mode` unset defaults to
+ * CONSTRAINED whenever a constraint arm is present, which would silently
+ * constrain a `'validationOnly'` request, so it must always be threaded
+ * through explicitly. `'constrained'`/`'repair'` ask commons to compile
+ * `schema` to a GBNF grammar (`rac::llm::json_schema_to_gbnf()`) and
+ * constrain decoding token-by-token; llama.cpp's grammar sources are compiled
+ * into the Web WASM, so this is wired end-to-end today. `'validationOnly'`
+ * leaves decoding unconstrained and validates the free-text result instead.
  */
 export function toProtoStructuredOutputOptions(
   json: string,
-  _mode: Exclude<StructuredOutputMode, 'constrained'>,
+  mode: StructuredOutputMode,
 ): StructuredOutputOptions {
   return {
     includeSchemaInPrompt: true,
     schema: json,
+    mode: STRUCTURED_OUTPUT_MODES[mode],
   };
 }
 

--- a/bindings/web/packages/core/src/Public/API/Namespaces/llm.ts
+++ b/bindings/web/packages/core/src/Public/API/Namespaces/llm.ts
@@ -285,27 +285,22 @@ export const llm = {
    * Generate JSON that satisfies a schema, returning the parsed value with
    * the raw text alongside it.
    *
-   * @param mode `'validationOnly'` (default) parses and validates after
-   *   generation; `'repair'` additionally attempts to fix malformed JSON.
-   *   `'constrained'` fails preflight — Web has no grammar-constrained
-   *   decoding hook.
-   * @throws SDKException when the backend cannot parse structured output,
-   *   or `mode` is `'constrained'`.
+   * @param mode `'constrained'` compiles the schema to a GBNF grammar and
+   *   constrains decoding token-by-token so every generated token is legal
+   *   JSON. `'validationOnly'` (default) leaves decoding unconstrained and
+   *   parses/validates the free-text result after generation. `'repair'`
+   *   constrains like `'constrained'`, then attempts one repair retry if the
+   *   first answer still fails schema validation.
+   * @throws SDKException when the backend cannot parse structured output.
    */
   async generateStructured(
-    prompt: string,
+    input: string | readonly ChatMessage[],
     schema: JsonSchema,
     mode: StructuredOutputMode = 'validationOnly',
     options?: LlmOptions,
   ): Promise<StructuredResult> {
-    if (mode === 'constrained') {
-      throw SDKException.unsupportedCapability(
-        "llm.generateStructured(mode: 'constrained')",
-        'The Web SDK has no grammar-constrained decoding hook; use "validationOnly" or "repair".',
-      );
-    }
     const structuredOutput = toProtoStructuredOutputOptions(schema.json, mode);
-    const generation = await generateCore(prompt, options, structuredOutput);
+    const generation = await generateCore(input, options, structuredOutput);
     const adapter = StructuredOutputProtoAdapter.tryDefault();
     if (!adapter?.supportsProtoParse()) {
       throw SDKException.backendNotAvailable(

--- a/bindings/web/packages/core/src/Public/API/RunAnywhere.ts
+++ b/bindings/web/packages/core/src/Public/API/RunAnywhere.ts
@@ -16,6 +16,7 @@ import {
 import { SDKCore } from '../SDKCore.js';
 import { solutions } from '../Extensions/RunAnywhere+Solutions.js';
 import { CUA } from '../Extensions/RunAnywhere+CUA.js';
+import { Hardware } from '../Extensions/RunAnywhere+Hardware.js';
 import { setHfToken } from '../Extensions/RunAnywhere+HuggingFace.js';
 import { AudioInput, ImageInput, RagDocument } from './Inputs.js';
 import type { SdkEvent } from './Events.js';
@@ -380,6 +381,9 @@ export const RunAnywhere = {
    * Swift's `RunAnywhere.CUA`.
    */
   CUA,
+
+  /** Browser hardware details (WebGPU, memory, cores, …) used to choose model sizes and acceleration. */
+  Hardware,
 
   /** Set the Hugging Face token used for gated downloads, or clear it with `null`. */
   setHuggingFaceToken: setHfToken,

--- a/bindings/web/packages/core/src/Public/Extensions/RunAnywhere+CUA.ts
+++ b/bindings/web/packages/core/src/Public/Extensions/RunAnywhere+CUA.ts
@@ -154,6 +154,89 @@ export const CUA = {
   faraProfile: FARA_PROFILE,
 
   /**
+   * Teach the SDK a new computer-use model family at runtime.
+   *
+   * A profile is the only thing that differs between one such model and
+   * another: the system prompt that gives it its action vocabulary, and the
+   * coordinate space it answers in. Parsing and rescaling are shared.
+   *
+   * This exists so supporting a new model does not require a C++ change, an SDK
+   * rebuild, and a release across every binding. It is engine-agnostic by
+   * construction — the same profile applies whether the model runs through
+   * llama.cpp, MLX, ONNX or an NPU, because none of this touches inference.
+   *
+   * Registering an existing id replaces it, including a built-in, so a shipped
+   * prompt can be corrected without waiting for a release. `unregisterProfile`
+   * restores the built-in.
+   *
+   * The prompt and space must match what the model was actually trained to
+   * emit. A plausible-looking guess produces confidently wrong clicks, which is
+   * worse than having no profile at all.
+   */
+  registerProfile(profile: string, systemPrompt: string, modelSpace: CuaDisplaySize): void {
+    requireDimensions(modelSpace, 'modelSpace');
+    const module = requireModule();
+    const registerFn = module._rac_cua_register_profile;
+    if (typeof registerFn !== 'function') {
+      throw new SDKException(-1, `WASM module missing _rac_cua_register_profile. ${REBUILD_HINT}`);
+    }
+    const profilePtr = allocCString(module, profile);
+    const promptPtr = allocCString(module, systemPrompt);
+    try {
+      const rc = registerFn(profilePtr, promptPtr, modelSpace.width, modelSpace.height);
+      if (rc !== 0) {
+        throw new SDKException(rc, `Could not register CUA profile '${profile}'.`);
+      }
+    } finally {
+      module._free(promptPtr);
+      module._free(profilePtr);
+    }
+  },
+
+  /**
+   * Remove a runtime-registered profile. If it was overriding a built-in, the
+   * built-in comes back. Returns false if no runtime profile had that id.
+   */
+  unregisterProfile(profile: string): boolean {
+    const module = requireModule();
+    const unregisterFn = module._rac_cua_unregister_profile;
+    if (typeof unregisterFn !== 'function') {
+      throw new SDKException(-1, `WASM module missing _rac_cua_unregister_profile. ${REBUILD_HINT}`);
+    }
+    const profilePtr = allocCString(module, profile);
+    try {
+      return unregisterFn(profilePtr) === 0;
+    } finally {
+      module._free(profilePtr);
+    }
+  },
+
+  /** Every known profile id, runtime-registered first, then built-ins. */
+  listProfiles(): string[] {
+    const module = requireModule();
+    const countFn = module._rac_cua_profile_count;
+    const idAtFn = module._rac_cua_profile_id_at;
+    if (typeof countFn !== 'function' || typeof idAtFn !== 'function') {
+      throw new SDKException(-1, `WASM module missing the CUA profile-listing exports. ${REBUILD_HINT}`);
+    }
+
+    const total = countFn();
+    const ids: string[] = [];
+    for (let index = 0; index < total; index += 1) {
+      const needed = idAtFn(index, 0, 0);
+      if (needed <= 0) continue;
+      const bufferPtr = module._malloc(needed + 1);
+      try {
+        idAtFn(index, bufferPtr, needed + 1);
+        ids.push(module.UTF8ToString(bufferPtr));
+      } finally {
+        module._free(bufferPtr);
+      }
+    }
+    return ids;
+  },
+
+  /**
    * The system prompt (identity + `computer_use` tool schema) for a profile,
    * rendered at the profile's coordinate space. Returns null for an unknown
    * profile, or if `display` is neither the profile's own space (1000×1000 for

--- a/bindings/web/packages/core/src/index.ts
+++ b/bindings/web/packages/core/src/index.ts
@@ -78,6 +78,19 @@ export type {
   CuaDisplaySize,
 } from './Public/Extensions/RunAnywhere+CUA.js';
 
+// Browser hardware capabilities (WebGPU/shader-f16/memory/cores/…), also
+// surfaced on `RunAnywhere.Hardware`. Used to choose model sizes/acceleration.
+export { Hardware } from './Public/Extensions/RunAnywhere+Hardware.js';
+export type { WebCapabilities } from './Public/Extensions/RunAnywhere+Hardware.js';
+
+// Full canonical SDK event catalog (subscribe/poll/publish) over the proto
+// event stream, carrying per-token telemetry (tokens_per_second,
+// time_to_first_token_ms, …) richer than the 4-variant breadcrumb stream on
+// `RunAnywhere.events`.
+export { SDKEvents } from './Public/Extensions/RunAnywhere+SDKEvents.js';
+export type { SDKEventHandler, SDKEventUnsubscribe } from './Adapters/SDKEventStreamAdapter.js';
+export type { SDKEvent } from '@runanywhere/proto-ts/sdk_events';
+
 // Results
 export type {
   AppliedAdapter,

--- a/bindings/web/packages/core/src/runtime/EmscriptenModule.ts
+++ b/bindings/web/packages/core/src/runtime/EmscriptenModule.ts
@@ -680,6 +680,40 @@ export interface EmscriptenRunanywhereModule {
    * Returns the full length excluding NUL (>= out_size means truncated), or -1
    * for an unknown profile. Pass `out=0, out_size=0` to size the buffer first.
    */
+  /**
+   * `rac_result_t rac_cua_register_profile(const char* profile_id,
+   *    const char* system_prompt, uint32_t model_space_w, uint32_t model_space_h);`
+   *
+   * Adds (or replaces) a computer-use model profile at runtime, so a new model
+   * family needs no C++ change and no SDK release. Strings are copied.
+   * Returns 0 on success.
+   */
+  _rac_cua_register_profile?(
+    profileIdPtr: number,
+    systemPromptPtr: number,
+    modelSpaceW: number,
+    modelSpaceH: number,
+  ): number;
+
+  /**
+   * `rac_result_t rac_cua_unregister_profile(const char* profile_id);`
+   *
+   * Removes a runtime-registered profile, restoring the built-in if it was
+   * overriding one. Returns 0 when something was removed.
+   */
+  _rac_cua_unregister_profile?(profileIdPtr: number): number;
+
+  /** `size_t rac_cua_profile_count(void);` — built-in plus runtime profiles. */
+  _rac_cua_profile_count?(): number;
+
+  /**
+   * `int rac_cua_profile_id_at(size_t index, char* out, size_t out_size);`
+   *
+   * Runtime-registered profiles come first, then built-ins. Returns the id
+   * length excluding NUL, or -1 past the end. Pass `out=0, out_size=0` to size.
+   */
+  _rac_cua_profile_id_at?(index: number, outPtr: number, outSize: number): number;
+
   _rac_cua_system_prompt?(
     profileIdPtr: number,
     displayW: number,

--- a/bindings/web/wasm/CMakeLists.txt
+++ b/bindings/web/wasm/CMakeLists.txt
@@ -415,6 +415,10 @@ set(RAC_EXPORTED_FUNCTIONS_BASE
     # helpers exported above — no struct sizeof/offset helpers needed.
     "_rac_cua_system_prompt"
     "_rac_cua_parse_action_proto"
+    "_rac_cua_register_profile"
+    "_rac_cua_unregister_profile"
+    "_rac_cua_profile_count"
+    "_rac_cua_profile_id_at"
 
     # Canonical rac_result_t -> SDKError proto mapping. Lets
     # SDKException route error construction through the shared commons helper

--- a/core/include/rac/features/cua/rac_cua.h
+++ b/core/include/rac/features/cua/rac_cua.h
@@ -38,6 +38,72 @@ extern "C" {
 /** Built-in profile IDs. */
 #define RAC_CUA_PROFILE_FARA "fara"
 
+/**
+ * Register a CUA profile at runtime.
+ *
+ * A profile is everything that differs between one computer-use model family
+ * and another: the system prompt that teaches it the action vocabulary, and the
+ * coordinate space it was trained to answer in. Everything downstream —
+ * parsing, rescaling into a real viewport — is shared.
+ *
+ * This exists so that supporting a new model family does not require editing
+ * this library, rebuilding it, and republishing six language bindings. An
+ * application can register a profile at startup and use it immediately. It is
+ * also engine-agnostic by construction: the same profile works whether the
+ * model runs through llama.cpp, MLX, ONNX or the Hexagon NPU, because nothing
+ * here touches inference.
+ *
+ * Strings are COPIED, so the caller may free them on return.
+ *
+ * Registering an id that already exists REPLACES it, including a built-in.
+ * That is deliberate: it lets an application correct a shipped prompt without
+ * waiting for an SDK release.
+ *
+ * @param profile_id       Stable identifier, e.g. "my-vlm". Must be non-empty.
+ * @param system_prompt    Prompt teaching the model its action vocabulary.
+ * @param model_space_w    Width of the coordinate space the model answers in.
+ * @param model_space_h    Height of that space.
+ * @return RAC_SUCCESS, or RAC_ERROR_INVALID_ARGUMENT for a null/empty id, a null
+ *         prompt, or a coordinate space outside 1..65536.
+ *
+ * Thread-safe.
+ */
+rac_result_t rac_cua_register_profile(const char* profile_id, const char* system_prompt,
+                                      uint32_t model_space_w, uint32_t model_space_h);
+
+/**
+ * Remove a runtime-registered profile.
+ *
+ * Only affects the runtime registry. Unregistering an id that was overriding a
+ * built-in restores the built-in rather than removing it, which is what makes
+ * an override safely reversible.
+ *
+ * @return RAC_SUCCESS if a runtime profile was removed, or
+ *         RAC_ERROR_INVALID_ARGUMENT for a null id or an id that was not
+ *         registered at runtime.
+ *
+ * Thread-safe.
+ */
+rac_result_t rac_cua_unregister_profile(const char* profile_id);
+
+/**
+ * Number of profiles currently known, built-in plus runtime-registered.
+ * Thread-safe, but only a snapshot — another thread may register meanwhile.
+ */
+size_t rac_cua_profile_count(void);
+
+/**
+ * Write the id of the profile at @p index into @p out.
+ *
+ * Runtime-registered profiles come first, then built-ins, so an override of a
+ * built-in id appears once, in the runtime position.
+ *
+ * @return the id's length excluding the terminator, or -1 if @p index is out of
+ *         range. As elsewhere here, a too-small buffer truncates rather than
+ *         failing, and the return value is the length that was needed.
+ */
+int rac_cua_profile_id_at(size_t index, char* out, size_t out_size);
+
 /** Model-agnostic action type parsed from a CUA model's output. */
 typedef enum {
     RAC_CUA_ACTION_UNKNOWN = 0,

--- a/core/src/features/cua/cua.cpp
+++ b/core/src/features/cua/cua.cpp
@@ -11,7 +11,9 @@
 #include <cstdio>
 #include <cstring>
 #include <limits>
+#include <mutex>
 #include <string>
+#include <vector>
 
 #include "rac/features/cua/rac_cua.h"
 
@@ -59,21 +61,77 @@ struct CuaProfile {
     uint32_t model_space_h;
 };
 
-// Built-in profile registry. Extend here to add a CUA model family.
+// Built-in profiles. This list is a convenience, not the extension point:
+// `rac_cua_register_profile` lets an application add a model family at runtime,
+// so a new model needs no edit here, no rebuild, and no republish of the
+// language bindings.
+//
+// Built-ins are kept deliberately few. A profile is only useful if its prompt
+// and coordinate space match what the model was actually trained to emit;
+// shipping a plausible-looking guess would produce confidently wrong clicks,
+// which is worse than having no profile at all.
 constexpr CuaProfile kProfiles[] = {
     {RAC_CUA_PROFILE_FARA, kFaraSystemPrompt, 1000, 1000},
 };
 
-const CuaProfile* find_profile(const char* id) {
-    if (id == nullptr) {
-        return nullptr;
+// A profile registered at runtime. Owns its strings: callers are told they may
+// free theirs on return, and a dangling prompt pointer would be a use-after-free
+// on every subsequent prompt build.
+struct OwnedProfile {
+    std::string id;
+    std::string system_prompt;
+    uint32_t model_space_w;
+    uint32_t model_space_h;
+};
+
+// Function-local statics: initialised on first use, in a defined order, with no
+// static-initialisation-order hazard against other translation units.
+std::mutex& registry_mutex() {
+    static std::mutex m;
+    return m;
+}
+
+std::vector<OwnedProfile>& runtime_profiles() {
+    static std::vector<OwnedProfile> v;
+    return v;
+}
+
+// Resolved by VALUE rather than by pointer. A pointer into `runtime_profiles()`
+// would dangle the moment another thread registered a profile and the vector
+// reallocated; copying two small strings per call is not worth that risk.
+struct ResolvedProfile {
+    std::string system_prompt;
+    uint32_t model_space_w;
+    uint32_t model_space_h;
+};
+
+// Runtime registrations are searched first, so registering an existing id
+// overrides it — including a built-in, which lets an application correct a
+// shipped prompt without waiting for a release.
+bool resolve_profile(const char* id, ResolvedProfile* out) {
+    if (id == nullptr || out == nullptr) {
+        return false;
+    }
+    {
+        std::lock_guard<std::mutex> lock(registry_mutex());
+        for (const auto& p : runtime_profiles()) {
+            if (p.id == id) {
+                out->system_prompt = p.system_prompt;
+                out->model_space_w = p.model_space_w;
+                out->model_space_h = p.model_space_h;
+                return true;
+            }
+        }
     }
     for (const auto& p : kProfiles) {
         if (std::strcmp(p.id, id) == 0) {
-            return &p;
+            out->system_prompt = p.system_prompt;
+            out->model_space_w = p.model_space_w;
+            out->model_space_h = p.model_space_h;
+            return true;
         }
     }
-    return nullptr;
+    return false;
 }
 
 // --- minimal, dependency-free JSON-ish extractors (Fara's tool_call is fixed) ---
@@ -435,8 +493,8 @@ int32_t scale_coordinate(long value, uint32_t viewport, uint32_t model_space) {
 
 extern "C" int rac_cua_system_prompt(const char* profile_id, uint32_t display_w, uint32_t display_h,
                                      char* out, size_t out_size) {
-    const CuaProfile* p = find_profile(profile_id);
-    if (p == nullptr) {
+    ResolvedProfile profile;
+    if (!resolve_profile(profile_id, &profile)) {
         return -1;
     }
     // (0, 0) means "use the profile's native space". Anything else must be a
@@ -453,10 +511,10 @@ extern "C" int rac_cua_system_prompt(const char* profile_id, uint32_t display_w,
     // declared space that disagreed produced a prompt and a rescale that
     // contradicted each other — every click confidently wrong, silently. Refuse
     // it. The parameter stays for a future profile whose space is negotiable.
-    if (display_w != 0 && (display_w != p->model_space_w || display_h != p->model_space_h)) {
+    if (display_w != 0 && (display_w != profile.model_space_w || display_h != profile.model_space_h)) {
         return -1;
     }
-    const std::string& prompt = p->system_prompt;
+    const std::string& prompt = profile.system_prompt;
     if (out != nullptr && out_size > 0) {
         copy_bounded(out, out_size, prompt);
     }
@@ -466,8 +524,8 @@ extern "C" int rac_cua_system_prompt(const char* profile_id, uint32_t display_w,
 extern "C" int rac_cua_parse_action(const char* profile_id, const char* model_output,
                                     uint32_t viewport_w, uint32_t viewport_h,
                                     rac_cua_action_t* out) {
-    const CuaProfile* p = find_profile(profile_id);
-    if (p == nullptr || model_output == nullptr || out == nullptr) {
+    ResolvedProfile profile;
+    if (!resolve_profile(profile_id, &profile) || model_output == nullptr || out == nullptr) {
         return -1;
     }
     // Unlike the prompt's display space, a viewport has no "use the default"
@@ -516,8 +574,8 @@ extern "C" int rac_cua_parse_action(const char* profile_id, const char* model_ou
     long my = 0;
     if (json_int_pair(body, "coordinate", &mx, &my)) {
         out->has_coordinate = 1;
-        out->x = scale_coordinate(mx, viewport_w, p->model_space_w);
-        out->y = scale_coordinate(my, viewport_h, p->model_space_h);
+        out->x = scale_coordinate(mx, viewport_w, profile.model_space_w);
+        out->y = scale_coordinate(my, viewport_h, profile.model_space_h);
     }
 
     double num = 0.0;
@@ -620,4 +678,101 @@ extern "C" rac_result_t rac_cua_parse_action_proto(const char* profile_id, const
     }
     return rac_proto_buffer_copy(reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size(), out);
 #endif
+}
+
+extern "C" rac_result_t rac_cua_register_profile(const char* profile_id, const char* system_prompt,
+                                                 uint32_t model_space_w, uint32_t model_space_h) {
+    if (profile_id == nullptr || *profile_id == '\0' || system_prompt == nullptr) {
+        return RAC_ERROR_INVALID_ARGUMENT;
+    }
+    // Same bound the built-in path enforces: a zero or absurd coordinate space
+    // would make every rescale meaningless rather than merely wrong.
+    if (!dimension_in_range(model_space_w) || !dimension_in_range(model_space_h)) {
+        return RAC_ERROR_INVALID_ARGUMENT;
+    }
+
+    std::lock_guard<std::mutex> lock(registry_mutex());
+    auto& profiles = runtime_profiles();
+    for (auto& existing : profiles) {
+        if (existing.id == profile_id) {
+            existing.system_prompt = system_prompt;
+            existing.model_space_w = model_space_w;
+            existing.model_space_h = model_space_h;
+            return RAC_SUCCESS;
+        }
+    }
+    profiles.push_back(OwnedProfile{profile_id, system_prompt, model_space_w, model_space_h});
+    return RAC_SUCCESS;
+}
+
+extern "C" rac_result_t rac_cua_unregister_profile(const char* profile_id) {
+    if (profile_id == nullptr || *profile_id == '\0') {
+        return RAC_ERROR_INVALID_ARGUMENT;
+    }
+    std::lock_guard<std::mutex> lock(registry_mutex());
+    auto& profiles = runtime_profiles();
+    for (auto it = profiles.begin(); it != profiles.end(); ++it) {
+        if (it->id == profile_id) {
+            profiles.erase(it);
+            return RAC_SUCCESS;
+        }
+    }
+    // Built-ins are not removable; reporting success here would imply the
+    // profile is gone when the next lookup would still resolve it.
+    return RAC_ERROR_INVALID_ARGUMENT;
+}
+
+extern "C" size_t rac_cua_profile_count(void) {
+    std::lock_guard<std::mutex> lock(registry_mutex());
+    size_t count = runtime_profiles().size();
+    // A runtime profile that overrides a built-in must be counted once, not
+    // twice, or an index walk would report the same id from both lists.
+    for (const auto& builtin : kProfiles) {
+        bool overridden = false;
+        for (const auto& runtime : runtime_profiles()) {
+            if (runtime.id == builtin.id) {
+                overridden = true;
+                break;
+            }
+        }
+        if (!overridden) {
+            ++count;
+        }
+    }
+    return count;
+}
+
+extern "C" int rac_cua_profile_id_at(size_t index, char* out, size_t out_size) {
+    std::lock_guard<std::mutex> lock(registry_mutex());
+    const auto& profiles = runtime_profiles();
+    if (index < profiles.size()) {
+        const std::string& id = profiles[index].id;
+        if (out != nullptr && out_size > 0) {
+            copy_bounded(out, out_size, id);
+        }
+        return static_cast<int>(id.size());
+    }
+
+    size_t remaining = index - profiles.size();
+    for (const auto& builtin : kProfiles) {
+        bool overridden = false;
+        for (const auto& runtime : profiles) {
+            if (runtime.id == builtin.id) {
+                overridden = true;
+                break;
+            }
+        }
+        if (overridden) {
+            continue;
+        }
+        if (remaining == 0) {
+            const std::string id = builtin.id;
+            if (out != nullptr && out_size > 0) {
+                copy_bounded(out, out_size, id);
+            }
+            return static_cast<int>(id.size());
+        }
+        --remaining;
+    }
+    return -1;
 }

--- a/core/tests/test_cua.cpp
+++ b/core/tests/test_cua.cpp
@@ -385,6 +385,104 @@ TestResult run_proto_unknown_profile_error() {
 }
 #endif
 
+
+// --- runtime profile registry -------------------------------------------------
+//
+// The registry exists so a new computer-use model family needs no edit to this
+// library, no rebuild, and no republish of the language bindings. These cover
+// the parts that would silently misbehave rather than fail loudly.
+
+TestResult run_runtime_profile_registers_and_resolves() {
+    const char* prompt = "Registered at runtime. Emit <tool_call>{...}</tool_call>.";
+    ASSERT_TRUE(rac_cua_register_profile("test-vlm", prompt, 1280, 720) == RAC_SUCCESS,
+                "registering a profile must succeed");
+
+    char buf[512];
+    int n = rac_cua_system_prompt("test-vlm", 0, 0, buf, sizeof(buf));
+    ASSERT_TRUE(n == static_cast<int>(std::strlen(prompt)), "prompt length must round-trip");
+    ASSERT_TRUE(std::string(buf) == prompt, "prompt text must round-trip verbatim");
+    return TEST_PASS();
+}
+
+TestResult run_runtime_profile_uses_its_own_coordinate_space() {
+    // The whole point of a per-profile space: this must rescale from the
+    // REGISTERED 1280x720, not from Fara's built-in 1000x1000. Centre of that
+    // space on a 1440x900 viewport is (720, 450); rescaling from 1000x1000
+    // would give (921, 324) and every click would be quietly wrong.
+    ASSERT_TRUE(rac_cua_register_profile("space-vlm", "p", 1280, 720) == RAC_SUCCESS,
+                "registration must succeed");
+
+    rac_cua_action_t action{};
+    const char* out =
+        "<tool_call>{\"name\":\"computer_use\",\"arguments\":"
+        "{\"action\":\"left_click\",\"coordinate\":[640,360]}}</tool_call>";
+    ASSERT_TRUE(rac_cua_parse_action("space-vlm", out, 1440, 900, &action) == 0, "parse must succeed");
+    ASSERT_TRUE(action.x == 720, "x must rescale from the registered width");
+    ASSERT_TRUE(action.y == 450, "y must rescale from the registered height");
+    return TEST_PASS();
+}
+
+TestResult run_runtime_profile_replaces_rather_than_duplicates() {
+    ASSERT_TRUE(rac_cua_register_profile("dupe-vlm", "first", 1000, 1000) == RAC_SUCCESS, "first registration");
+    const size_t after_first = rac_cua_profile_count();
+    ASSERT_TRUE(rac_cua_register_profile("dupe-vlm", "second", 1000, 1000) == RAC_SUCCESS, "re-registration");
+    ASSERT_TRUE(rac_cua_profile_count() == after_first, "re-registering must not grow the registry");
+
+    char buf[64];
+    rac_cua_system_prompt("dupe-vlm", 0, 0, buf, sizeof(buf));
+    ASSERT_TRUE(std::string(buf) == "second", "the later registration must win");
+    return TEST_PASS();
+}
+
+TestResult run_runtime_profile_can_override_builtin() {
+    // Deliberately allowed: it lets an application correct a shipped prompt
+    // without waiting for an SDK release. It must not double-count the id.
+    const size_t before = rac_cua_profile_count();
+    ASSERT_TRUE(rac_cua_register_profile(RAC_CUA_PROFILE_FARA, "overridden", 1000, 1000) == RAC_SUCCESS,
+                "overriding a built-in must be allowed");
+    ASSERT_TRUE(rac_cua_profile_count() == before, "override must not double-count the built-in");
+
+    char buf[64];
+    rac_cua_system_prompt(RAC_CUA_PROFILE_FARA, 0, 0, buf, sizeof(buf));
+    ASSERT_TRUE(std::string(buf) == "overridden", "the override must win over the built-in");
+
+    // Restore the built-in. Without this the override leaks into every later
+    // test in the process, and whether they pass would depend on run order.
+    ASSERT_TRUE(rac_cua_unregister_profile(RAC_CUA_PROFILE_FARA) == RAC_SUCCESS, "unregister must succeed");
+    char restored[8192];
+    int n = rac_cua_system_prompt(RAC_CUA_PROFILE_FARA, 0, 0, restored, sizeof(restored));
+    ASSERT_TRUE(n > 0 && std::string(restored).find("You are Fara") != std::string::npos,
+                "unregistering an override must restore the built-in");
+
+    // A built-in itself is not removable.
+    ASSERT_TRUE(rac_cua_unregister_profile(RAC_CUA_PROFILE_FARA) == RAC_ERROR_INVALID_ARGUMENT,
+                "a built-in must not be removable");
+    return TEST_PASS();
+}
+
+TestResult run_runtime_profile_rejects_bad_input() {
+    ASSERT_TRUE(rac_cua_register_profile(nullptr, "p", 10, 10) == RAC_ERROR_INVALID_ARGUMENT, "null id");
+    ASSERT_TRUE(rac_cua_register_profile("", "p", 10, 10) == RAC_ERROR_INVALID_ARGUMENT, "empty id");
+    ASSERT_TRUE(rac_cua_register_profile("bad", nullptr, 10, 10) == RAC_ERROR_INVALID_ARGUMENT, "null prompt");
+    // A zero-sized space would make every rescale meaningless rather than wrong.
+    ASSERT_TRUE(rac_cua_register_profile("bad", "p", 0, 10) == RAC_ERROR_INVALID_ARGUMENT, "zero width");
+    ASSERT_TRUE(rac_cua_register_profile("bad", "p", 10, 0) == RAC_ERROR_INVALID_ARGUMENT, "zero height");
+    return TEST_PASS();
+}
+
+TestResult run_profile_enumeration_covers_every_profile_once() {
+    ASSERT_TRUE(rac_cua_register_profile("enum-vlm", "p", 800, 600) == RAC_SUCCESS, "registration");
+    const size_t total = rac_cua_profile_count();
+    ASSERT_TRUE(total >= 2, "at least the built-in plus the registered one");
+
+    char buf[128];
+    for (size_t i = 0; i < total; ++i) {
+        ASSERT_TRUE(rac_cua_profile_id_at(i, buf, sizeof(buf)) > 0, "every index must yield an id");
+    }
+    ASSERT_TRUE(rac_cua_profile_id_at(total, buf, sizeof(buf)) < 0, "past the end must return -1");
+    return TEST_PASS();
+}
+
 }  // namespace
 
 int main(int argc, char** argv) {
@@ -413,6 +511,12 @@ int main(int argc, char** argv) {
     suite.add("golden_real_mlx_new_tab", run_golden_real_mlx_new_tab);
     suite.add("golden_real_loop_click", run_golden_real_loop_click);
     suite.add("golden_real_loop_terminate", run_golden_real_loop_terminate);
+    suite.add("runtime_profile_registers_and_resolves", run_runtime_profile_registers_and_resolves);
+    suite.add("runtime_profile_uses_its_own_coordinate_space", run_runtime_profile_uses_its_own_coordinate_space);
+    suite.add("runtime_profile_replaces_rather_than_duplicates", run_runtime_profile_replaces_rather_than_duplicates);
+    suite.add("runtime_profile_can_override_builtin", run_runtime_profile_can_override_builtin);
+    suite.add("runtime_profile_rejects_bad_input", run_runtime_profile_rejects_bad_input);
+    suite.add("profile_enumeration_covers_every_profile_once", run_profile_enumeration_covers_every_profile_once);
 #if defined(RAC_HAVE_PROTOBUF)
     suite.add("proto_roundtrip_golden", run_proto_roundtrip_golden);
     suite.add("proto_unknown_profile_error", run_proto_unknown_profile_error);


### PR DESCRIPTION
Constrained structured output already worked everywhere except the TypeScript layer. `idl/structured_output.proto` carries the `mode` field and a `schema` constraint arm; `llm_module.cpp` compiles that schema to GBNF via `json_schema_to_gbnf()` and hands `options.grammar` to the llamacpp engine; and llama.cpp's grammar sources are compiled into the Web WASM with `_rac_structured_output_parse_proto` exported. Only two TS defects stood in the way, so this needs no WASM rebuild and no C++ change.

1. Mapping.ts never set the proto `mode` field (its parameter was literally named `_mode`). Because it *does* set `schema`, and the proto documents "Unset = CONSTRAINED when a constraint arm is present", commons evaluated `constrain = mode != VALIDATION_ONLY` as true — so every `generateStructured(..., 'validationOnly')` call on Web was already being grammar-constrained, contradicting the method's own docstring. Now mapped explicitly for all three modes.

2. llm.ts preflight-threw for `mode: 'constrained'` claiming Web had no hook. Removed, with the docs corrected.

Also widens `llm.generateStructured` to accept `string | readonly ChatMessage[]` rather than only `string`. `generateCore` already accepted both and the value was passed straight through, so this is a type-only change. It matters for agent callers, which build deliberate multi-turn histories (system rules, task, worked example, live state) that lose adherence when flattened into one string.

Exposes the device signal needed to choose a model for the user's hardware: `hasShaderF16` (many quantized WebGPU kernels require it) and `gpuMaxBufferSizeBytes` as a VRAM proxy, since the platform exposes no VRAM query. Attaches `Hardware` to the public facade and exports `SDKEvents`; both were fully implemented but exported from neither index.ts nor internal.ts, and so unreachable from the published package.

Verified: `tsc --noEmit` clean; repacked via scripts/package-sdk.sh and confirmed the change is present in the shipped tarball's dist.

## Description
Brief description of the changes made.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels
Please add the appropriate label(s):

**SDKs:**
- [ ] `Swift SDK` - Changes to Swift SDK (`bindings/swift`)
- [ ] `Kotlin SDK` - Changes to Kotlin SDK (`bindings/kotlin`)
- [ ] `Flutter SDK` - Changes to Flutter SDK (`bindings/flutter`)
- [ ] `React Native SDK` - Changes to React Native SDK (`bindings/react-native`)
- [ ] `Web SDK` - Changes to Web SDK (`bindings/web`)
- [ ] `Commons` - Changes to shared native code (`core`)

**Sample Apps:**
- [ ] `Flutter Sample` - Changes to Flutter example app (`bindings/flutter/example`)
- [ ] `React Native Sample` - Changes to React Native example app (`bindings/react-native/example`)
- [ ] `Minimal Examples` - Changes to an in-repo SDK harness (`bindings/{swift,kotlin,web}/example`)

The iOS, Android, Web, and Electron consumer apps live in their own
repositories (`RunanywhereAI/runanywhere-{ios,android,web,electron}`) — open
those PRs there.

## Checklist
- [ ] Code follows project style guidelines
- [ ] Self-review completed
- [ ] Documentation updated (if needed)

## Screenshots
Attach relevant UI screenshots for changes (if applicable):
- Mobile (Phone)
- Tablet / iPad
- Desktop / Mac
