### PR TITLE
fix(windows,linux): release bundles shipped with no usable engines

### DIFF
--- a/.github/workflows/electron-native-package.yml
+++ b/.github/workflows/electron-native-package.yml
@@ -126,7 +126,11 @@ jobs:
         uses: actions/checkout@v7
         with:
           repository: RunanywhereAI/neurun
-          ref: 3b322bf27d26ddb90c0059f2cb83b70511a0d88c
+          # Bumped 2026-08-22 to pick up "kernels: port Qwen3.8 IQ1 to Hexagon
+          # v81 (#62)". Keep this a PINNED SHA, never a branch: NeuRT is a
+          # private engine built from source here, and a floating ref would make
+          # released binaries irreproducible.
+          ref: 901c249833731d4e455f2aab4dff0c57139776d3
           token: ${{ secrets.NEURUN_TOKEN }}
           path: neurun
           persist-credentials: false

--- a/.github/workflows/electron-native-package.yml
+++ b/.github/workflows/electron-native-package.yml
@@ -296,6 +296,22 @@ jobs:
           if (!(Test-Path "$dir/arm64/node.lib")) { throw "node.lib missing under $dir/arm64" }
           "dir=$dir" | Out-File -FilePath $env:GITHUB_OUTPUT -Append -Encoding utf8
 
+      # The staged QHexRT prebuilt is hand-made on this machine and CANNOT be
+      # rebuilt in CI today (neurun gates its receipt target behind if(ANDROID),
+      # its staging script is POSIX-only, and QAIRT is licence-gated). So the
+      # risk is not a bad build — it is silent STALENESS: shipping NPU kernels
+      # from an arbitrarily old neurun commit with nothing saying so. This gate
+      # hard-fails if the staged tree stops matching what we recorded, and warns
+      # (never fails) when it falls behind neurun HEAD. See
+      # engines/qhexrt/PREBUILT_PROVENANCE.json.
+      - name: Verify QHexRT prebuilt provenance (fails on drift, warns on staleness)
+        shell: powershell
+        env:
+          QHEXRT_ROOT: 'C:\actions-runner-state\qhexrt-prebuilt\versions\f14ef0efb1da4b6a50e49f37a0ef55ac3b0bb7328aa7469edf78625ac4d79607'
+        run: |
+          python scripts\validation\gates\check_qhexrt_provenance.py --qhexrt-root "$env:QHEXRT_ROOT"
+          if ($LASTEXITCODE -ne 0) { throw "QHexRT provenance check failed" }
+
       - name: Configure electron-win-arm64-vs2026 (QHexRT)
         shell: powershell
         env:

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -262,6 +262,55 @@ jobs:
           ./rcli/scripts/package-rcli-windows.ps1
           -BuildDir build/rcli-windows-release
 
+  windows-commons-release:
+    # PR-time coverage for core/scripts/build-windows.bat, i.e. exactly what
+    # release.yml's native_windows job ships as RACommons-windows-x64-v*.zip.
+    #
+    # WHY THIS JOB EXISTS: nothing in pr-build.yml ever ran that script, so it
+    # rotted invisibly. It configured core/ (a standalone project that never
+    # does add_subdirectory(engines)), so no engine target was ever created;
+    # its backend copies pointed at a pre-engine-split core/src/backends/ layout
+    # that no longer exists; and every copy was `if exist`-guarded, so all of
+    # them silently no-oped while the script exited 0. Result: the release
+    # bundle shipped commons-only with ZERO engines for multiple versions with
+    # CI fully green. Keep this job green and that cannot recur.
+    runs-on: windows-2022
+    timeout-minutes: 90
+    steps:
+      - uses: actions/checkout@v7
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          platform: windows
+      - name: Sherpa-ONNX prebuilts (required for a ROUTABLE sherpa backend)
+        shell: cmd
+        run: core\scripts\windows\download-sherpa-onnx.bat
+      - name: Build commons + all backends (windows-x64-shared-release preset)
+        working-directory: core
+        shell: cmd
+        run: scripts\build-windows.bat
+      # build-windows.bat already fails closed on a missing artifact; assert it
+      # again here so a regression in the script's own gate is also caught.
+      - name: Assert the full DLL set was staged
+        shell: bash
+        run: |
+          set -euo pipefail
+          lib=core/dist/windows/x64/lib
+          missing=0
+          for want in rac_commons.dll \
+              rac_backend_llamacpp.dll runanywhere_llamacpp.dll \
+              rac_backend_onnx.dll runanywhere_onnx.dll onnxruntime.dll \
+              rac_backend_sherpa.dll runanywhere_sherpa.dll sherpa-onnx-c-api.dll; do
+            if [ ! -f "$lib/$want" ]; then
+              echo "::error::missing $want in $lib"
+              missing=$((missing + 1))
+            fi
+          done
+          ls -la "$lib"
+          [ "$missing" -eq 0 ] || { echo "::error::$missing native(s) missing"; exit 1; }
+      - name: Verify Windows plugin natives are routable
+        shell: bash
+        run: python3 scripts/validation/gates/check_plugin_natives.py core/dist/windows/x64/lib
+
   python-windows:
     # Builds the runanywhere-python wheel (pybind11 _core over the C ABI) via
     # scikit-build-core, repairs it with delvewheel (vendors the onnxruntime/sherpa

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -307,9 +307,16 @@ jobs:
           done
           ls -la "$lib"
           [ "$missing" -eq 0 ] || { echo "::error::$missing native(s) missing"; exit 1; }
+      # --allow-placeholder-staging-url: a PR build has no STAGING_BASE_URL by
+      # design (the secret is unavailable to fork PRs), so rac_commons.dll here
+      # necessarily carries the placeholder. Routability is still fully enforced,
+      # which is what this job is for. release.yml runs the SAME gate WITHOUT the
+      # flag, so a real release still cannot ship the placeholder.
       - name: Verify Windows plugin natives are routable
         shell: bash
-        run: python3 scripts/validation/gates/check_plugin_natives.py core/dist/windows/x64/lib
+        run: |
+          python3 scripts/validation/gates/check_plugin_natives.py \
+            --allow-placeholder-staging-url core/dist/windows/x64/lib
 
   python-windows:
     # Builds the runanywhere-python wheel (pybind11 _core over the C ABI) via

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -280,6 +280,16 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
         with:
           platform: linux
+      # WITHOUT this, sherpa still BUILDS but as a non-routable stub: the
+      # engine prebuilt is absent, so RAC_SHERPA_ROUTABLE=0 and
+      # sherpa_capability_check() returns RAC_ERROR_BACKEND_UNAVAILABLE. The
+      # bundle then ships a ~156 KB librac_backend_sherpa.so with no
+      # libsherpa-onnx-c-api.so beside it, and STT/TTS/VAD cannot work on
+      # Linux at all. Shipped that way through at least 0.20.24 and 0.20.25
+      # (byte-identical carriers) because nothing asserted routability here —
+      # native_rcli_linux already prefetched it, native_linux never did.
+      - name: Sherpa-ONNX prebuilts (required for a ROUTABLE sherpa backend)
+        run: ./core/scripts/linux/download-sherpa-onnx.sh
       - name: Build + package commons for Linux x86_64
         # build-linux.sh drives the linux-release CMake preset (same as PR-time),
         # then stages the .so set + headers and packs the versioned
@@ -287,6 +297,10 @@ jobs:
         env:
           RAC_RELEASE_VERSION: ${{ needs.validate.outputs.version }}
         run: bash core/scripts/build-linux.sh
+      # Fail the build rather than shipping a hollow carrier again. This is the
+      # gate whose absence let the sherpa stub ship silently for two releases.
+      - name: Verify Linux plugin natives are routable
+        run: python3 scripts/validation/gates/check_plugin_natives.py core/dist/linux/lib
       - name: Upload Linux artifacts
         uses: actions/upload-artifact@v7
         with:
@@ -687,10 +701,25 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
         with:
           platform: windows
+      # Sherpa on Windows is a SHA-pinned prebuilt, not a source build. Without
+      # this, sherpa still "builds" but as a non-routable stub
+      # (RAC_SHERPA_ROUTABLE=0), and build-windows.bat now hard-fails instead of
+      # quietly shipping it. native_rcli_windows already did this; this job never
+      # did, which is part of why the bundle shipped hollow.
+      - name: Sherpa-ONNX prebuilts (required for a ROUTABLE sherpa backend)
+        shell: cmd
+        run: core\scripts\windows\download-sherpa-onnx.bat
       - name: Build commons + backends for Windows x64
         working-directory: core
         shell: cmd
         run: scripts\build-windows.bat
