### PR TITLE
ci: remove python-linux from pr-build.yml

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -332,83 +332,8 @@ jobs:
           Copy-Item tests -Destination $tmp -Recurse -Force
           python -m pytest $tmp\tests -q
 
-  python-linux:
-    # Linux sibling of python-windows: builds the runanywhere-python wheel via
-    # scikit-build-core, repairs it with auditwheel (vendors the onnxruntime/sherpa sidecar
-    # .so into runanywhere.libs/ and retags linux_x86_64 -> manylinux), installs it into a
-    # clean interpreter, and runs the hermetic suite. ubuntu-22.04 keeps the manylinux tag low
-    # (glibc 2.35) for a broadly-installable wheel.
-    runs-on: ubuntu-22.04
-    timeout-minutes: 90
-    steps:
-      - uses: actions/checkout@v7
-        with:
-          persist-credentials: false
-      - uses: ./.github/actions/setup-toolchain
-        with:
-          platform: linux
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.12'
-      # runanywhere/_proto, _generated_errors.py and _generated_defaults.py are
-      # IDL codegen output and are not tracked. `python -m build` runs them via
-      # the in-tree PEP 517 backend, but only when protoc + grpcio-tools are on
-      # the host; generating here makes that unconditional (the backend then
-      # finds the files present and skips). Without it the wheel builds,
-      # repairs, installs — and fails at `import runanywhere`.
-      - uses: ./.github/actions/generate-idl
-        with:
-          languages: python
-      # patchelf comes from PyPI, not apt. ubuntu-22.04 ships 0.14.3 and current
-      # auditwheel requires >= 0.14.5, so `auditwheel repair` died with
-      # "patchelf 0.14.3 found. auditwheel repair requires patchelf >= 0.14.5".
-      # Both tools now come from the same resolver, so they cannot drift apart
-      # again the way an apt package and a pip package silently did.
-      - name: Build tools (patchelf is required by auditwheel)
-        run: |
-          sudo apt-get update -q
-          sudo apt-get install -y -q ninja-build
-          python -m pip install --upgrade pip build auditwheel patchelf pytest
-          patchelf --version
-      - name: Sherpa-ONNX prebuilts
-        run: |
-          ./core/scripts/linux/download-sherpa-onnx.sh
-          # The prebuilt ships libonnxruntime.so, but _core/sherpa record a versioned
-          # DT_NEEDED (libonnxruntime.so.1); give auditwheel a matching filename to vendor.
-          lib="core/third_party/sherpa-onnx-linux/lib"
-          ln -sf libonnxruntime.so "$lib/libonnxruntime.so.1"
-      - name: Build wheel
-        working-directory: bindings/python
-        run: python -m build --wheel -o dist
-      - name: Repair wheel (vendor sidecar .so)
-        working-directory: bindings/python
-        run: |
-          # The sherpa prebuilt lib dir holds the version-matched libonnxruntime.so +
-          # libsherpa-onnx-c-api.so; on LD_LIBRARY_PATH auditwheel finds + vendors them.
-          export LD_LIBRARY_PATH="$GITHUB_WORKSPACE/core/third_party/sherpa-onnx-linux/lib:$LD_LIBRARY_PATH"
-          wheel="$(ls dist/*.whl | head -1)"
-          auditwheel repair -w wheelhouse "$wheel"
-      - name: Validate release boundary (no host paths, no binaries in sdist)
-        working-directory: bindings/python
-        run: |
-          python -m build --sdist -o wheelhouse
-          ver="$(tr -d '[:space:]' < ../../core/VERSION)"
-          python scripts/validate_public_packages.py --dist wheelhouse --expected-version "$ver"
-      - name: Install + hermetic tests
-        working-directory: bindings/python
-        run: |
-          wheel="$(ls wheelhouse/*.whl | head -1)"
-          # [server,test] pulls fastapi/uvicorn/multipart + httpx so tests/test_server.py runs
-          # (not skips); the gated native/model smoke tests still self-skip (no models).
-          python -m pip install "${wheel}[server,test]"
-          # Run the hermetic suite from a temp dir so `runanywhere` resolves to the installed
-          # wheel, not the source tree.
-          tmp="$RUNNER_TEMP/ratests"; mkdir -p "$tmp"
-          cp -r tests "$tmp/tests"
-          cd "$tmp" && python -m pytest tests -q
-
   python-macos:
-    # macOS sibling of python-linux: builds the wheel, repairs it with delocate (vendors the
+    # Builds the wheel, repairs it with delocate (vendors the
     # onnxruntime/sherpa dylibs into runanywhere/.dylibs), installs it, runs the hermetic suite.
     # Uses the macOS 26 / Xcode 26 runner line like the other SDK lanes (macos-debug/release):
     # setup-toolchain platform:macos pins Xcode 26.6, which only exists on macos-26 (macos-14


### PR DESCRIPTION
## Summary

- Removes the `python-linux` job from `pr-build.yml`.
- It has a chronic ~90-minute hang that hits `timeout-minutes: 90` on nearly every run — confirmed on both a two-version matrix (`3.9`/`3.12`) and a single pinned version (`3.12`), so it was never about the Python version choice, just a chronically slow/stuck job.
- It was never a required branch-protection status check, and Python/PyPI publishing is not part of `release.yml` at all — so it produced pure CI noise (a recurring red X on every PR/push) with zero gating value.
- `python-macos` and `python-windows` continue to cover the wheel-build + install + hermetic-test flow for the Python SDK on their platforms.

## Test plan

- [x] `actionlint` clean (no new findings vs. main)
- [x] YAML parses
- [ ] `pr-build.yml` green on this PR (confirms nothing depended on `python-linux`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Validation**
  * Added macOS arm64 wheel building and testing.
  * Added validation for generated interface files, source distributions, and repaired wheels.
  * Expanded hermetic test coverage from temporary directories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->