### PR TITLE
docs: two stale references (removed CI job, renamed codegen script)

### DIFF
--- a/bindings/python/PACKAGING.md
+++ b/bindings/python/PACKAGING.md
@@ -23,8 +23,10 @@ wheel on `python-windows` and `python-macos`. The release just collects those ar
 1. **Version** — bump `core/VERSION`; `scripts/release/sync-versions.sh` propagates
    it into `pyproject.toml`. Confirm `pip show`/`__version__` match.
 2. **Build sdist** — `python -m build --sdist -o dist`.
-3. **Build + repair each wheel** on its platform (Win/Linux/macOS) via the CI recipe (build →
-   delvewheel/auditwheel/delocate).
+3. **Build + repair each wheel** on its platform (Win/Linux/macOS) (build →
+   delvewheel/auditwheel/delocate). Windows and macOS can follow the `python-windows` /
+   `python-macos` jobs in `pr-build.yml`; since #757 removed `python-linux` there is no CI recipe
+   left to copy for the manylinux wheel, so it has to be built and `auditwheel`-repaired by hand.
 4. **Validate the release boundary** — `python scripts/validate_public_packages.py --dist dist
    --expected-version <VERSION>` (asserts: `_core` + sidecar libs present in the right dir per
    platform, no host-path leaks in text/metadata members, the sdist has sources only, version matches).

--- a/bindings/python/PACKAGING.md
+++ b/bindings/python/PACKAGING.md
@@ -15,8 +15,8 @@ wheel. The sdist is source-only.
 | `runanywhere-*.tar.gz` (sdist) | scikit-build-core | — | source only (no binaries) |
 
 CI (`.github/workflows/pr-build.yml`) already builds + repairs + validates + hermetic-tests the
-wheel on `python-windows`, `python-linux`, and `python-macos`. The release just collects those
-artifacts.
+wheel on `python-windows` and `python-macos`. The release just collects those artifacts.
+`python-linux` was removed in #757, so the manylinux wheel above is not built by CI today.
 
 ## Dry-run checklist (before `twine upload`)
 

--- a/scripts/validation/verify_default_pool.sh
+++ b/scripts/validation/verify_default_pool.sh
@@ -23,7 +23,7 @@
 # Exit codes:
 #   0  Every language agrees with the proto.
 #   1  At least one value disagrees, or a language is missing a field.
-#   2  A generated file is missing (run idl/codegen/generate_defaults_pool.sh).
+#   2  A generated file is missing (run idl/codegen/generate_defaults_pool.py).
 
 set -euo pipefail
 


### PR DESCRIPTION
Two documentation references that point at things which do not exist. Bundled rather than sent separately.

## 1. `bindings/python/PACKAGING.md:18`

> CI (`.github/workflows/pr-build.yml`) already builds + repairs + validates + hermetic-tests the wheel on `python-windows`, **`python-linux`**, and `python-macos`.

#757 removed `python-linux` earlier today, so a reader following this goes looking for a job that is not there. The row above it in the artifact table (`runanywhere-*-manylinux_2_35_x86_64.whl`) is also no longer produced by CI, so I noted that in the same sentence rather than leaving the table silently implying otherwise. I left the table row itself alone, since a manylinux wheel is still a thing the project can produce, just not from `pr-build.yml`.

## 2. `scripts/validation/verify_default_pool.sh:26`

The exit-code legend says:

> `2  A generated file is missing (run idl/codegen/generate_defaults_pool.sh).`

The generator is `generate_defaults_pool.py`. There is no `.sh`. This is self-evidently the outlier rather than a judgement call, because the same script's runtime message on that exact path already prints the right name:

```
$ bash scripts/validation/verify_default_pool.sh --quiet
...
Run: idl/codegen/generate_defaults_pool.py
```

## Verification

`bash -n` on the shell script passes, and I ran it to confirm the behaviour is untouched (it is a comment change) and to capture the runtime line quoted above. `ls idl/codegen/generate_defaults_pool.*` returns only the `.py`.

Docs only, no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Clarified that CI builds Windows and macOS wheels only.
  - Documented the manual process for building and repairing manylinux wheels with `auditwheel`.

- **Bug Fixes**
  - Updated validation guidance to reference the current command for generating missing default files.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->