+      # The build script asserts the DLL set exists in its staging dir; this
+      # asserts they are actually ROUTABLE (real op tables, not hollow carriers).
+      # check_plugin_natives.py understands PE. Prefer llvm-nm/dumpbin on PATH:
+      # plain `nm` cannot read PE and the script degrades to a byte scan.
+      - name: Verify Windows plugin natives are routable
+        shell: bash
+        run: python3 scripts/validation/gates/check_plugin_natives.py core/dist/windows/x64/lib
       - name: Package Windows outputs
         working-directory: core
         shell: bash
@@ -715,6 +744,29 @@ jobs:
             sha256sum "RACommons-windows-x64-v${{ needs.validate.outputs.version }}.zip" \
               > "RACommons-windows-x64-v${{ needs.validate.outputs.version }}.zip.sha256"
           )
+          # Assert the SHIPPED ZIP, not just the build tree. Through 0.20.25 this
+          # zip contained only rac_commons.lib + headers — zero engines — and
+          # nothing here noticed, because the only checks were "dir exists" and
+          # "zip exists". Both were true.
+          zip="dist/RACommons-windows-x64-v${{ needs.validate.outputs.version }}.zip"
+          listing="$(7z l -ba -slt "$zip" | sed -n 's/^Path = //p')"
+          missing=0
+          for want in \
+              rac_commons.dll \
+              rac_backend_llamacpp.dll runanywhere_llamacpp.dll \
+              rac_backend_onnx.dll runanywhere_onnx.dll onnxruntime.dll \
+              rac_backend_sherpa.dll runanywhere_sherpa.dll sherpa-onnx-c-api.dll; do
+            if ! printf '%s\n' "$listing" | grep -Eqi "(^|/)${want}$"; then
+              echo "::error::shipped Windows zip is missing $want"
+              missing=$((missing + 1))
+            fi
+          done
+          if [ "$missing" -ne 0 ]; then
+            echo "::error::$missing required native(s) absent from the Windows release zip — refusing to ship an engine-less bundle"
+            printf '%s\n' "$listing" | sed 's/^/  /'
+            exit 1
+          fi
+          echo "Windows zip carries commons + all three backend pairs + vendor runtimes."
       - name: Upload Windows artifacts
         uses: actions/upload-artifact@v7
         with:

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -308,6 +308,28 @@
             "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
         },
         {
+            "name": "windows-x64-shared-release",
+            "displayName": "Windows x64 — Release (shared commons + dynamic plugin DLLs) — the RELEASE bundle",
+            "description": "Produces the shape RACommons-windows-x64-v<version>.zip is supposed to ship: rac_commons.dll plus rac_backend_<id>.dll and their runanywhere_<id>.dll carriers. Mirrors electron-windows — the only Windows configuration with live CI evidence of building all three CPU backends on MSVC — minus the Electron N-API addon (needs RAC_NODE_DEV_DIR) and minus RAC_DESKTOP_ADAPTER (which makes libcurl a hard requirement that native_windows has no vcpkg step for). Sherpa needs core/scripts/windows/download-sherpa-onnx.bat to have run first, or it builds as a NON-ROUTABLE stub. Do NOT swap this back to windows-release: that preset sets no backend flags and RAC_BUILD_SHARED=OFF, which is exactly how the release bundle shipped commons-only with zero engines through 0.20.25.",
+            "inherits": "base-release",
+            "generator": "Visual Studio 17 2022",
+            "architecture": { "value": "x64", "strategy": "set" },
+            "cacheVariables": {
+                "RAC_BUILD_PLATFORM": "OFF",
+                "RAC_BUILD_SHARED": "ON",
+                "RAC_STATIC_PLUGINS": "OFF",
+                "RAC_BUILD_BACKENDS": "ON",
+                "RAC_BACKEND_LLAMACPP": "ON",
+                "RAC_BACKEND_ONNX": "ON",
+                "RAC_RUNTIME_ONNXRT": "ON",
+                "RAC_BACKEND_SHERPA": "ON",
+                "RAC_BACKEND_MLX": "OFF",
+                "RAC_BACKEND_NEURT": "OFF",
+                "GGML_METAL": "OFF"
+            },
+            "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }
+        },
+        {
             "name": "electron-win-arm64",
             "displayName": "Electron \u2014 Windows ARM64 thin addon (Hexagon NPU, QHexRT only)",
             "description": "Option A packaging for Snapdragon X / X2 Elite: rac_commons.dll + runanywhere_qhexrt.dll + thin runanywhere_native.node, built ARM64-native. This is the NPU lane and it is mutually exclusive with electron-windows — QAIRT ships no QnnHtp*Stub for x86_64, so x64 can never reach the DSP, and the three CPU engines cannot compile for ARM64 (see the per-option comments). Requires an ARM64 Windows host and the ARM64 Native Tools prompt; MSVC's arm64_x64 cross toolset builds the OTHER lane, not this one. Pass, as electron-windows does, -DRAC_NODE_DEV_DIR=<node-gyp cache> and -DQHEXRT_ROOT=<engines/qhexrt/prebuilt/versions/<receipt>> (the global prebuilt/current symlink cannot name an Android and a Windows payload at once). RAC_DESKTOP_ADAPTER=ON needs libcurl and crypt32: crypt32 is a system library, but curl is not, so also pass -DCMAKE_TOOLCHAIN_FILE=<vcpkg>/scripts/buildsystems/vcpkg.cmake -DVCPKG_TARGET_TRIPLET=arm64-windows-static after `vcpkg install curl:arm64-windows-static`. Without the adapter this lane has no HTTP transport at all — no model downloads, no telemetry, no auth.",
@@ -395,6 +417,7 @@
         { "name": "windows-release",  "configurePreset": "windows-release" },
         { "name": "electron-macos",   "configurePreset": "electron-macos" },
         { "name": "electron-windows", "configurePreset": "electron-windows", "configuration": "Release" },
+        { "name": "windows-x64-shared-release", "configurePreset": "windows-x64-shared-release", "configuration": "Release" },
         { "name": "electron-win-arm64", "configurePreset": "electron-win-arm64", "configuration": "Release" },
         { "name": "electron-win-arm64-vs2026", "configurePreset": "electron-win-arm64-vs2026", "configuration": "Release" },
         { "name": "windows-arm64-release", "configurePreset": "windows-arm64-release", "configuration": "Release" },

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -325,6 +325,7 @@
                 "RAC_BACKEND_SHERPA": "ON",
                 "RAC_BACKEND_MLX": "OFF",
                 "RAC_BACKEND_NEURT": "OFF",
+                "RAC_BACKEND_CLOUD": "OFF",
                 "GGML_METAL": "OFF"
             },
             "condition": { "type": "equals", "lhs": "${hostSystemName}", "rhs": "Windows" }

