### PR TITLE
llamacpp: honour accelerator_policy and context_length instead of dropping them

### DIFF
--- a/core/include/rac/backends/rac_llm_llamacpp.h
+++ b/core/include/rac/backends/rac_llm_llamacpp.h
@@ -11,6 +11,8 @@
 #ifndef RAC_LLM_LLAMACPP_H
 #define RAC_LLM_LLAMACPP_H
 
+#include <stdint.h>
+
 #include "rac/core/rac_benchmark.h"
 #include "rac/core/rac_error.h"
 #include "rac/core/rac_types.h"
@@ -52,6 +54,9 @@ extern "C" {
  *
  * Mirrors Swift's LlamaCPPGenerationConfig.
  */
+/** `gpu_layers` value meaning "let llama.cpp decide" (see the field docs). */
+#define RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO INT32_MIN
+
 typedef struct rac_llm_llamacpp_config {
     /** Context size (0 = auto-detect from model) */
     int32_t context_size;
@@ -59,7 +64,15 @@ typedef struct rac_llm_llamacpp_config {
     /** Number of threads (0 = auto-detect) */
     int32_t num_threads;
 
-    /** Number of layers to offload to GPU (Metal on iOS/macOS) */
+    /**
+     * Number of layers to offload to GPU (Metal on iOS/macOS).
+     *
+     * `RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO` leaves the decision to llama.cpp's own
+     * fitting pass; `-1` offloads every layer; `0` pins the model to the CPU.
+     * Zero used to double as "unspecified", which made pinning to CPU
+     * impossible to express: the value was indistinguishable from a caller who
+     * had simply left the field alone.
+     */
     int32_t gpu_layers;
 
     /** Batch size for prompt processing */

--- a/core/include/rac/server/rac_server.h
+++ b/core/include/rac/server/rac_server.h
@@ -29,6 +29,7 @@
 #ifndef RAC_SERVER_H
 #define RAC_SERVER_H
 
+#include "rac/backends/rac_llm_llamacpp.h"
 #include "rac/core/rac_types.h"
 
 #ifdef __cplusplus
@@ -91,7 +92,7 @@ static const rac_server_config_t RAC_SERVER_CONFIG_DEFAULT = {.host = "127.0.0.1
                                                               .model_id = RAC_NULL,
                                                               .context_size = 8192,
                                                               .threads = 4,
-                                                              .gpu_layers = 0,
+                                                              .gpu_layers = RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO,
                                                               .enable_cors = RAC_TRUE,
                                                               .cors_origins = "*",
                                                               .request_timeout_seconds = 300,

--- a/core/include/rac/server/rac_server.h
+++ b/core/include/rac/server/rac_server.h
@@ -64,7 +64,12 @@ typedef struct rac_server_config {
     /** Number of threads for inference (default: 4, 0 = auto) */
     int32_t threads;
 
-    /** Number of GPU layers to offload (default: 0 = CPU only) */
+    /**
+     * Number of GPU layers to offload. Defaults to
+     * RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO, which leaves placement to
+     * llama.cpp's own fitting pass; -1 offloads every layer and 0 pins the
+     * model to the CPU.
+     */
     int32_t gpu_layers;
 
     /** Enable CORS headers for browser access (default: true) */

--- a/core/tools/runanywhere-server.cpp
+++ b/core/tools/runanywhere-server.cpp
@@ -68,7 +68,7 @@ struct ServerOptions {
     uint16_t port = 8080;
     int32_t threads = 4;
     int32_t contextSize = 8192;
-    int32_t gpuLayers = 0;
+    int32_t gpuLayers = RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO;  // -1 all, 0 CPU
     bool enableCors = true;
     bool verbose = false;
     bool showHelp = false;

--- a/core/tools/runanywhere-server.cpp
+++ b/core/tools/runanywhere-server.cpp
@@ -11,7 +11,7 @@
  *   --port, -p <port>      Port to listen on (default: 8080)
  *   --threads, -t <n>      Number of threads (default: 4)
  *   --context, -c <n>      Context window size (default: 8192)
- *   --gpu-layers, -ngl <n> GPU layers to offload (default: 0)
+ *   --gpu-layers, -ngl <n> GPU layers to offload (default: automatic; -1 all, 0 CPU only)
  *   --cors                 Enable CORS (default: enabled)
  *   --no-cors              Disable CORS
  *   --verbose, -v          Enable verbose logging
@@ -84,7 +84,7 @@ static void printUsage(const char* programName) {
     printf("  --port, -p <port>      Port to listen on (default: 8080)\n");
     printf("  --threads, -t <n>      Number of threads (default: 4)\n");
     printf("  --context, -c <n>      Context window size (default: 8192)\n");
-    printf("  --gpu-layers, -ngl <n> GPU layers to offload (default: 0)\n");
+    printf("  --gpu-layers, -ngl <n> GPU layers to offload (default: automatic; -1 all, 0 CPU only)\n");
     printf("  --cors                 Enable CORS (default)\n");
     printf("  --no-cors              Disable CORS\n");
     printf("  --verbose, -v          Enable verbose logging\n");

--- a/engines/llamacpp/rac_backend_llamacpp_register.cpp
+++ b/engines/llamacpp/rac_backend_llamacpp_register.cpp
@@ -49,6 +49,50 @@ rac_handle_t legacy_handle(void* impl) {
     return runtime_impl ? runtime_impl->legacy_handle : nullptr;
 }
 
+// AcceleratorPolicy wire values (idl/public_api_v4.proto), mirrored the same way
+// core/src/core/model_lifecycle.cpp mirrors them rather than pulling the
+// generated enum in for three integers.
+constexpr int kAcceleratorPolicyCpu = 2;
+constexpr int kAcceleratorPolicyGpu = 3;
+
+// Translate commons' advisory load JSON into llama.cpp's own knobs. Returns
+// false when there was nothing to say, so the caller can keep passing nullptr
+// and leave today's behaviour exactly as it was.
+bool parse_load_options(const char* options_json, rac_llm_llamacpp_config_t* config) {
+    if (options_json == nullptr || options_json[0] == '\0' || config == nullptr) {
+        return false;
+    }
+    nlohmann::json parsed = nlohmann::json::parse(options_json, nullptr, /*allow_exceptions=*/false);
+    if (parsed.is_discarded() || !parsed.is_object()) {
+        RAC_LOG_WARNING(LOG_CAT, "ignoring unparseable load options: %s", options_json);
+        return false;
+    }
+
+    bool any = false;
+    if (parsed.contains("context_length") && parsed["context_length"].is_number_integer()) {
+        config->context_size = parsed["context_length"].get<int32_t>();
+        any = true;
+    }
+    // accelerator_policy wins over the deprecated use_gpu when both are present,
+    // matching the proto comment that calls use_gpu an adapter onto it.
+    int policy = 0;
+    if (parsed.contains("accelerator_policy") && parsed["accelerator_policy"].is_number_integer()) {
+        policy = parsed["accelerator_policy"].get<int>();
+    } else if (parsed.contains("use_gpu") && parsed["use_gpu"].is_boolean()) {
+        policy = parsed["use_gpu"].get<bool>() ? kAcceleratorPolicyGpu : kAcceleratorPolicyCpu;
+    }
+    if (policy == kAcceleratorPolicyCpu) {
+        config->gpu_layers = 0;  // every layer stays on the CPU
+        any = true;
+    } else if (policy == kAcceleratorPolicyGpu) {
+        config->gpu_layers = -1;  // offload all of them
+        any = true;
+    }
+    // AUTO and NPU are left alone: AUTO is llama.cpp's own fitting pass, and
+    // llama.cpp has no NPU path, which commons already warns about separately.
+    return any;
+}
+
 rac_result_t llamacpp_cpu_provider_create_session(const rac_runtime_session_desc_t* desc,
                                                   rac_runtime_session_t** out) {
     if (desc == nullptr || out == nullptr)
@@ -58,8 +102,18 @@ rac_result_t llamacpp_cpu_provider_create_session(const rac_runtime_session_desc
         return RAC_ERROR_INVALID_PATH;
     }
 
+    // Commons hands the v4 load knobs down as advisory JSON
+    // ({"context_length":N,"use_gpu":bool,"accelerator_policy":int}, see
+    // model_lifecycle_translation.cpp). Translating them here is what makes
+    // `--accelerator cpu|gpu` and `--context-length` actually reach llama.cpp;
+    // passing nullptr meant every one of them was dropped on the floor.
+    rac_llm_llamacpp_config_t config = RAC_LLM_LLAMACPP_CONFIG_DEFAULT;
+    config.gpu_layers = RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO;
+    const bool have_config = parse_load_options(desc->options_json, &config);
+
     rac_handle_t backend_handle = nullptr;
-    rac_result_t rc = rac_llm_llamacpp_create(desc->model_path, nullptr, &backend_handle);
+    rac_result_t rc = rac_llm_llamacpp_create(desc->model_path,
+                                              have_config ? &config : nullptr, &backend_handle);
     if (rc != RAC_SUCCESS)
         return rc;
     *out = reinterpret_cast<rac_runtime_session_t*>(backend_handle);
@@ -290,10 +344,10 @@ static rac_result_t llamacpp_vtable_get_stream_token_counts(void* impl,
 // limited to the backend library via symbol hiding (the struct is `const`).
 // The `create` adapter called by commons rac_llm_create() after
 // rac_plugin_find picks this plugin. Replaces the legacy factory that was
-// registered via rac_service_provider_t::create. The config_json parameter is
-// reserved for future engine-specific tuning (num_threads, gpu_layers, etc.);
-// today we pass nullptr to rac_llm_llamacpp_create to use defaults.
-rac_result_t llamacpp_llm_create_impl(const char* model_id, const char* /*config_json*/,
+// registered via rac_service_provider_t::create. config_json carries commons'
+// advisory load knobs and rides on the session descriptor to the provider,
+// which translates it into rac_llm_llamacpp_config_t.
+rac_result_t llamacpp_llm_create_impl(const char* model_id, const char* config_json,
                                       void** out_impl) {
     if (!model_id || !out_impl) {
         return RAC_ERROR_NULL_POINTER;
@@ -313,6 +367,9 @@ rac_result_t llamacpp_llm_create_impl(const char* model_id, const char* /*config
     desc.primitive = RAC_PRIMITIVE_GENERATE_TEXT;
     desc.model_format = RAC_MODEL_FORMAT_ID_GGUF;
     desc.model_path = model_id;
+    // The CPU runtime forwards the descriptor untouched, so this is how the
+    // load knobs reach llamacpp_cpu_provider_create_session.
+    desc.options_json = config_json;
 
     rac_runtime_session_t* runtime_session = nullptr;
     rc = runtime->create_session(&desc, &runtime_session);

--- a/engines/llamacpp/rac_backend_llamacpp_register.cpp
+++ b/engines/llamacpp/rac_backend_llamacpp_register.cpp
@@ -49,11 +49,15 @@ rac_handle_t legacy_handle(void* impl) {
     return runtime_impl ? runtime_impl->legacy_handle : nullptr;
 }
 
-// AcceleratorPolicy wire values (idl/public_api_v4.proto), mirrored the same way
-// core/src/core/model_lifecycle.cpp mirrors them rather than pulling the
-// generated enum in for three integers.
-constexpr int kAcceleratorPolicyCpu = 2;
-constexpr int kAcceleratorPolicyGpu = 3;
+// AcceleratorPolicy wire values, mirrored from idl/model_types.proto rather
+// than taken from the generated enum: these arrive here as JSON numbers over
+// the config_json ABI, and this engine links neither protobuf nor the generated
+// tree (only qhexrt does). Adding that dependency for two integers would put
+// protobuf into the llamacpp plugin on every platform it ships to.
+// core/src/core/model_lifecycle.cpp mirrors the same enum for the same reason.
+// Keep these in step with ACCELERATOR_POLICY_CPU and ACCELERATOR_POLICY_GPU.
+constexpr int kAcceleratorPolicyCpu = 2;  // ACCELERATOR_POLICY_CPU
+constexpr int kAcceleratorPolicyGpu = 3;  // ACCELERATOR_POLICY_GPU
 
 // Translate commons' advisory load JSON into llama.cpp's own knobs. Returns
 // false when there was nothing to say, so the caller can keep passing nullptr

--- a/engines/llamacpp/rac_llm_llamacpp.cpp
+++ b/engines/llamacpp/rac_llm_llamacpp.cpp
@@ -180,7 +180,10 @@ rac_result_t rac_llm_llamacpp_create(const char* model_path,
         if (config->context_size > 0) {
             model_config["context_size"] = config->context_size;
         }
-        if (config->gpu_layers != 0) {
+        // AUTO means "no opinion"; every other value, INCLUDING 0, is an
+        // explicit placement request and must reach the backend. Gating on
+        // `!= 0` here is what silently swallowed a CPU pin.
+        if (config->gpu_layers != RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO) {
             model_config["gpu_layers"] = config->gpu_layers;
         }
         if (config->batch_size > 0) {


### PR DESCRIPTION
## What

`llamacpp_cpu_provider_create_session` passed `nullptr` where `rac_llm_llamacpp_create` takes a
config, so everything commons had already worked out about placement and context size was thrown
away at the last hop. `--accelerator cpu` and `--context-length` parsed correctly, travelled all
the way down as advisory JSON, and then stopped.

This translates that JSON into llama.cpp's own knobs.

## The part worth reviewing

`gpu_layers == 0` used to mean two different things: "pin this model to the CPU" and "the caller
said nothing". Those need to be distinguishable before CPU placement can be expressed at all, so
this adds a sentinel:

```c
#define RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO INT32_MIN
```

`0` now means CPU only, `-1` offloads every layer, and AUTO defers to llama.cpp's fitting pass.
`RAC_SERVER_CONFIG_DEFAULT.gpu_layers` and `runanywhere-server`'s default both move from `0` to
AUTO, which is a behaviour change: a server started with no placement flag used to be pinned to
the CPU by accident and now lets llama.cpp choose. That looks like the intended reading of the
field, but it is the one thing here that is not purely additive, so it deserves a second opinion.

`accelerator_policy` wins over `use_gpu` when both are present, matching the proto comment that
describes `use_gpu` as an adapter onto it. AUTO and NPU are deliberately left alone: AUTO is
llama.cpp's own pass, and llama.cpp has no NPU path, which commons already warns about elsewhere.
When the JSON says nothing usable the caller still gets `nullptr`, so existing behaviour is
untouched.

## Relationship to #726

#726 was closed without merging. It carried this fix plus a larger set of rcli changes; this is
the engine half on its own, so the placement flags can land without waiting on the rest.

CodeRabbit left six actionable comments on #726. Five were against `rcli/src/commands/*`, which is
not in this branch. The sixth was valid here and is fixed in 439f12c19: the `gpu_layers` field
still documented `default: 0 = CPU only` after the default had moved to AUTO.

## Testing

Confirmed `n_gpu_layers=0` reaches llama.cpp in the engine log when loading with the CPU policy,
which is what was silently not happening before.

## Open gaps

Not yet measured whether pinning to CPU changes throughput by the amount you would expect, so the
plumbing is verified but the performance claim is not.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automatic GPU-layer selection for Llama.cpp models.
  * Clarified options for automatic fitting, full GPU offload, and CPU-only execution.
  * Added support for advisory load options, including context length and accelerator preferences.

* **Bug Fixes**
  * GPU-layer settings now correctly honor explicit CPU-only configuration.
  * Model configuration options are forwarded during CPU session creation.
  * Deprecated GPU settings remain supported as a fallback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->