### PR TITLE
build: resolve SDK paths from RAC_ROOT_DIR so commons can be embedded as a subproject

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -176,6 +176,15 @@ endif()
 # Shared cmake/ helpers
 # =============================================================================
 
+# Where this repository's own tree starts.
+#
+# CMAKE_SOURCE_DIR is the TOP-LEVEL project, which is this repo only when it is
+# built directly. Embedded with add_subdirectory or FetchContent — the rcli
+# repo, the Electron addon, anything that consumes commons as a subproject —
+# it points at the consumer, and every path built from it resolves into their
+# tree instead of ours. Sub-CMakeLists use this variable instead.
+set(RAC_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}" CACHE INTERNAL "runanywhere-sdks source root")
+
 list(APPEND CMAKE_MODULE_PATH
     "${CMAKE_CURRENT_SOURCE_DIR}/cmake"
     "${CMAKE_CURRENT_SOURCE_DIR}/core/cmake"  # LoadVersions, FetchONNXRuntime, ... — kept for engine subdirs

--- a/Package.swift
+++ b/Package.swift
@@ -59,6 +59,8 @@ import Foundation
 // avoids committing a local-only manifest or hand-editing it around a tag.
 //
 // =============================================================================
+let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent().path
+
 let localNativesMarkerPath = URL(fileURLWithPath: #filePath)
     .deletingLastPathComponent()
     .appendingPathComponent(".runanywhere-local-natives")
@@ -103,7 +105,11 @@ let mlxRuntimeDistributionSwiftSettings: [SwiftSetting] = buildMLXDistributionFr
         // the canonical ABI declarations without linking a second Commons
         // archive into the runtime artifact.
         .define("RUNANYWHERE_MLX_DISTRIBUTION"),
-        .unsafeFlags(["-Xcc", "-Icore/include"]),
+        // Absolute, because a relative path resolves against whatever package
+        // happens to be the root. It worked only while this package WAS the
+        // root; as a dependency the headers vanished and MLXBackend failed to
+        // build for the consumer.
+        .unsafeFlags(["-Xcc", "-I\(packageRoot)/core/include"]),
     ]
     : []
 

--- a/engines/cloud/CMakeLists.txt
+++ b/engines/cloud/CMakeLists.txt
@@ -33,7 +33,7 @@ endif()
 
 message(STATUS "Configuring cloud backend...")
 
-include(${CMAKE_SOURCE_DIR}/cmake/plugins.cmake)
+include(${RAC_ROOT_DIR}/cmake/plugins.cmake)
 
 get_filename_component(RAC_COMMONS_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../core" ABSOLUTE)
 

--- a/engines/llamacpp/CMakeLists.txt
+++ b/engines/llamacpp/CMakeLists.txt
@@ -299,7 +299,7 @@ list(APPEND LLAMACPP_BACKEND_SOURCES ${_RAC_MTMD_MODEL_SOURCES})
 # ../../core.
 get_filename_component(RAC_COMMONS_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../core" ABSOLUTE)
 
-include(${CMAKE_SOURCE_DIR}/cmake/plugins.cmake)
+include(${RAC_ROOT_DIR}/cmake/plugins.cmake)
 
 rac_add_engine_plugin(llamacpp
     TARGET_NAME         rac_backend_llamacpp

--- a/engines/mlx/CMakeLists.txt
+++ b/engines/mlx/CMakeLists.txt
@@ -14,7 +14,7 @@ endif()
 
 message(STATUS "Configuring mlx engine...")
 
-include(${CMAKE_SOURCE_DIR}/cmake/plugins.cmake)
+include(${RAC_ROOT_DIR}/cmake/plugins.cmake)
 
 get_filename_component(RAC_COMMONS_ROOT_DIR
     "${CMAKE_CURRENT_SOURCE_DIR}/../../core" ABSOLUTE)

--- a/engines/neurt/CMakeLists.txt
+++ b/engines/neurt/CMakeLists.txt
@@ -34,7 +34,7 @@ endif()
 
 message(STATUS "Configuring neurt engine...")
 
-include(${CMAKE_SOURCE_DIR}/cmake/plugins.cmake)
+include(${RAC_ROOT_DIR}/cmake/plugins.cmake)
 if(NOT TARGET rac_runtime_coreml)
     message(FATAL_ERROR "RAC_BACKEND_NEURT requires rac_runtime_coreml.")
 endif()

--- a/engines/onnx/CMakeLists.txt
+++ b/engines/onnx/CMakeLists.txt
@@ -41,7 +41,7 @@
 #
 # Gate recipe (replace the current force-OFF):
 #   set(RAC_ONNX_WASM_RUNTIME_DIR
-#       "${CMAKE_SOURCE_DIR}/core/third_party/onnxruntime-wasm")
+#       "${RAC_ROOT_DIR}/core/third_party/onnxruntime-wasm")
 #   if(EMSCRIPTEN AND NOT EXISTS "${RAC_ONNX_WASM_RUNTIME_DIR}/lib/libonnxruntime.a")
 #       set(RAC_BACKEND_ONNX OFF CACHE BOOL "" FORCE)
 #   endif()
@@ -58,7 +58,7 @@ option(RAC_BACKEND_ONNX "Build ONNX backend" ON)
 if(EMSCRIPTEN)
     if(NOT DEFINED RAC_ONNX_WASM_RUNTIME_DIR OR RAC_ONNX_WASM_RUNTIME_DIR STREQUAL "")
         set(RAC_ONNX_WASM_RUNTIME_DIR
-            "${CMAKE_SOURCE_DIR}/core/third_party/onnxruntime-wasm"
+            "${RAC_ROOT_DIR}/core/third_party/onnxruntime-wasm"
             CACHE PATH "Vendored ONNX Runtime WASM root (CPU or WebGPU)" FORCE)
     endif()
     if(NOT EXISTS "${RAC_ONNX_WASM_RUNTIME_DIR}/lib/libonnxruntime.a")
@@ -112,7 +112,7 @@ endif()
 # Target declaration migrated to rac_add_engine_plugin() macro
 # (cmake/plugins.cmake).
 
-include(${CMAKE_SOURCE_DIR}/cmake/plugins.cmake)
+include(${RAC_ROOT_DIR}/cmake/plugins.cmake)
 
 # Resolve the runanywhere-commons root for include paths.
 get_filename_component(RAC_COMMONS_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../core" ABSOLUTE)

--- a/engines/qhexrt/CMakeLists.txt
+++ b/engines/qhexrt/CMakeLists.txt
@@ -52,7 +52,7 @@ endif()
 
 message(STATUS "Configuring QHexRT (Qualcomm Hexagon NPU) backend...")
 
-include(${CMAKE_SOURCE_DIR}/cmake/plugins.cmake)
+include(${RAC_ROOT_DIR}/cmake/plugins.cmake)
 
 function(_qhexrt_require_json_keys json_variable label expected_csv)
     set(_json "${${json_variable}}")
@@ -556,7 +556,7 @@ if(_qhexrt_platform_supported AND _qhexrt_prebuilt_valid)
             find_file(QHEXRT_LIBCDSPRPC libcdsprpc.so
                 PATHS
                     "$ENV{HEXAGON_SDK_ROOT}/ipc/fastrpc/remote/ship/android_aarch64"
-                    "${CMAKE_SOURCE_DIR}/../hexagon-sdk/root/Hexagon_SDK/6.6.0.0/ipc/fastrpc/remote/ship/android_aarch64"
+                    "${RAC_ROOT_DIR}/../hexagon-sdk/root/Hexagon_SDK/6.6.0.0/ipc/fastrpc/remote/ship/android_aarch64"
                     "${CMAKE_CURRENT_SOURCE_DIR}/../../bindings/kotlin/src/main/jniLibs/arm64-v8a"
                 NO_DEFAULT_PATH)
         endif()

--- a/engines/sherpa/CMakeLists.txt
+++ b/engines/sherpa/CMakeLists.txt
@@ -76,7 +76,7 @@
 #
 # Gate recipe (replace the current force-OFF):
 #   set(RAC_SHERPA_WASM_RUNTIME_DIR
-#       "${CMAKE_SOURCE_DIR}/core/third_party/sherpa-onnx-wasm")
+#       "${RAC_ROOT_DIR}/core/third_party/sherpa-onnx-wasm")
 #   if(EMSCRIPTEN AND NOT EXISTS "${RAC_SHERPA_WASM_RUNTIME_DIR}/lib/libsherpa-onnx-c-api.a")
 #       set(RAC_BACKEND_SHERPA OFF CACHE BOOL "" FORCE)
 #   endif()
@@ -92,7 +92,7 @@ option(RAC_BACKEND_SHERPA "Build Sherpa-ONNX backend (STT/TTS/VAD via Sherpa-ONN
 # core/third_party/sherpa-onnx-wasm/lib/ to enable.
 if(EMSCRIPTEN)
     set(RAC_SHERPA_WASM_RUNTIME_DIR
-        "${CMAKE_SOURCE_DIR}/core/third_party/sherpa-onnx-wasm")
+        "${RAC_ROOT_DIR}/core/third_party/sherpa-onnx-wasm")
     if(NOT EXISTS "${RAC_SHERPA_WASM_RUNTIME_DIR}/lib/libsherpa-onnx-c-api.a")
         message(STATUS "RAC_BACKEND_SHERPA: no WASM Sherpa archive at "
                        "${RAC_SHERPA_WASM_RUNTIME_DIR}/lib/libsherpa-onnx-c-api.a; "
@@ -358,7 +358,7 @@ set(RAC_SHERPA_ONNX_AVAILABLE "${SHERPA_ONNX_AVAILABLE}" CACHE INTERNAL
 #   - the plugin registry gains a "sherpa" engine name that future
 #     router hints can target.
 
-include(${CMAKE_SOURCE_DIR}/cmake/plugins.cmake)
+include(${RAC_ROOT_DIR}/cmake/plugins.cmake)
 
 get_filename_component(RAC_COMMONS_ROOT_DIR "${CMAKE_CURRENT_SOURCE_DIR}/../../core" ABSOLUTE)
 

--- a/runtimes/coreml/CMakeLists.txt
+++ b/runtimes/coreml/CMakeLists.txt
@@ -19,7 +19,7 @@ set_target_properties(rac_runtime_coreml PROPERTIES
 
 target_include_directories(rac_runtime_coreml PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/core/include
+    ${RAC_ROOT_DIR}/core/include
 )
 
 target_link_libraries(rac_runtime_coreml PUBLIC

--- a/runtimes/cpu/CMakeLists.txt
+++ b/runtimes/cpu/CMakeLists.txt
@@ -21,6 +21,6 @@ set_target_properties(rac_runtime_cpu PROPERTIES
 )
 
 target_include_directories(rac_runtime_cpu PRIVATE
-    ${CMAKE_SOURCE_DIR}/core/include
+    ${RAC_ROOT_DIR}/core/include
     ${CMAKE_CURRENT_SOURCE_DIR}
 )

--- a/runtimes/onnxrt/CMakeLists.txt
+++ b/runtimes/onnxrt/CMakeLists.txt
@@ -9,7 +9,7 @@ if(EMSCRIPTEN)
         set(_rac_onnxrt_wasm_dir "${RAC_ONNX_WASM_RUNTIME_DIR}")
     else()
         set(_rac_onnxrt_wasm_dir
-            "${CMAKE_SOURCE_DIR}/core/third_party/onnxruntime-wasm")
+            "${RAC_ROOT_DIR}/core/third_party/onnxruntime-wasm")
     endif()
     if(NOT EXISTS "${_rac_onnxrt_wasm_dir}/lib/libonnxruntime.a")
         set(_rac_runtime_onnxrt_default OFF)
@@ -35,11 +35,11 @@ set_target_properties(rac_runtime_onnxrt PROPERTIES
 
 target_include_directories(rac_runtime_onnxrt PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}
-    ${CMAKE_SOURCE_DIR}/core/include
+    ${RAC_ROOT_DIR}/core/include
 )
 
 target_include_directories(rac_runtime_onnxrt PRIVATE
-    ${CMAKE_SOURCE_DIR}/core/src
+    ${RAC_ROOT_DIR}/core/src
 )
 
 target_link_libraries(rac_runtime_onnxrt PUBLIC


### PR DESCRIPTION
## What

`CMAKE_SOURCE_DIR` always names the top-level project. That is this repo only when the SDK is
built on its own. Embed commons with `add_subdirectory` or `FetchContent` and it points at the
consumer instead, so every path built from it resolves into their tree.

This adds `RAC_ROOT_DIR`, set once at the top of the root `CMakeLists.txt` to
`CMAKE_CURRENT_SOURCE_DIR`, and switches the 15 affected sites over to it. When the SDK is the
top-level project the two variables are equal, so a standalone build is unchanged.

`Package.swift` had the same bug in a different form. The MLX distribution lane passed
`-Xcc -Icore/include`, a relative path that only resolved while this package was the root. As a
dependency the headers disappeared and `MLXBackend` failed to build for the consumer. It now
derives an absolute `packageRoot` from `#filePath`.

## Where the paths were wrong

| File | Sites |
|---|---|
| `engines/{cloud,llamacpp,mlx,neurt,onnx,qhexrt,sherpa}/CMakeLists.txt` | `include(${CMAKE_SOURCE_DIR}/cmake/plugins.cmake)` |
| `runtimes/{coreml,cpu,onnxrt}/CMakeLists.txt` | `core/include`, `core/src`, the wasm third_party paths |
| `Package.swift` | the `-Xcc` include for the MLX distribution lane |

## Why now

The `RunanywhereAI/RCLI` rework consumes commons as a subproject. Without this it cannot
configure at all: the includes land in the RCLI tree and `plugins.cmake` resolves to a path that
does not exist. Nothing downstream of that repo can build or release until this lands.

## Testing

Configured standalone to confirm the substitution is a no-op for this repo's own build, and
configured RCLI against this branch to confirm the embedded case now resolves. No compile
behaviour changes: this only moves where paths are computed from.

## Open gaps

`/set accelerator cpu` still does not reach llama.cpp. That fix is separate and is in
`siddhesh/llamacpp-accelerator-policy`, since PR #726 was closed without merging.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Fixed package builds when integrated as a dependency or subproject.
  - Corrected header and runtime path resolution across supported engine and runtime configurations.
  - Improved reliability for MLX, ONNX, CoreML, CPU, QHexRT, Sherpa-ONNX, and other backend builds.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->