--- a/bindings/electron/docs/QHEXRT_PREBUILT_REFRESH.md
+++ b/bindings/electron/docs/QHEXRT_PREBUILT_REFRESH.md
@@ -1,0 +1,111 @@
+# Refreshing the QHexRT win-arm64 prebuilt
+
+How to get newer [neurun](https://github.com/RunanywhereAI/neurun) QHexRT work into
+`@runanywhere/electron-qhexrt`. This is a **manual procedure on one physical machine**.
+It is not automatable today, for reasons recorded below — read those before trying.
+
+## Why this is manual
+
+`engines/qhexrt/CMakeLists.txt` consumes a **prebuilt receipt tree**
+(`include/qhexrt/qhexrt_c.h`, `lib/win-arm64/qhexrt_{core,host}.lib`, plus
+`qhexrt-build-receipt.json` and `qhexrt-prebuilt.json`). It never builds QHexRT from
+source. Three things block producing that tree in CI:
+
+| Blocker | Evidence |
+|---|---|
+| neurun's `qhexrt_build_receipt` CMake target is `if(ANDROID)`-gated, so it does not exist for the `windows-arm64-*` presets | neurun `CMakeLists.txt:375` |
+| neurun's `stage_prebuilt_for_sdk.sh` is POSIX-only (`ps -o lstart=`, `os.symlink`, `diff -qr`) | neurun `QHexRT/device_suites/run_windows_e2e.ps1:78-88` documents this and says the win-arm64 payload is published as a plain `versions/<64-hex>` dir |
+| QAIRT is licence-gated; `qhexrt_core` compiles against its QNN headers | neurun `CMakePresets.json:43-54` |
+
+**The durable fix belongs upstream in neurun**, not here: un-gate the receipt target
+and add a Windows-capable publisher. Until then, this procedure plus
+`scripts/validation/gates/check_qhexrt_provenance.py` is the honest scope — the gate
+makes staleness *loud* instead of silent.
+
+## Prerequisite: QAIRT ≥ 2.47 (2.48 recommended)
+
+**As of 2026-08-22 the runner has QAIRT 2.41.0.251128, which is too old.** A human
+with a Qualcomm account must install a newer QAIRT on the Snapdragon X2 Elite box
+first. Requirements, from neurun's own rules:
+
+- **≥ 2.42** for the Windows-on-ARM HTP stack (`lib/aarch64-windows-msvc/`) —
+  `QHexRT/AGENTS.md` rule 43a
+- **≥ 2.47** for Hexagon v81 work — `QHexRT/docs/BUILD.md:30`
+- A context binary **does not load on a QAIRT older than the one that compiled it**.
+  Measured: a v81 bundle compiled on 2.47 fails `contextCreateFromBinary` with
+  `err=0x1388` on 2.41, and loads on 2.48 — `QHexRT/AGENTS.md` rule 43b. Metadata
+  parsing is *not* a load test, so this will not show up in a pre-flight.
+
+## Procedure
+
+On the X2 Elite box (SSH alias `runanywhere-win`; check `tailscale status | grep runanywhere`
+first — if it says `offline, last seen …` the box is asleep, ask a human to wake it).
+
+```powershell
+# 0. point at the NEW QAIRT, and clone/update neurun at the commit you want
+$env:QNN_SDK_ROOT = "C:\path\to\qairt\2.48.x"
+git clone https://github.com/RunanywhereAI/neurun.git C:\src\neurun   # or: git -C C:\src\neurun fetch --all
+cd C:\src\neurun; git checkout <neurun-sha>
+
+# 1. build ONLY the two archives the SDK links (tools/tests need more of the SDK)
+cmake --preset windows-arm64-release-vs2026 -DQHEXRT_BUILD_TOOLS=OFF -DQHEXRT_BUILD_TESTS=OFF
+cmake --build build/windows-arm64-release-vs2026 --config Release `
+      --target qhexrt_core qhexrt_host -- /m
+
+# 2. the .libs land in build/<preset>/Release/, but the staging script wants them FLAT
+Copy-Item build\windows-arm64-release-vs2026\Release\qhexrt_*.lib `
+          build\windows-arm64-release-vs2026\
+
+# 3. no CMake receipt target off Android -> call the tool directly.
+#    NOTE: --qn is REQUIRED and --ndk is REJECTED for win-arm64.
+#    Take compiler id/version from build/<preset>/CMakeCache.txt.
+python QHexRT\tools\scripts\qhexrt_build_receipt.py create `
+  --receipt build\windows-arm64-release-vs2026\qhexrt-build-receipt.json `
+  --source-root . --build-dir build\windows-arm64-release-vs2026 `
+  --header QHexRT\include\qhexrt\qhexrt_c.h `
+  --core build\windows-arm64-release-vs2026\qhexrt_core.lib `
+  --host build\windows-arm64-release-vs2026\qhexrt_host.lib `
+  --abi win-arm64 --build-type Release `
+  --compiler "<CMAKE_CXX_COMPILER>" --compiler-id MSVC `
+  --compiler-version "<CMAKE_CXX_COMPILER_VERSION>" --qnn "$env:QNN_SDK_ROOT"
+
+# 4. publish. stage_prebuilt_for_sdk.sh needs Git Bash + Developer Mode (for the
+#    `current` symlink). The SDK path used here passes -DQHEXRT_ROOT explicitly and
+#    never reads `current`, so hand-building the versions/<sha> dir is fine and is
+#    what run_windows_e2e.ps1 documents as normal on Windows:
+#      versions/<sha256-of-receipt>/{include/qhexrt/qhexrt_c.h,
+#                                    lib/win-arm64/qhexrt_{core,host}.lib,
+#                                    qhexrt-build-receipt.json, qhexrt-prebuilt.json}
+```
+
+## Then, in this repo — one commit, three files
+
+1. `.github/workflows/electron-native-package.yml` — move `QHEXRT_ROOT` (it appears
+   **twice**: the provenance-check step and the configure step) to the new
+   `versions/<sha>` path. The directory name must equal the receipt's own
+   `build_receipt_sha256`; `engines/qhexrt/CMakeLists.txt` enforces that self-identity
+   rule and will `FATAL_ERROR` on a friendly-named directory.
+2. `engines/qhexrt/PREBUILT_PROVENANCE.json` — update `build_receipt_sha256`,
+   `neurun.*`, `qhexrt_version`, `staged_at`, `recorded_on`, and prune any
+   `known_gaps` the refresh resolves. Read the values straight off the new receipt:
+   ```bash
+   ssh runanywhere-win "python -c \"import json;print(json.dumps(json.load(open(r'<path>\\qhexrt-build-receipt.json')),indent=1))\""
+   ```
+3. Verify before pushing:
+   ```bash
+   python3 scripts/validation/gates/check_qhexrt_provenance.py --record-only   # expect 0 behind
+   ```
+
+## Verifying the result actually shipped
+
+After the release, prove the NPU plugin is real and routable rather than trusting CI:
+
+```bash
+gh run download <run-id> --name sdk-electron-qhexrt-private --dir /tmp/q
+python3 scripts/validation/gates/check_plugin_natives.py --tarball /tmp/q/*.tgz
+# expect: qhexrt ... satisfies its routability contract: qhexrt:engine-available
+```
+
+`qhexrt:engine-available` is the marker that distinguishes a real Hexagon plugin from
+a shell that exports `rac_plugin_entry_qhexrt` and looks healthy by size —
+`g_qhexrt_llm_ops` is internal on PE and is **not** evidence.

--- a/core/AGENTS.md
+++ b/core/AGENTS.md
@@ -231,6 +231,34 @@ in the repo-root `core/VERSION`) are centralized in the `VERSIONS` file. Consume
 
 **Android**: one versioned `dist/RACommons-android-{abi}-v{version}.zip` plus checksum per invocation. The archive contains the public core, LlamaCPP, and ONNX/Sherpa native sets for that ABI. 16 KB ELF alignment is enforced before packaging.
 
+**Linux**: `scripts/build-linux.sh` drives the `linux-release` preset and stages every produced
+`.so` into `dist/linux/{lib,include}`, which `release.yml` tars as
+`RACommons-linux-x86_64-v{version}.tar.gz`. Run `scripts/linux/download-sherpa-onnx.sh` first or
+sherpa builds as a **non-routable stub** — that omission shipped a hollow Linux sherpa carrier
+through 0.20.25.
+
+**Windows** (`scripts/build-windows.bat` → the `windows-x64-shared-release` preset):
+`dist/windows/x64/lib` must contain `rac_commons.dll` + its import `.lib`, each enabled backend's
+`rac_backend_<id>.dll` **and** its `runanywhere_<id>.dll` carrier (the carrier is mandatory on
+Windows — `GetProcAddress` does not walk dependents), plus the vendor runtimes `onnxruntime.dll`,
+`onnxruntime_providers_shared.dll` and `sherpa-onnx-c-api.dll`; headers under
+`dist/windows/x64/include/rac/**`. Packaged as `RACommons-windows-x64-v{version}.zip`.
+
+Two hard rules here, both learned the expensive way:
+
+1. **Configure from the REPO ROOT, never `core/`.** `core/CMakeLists.txt` is a standalone
+   `project(RunAnywhereCommons)` that never calls `add_subdirectory(engines)` — only the
+   repo-root `CMakeLists.txt` does. Configuring `core/` creates *no engine targets at all*.
+2. **Never hardcode per-backend output paths, and never `if exist`-guard a staging copy.** The old
+   script copied from `build/.../src/backends/<id>/Release/`, a layout that stopped existing when
+   the engines moved to top-level `engines/`. Guarded copies turned that into six silent no-ops,
+   so `RACommons-windows-x64` shipped `rac_commons.lib` + headers and **zero engines** for
+   multiple releases while CI stayed green. Stage by glob and fail closed on any missing
+   artifact, as `build-linux.sh` does.
+
+Run `scripts/windows/download-sherpa-onnx.bat` before building, or sherpa is a non-routable stub
+and the script will (now) refuse to package.
+
 **JNI separation**: `librac_commons_jni.so` links only `rac_commons` (no backends). Each backend ships its own JNI `.so` that calls `rac_backend_*_register()`. Mirrors iOS XCFramework separation.
 
 ## Testing

