### PR TITLE
fix(cloud): decorate g_cloud_stt_ops so it resolves across the DLL boundary

### DIFF
--- a/engines/cloud/CMakeLists.txt
+++ b/engines/cloud/CMakeLists.txt
@@ -75,6 +75,9 @@ rac_add_engine_plugin(cloud
     ${_CLOUD_SHARED_ONLY_ARG}
     SOURCES             ${CLOUD_BACKEND_SOURCES}
     LINK_LIBRARIES      nlohmann_json::nlohmann_json
+    # Export side of RAC_CLOUD_API. Set on this target ONLY: runanywhere_cloud
+    # compiles rac_plugin_entry_cloud.cpp too and must see the dllimport side.
+    COMPILE_DEFINITIONS RAC_CLOUD_BUILDING
     INCLUDE_DIRECTORIES ${CMAKE_CURRENT_SOURCE_DIR}
                         ${CMAKE_CURRENT_SOURCE_DIR}/include
                         ${RAC_COMMONS_ROOT_DIR}/include

--- a/engines/cloud/include/rac/backends/rac_cloud_api.h
+++ b/engines/cloud/include/rac/backends/rac_cloud_api.h
@@ -1,0 +1,40 @@
+/**
+ * @file rac_cloud_api.h
+ * @brief Export/import decoration for symbols the cloud engine publishes to its
+ *        thin carrier.
+ *
+ * Peer of RAC_ONNX_API (engines/onnx/rac_onnx_api.h) and RAC_LLAMACPP_API.
+ *
+ * When building rac_backend_cloud: dllexport / default visibility.
+ * When the thin runanywhere_cloud carrier links that DLL on Windows: dllimport
+ * — MANDATORY for the DATA symbol g_cloud_stt_ops, because MSVC cannot fix up a
+ * cross-image data reference the way it can synthesize a function thunk.
+ * RAC_USING_SHARED is the INTERFACE define from shared rac_commons.
+ *
+ * RAC_CLOUD_BUILDING must therefore be set on rac_backend_cloud ONLY — never on
+ * runanywhere_cloud, which has to see the dllimport side.
+ *
+ * This lives under include/ rather than beside the sources, where
+ * rac_onnx_api.h sits, because the carrier target's include path is
+ * engines/cloud/include only; a header at the engine root would be invisible to
+ * exactly the target that needs the dllimport side.
+ */
+
+#ifndef RAC_CLOUD_API_H
+#define RAC_CLOUD_API_H
+
+#if defined(RAC_CLOUD_BUILDING)
+#if defined(_WIN32)
+#define RAC_CLOUD_API __declspec(dllexport)
+#elif defined(__GNUC__) || defined(__clang__)
+#define RAC_CLOUD_API __attribute__((visibility("default")))
+#else
+#define RAC_CLOUD_API
+#endif
+#elif defined(_WIN32) && defined(RAC_USING_SHARED)
+#define RAC_CLOUD_API __declspec(dllimport)
+#else
+#define RAC_CLOUD_API
+#endif
+
+#endif /* RAC_CLOUD_API_H */

--- a/engines/cloud/include/rac/backends/rac_stt_cloud.h
+++ b/engines/cloud/include/rac/backends/rac_stt_cloud.h
@@ -19,6 +19,7 @@
 #include "rac/core/rac_error.h"
 #include "rac/core/rac_types.h"
 #include "rac/features/stt/rac_stt_service.h"
+#include "rac/backends/rac_cloud_api.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -31,7 +32,7 @@ extern "C" {
  * or register the backend with a plugin registry. Most callers should use
  * rac_stt_cloud_create() / rac_stt_cloud_create_from_json() instead.
  */
-extern const rac_stt_service_ops_t g_cloud_stt_ops;
+extern RAC_CLOUD_API const rac_stt_service_ops_t g_cloud_stt_ops;
 
 /**
  * @brief Create a fully-wrapped cloud STT service using the default provider.

--- a/engines/cloud/rac_stt_cloud.cpp
+++ b/engines/cloud/rac_stt_cloud.cpp
@@ -510,7 +510,7 @@ rac_result_t cloud_stt_parse_flat_json(const rac_http_response_t* resp,
 // Engine ops vtable + C ABI factory
 // =============================================================================
 
-const rac_stt_service_ops_t g_cloud_stt_ops = {
+RAC_CLOUD_API const rac_stt_service_ops_t g_cloud_stt_ops = {
     /* initialize              */ rac::cloud_stt::ops_initialize,
     /* transcribe              */ rac::cloud_stt::ops_transcribe,
     /* transcribe_stream       */ nullptr,

--- a/engines/cloud/rac_stt_cloud.cpp
+++ b/engines/cloud/rac_stt_cloud.cpp
@@ -510,7 +510,7 @@ rac_result_t cloud_stt_parse_flat_json(const rac_http_response_t* resp,
 // Engine ops vtable + C ABI factory
 // =============================================================================
 
-RAC_CLOUD_API const rac_stt_service_ops_t g_cloud_stt_ops = {
+extern "C" RAC_CLOUD_API const rac_stt_service_ops_t g_cloud_stt_ops = {
     /* initialize              */ rac::cloud_stt::ops_initialize,
     /* transcribe              */ rac::cloud_stt::ops_transcribe,
     /* transcribe_stream       */ nullptr,


### PR DESCRIPTION
Follow-up to #761, which had to drop cloud from the Windows build:

> Cloud genuinely does not link on MSVC. It is the PE data-symbol problem already documented for QHexRT [...] the carrier references the op table as DATA, and MSVC resolves imported data only via `__declspec(dllimport)` on the declaration shared with the ELF/Mach-O builds. Linux gets cloud for free; Windows cannot ship it until that is fixed, so `RAC_BACKEND_CLOUD=OFF` in the preset with the reason recorded.

That diagnosis is right, and the repo already contains the remedy twice over. This applies it to cloud.

## The structure of the failure

`engines/cloud/CMakeLists.txt` compiles `rac_plugin_entry_cloud.cpp` into **both** `rac_backend_cloud` and the thin `runanywhere_cloud` carrier. The carrier's copy does `&g_cloud_stt_ops`, and that object is defined in `rac_backend_cloud`. So the carrier holds a cross-image reference to a data symbol.

Built on macOS with `RAC_STATIC_PLUGINS=OFF`, that is visible directly:

```
── librac_backend_cloud.dylib
000000000002c288 (__DATA_CONST,__const) external _g_cloud_stt_ops
── librunanywhere_cloud.dylib
                 (undefined) external _g_cloud_stt_ops (from librac_backend_cloud)
```

`__DATA_CONST` in the defining image, `undefined` in the consumer. Mach-O binds that at load time; the PE loader will not, absent an import descriptor, which is what produces `LNK2001: unresolved external symbol g_cloud_stt_ops`.

## Why this is the house fix and not an invention

`g_cloud_stt_ops` is the only engine op table in the tree declared bare:

```c
extern const rac_stt_service_ops_t g_cloud_stt_ops;          // cloud
extern RAC_ONNX_API const rac_embeddings_service_ops_t g_onnx_embeddings_ops;   // onnx
extern "C" RAC_LLAMACPP_API const rac_vlm_service_ops_t g_llamacpp_vlm_ops = {  // llamacpp
```

`engines/onnx/rac_onnx_api.h` already explains the exact case, including why it is mandatory rather than cosmetic:

> dllimport — MANDATORY for DATA symbols such as `g_onnx_{embeddings,segmentation,diarization}_ops`, because MSVC cannot fix up a cross-image data reference the way it can synthesize a function thunk.

So this adds `RAC_CLOUD_API` as a direct peer, with `RAC_CLOUD_BUILDING` set on `rac_backend_cloud` only, exactly as `RAC_ONNX_BUILDING` is set on `rac_backend_onnx` only. `cmake/plugins.cmake` applies `COMPILE_DEFINITIONS` on both the shared path (line 201, the engine target) and the `RAC_STATIC_PLUGINS` fold path (line 133, into `rac_commons`), so iOS and WASM stay correct too, where the macro expands to default visibility.

One deviation from onnx worth flagging: `rac_onnx_api.h` sits beside its sources, but `rac_cloud_api.h` goes under `include/`. The carrier target's include path is `engines/cloud/include` and the commons include dir only, so a header at the engine root would be invisible to precisely the target that needs the dllimport side. The cloud public header is consumed by three TUs, all inside `engines/cloud`, so nothing outside the engine is affected.

## Verification, and its limit

Configured and built on macOS with `-DRAC_BACKEND_CLOUD=ON -DRAC_STATIC_PLUGINS=OFF -DRAC_BUILD_SHARED=ON`: `rac_backend_cloud` and `runanywhere_cloud` both build and link, and the `nm` output above is from that build. `RAC_STATIC_PLUGINS=ON` also configures clean.

I cannot compile MSVC on this host, so I have not watched the `LNK2001` go away. That is the same limit #761 recorded for itself ("Not verifiable off-Windows: MSVC compile behavior"). What I can show is that the reference really is cross-image data, and that this is the mechanism the two engines which *do* link on MSVC use to solve it.

I deliberately left `CMakePresets.json` alone rather than flipping `RAC_BACKEND_CLOUD=ON` for Windows in the same diff. #763 is currently editing that file, and turning the backend on is the step that should be gated on a green Windows run rather than bundled with the enabling change. Happy to add it here if you would rather see the `windows-commons-release` job prove it in one go.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved cloud speech-to-text engine compatibility when built or consumed as a shared library.
  - Ensured the cloud speech service interface is correctly exposed across supported platforms.
  - Improved symbol visibility and linking reliability for applications using the cloud engine, including Windows and GCC/Clang environments.
  - Preserved consistent access to the cloud speech service interface without changing its available operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->