### PR TITLE
fix(swift,web): stop pointing deprecated TTS stop helpers at a deprecated API

### DIFF
--- a/bindings/swift/Sources/RunAnywhere/Public/Extensions/TTS/RunAnywhere+TTS.swift
+++ b/bindings/swift/Sources/RunAnywhere/Public/Extensions/TTS/RunAnywhere+TTS.swift
@@ -52,7 +52,7 @@ public extension RunAnywhere {
     }
 
     /// Stop current TTS synthesis.
-    @available(*, deprecated, renamed: "tts.stop()")
+    @available(*, deprecated, message: "Use the SpeechHandle returned by tts.speak(_:options:) to interrupt one utterance")
     static func stopSynthesis() async {
         await CppBridge.TTS.shared.stop()
     }
@@ -73,7 +73,7 @@ public extension RunAnywhere {
     }
 
     /// Stop current speech playback.
-    @available(*, deprecated, renamed: "tts.stop()")
+    @available(*, deprecated, message: "Use the SpeechHandle returned by tts.speak(_:options:) to interrupt one utterance")
     static func stopSpeaking() async {
         await stopSpeech()
     }

--- a/bindings/web/packages/core/src/Public/API/Deprecated.ts
+++ b/bindings/web/packages/core/src/Public/API/Deprecated.ts
@@ -79,12 +79,12 @@ export const deprecatedForwarders = {
     await tts.speak(text, options);
   },
 
-  /** @deprecated Use `RunAnywhere.tts.stop()`. */
+  /** @deprecated Use the `SpeechHandle` returned by `RunAnywhere.tts.speak(text, options)`. */
   stopSpeaking(): void {
     tts.stop();
   },
 
-  /** @deprecated Use `RunAnywhere.tts.stop()`. */
+  /** @deprecated Use the `SpeechHandle` returned by `RunAnywhere.tts.speak(text, options)`. */
   stopSynthesis(): void {
     tts.stop();
   },


### PR DESCRIPTION
## What is wrong

Four deprecated TTS helpers, two in Swift and two in Web, send the caller to `tts.stop()`. `tts.stop()` is itself deprecated.

`bindings/swift/.../Extensions/TTS/RunAnywhere+TTS.swift:55,76`

```swift
@available(*, deprecated, renamed: "tts.stop()")
static func stopSynthesis() async
```

`bindings/swift/.../API/Namespaces/TTSNamespace.swift:102`

```swift
@available(*, deprecated, message: "Use the SpeechHandle returned by speak(_:options:) to interrupt one utterance")
public func stop() async
```

Web is the same pair. `Public/API/Deprecated.ts:82,87` say ``Use `RunAnywhere.tts.stop()``` while `Namespaces/tts.ts:173` deprecates `stop()` in favour of the handle. The live namespace doc a few lines above it is explicit:

> There is no global `tts.stop()`; interrupt playback through the returned handle.

## Why it matters more on Swift

`renamed:` is not just prose, it produces a fix-it. Xcode offers to rewrite the call, and the rewrite lands on the deprecated API. Reduced to a self-contained file and compiled with the host `swiftc`:

```
dep-repro.swift:13:17: warning: 'stopSpeaking()' is deprecated: replaced by 'tts.stop()'
   |                 |- warning: 'stopSpeaking()' is deprecated: replaced by 'tts.stop()'
   |                 `- note: use 'tts.stop()' instead
dep-repro.swift:14:21: warning: 'stop()' is deprecated: Use the SpeechHandle returned by speak(_:options:) to interrupt one utterance
```

Take the compiler's advice on line 13 and you get line 14's warning. Net progress is zero.

## What this changes

All four now name the SpeechHandle, reusing the wording `tts.stop()` already uses so the two hops collapse into one. Swift moves from `renamed:` to `message:` because the replacement is a value returned from `speak(_:options:)`, not a symbol the call site can be rewritten to, so a fix-it would be wrong whatever it pointed at.

Kotlin's equivalents were the same defect and were fixed in #731; this is the Swift and Web half.

## Scope

I checked every deprecation in the repo for this shape, not just the ones I happened to hit: 83 Swift, 23 TypeScript across web/react-native/electron, and the Dart ones. Cross-referencing each recommended replacement against the set of deprecated symbols leaves exactly these four. The other apparent hits are name collisions rather than real chains: the deprecated `generate`, `generateStream` and `speak` are the legacy shims in `Deprecated.ts` itself, while `vlm.generate`, `vlm.generateStream` and `tts.speak` are live. React Native has no `stopSpeaking`/`stopSynthesis` forwarders, so nothing to change there.

## Verification

`swiftc -parse` on the changed Swift file passes. SwiftLint cannot run on this host (Command Line Tools only), so I checked the constraint by hand instead: `line_length` is `warning: 150`, and both new lines are 123 characters, the same length as the existing annotation on `TTSNamespace.swift:102` they are modelled on.

`scripts/validation/gates/check_deprecated_surfaces.sh` passes on the branch.

The Web change is inside a JSDoc comment, so it carries no type or runtime effect.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated deprecation guidance for the legacy `stopSpeaking` and `stopSynthesis` speech-stopping methods.
  * Developers are directed to use the `SpeechHandle` returned by `tts.speak` to interrupt an individual utterance.
  * Guidance is consistent across supported platforms.
  * Runtime behavior remains unchanged.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->