### PR TITLE
fix(llamacpp): honour the same load options on the VLM create path

### DIFF
--- a/engines/llamacpp/rac_llamacpp_vlm_ops.cpp
+++ b/engines/llamacpp/rac_llamacpp_vlm_ops.cpp
@@ -116,9 +116,16 @@ static void llamacpp_vlm_vtable_destroy(void* impl) {
     rac_vlm_llamacpp_destroy(impl);
 }
 
-// `create` adapter for llama.cpp VLM. Parses the optional "mmproj_path" key
-// from config_json (so VLM's 2-path create signature maps cleanly into the
-// uniform rac_vlm_service_ops_t::create slot).
+// AcceleratorPolicy wire values, mirrored from idl/model_types.proto for the
+// same reason rac_backend_llamacpp_register.cpp mirrors them: they arrive as
+// JSON numbers over the config_json ABI and this engine links neither protobuf
+// nor the generated tree. Keep in step with ACCELERATOR_POLICY_CPU/GPU.
+constexpr int kAcceleratorPolicyCpu = 2;  // ACCELERATOR_POLICY_CPU
+constexpr int kAcceleratorPolicyGpu = 3;  // ACCELERATOR_POLICY_GPU
+
+// `create` adapter for llama.cpp VLM. Parses "mmproj_path" (so VLM's 2-path
+// create signature maps cleanly into the uniform rac_vlm_service_ops_t::create
+// slot) plus the same load knobs the LLM path honours.
 rac_result_t llamacpp_vlm_create_impl(const char* model_id, const char* config_json,
                                       void** out_impl) {
     if (!model_id || !out_impl) {
@@ -128,6 +135,10 @@ rac_result_t llamacpp_vlm_create_impl(const char* model_id, const char* config_j
 
     std::string mmproj_path_owned;
     const char* mmproj_path = nullptr;
+    rac_vlm_llamacpp_config_t config = RAC_VLM_LLAMACPP_CONFIG_DEFAULT;
+    // Stays false when config_json said nothing about placement or context, so
+    // the create call below keeps passing nullptr and behaviour is unchanged.
+    bool have_config = false;
     if (config_json && config_json[0] != '\0') {
         try {
             auto json = nlohmann::json::parse(config_json);
@@ -136,6 +147,30 @@ rac_result_t llamacpp_vlm_create_impl(const char* model_id, const char* config_j
                 mmproj_path = mmproj_path_owned.c_str();
                 RAC_LOG_DEBUG(LOG_CAT, "Parsed mmproj_path from config_json: %s", mmproj_path);
             }
+            if (json.contains("context_length") && json["context_length"].is_number_integer()) {
+                config.context_size = json["context_length"].get<int32_t>();
+                have_config = true;
+            }
+            // accelerator_policy wins over the deprecated use_gpu when both are
+            // present, matching the proto comment that calls use_gpu an adapter
+            // onto it.
+            int policy = 0;
+            if (json.contains("accelerator_policy") &&
+                json["accelerator_policy"].is_number_integer()) {
+                policy = json["accelerator_policy"].get<int>();
+            } else if (json.contains("use_gpu") && json["use_gpu"].is_boolean()) {
+                policy = json["use_gpu"].get<bool>() ? kAcceleratorPolicyGpu
+                                                     : kAcceleratorPolicyCpu;
+            }
+            if (policy == kAcceleratorPolicyCpu) {
+                config.gpu_layers = 0;       // every layer stays on the CPU
+                config.use_gpu_vision = 0;   // and so does the vision encoder
+                have_config = true;
+            } else if (policy == kAcceleratorPolicyGpu) {
+                config.gpu_layers = -1;  // offload all of them
+                have_config = true;
+            }
+            // AUTO and NPU are left alone for the same reasons as the LLM path.
         } catch (const std::exception& e) {
             RAC_LOG_WARNING(LOG_CAT, "config_json parse failed (%s); using defaults", e.what());
         }
@@ -145,7 +180,8 @@ rac_result_t llamacpp_vlm_create_impl(const char* model_id, const char* config_j
                  mmproj_path ? mmproj_path : "(none)");
 
     rac_handle_t backend_handle = nullptr;
-    rac_result_t rc = rac_vlm_llamacpp_create(model_id, mmproj_path, nullptr, &backend_handle);
+    rac_result_t rc = rac_vlm_llamacpp_create(model_id, mmproj_path,
+                                              have_config ? &config : nullptr, &backend_handle);
     if (rc != RAC_SUCCESS) {
         RAC_LOG_ERROR(LOG_CAT, "rac_vlm_llamacpp_create failed: %d", rc);
         return rc;


### PR DESCRIPTION
## What is wrong

a46517cf1 taught the LLM path to read `context_length` and `accelerator_policy` out of the `config_json` load options "instead of dropping them". The VLM adapter one file over still drops them.

`llamacpp_vlm_create_impl` already receives `config_json` and already parses it, but only for `"mmproj_path"`, and then passes a null config:

```cpp
rac_result_t rc = rac_vlm_llamacpp_create(model_id, mmproj_path, nullptr, &backend_handle);
```

`rac_vlm_llamacpp_config_t` carries exactly the knobs that were just wired up on the LLM side:

```c
int32_t context_size;   // 0 = auto-detect
int32_t gpu_layers;     // -1 = all layers on GPU
```

So a VLM load that asks for a context length, or pins placement to CPU, is silently ignored and the backend runs on `RAC_VLM_LLAMACPP_CONFIG_DEFAULT`. That is the same defect the LLM path just had, reached through the same ABI, in the same engine.

## What this does

Parses the same keys in the block that already parses `mmproj_path`, with the same precedence and mapping the LLM helper uses:

- `accelerator_policy` wins over the deprecated `use_gpu`, matching the proto comment that calls `use_gpu` an adapter onto it
- CPU maps to `gpu_layers = 0`, GPU to `gpu_layers = -1`
- AUTO and NPU are left alone, for the reasons `parse_load_options` already gives

The config is passed only when something was actually requested. A load with no placement or context options keeps passing `nullptr`, so today's behaviour is unchanged, which mirrors the "returns false when there was nothing to say" contract on the LLM side.

I mirrored the two `AcceleratorPolicy` constants locally with the same rationale the LLM file gives, rather than pulling protobuf into this TU.

## The one judgement call

On `ACCELERATOR_POLICY_CPU` I also clear `use_gpu_vision`. The LLM config has no vision encoder, so a strict mirror would leave it set, and a caller that explicitly asked for CPU would still get the vision tower on the GPU. I think honouring the request across both compute paths is what CPU means here, but it is the one place I went past a literal copy of a46517cf1 — say the word and I will drop it to `gpu_layers` only.

## Verification

Built with backends enabled so this TU actually compiles, then ran the whole suite:

```
cmake -B build -DRAC_BUILD_TESTS=ON -DRAC_BUILD_BACKENDS=ON -DCMAKE_BUILD_TYPE=Debug
cmake --build build -j6     # 0 errors; rac_llamacpp_vlm_ops.cpp rebuilt
ctest --test-dir build -j4  # 100% tests passed out of 127
```

No test added: exercising this needs a loaded VLM plus a way to observe llama.cpp's context/placement, which the commons suite has no fixture for. The claim rests on the enumeration above, and the sibling it mirrors landed yesterday.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for configuring model context length during loading.
  * Added CPU and GPU accelerator placement options.
  * Retained compatibility with the existing GPU configuration setting.

* **Bug Fixes**
  * Invalid loading configuration values now fall back to safe defaults with a warning.
  * Existing behavior is preserved when no context or accelerator options are provided.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->