### PR TITLE
fix(electron): coerce producer throw/reject to SDKException in bridgeStream

### DIFF
--- a/bindings/electron/src/api/iter.ts
+++ b/bindings/electron/src/api/iter.ts
@@ -45,7 +45,29 @@ export function bridgeStream<T>(
   producer: (sink: StreamSink<T>) => void | Promise<void>,
   onCancel?: () => void | Promise<void>
 ): AsyncIterableIterator<T> {
-  return sharedBridgeStream<T>((sink) => producer(withTypedFail(sink)), onCancel);
+  return sharedBridgeStream<T>((sink) => {
+    // `pushStream` reports a producer that throws or rejects through the sink
+    // it owns, not the one the producer was handed, so those failures would
+    // skip `withTypedFail`. Route them ourselves.
+    //
+    // A synchronous producer must stay synchronous: returning a promise from
+    // this callback makes `pushStream` auto-`end()` the stream once it
+    // settles, which would truncate a producer that is still pushing.
+    const typed = withTypedFail(sink);
+    let pending: void | Promise<void>;
+    try {
+      pending = producer(typed);
+    } catch (error) {
+      typed.fail(error);
+      return;
+    }
+    if (pending != null && typeof (pending as Promise<void>).then === 'function') {
+      return (pending as Promise<void>).catch((error: unknown) => {
+        typed.fail(error);
+      });
+    }
+    return pending;
+  }, onCancel);
 }
 
 /** Wrap a ready array as a bridge-safe stream (used for synthetic events). */


### PR DESCRIPTION
## What is wrong

`bindings/electron/src/api/iter.ts` opens with the contract it exists to enforce:

> This file is a thin Electron binding that coerces stream failures through `asSDKException` so renderer and main consumers **always** see the house error type.

It is not always. It holds when a producer calls `sink.fail()`, and breaks when a producer throws or rejects.

The wrapper only wraps the sink:

```ts
return sharedBridgeStream<T>((sink) => producer(withTypedFail(sink)), onCancel);
```

`pushStream` reports a producer failure through the sink **it** owns, which is the unwrapped one:

```ts
    try {
      const maybe = producer(sink);
      if (maybe != null && typeof (maybe as Promise<void>).then === 'function') {
        (maybe as Promise<void>).then(
          () => sink.end(),
          (e: unknown) => sink.fail(e),   // raw sink
        );
      }
    } catch (e) {
      sink.fail(e);                       // raw sink
    }
```

So an error that reaches the consumer by escaping the producer never passes through `asSDKException`.

## Evidence

Driving the real `pushStream` from `@runanywhere/proto-ts/streams/push` with `withTypedFail` and `bridgeStream` copied verbatim out of `iter.ts`:

```
A  producer calls sink.fail(raw)  -> SDKException  (contract held)
B  async producer rejects         -> Error  <-- RAW, contract broken
C  sync producer throws           -> Error  <-- RAW, contract broken
```

Most of the 20-odd `bridgeStream` call sites are `async (sink) => { ... }` producers, and `bridge.ts` already funnels native rejections through `asSDKException`, so a native failure is unaffected. What does leak is anything thrown outside a bridge call. The clearest case is a caller-supplied iterable: `stt.transcribeStream(input)` does `for await (const chunk of input)` inside the producer, so if the app's audio iterable rejects with a plain `Error`, the consumer of the returned stream gets that plain `Error` instead of an `SDKException`.

The sibling adapter in this same SDK already guarantees and tests this. `test/unit/stream.test.ts` on `toAsyncIterable`:

```ts
      // Coerced to SDKException so consumers always see the house error type.
      assert.ok(isSDKException(thrown));
```

`bridgeStream` states the same contract in prose and does not deliver it on two of its three failure paths.

## What this changes

Wraps the producer call rather than only the sink, so a throw and a rejection route through the same `withTypedFail` sink that an explicit `fail()` uses.

The one thing worth reviewing is that a synchronous producer has to stay synchronous. `pushStream` auto-`end()`s the stream when the callback's promise settles, so returning a promise unconditionally would truncate a sync producer that registers a callback and keeps pushing (`assets.ts:1462` is one). The callback therefore returns a promise only when the producer returned one.

Re-running the probes against the patched wrapper, with two cases added to pin the semantics that must not move:

```
A  producer calls sink.fail(raw)  -> SDKException  (contract held)
B  async producer rejects         -> SDKException  (contract held)
C  sync producer throws           -> SDKException  (contract held)
D  sync producer, pushes later    -> ended, values=["late"]
E  async producer, normal end     -> ended, values=["x"]
```

## Verification

`npm ci && npm run build` in `bindings/electron` on this branch and on unpatched `main`: 118 type errors both times, identical sets. The only difference is a line number moving on a pre-existing error in this file (`iter.ts(71)` to `iter.ts(93)`) because the diff inserts lines above it. Those 118 are all `Cannot find module '@runanywhere/proto-ts/...'` and their cascade, because I have not run the IDL codegen that `electron-unit` does before building. The diff adds none.

No test here, following the repo's standing instruction not to add unit tests unless asked. Happy to add the `bridgeStream` counterpart to `test/unit/stream.test.ts`'s coercion case if you would like it, since it fails on the unpatched code.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stream error handling for failures during synchronous or asynchronous data production.
  * Prevented streams from completing prematurely when processing synchronous producers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->