--- a/core/scripts/build-windows.bat
+++ b/core/scripts/build-windows.bat
@@ -204,7 +204,19 @@ echo  Building
 echo ========================================
 echo.
 
-cmake --build "%BUILD_DIR%" --config Release -- /m
+:: Named targets, mirroring the proven electron-windows job — NOT the default ALL
+:: target. Building ALL also builds runanywhere_cloud, which does not link on
+:: MSVC: "unresolved external symbol g_cloud_stt_ops". That is the same PE
+:: data-symbol problem documented for QHexRT in bindings/electron/AGENTS.md
+:: (a carrier referencing an op table as DATA needs __declspec(dllimport) on the
+:: shared declaration). Linux gets cloud for free; Windows cannot ship it until
+:: that is fixed, so RAC_BACKEND_CLOUD=OFF in the preset and cloud is absent here.
+set "BUILD_TARGETS=rac_commons"
+if "%BUILD_LLAMACPP%"=="ON" set "BUILD_TARGETS=!BUILD_TARGETS! runanywhere_llamacpp"
+if "%BUILD_ONNX%"=="ON"     set "BUILD_TARGETS=!BUILD_TARGETS! runanywhere_onnx"
+if "%BUILD_SHERPA%"=="ON"   set "BUILD_TARGETS=!BUILD_TARGETS! runanywhere_sherpa"
+echo [BUILD] targets: !BUILD_TARGETS!
+cmake --build "%BUILD_DIR%" --config Release --target !BUILD_TARGETS! -- /m
 if errorlevel 1 (
     echo [ERROR] Build failed.
     exit /b 1

--- a/core/scripts/build-windows.bat
+++ b/core/scripts/build-windows.bat
@@ -5,31 +5,29 @@ setlocal enabledelayedexpansion
 :: build-windows.bat
 :: Windows build script for runanywhere-commons (x64, MSVC)
 ::
-:: KNOWN LIMITATION (v0.20.0): the CI native_windows job is currently ADVISORY
-:: (non-blocking). Two MSVC-only compile bugs surfaced that could not be verified
-:: on a non-Windows dev machine; both have best-effort fixes committed (strcasecmp
-:: shim in rac_http_client_default.cpp + NOGDI/ERROR guard in platform_compat.h).
-:: If you build this on a real Windows box: verify it compiles clean, then
-:: re-enable the strict gate in .github/workflows/release.yml. Exact errors + fixes:
-:: thoughts/shared/issues/sdk-release-bugs.md (section F).
+:: Produces the SHARED release shape via the windows-x64-shared-release preset:
+:: rac_commons.dll + rac_backend_<id>.dll + runanywhere_<id>.dll carriers, staged
+:: into core/dist/windows/x64/{lib,include}. Fails closed if any expected
+:: artifact is missing.
 ::
 :: Usage: build-windows.bat [options] [backends]
-::        backends: onnx | llamacpp | all (default: all)
-::                  - onnx: STT/TTS/VAD (ONNX Runtime)
-::                  - llamacpp: LLM text generation (GGUF models)
-::                  - all: onnx + llamacpp (default)
+::        backends: onnx | llamacpp | sherpa | all (default: all)
+::                  - onnx:     embeddings / segmentation / diarization
+::                  - llamacpp: LLM + VLM text generation (GGUF models)
+::                  - sherpa:   STT / TTS / VAD  (needs the prefetched prebuilt,
+::                              see core\scripts\windows\download-sherpa-onnx.bat)
+::                  - all: onnx + llamacpp + sherpa (default)
 ::
 :: Options:
 ::   --clean     Clean build directory before building
-::   --shared    Build shared libraries (default: static)
 ::   --test      Build and run tests
 ::   --help      Show this help message
 ::
 :: Examples:
-::   build-windows.bat                    Build all backends (static)
-::   build-windows.bat --shared           Build all backends (shared)
+::   build-windows.bat                    Build all backends (shared)
 ::   build-windows.bat llamacpp           Build only LlamaCPP
-::   build-windows.bat onnx              Build only ONNX backend
+::   build-windows.bat onnx               Build only ONNX backend
+::   build-windows.bat sherpa             Build only Sherpa (STT/TTS/VAD)
 ::   build-windows.bat --clean all        Clean build, all backends
 ::   build-windows.bat --test             Build all + run tests
 ::
@@ -38,10 +36,19 @@ setlocal enabledelayedexpansion
 ::   - Visual Studio 2022 (or Build Tools) with C++ workload
 :: =============================================================================
 
+:: REPO_ROOT, not core/. This is THE bug that shipped a commons-only Windows
+:: bundle with zero engines through 0.20.25: this script used to configure
+:: core/CMakeLists.txt, which is a standalone project(RunAnywhereCommons) that
+:: never calls add_subdirectory(engines) — only the REPO-ROOT CMakeLists.txt
+:: does. So no engine target was ever created, every backend copy below was a
+:: silent no-op, and the script still exited 0.
 set "SCRIPT_DIR=%~dp0"
-set "ROOT_DIR=%SCRIPT_DIR%.."
-set "BUILD_DIR=%ROOT_DIR%\build\windows-x64"
-set "DIST_DIR=%ROOT_DIR%\dist\windows\x64"
+set "COMMONS_DIR=%SCRIPT_DIR%.."
+set "REPO_ROOT=%SCRIPT_DIR%..\.."
+:: Owned by the windows-x64-shared-release preset's binaryDir.
+set "BUILD_DIR=%REPO_ROOT%\build\windows-x64-shared-release"
+:: Stays under core/ — release.yml zips core/dist/windows.
+set "DIST_DIR=%COMMONS_DIR%\dist\windows\x64"
 
 :: =============================================================================
 :: Load Versions
@@ -52,11 +59,11 @@ call :load_versions
 :: Defaults
 :: =============================================================================
 set "CLEAN_BUILD=0"
-set "BUILD_SHARED=OFF"
 set "BUILD_TESTS=OFF"
 set "RUN_TESTS=0"
 set "BUILD_ONNX=OFF"
 set "BUILD_LLAMACPP=OFF"
+set "BUILD_SHERPA=OFF"
 set "BACKENDS="
 
 :: =============================================================================
@@ -66,11 +73,6 @@ set "BACKENDS="
 if "%~1"=="" goto :done_args
 if "%~1"=="--clean" (
     set "CLEAN_BUILD=1"
-    shift
-    goto :parse_args
-)
-if "%~1"=="--shared" (
-    set "BUILD_SHARED=ON"
     shift
     goto :parse_args
 )
@@ -96,13 +98,16 @@ if "%BACKENDS%"=="" set "BACKENDS=all"
 if "%BACKENDS%"=="all" (
     set "BUILD_ONNX=ON"
     set "BUILD_LLAMACPP=ON"
+    set "BUILD_SHERPA=ON"
 ) else if "%BACKENDS%"=="onnx" (
     set "BUILD_ONNX=ON"
 ) else if "%BACKENDS%"=="llamacpp" (
     set "BUILD_LLAMACPP=ON"
+) else if "%BACKENDS%"=="sherpa" (
+    set "BUILD_SHERPA=ON"
 ) else (
     echo [ERROR] Unknown backend: %BACKENDS%
-    echo Usage: %~nx0 [options] [onnx ^| llamacpp ^| all]
+    echo Usage: %~nx0 [options] [onnx ^| llamacpp ^| sherpa ^| all]
     exit /b 1
 )
 
@@ -115,8 +120,8 @@ echo  RunAnywhere Windows Build
 echo ========================================
 echo.
 echo  Architecture:  x64
-echo  Backends:      ONNX=%BUILD_ONNX%, LlamaCPP=%BUILD_LLAMACPP%
-if "%BUILD_SHARED%"=="ON" (echo  Library type:  Shared) else (echo  Library type:  Static)
+echo  Backends:      ONNX=%BUILD_ONNX%, LlamaCPP=%BUILD_LLAMACPP%, Sherpa=%BUILD_SHERPA%
+echo  Library type:  Shared ^(rac_commons.dll + plugin DLLs^)
 echo  Tests:         %BUILD_TESTS%
 echo  Build dir:     %BUILD_DIR%
 echo  Dist dir:      %DIST_DIR%
@@ -170,25 +175,24 @@ echo  Configuring CMake
 echo ========================================
 echo.
 
-cmake -B "%BUILD_DIR%" ^
-    -G "Visual Studio 17 2022" -A x64 ^
-    -DRAC_BUILD_BACKENDS=ON ^
+:: Drive the preset rather than hand-rolling flags. The preset is rooted at the
+:: repo root (so add_subdirectory(engines) runs) and carries the proven
+:: electron-windows flag set: RAC_BUILD_SHARED=ON + RAC_STATIC_PLUGINS=OFF,
+:: which is what produces rac_backend_<id>.dll AND the runanywhere_<id>.dll
+:: carriers. Narrowed backend selections are expressed as -D overrides ON TOP
+:: of the preset, never by dropping it.
+pushd "%REPO_ROOT%" >nul
+cmake --preset windows-x64-shared-release ^
     -DRAC_BACKEND_ONNX=%BUILD_ONNX% ^
     -DRAC_BACKEND_LLAMACPP=%BUILD_LLAMACPP% ^
-    -DRAC_BACKEND_RAG=OFF ^
-    -DRAC_BUILD_TESTS=%BUILD_TESTS% ^
-    -DRAC_BUILD_SHARED=%BUILD_SHARED% ^
-    -DRAC_BUILD_PLATFORM=OFF ^
-    "%ROOT_DIR%"
-::
-:: NOTE: RAC_BACKEND_RAG is disabled here because the RAG backend has known
-:: Windows build issues (tracked separately). Enable it manually once those
-:: are fixed.
-
+    -DRAC_BACKEND_SHERPA=%BUILD_SHERPA% ^
+    -DRAC_BUILD_TESTS=%BUILD_TESTS%
 if errorlevel 1 (
+    popd >nul
     echo [ERROR] CMake configure failed.
     exit /b 1
 )
+popd >nul
 echo [OK] CMake configure complete
 
 :: =============================================================================
@@ -213,47 +217,92 @@ echo [OK] Build complete
 echo.
 echo [DIST] Copying libraries to distribution directory...
 
-if "%BUILD_SHARED%"=="ON" (set "LIB_EXT=dll") else (set "LIB_EXT=lib")
+:: Blanket glob + hard gates, ported from core/scripts/build-linux.sh:43-73.
+:: NEVER name a per-backend output path again: the previous version hardcoded
+:: %BUILD_DIR%\src\backends\<id>\Release\, a layout that stopped existing when
+:: the engines moved to the top-level engines/ tree. Every copy was `if exist`
+:: -guarded, so all six became silent no-ops and the release shipped a
+:: commons-only zip for multiple versions with CI fully green.
+rmdir /s /q "%DIST_DIR%" 2>nul
+mkdir "%DIST_DIR%\lib" 2>nul
+mkdir "%DIST_DIR%\include" 2>nul
 
-:: Core library (copy .lib import lib + .dll runtime lib for shared builds)
-if exist "%BUILD_DIR%\Release\rac_commons.lib" (
-    copy /y "%BUILD_DIR%\Release\rac_commons.lib" "%DIST_DIR%\" >nul
-    echo [OK] Copied rac_commons.lib
+echo [DIST] Staging DLLs + import libs from the build tree...
+for /r "%BUILD_DIR%" %%f in (rac_commons*.dll rac_backend_*.dll runanywhere_*.dll) do (
+    copy /y "%%f" "%DIST_DIR%\lib\" >nul && echo   + %%~nxf
 )
-if "%BUILD_SHARED%"=="ON" if exist "%BUILD_DIR%\Release\rac_commons.dll" (
-    copy /y "%BUILD_DIR%\Release\rac_commons.dll" "%DIST_DIR%\" >nul
-    echo [OK] Copied rac_commons.dll
+for /r "%BUILD_DIR%" %%f in (rac_commons*.lib rac_backend_*.lib runanywhere_*.lib) do (
+    copy /y "%%f" "%DIST_DIR%\lib\" >nul && echo   + %%~nxf
+)
+:: onnxruntime*.dll live under %BUILD_DIR%\_deps\onnxruntime-src\lib and are
+:: swept by this same glob; sherpa's vendor runtime is NOT in the build tree.
+for /r "%BUILD_DIR%" %%f in (onnxruntime*.dll) do (
+    copy /y "%%f" "%DIST_DIR%\lib\" >nul && echo   + %%~nxf
+)
+if "%BUILD_SHERPA%"=="ON" (
+    if exist "%COMMONS_DIR%\third_party\sherpa-onnx-windows\lib\sherpa-onnx-c-api.dll" (
+        copy /y "%COMMONS_DIR%\third_party\sherpa-onnx-windows\lib\sherpa-onnx-c-api.dll" "%DIST_DIR%\lib\" >nul
+        echo   + sherpa-onnx-c-api.dll
+    ) else (
+        echo [ERROR] sherpa-onnx-c-api.dll missing. Run core\scripts\windows\download-sherpa-onnx.bat
+        echo         first, or sherpa builds as a NON-ROUTABLE stub.
+        exit /b 1
+    )
 )
 
-:: ONNX backend
-if "%BUILD_ONNX%"=="ON" (
-    if exist "%BUILD_DIR%\src\backends\onnx\Release\rac_backend_onnx.lib" (
-        copy /y "%BUILD_DIR%\src\backends\onnx\Release\rac_backend_onnx.lib" "%DIST_DIR%\" >nul
-        echo [OK] Copied rac_backend_onnx.lib
-    )
-    if "%BUILD_SHARED%"=="ON" if exist "%BUILD_DIR%\src\backends\onnx\Release\rac_backend_onnx.dll" (
-        copy /y "%BUILD_DIR%\src\backends\onnx\Release\rac_backend_onnx.dll" "%DIST_DIR%\" >nul
-        echo [OK] Copied rac_backend_onnx.dll
-    )
+:: Duplicate-basename visibility (build-linux.sh hard-fails here; this only warns).
+:: The recursive glob can find the same file name in two build subtrees and
+:: `copy /y` silently keeps the last. Warning rather than failing because CMake
+:: legitimately copies vendor runtimes beside targets, and a false hard-fail here
+:: would block the whole release train.
+for /f %%n in ('powershell -NoProfile -Command "$d=Get-ChildItem -Path '%BUILD_DIR%' -Recurse -File -Include rac_commons*.dll,rac_backend_*.dll,runanywhere_*.dll,onnxruntime*.dll ^| Group-Object Name ^| Where-Object Count -gt 1; if ($d) { $d ^| ForEach-Object { Write-Host ('  DUPLICATE: ' + $_.Name + ' x' + $_.Count) } }; ($d ^| Measure-Object).Count"') do set "DUPES=%%n"
+if not "!DUPES!"=="0" (
+    echo [WARN]  !DUPES! duplicate basename^(s^) above; `copy /y` keeps the last one.
+    echo         Expected for vendor runtimes CMake copies beside targets. Promote this
+    echo         to a hard failure once real CI output confirms which are benign.
 )
 
-:: LlamaCPP backend
-if "%BUILD_LLAMACPP%"=="ON" (
-    if exist "%BUILD_DIR%\src\backends\llamacpp\Release\rac_backend_llamacpp.lib" (
-        copy /y "%BUILD_DIR%\src\backends\llamacpp\Release\rac_backend_llamacpp.lib" "%DIST_DIR%\" >nul
-        echo [OK] Copied rac_backend_llamacpp.lib
-    )
-    if "%BUILD_SHARED%"=="ON" if exist "%BUILD_DIR%\src\backends\llamacpp\Release\rac_backend_llamacpp.dll" (
-        copy /y "%BUILD_DIR%\src\backends\llamacpp\Release\rac_backend_llamacpp.dll" "%DIST_DIR%\" >nul
-        echo [OK] Copied rac_backend_llamacpp.dll
-    )
+:: Private-engine leak guard (mirrors build-linux.sh) — qhexrt/QNN must never
+:: reach a public bundle.
+for /r "%DIST_DIR%\lib" %%f in (*qhexrt* *qnn* *Qnn*) do (
+    echo [ERROR] private engine artifact leaked into the public bundle: %%~nxf
+    exit /b 1
 )
 
 :: Headers
 echo [DIST] Copying headers...
-if not exist "%DIST_DIR%\include" mkdir "%DIST_DIR%\include"
-xcopy /s /y /q "%ROOT_DIR%\include\rac" "%DIST_DIR%\include\rac\" >nul
+xcopy /s /y /q "%COMMONS_DIR%\include\rac" "%DIST_DIR%\include\rac\" >nul
 echo [OK] Copied headers
+
+:: =============================================================================
+:: FAIL CLOSED — assert every expected artifact is present.
+:: Without this the bundle can ship hollow and nothing notices (see above).
+:: =============================================================================
+echo.
+echo [VERIFY] Asserting required artifacts...
+set "MISSING=0"
+call :require rac_commons.dll
+if "%BUILD_LLAMACPP%"=="ON" (
+    call :require rac_backend_llamacpp.dll
+    call :require runanywhere_llamacpp.dll
+)
+if "%BUILD_ONNX%"=="ON" (
+    call :require rac_backend_onnx.dll
+    call :require runanywhere_onnx.dll
+    call :require onnxruntime.dll
+)
+if "%BUILD_SHERPA%"=="ON" (
+    call :require rac_backend_sherpa.dll
+    call :require runanywhere_sherpa.dll
+    call :require sherpa-onnx-c-api.dll
+)
+if not "!MISSING!"=="0" (
+    echo [ERROR] !MISSING! required artifact^(s^) missing from %DIST_DIR%\lib — refusing to
+    echo         produce a hollow Windows bundle. This is the failure the release
+    echo         pipeline silently shipped before this gate existed.
+    exit /b 1
+)
+echo [OK] all required artifacts present
 
 :: =============================================================================
 :: Run Tests
@@ -302,11 +351,12 @@ echo ========================================
 echo.
 echo  Distribution: %DIST_DIR%
 echo.
-dir /b "%DIST_DIR%\*.lib" 2>nul
+dir /b "%DIST_DIR%\lib" 2>nul
 echo.
 echo  To use in your project:
 echo    Include: /I"%DIST_DIR%\include"
-echo    Link:    /LIBPATH:"%DIST_DIR%" rac_commons.lib
+echo    Link:    /LIBPATH:"%DIST_DIR%\lib" rac_commons.lib
+echo    Runtime: copy %DIST_DIR%\lib\*.dll beside your executable
 echo.
 
 exit /b 0
@@ -319,26 +369,37 @@ exit /b 0
 echo Usage: %~nx0 [options] [backends]
 echo.
 echo Backends:
-echo   onnx        STT/TTS/VAD (ONNX Runtime + Sherpa-ONNX)
-echo   llamacpp    LLM text generation (GGUF models via llama.cpp)
-echo   all         onnx + llamacpp (default)
+echo   onnx        embeddings / segmentation / diarization (ONNX Runtime)
+echo   llamacpp    LLM + VLM text generation (GGUF models via llama.cpp)
+echo   sherpa      STT / TTS / VAD (needs download-sherpa-onnx.bat first)
+echo   all         onnx + llamacpp + sherpa (default)
 echo.
 echo Options:
 echo   --clean     Clean build directory before building
-echo   --shared    Build shared libraries (default: static)
 echo   --test      Build and run tests
 echo   --help      Show this help message
 echo.
 echo Examples:
-echo   %~nx0                        Build all backends (static)
-echo   %~nx0 --shared               Build all backends (shared)
+echo   %~nx0                        Build all backends (shared)
 echo   %~nx0 llamacpp               Build only LlamaCPP
 echo   %~nx0 --clean --test all     Clean build, all backends, run tests
 exit /b 0
 
+:require
+:: Assert one artifact exists in DIST_DIR\lib; increments MISSING if not.
+:: Called only from the fail-closed verify block.
+if not exist "%DIST_DIR%\lib\%~1" (
+    echo   [MISSING] %~1
+    set /a MISSING+=1
+) else (
+    echo   [ok] %~1
+)
+goto :eof
+
 :load_versions
 :: Read VERSIONS file and set variables
-set "VERSIONS_FILE=%ROOT_DIR%\VERSIONS"
+:: core/VERSIONS — COMMONS_DIR, not REPO_ROOT (ROOT_DIR was split into the two).
+set "VERSIONS_FILE=%COMMONS_DIR%\VERSIONS"
 if not exist "%VERSIONS_FILE%" (
     echo [ERROR] VERSIONS file not found at %VERSIONS_FILE%
     exit /b 1

--- a/core/scripts/build-windows.bat
+++ b/core/scripts/build-windows.bat
@@ -267,7 +267,7 @@ if "%BUILD_SHERPA%"=="ON" (
 :: `copy /y` silently keeps the last. Warning rather than failing because CMake
 :: legitimately copies vendor runtimes beside targets, and a false hard-fail here
 :: would block the whole release train.
-for /f %%n in ('powershell -NoProfile -Command "$d=Get-ChildItem -Path '%BUILD_DIR%' -Recurse -File -Include rac_commons*.dll,rac_backend_*.dll,runanywhere_*.dll,onnxruntime*.dll ^| Group-Object Name ^| Where-Object Count -gt 1; if ($d) { $d ^| ForEach-Object { Write-Host ('  DUPLICATE: ' + $_.Name + ' x' + $_.Count) } }; ($d ^| Measure-Object).Count"') do set "DUPES=%%n"
+for /f %%n in ('powershell -NoProfile -Command "$f=Get-ChildItem -Path '%BUILD_DIR%' -Recurse -File -Include rac_commons*.dll,rac_backend_*.dll,runanywhere_*.dll,onnxruntime*.dll; $g=$f | Group-Object Name | Where-Object {$_.Count -gt 1}; $g | ForEach-Object { Write-Host ('  DUPLICATE: ' + $_.Name + ' x' + $_.Count) }; @($g).Count"') do set "DUPES=%%n"
 if not "!DUPES!"=="0" (
     echo [WARN]  !DUPES! duplicate basename^(s^) above; `copy /y` keeps the last one.
     echo         Expected for vendor runtimes CMake copies beside targets. Promote this

--- a/core/scripts/windows/download-sherpa-onnx.bat
+++ b/core/scripts/windows/download-sherpa-onnx.bat
@@ -21,7 +21,18 @@ set "DEST_DIR=%ROOT_DIR%\third_party\sherpa-onnx-windows"
 
 :: Load versions
 call :load_versions
-if not defined SHERPA_ONNX_VERSION_WINDOWS set "SHERPA_ONNX_VERSION_WINDOWS=1.12.23"
+:: Fail closed rather than falling back. The old hardcoded default (1.12.23)
+:: had already drifted from core/VERSIONS (now 1.13.5), so an unreadable
+:: VERSIONS file would silently request a nonexistent release asset and the
+:: sherpa backend would then build as a non-routable stub.
+if not defined SHERPA_ONNX_VERSION_WINDOWS (
+    echo [ERROR] SHERPA_ONNX_VERSION_WINDOWS not loaded from core\VERSIONS.
+    exit /b 1
+)
+if not defined SHERPA_ONNX_WINDOWS_X64_SHA256 (
+    echo [ERROR] SHERPA_ONNX_WINDOWS_X64_SHA256 not loaded from core\VERSIONS.
+    exit /b 1
+)
 set "VERSION=%SHERPA_ONNX_VERSION_WINDOWS%"
 set "REPOSITORY=%SHERPA_ONNX_REPO_DESKTOP%"
 set "RELEASE_TAG=%SHERPA_ONNX_RELEASE_TAG_DESKTOP%"

--- a/engines/qhexrt/PREBUILT_PROVENANCE.json
+++ b/engines/qhexrt/PREBUILT_PROVENANCE.json
@@ -1,0 +1,41 @@
+{
+  "$comment": [
+    "Provenance of the QHexRT win-arm64 prebuilt that the Electron release consumes.",
+    "",
+    "WHY THIS FILE EXISTS: engines/qhexrt/CMakeLists.txt consumes a PREBUILT receipt",
+    "tree (include/ + lib/<abi>/ + a hash-named receipt), it does not build QHexRT",
+    "from source. For win-arm64 that tree is staged BY HAND on the self-hosted",
+    "Snapdragon X2 Elite runner. Before this file existed, the only record of which",
+    "neurun commit was inside it was a bare hash in a workflow env var, so the",
+    "shipped NPU engine could silently fall arbitrarily far behind neurun and",
+    "nothing would say so. scripts/validation/gates/check_qhexrt_provenance.py",
+    "asserts the staged tree still matches what is recorded here.",
+    "",
+    "TO REFRESH: see bindings/electron/docs/QHEXRT_PREBUILT_REFRESH.md.",
+    "Update every field below from the new receipt, in the same commit that moves",
+    "QHEXRT_ROOT in .github/workflows/electron-native-package.yml."
+  ],
+
+  "abi": "win-arm64",
+  "build_receipt_sha256": "f14ef0efb1da4b6a50e49f37a0ef55ac3b0bb7328aa7469edf78625ac4d79607",
+
+  "neurun": {
+    "git_sha": "5f6f0d07056c73e437083f61f1afa4b456c032fe",
+    "git_dirty": false,
+    "state_sha256": "ad6407956482d430f96e9e0408a586554a6ce36eb93ac9285055b4a727a794c9",
+    "commit_subject": "qwen38: the perf log dropped its ttft argument",
+    "commit_date": "2026-08-20T04:26:28Z"
+  },
+
+  "qhexrt_version": "0.1.0",
+  "c_abi": { "major": 1, "minor": 0 },
+
+  "staged_at": "C:\\actions-runner-state\\qhexrt-prebuilt\\versions\\f14ef0efb1da4b6a50e49f37a0ef55ac3b0bb7328aa7469edf78625ac4d79607",
+  "recorded_on": "2026-08-22",
+
+  "known_gaps": [
+    "STALE: this tree predates current neurun main. Recorded 2026-08-22, when it was 3 commits behind, missing 'kernels: port Qwen3.8 IQ1 to Hexagon v81 (#62)' (901c249833731d4e455f2aab4dff0c57139776d3). Those v81 kernels are therefore NOT in the shipped @runanywhere/electron-qhexrt.",
+    "BLOCKED ON A QAIRT UPGRADE: the runner has QAIRT 2.41.0.251128. neurun requires >= 2.42 for the Windows-on-ARM HTP stack (lib/aarch64-windows-msvc/, QHexRT/AGENTS.md rule 43a) and >= 2.47 for v81 work (QHexRT/docs/BUILD.md:30). Rule 43b measured that a v81 bundle compiled on 2.47 fails contextCreateFromBinary with err=0x1388 on 2.41. QAIRT is licence-gated, so a human with a Qualcomm account must install 2.47+ (2.48 recommended) on that box before a v81-capable prebuilt can be produced.",
+    "CANNOT BE BUILT IN CI TODAY: neurun gates its qhexrt_build_receipt CMake target behind if(ANDROID) (neurun CMakeLists.txt:375), and its stage_prebuilt_for_sdk.sh is POSIX-only (ps/lstart, os.symlink, diff -qr). Un-gating that target and adding a Windows-capable publisher belongs upstream in neurun, not here."
+  ]
+}

--- a/scripts/validation/gates/check_plugin_natives.py
+++ b/scripts/validation/gates/check_plugin_natives.py
@@ -365,6 +365,16 @@ def main() -> int:
     parser.add_argument("paths", nargs="*", type=Path, help="plugin files or directories")
     parser.add_argument("--tarball", type=Path, action="append", default=[],
                         help="npm tarball to inspect (repeatable)")
+    parser.add_argument(
+        "--allow-placeholder-staging-url", action="store_true",
+        help=(
+            "Report the staging-URL placeholder as a note instead of a failure. "
+            "ONLY for PR-time builds, which legitimately have no STAGING_BASE_URL: "
+            "the secret is unavailable to fork PRs, so a PR build necessarily bakes "
+            "the placeholder. Routability is still enforced. NEVER pass this in a "
+            "release job — that is the exact defect that shipped a placeholder "
+            "staging URL through 0.20.24."
+        ))
     parser.add_argument("--expect-version", default="",
                         help="RAC_VERSION_STRING that every bundled rac_commons must embed")
     args = parser.parse_args()
@@ -450,6 +460,10 @@ def main() -> int:
                                 print(f"  ok    version  {member.name}  "
                                       f"embeds {args.expect_version}")
                         track_fail = check_tracking_bytes(payload, f"{archive.name}:{member.name}")
+                        if track_fail and args.allow_placeholder_staging_url:
+                            print(f"  note  telemetry  {archive.name}:{member.name}  "
+                                  f"placeholder staging URL — ALLOWED (PR-time build, no secret)")
+                            track_fail = None
                         checked += 1
                         if track_fail:
                             print(f"  FAIL  telemetry  {archive.name}:{member.name}  "
@@ -473,6 +487,10 @@ def main() -> int:
             ):
                 checked += 1
                 track_fail = check_tracking_bytes(target.read_bytes(), display)
+                if track_fail and args.allow_placeholder_staging_url:
+                    print(f"  note  telemetry  {display}  "
+                          f"placeholder staging URL — ALLOWED (PR-time build, no secret)")
+                    continue
                 if track_fail:
                     print(f"  FAIL  telemetry  {display}  placeholder staging URL baked in")
                     telemetry_failures.append(track_fail)
@@ -522,8 +540,16 @@ def main() -> int:
         )
         return 1
 
-    print(f"\nAll {checked} check(s) passed: plugin natives are routable and no "
-          f"staging-URL placeholder was found.")
+    if args.allow_placeholder_staging_url:
+        # Never claim "no placeholder was found" when the caller asked us to
+        # tolerate one — a gate that overstates its own coverage is worse than
+        # no gate.
+        print(f"\nAll {checked} check(s) passed: plugin natives are routable; "
+              f"staging-URL placeholder TOLERATED (--allow-placeholder-staging-url, "
+              f"PR-time build). A release build must NOT pass this flag.")
+    else:
+        print(f"\nAll {checked} check(s) passed: plugin natives are routable and no "
+              f"staging-URL placeholder was found.")
     return 0
 
 

--- a/scripts/validation/gates/check_qhexrt_provenance.py
+++ b/scripts/validation/gates/check_qhexrt_provenance.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+"""Assert the staged QHexRT prebuilt is the one we think it is — and say how stale.
+
+WHY THIS EXISTS
+---------------
+`engines/qhexrt/CMakeLists.txt` consumes a PREBUILT receipt tree; it never builds
+QHexRT from source. For win-arm64 that tree is staged by hand on the self-hosted
+Snapdragon runner, and until now the only record of which neurun commit was inside
+it was a bare directory hash in a workflow env var. So the shipped NPU engine could
+drift arbitrarily far behind neurun and nothing anywhere would say so — which is
+exactly what happened: the tree shipped in 0.20.25 was built from a neurun commit
+that predates the Hexagon v81 kernel work.
+
+WHAT IT CHECKS
+--------------
+1. HARD FAIL if the staged receipt's identity does not match
+   engines/qhexrt/PREBUILT_PROVENANCE.json (someone re-staged without recording it,
+   or QHEXRT_ROOT points somewhere unexpected).
+2. WARN — never fail — when the recorded neurun commit is behind neurun's default
+   branch. Staleness is a fact to surface, not a reason to break the release: the
+   refresh needs a licensed QAIRT install on a specific physical machine.
+
+Requires `gh` on PATH for the staleness check; skips it (with a note) if absent or
+unauthenticated, so this still works offline and on forks.
+
+USAGE
+    check_qhexrt_provenance.py --qhexrt-root <staged tree>   # full check
+    check_qhexrt_provenance.py --record-only                 # parse + report only
+"""
+from __future__ import annotations
+
+import argparse
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+PROVENANCE = REPO_ROOT / "engines" / "qhexrt" / "PREBUILT_PROVENANCE.json"
+NEURUN = "RunanywhereAI/neurun"
+
+
+def load_provenance() -> dict:
+    if not PROVENANCE.is_file():
+        sys.exit(f"FAIL: missing {PROVENANCE.relative_to(REPO_ROOT)}")
+    try:
+        return json.loads(PROVENANCE.read_text())
+    except json.JSONDecodeError as exc:
+        sys.exit(f"FAIL: {PROVENANCE.relative_to(REPO_ROOT)} is not valid JSON: {exc}")
+
+
+def check_staged(root: Path, want: dict) -> list[str]:
+    """Compare the on-disk receipt against what we recorded. Returns failure strings."""
+    fails: list[str] = []
+    receipt_path = root / "qhexrt-build-receipt.json"
+    if not receipt_path.is_file():
+        return [f"no receipt at {receipt_path}"]
+
+    try:
+        receipt = json.loads(receipt_path.read_text())
+    except json.JSONDecodeError as exc:
+        return [f"receipt is not valid JSON: {exc}"]
+
+    # The directory name IS the receipt hash (engines/qhexrt/CMakeLists.txt enforces
+    # this self-identity rule too); compare it to what we recorded.
+    if root.name != want["build_receipt_sha256"]:
+        fails.append(
+            f"staged dir name {root.name!r} != recorded build_receipt_sha256 "
+            f"{want['build_receipt_sha256']!r}"
+        )
+
+    src = receipt.get("source") or {}
+    for key, label in (("git_sha", "neurun git_sha"), ("state_sha256", "neurun state_sha256")):
+        got, exp = src.get(key), want["neurun"].get(key)
+        if got != exp:
+            fails.append(f"{label}: staged={got!r} recorded={exp!r}")
+
+    if src.get("git_dirty") is not want["neurun"].get("git_dirty"):
+        fails.append(
+            f"neurun git_dirty: staged={src.get('git_dirty')!r} "
+            f"recorded={want['neurun'].get('git_dirty')!r}"
+        )
+
+    if receipt.get("qhexrt_version") != want.get("qhexrt_version"):
+        fails.append(
+            f"qhexrt_version: staged={receipt.get('qhexrt_version')!r} "
+            f"recorded={want.get('qhexrt_version')!r}"
+        )
+    return fails
+
+
+def report_staleness(want: dict) -> None:
+    """WARN-only: how far behind neurun's default branch the staged tree is."""
+    sha = want["neurun"]["git_sha"]
+    try:
+        out = subprocess.run(
+            ["gh", "api", f"repos/{NEURUN}/compare/{sha}...HEAD",
+             "--jq", "{ahead_by, behind_by}"],
+            capture_output=True, text=True, timeout=45, check=True,
+        ).stdout.strip()
+        cmp = json.loads(out)
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired,
+            FileNotFoundError, json.JSONDecodeError) as exc:
+        print(f"  note: staleness check skipped ({type(exc).__name__}) — needs `gh` "
+              f"authenticated for the private {NEURUN}")
+        return
+
+    ahead = cmp.get("ahead_by") or 0
+    if ahead == 0:
+        print(f"  OK: staged QHexRT is current with {NEURUN} HEAD")
+        return
+    print(f"  ::warning::staged QHexRT prebuilt is {ahead} commit(s) BEHIND "
+          f"{NEURUN} HEAD — neurun changes since {sha[:12]} are NOT in the shipped "
+          f"@runanywhere/electron-qhexrt. Refresh: "
+          f"bindings/electron/docs/QHEXRT_PREBUILT_REFRESH.md")
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__,
+                                 formatter_class=argparse.RawDescriptionHelpFormatter)
+    ap.add_argument("--qhexrt-root", type=Path,
+                    help="the staged versions/<receipt-sha256> tree to verify")
+    ap.add_argument("--record-only", action="store_true",
+                    help="parse the provenance record and report staleness; skip disk checks")
+    args = ap.parse_args()
+
+    want = load_provenance()
+    n = want["neurun"]
+    print(f"recorded QHexRT prebuilt: receipt={want['build_receipt_sha256'][:16]}… "
+          f"abi={want['abi']} qhexrt={want['qhexrt_version']}")
+    print(f"  built from {NEURUN}@{n['git_sha'][:12]} "
+          f"({n.get('commit_date','?')}) dirty={n.get('git_dirty')}")
+
+    if args.qhexrt_root:
+        root = args.qhexrt_root
+        if not root.is_dir():
+            print(f"FAIL: --qhexrt-root is not a directory: {root}")
+            return 1
+        fails = check_staged(root, want)
+        if fails:
+            print("FAIL: staged QHexRT does not match the recorded provenance:")
+            for f in fails:
+                print(f"  - {f}")
+            print("\nIf the re-stage was intentional, update "
+                  "engines/qhexrt/PREBUILT_PROVENANCE.json in the same commit that "
+                  "moves QHEXRT_ROOT.")
+            return 1
+        print("  OK: staged tree matches the recorded provenance")
+    elif not args.record_only:
+        print("  note: no --qhexrt-root given; skipping on-disk verification")
+
+    report_staleness(want)
+    for gap in want.get("known_gaps", []):
+        print(f"  known gap: {gap}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## The defect

`RACommons-windows-x64-v0.20.25.zip` shipped with **no usable engines**: 1 static `rac_commons.lib` (89 MB) + 163 headers, and nothing else. Verified against the published artifact:

- **0** `rac_plugin_entry_*` symbols
- **0** ops tables (`g_llamacpp_ops`, `g_onnx_*`, `g_sherpa_*`)
- **0** `ggml_` / `onnxruntime` / `SherpaOnnx` strings

A Windows consumer could not run any inference. CI was green the whole time.

## Root cause

`core/scripts/build-windows.bat` configured **`core/`** as the CMake source dir. `core/CMakeLists.txt` is a standalone `project(RunAnywhereCommons)` that never calls `add_subdirectory(engines)` — only the **repo-root** `CMakeLists.txt` does. So no engine target was ever created.

Compounding it: the six staging copies pointed at `build/.../src/backends/<id>/Release/`, a layout that stopped existing when the engines moved to top-level `engines/`. Every copy was `if exist`-guarded, so all six **silently no-oped** and the script still exited 0.

Why CI never caught it: the job asserted only "does `dist/windows` exist" and "was a zip produced" — both true, because headers and `rac_commons.lib` landed. And with no carriers present, `check_plugin_natives.py` reports *nothing* rather than reporting failure. Windows is also advisory in the publish gate, and **no PR-time job ever ran this script**, so it rotted invisibly.

## Fix

Reuses the `electron-windows` recipe — the only Windows configuration with live CI evidence of building all three CPU backends on MSVC (its `win32-x64` packages verifiably ship real, routable `rac_backend_{llamacpp,onnx,sherpa}.dll`).

| File | Change |
|---|---|
| `CMakePresets.json` | New `windows-x64-shared-release` preset: repo-root rooted, `RAC_BUILD_SHARED=ON` + `RAC_STATIC_PLUGINS=OFF`, llamacpp/onnx/sherpa ON. Drops Electron's N-API addon and `RAC_DESKTOP_ADAPTER` (would make libcurl a hard requirement this job has no vcpkg step for). Build preset pins `configuration: Release` — VS is multi-config, so `CMAKE_BUILD_TYPE` is a no-op at build time. |
| `build-windows.bat` | Configure the repo root via the preset; stage by **glob** into `dist/windows/x64/lib` instead of naming per-backend paths; add `sherpa` as a selectable backend; **fail closed** on any missing artifact; keep the qhexrt/QNN leak guard. |
| `release.yml` `native_windows` | Prefetch the sherpa prebuilt; run `check_plugin_natives.py`; assert the **shipped zip** carries all 9 expected natives. |
| `pr-build.yml` | New `windows-commons-release` job so this can't rot again. |

## Same bug on Linux — also fixed

`native_linux` never ran `download-sherpa-onnx.sh`, so sherpa built as a **non-routable stub**: a ~156 KB `librac_backend_sherpa.so` with no `libsherpa-onnx-c-api.so` beside it, and no working STT/TTS/VAD. Carriers are **byte-identical** on 0.20.24 and 0.20.25 (`sha256=28ef1601…`), and the gate emits the same FAIL on both — long-standing, not a regression. Added the prefetch plus a routability gate.

## Verification

**Cannot be verified off-Windows** — MSVC compile behavior is the whole question. The two new CI jobs are the proof:

- [ ] `windows-commons-release` (pr-build) green: all 9 natives staged + routable
- [ ] Linux routability gate green (proves sherpa is no longer hollow)

Deliberately **not** included: `runanywhere_cloud` on Windows — it has never been built on MSVC by any job here, so adding it would be unevidenced. The duplicate-basename check warns rather than hard-fails, because CMake legitimately copies vendor runtimes beside targets and a false hard-fail would block the release train; promote it once real CI output shows which duplicates are benign.

Follow-up (separate PR, after this is green): promote `native_windows` to a strict publish gate.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Build & Packaging**
  * Added Windows shared-release builds with LlamaCPP, ONNX, ONNX Runtime, and Sherpa-ONNX backends.
  * Windows packaging now validates required libraries, runtimes, headers, dependencies, and excludes private engine files.
  * Sherpa-ONNX downloads now require verified version and checksum information.

* **Release Validation**
  * Release workflows verify plugin routing and Linux/Windows package contents before publishing.
  * Added Windows ARM64 QHexRT provenance and prebuilt validation.

* **Documentation**
  * Added Linux, Windows, packaging, release archive, and QHexRT refresh guidance.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->