### PR TITLE
release: sync real v0.20.25 Apple checksums

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -721,12 +721,12 @@ func binaryTargets() -> [Target] {
             .binaryTarget(
                 name: "RACommonsBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RACommons-ios-v\(sdkVersion).zip",
-                checksum: "0609dae68dc9b477daa70c8fa17c266a98a288eb0b712c3d77184e93d7ad1e71"
+                checksum: "1ae55ae456810e8115aedaf94671fc9bae280954422839bb50497da009775851"
             ),
             .binaryTarget(
                 name: "RABackendLlamaCPPBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RABackendLLAMACPP-ios-v\(sdkVersion).zip",
-                checksum: "0597442fa030fe6eb69f2f01c63d098e090c0b60469847e2a2614bcf4d32210a"
+                checksum: "7062f7c8da988e6aee323efbb03f09b70cde7956138191e82720b81c7ed90a2b"
             ),
             .binaryTarget(
                 name: "RABackendONNXBinary",

--- a/bindings/flutter/packages/runanywhere/ios/runanywhere/Package.swift
+++ b/bindings/flutter/packages/runanywhere/ios/runanywhere/Package.swift
@@ -23,7 +23,7 @@ func runAnywhereBinaryTarget(name: String, checksum: String) -> Target {
 
 let raCommonsTarget = runAnywhereBinaryTarget(
     name: "RACommons",
-    checksum: "0609dae68dc9b477daa70c8fa17c266a98a288eb0b712c3d77184e93d7ad1e71"
+    checksum: "1ae55ae456810e8115aedaf94671fc9bae280954422839bb50497da009775851"
 )
 
 let package = Package(

--- a/bindings/flutter/packages/runanywhere_llamacpp/ios/runanywhere_llamacpp/Package.swift
+++ b/bindings/flutter/packages/runanywhere_llamacpp/ios/runanywhere_llamacpp/Package.swift
@@ -23,7 +23,7 @@ func runAnywhereBinaryTarget(name: String, checksum: String) -> Target {
 
 let llamaTarget = runAnywhereBinaryTarget(
     name: "RABackendLLAMACPP",
-    checksum: "0597442fa030fe6eb69f2f01c63d098e090c0b60469847e2a2614bcf4d32210a"
+    checksum: "7062f7c8da988e6aee323efbb03f09b70cde7956138191e82720b81c7ed90a2b"
 )
 
 let package = Package(

--- a/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
+++ b/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
@@ -9,7 +9,7 @@
 
 mlx_checksums = {
   'RABackendMLX' => '0802fe58480c3e03e94498d46adb50fda7b9ade491807c7e0392a7fd68b83b59',
-  'RunAnywhereMLXRuntime' => 'a92ce648106304e83d025503e7d21bfffe7c5c50fe540d71c43ce37bd2aa11d3',
+  'RunAnywhereMLXRuntime' => '6183c3742d6d44228cfcfe5d3d985a303de7e6f4de2ec39e0ff0e5ed2f8713bd',
   'RunAnywhereMLXMetal' => '17a2f8c4ce09ef691cde5e7d04171ce749fca89315205f90eb2eed5a76b682b1',
   'RunAnywhereMLXResources' => 'ace624c5cffa32f789cd3beee8d140740daadd793b1315c3583ab670410b3ca3'
 }.freeze


### PR DESCRIPTION
## Summary

The `v0.20.25` publish run failed its **"Verify built Apple checksums match tagged package contracts"** gate. `RACommons`, `RABackendLLAMACPP`, and `RunAnywhereMLXRuntime` are not byte-reproducible across rebuilds, so the committed manifests still carried the previous release's hashes while the actual 0.20.25 archives hash differently. 6 of 8 gated archives already matched — only these drifted.

This is the documented pre-tag step (sync real checksums from the built artifacts) that must land **before** the tag is cut.

- Checksums taken from the exact artifacts the release publishes: candidate run `32542992799`'s `native-ios-macos` bundle.
- Every one of the 9 archives was verified against its own `.sha256` sidecar before syncing.
- `sync-checksums.sh --check` now reports **9 processed / 0 missing / 0 failed**.

Touches only the 4 manifests that carry Apple checksums: root `Package.swift`, Flutter's two nested iOS `Package.swift` files, and the Flutter MLX podspec.

## Test plan

- [x] `bindings/swift/scripts/sync-checksums.sh --check <zips>` → 9 processed, 0 failed
- [x] `check_release_version_coherence.sh` → OK (0.20.25)
- [x] `check_flutter_centralization.sh` → 0 drift
- [ ] `pr-build.yml` green
- [ ] `v0.20.25` re-pointed at this commit, then publish-only re-dispatched (no release exists yet — the prior publish failed before creating one, so nothing was ever published)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS package and runtime archive checksums to align with the latest released binaries.
  * Refreshed checksum values across the Flutter RunAnywhere, LlamaCPP, and MLX integrations.
  * No user-facing functionality or configuration changed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->