### PR TITLE
fix(windows): fall back to bsdtar when 7-Zip is absent

### DIFF
--- a/core/scripts/windows/download-sherpa-onnx.bat
+++ b/core/scripts/windows/download-sherpa-onnx.bat
@@ -117,25 +117,51 @@ if /i not "%ACTUAL_SHA256%"=="%EXPECTED_SHA256%" (
 )
 echo [OK] Verified archive SHA-256: %ACTUAL_SHA256%
 
-:: Extract. Windows' bundled bsdtar hangs indefinitely decompressing .tar.bz2
-:: on CI (its bzip2 filter stalls with no console), so use 7-Zip — preinstalled
-:: on GitHub windows runners — to turn .tar.bz2 into a plain .tar, then plain
-:: tar (no bzip2) to lay it down, dropping the archive's top-level directory.
-:: -y answers any 7-Zip prompt so it can never block on stdin.
-echo [EXTRACT] Decompressing (7-Zip)...
+:: Extract. Two paths, chosen by whether 7-Zip is actually present.
+::
+:: 7-Zip is preinstalled on GitHub's windows runners, and the two-step
+:: (.tar.bz2 -> .tar -> extract) is the path proven there: bsdtar's bzip2 filter
+:: was observed stalling indefinitely on CI with no console attached. That path
+:: is unchanged.
+::
+:: But 7-Zip is NOT part of a stock Windows install, and this script invoked it
+:: unconditionally — so on a developer machine without it the download failed
+:: outright and there was no way to build commons locally on Windows. Measured on
+:: a Snapdragon X2 Elite / Windows 11 ARM64 box with no 7-Zip: bsdtar 3.8.4
+:: (bz2lib 1.0.8) extracted the real pinned asset directly, exit 0, in 2.5 s,
+:: producing onnxruntime.dll, onnxruntime_providers_shared.dll and
+:: sherpa-onnx-c-api.dll. So fall back to it rather than refusing to run.
 mkdir "%DEST_DIR%" 2>nul
-7z x -y "%TEMP_DL%\sherpa-onnx.tar.bz2" -o"%TEMP_DL%"
+where 7z >nul 2>&1
 if errorlevel 1 (
-    echo [ERROR] 7-Zip bzip2 decompression failed.
-    rmdir /s /q "%TEMP_DL%" 2>nul
-    exit /b 1
-)
-echo [EXTRACT] Unpacking tar...
-tar -xf "%TEMP_DL%\sherpa-onnx.tar" --strip-components=1 -C "%DEST_DIR%"
-if errorlevel 1 (
-    echo [ERROR] Extraction failed.
-    rmdir /s /q "%TEMP_DL%" 2>nul
-    exit /b 1
+    echo [EXTRACT] 7-Zip not found; extracting .tar.bz2 directly with bsdtar...
+    tar -xf "%TEMP_DL%\sherpa-onnx.tar.bz2" --strip-components=1 -C "%DEST_DIR%"
+    if errorlevel 1 (
+        echo [ERROR] bsdtar extraction failed.
+        rmdir /s /q "%TEMP_DL%" 2>nul
+        exit /b 1
+    )
+) else (
+    rem Parens in an echo MUST be escaped inside a parenthesized block: an
+    rem unescaped ^) closes the block early and cmd fails the whole thing with
+    rem "... was unexpected at this time." This echo was harmless at top level
+    rem and broke the moment it moved in here. Measured: exit 255.
+    rem Same reason this is `rem` and not `::` — a label inside ^( ^) is illegal.
+    rem -y answers any 7-Zip prompt so it can never block on stdin.
+    echo [EXTRACT] Decompressing ^(7-Zip^)...
+    7z x -y "%TEMP_DL%\sherpa-onnx.tar.bz2" -o"%TEMP_DL%"
+    if errorlevel 1 (
+        echo [ERROR] 7-Zip bzip2 decompression failed.
+        rmdir /s /q "%TEMP_DL%" 2>nul
+        exit /b 1
+    )
+    echo [EXTRACT] Unpacking tar...
+    tar -xf "%TEMP_DL%\sherpa-onnx.tar" --strip-components=1 -C "%DEST_DIR%"
+    if errorlevel 1 (
+        echo [ERROR] Extraction failed.
+        rmdir /s /q "%TEMP_DL%" 2>nul
+        exit /b 1
+    )
 )
 
 :: Cleanup temp


### PR DESCRIPTION
`core/scripts/windows/download-sherpa-onnx.bat` invoked `7z` unconditionally. 7-Zip ships
on GitHub's windows runners but is **not** part of a stock Windows install, so on a
developer machine without it the download failed outright — and commons could not be
built locally on Windows at all.

The 7-Zip two-step stays the default wherever it exists. Its comment records a real
finding (bsdtar's bzip2 filter stalling indefinitely on CI with no console attached), so
that path is untouched; this only adds a fallback.

## Verified on hardware, not reasoned about

Run on `runanywhere-win` — Snapdragon X2 Elite X2E88100, Windows 11 ARM64, **no 7-Zip
installed**:

```
[OK] Verified archive SHA-256: f3985b5b91536a8c06fafd3d0118479a09eaa71d4c95795424c5819162a913e9
[EXTRACT] 7-Zip not found; extracting .tar.bz2 directly with bsdtar...
[VERIFY] Checking installation...
[OK] Sherpa-ONNX v1.13.5 downloaded successfully
```

All seven artifacts landed — `onnxruntime.dll`, `onnxruntime_providers_shared.dll`,
`sherpa-onnx-c-api.dll`, `sherpa-onnx-cxx-api.dll` and the three import `.lib`s — and the
release-provenance check passed. bsdtar 3.8.4 (bz2lib 1.0.8) took **2.5 s**; it did not
stall.

## Two batch traps this hit, both caught on the box

Moving existing lines *into* a parenthesized block changed their meaning:

1. **`::` is a label, and a label inside `( )` is illegal** — cmd fails the whole block
   with `... was unexpected at this time.` Comments inside the block must be `rem`.
2. **Unescaped parens in an `echo` close the block early.**
   `echo [EXTRACT] Decompressing (7-Zip)...` was harmless at top level and broke
   immediately once nested; it needs `^(` / `^)`.

Both produced the same opaque message and **exit 255 after a successful download**, which
is why this was verified by running it rather than by reading it.

## Also confirmed while there (no change needed)

The Windows pin in `core/VERSIONS` is accurate: `sherpa-onnx v1.13.5` + `ort 1.28.0` at
tag `v1.13.5-rac-desktop.4` resolves HTTP 200, is 13,088,464 bytes, and its SHA-256
matches `SHERPA_ONNX_WINDOWS_X64_SHA256` — verified independently from macOS and from the
Windows box.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows archive extraction by supporting systems without 7-Zip.
  * Added clearer failure handling when extraction does not complete successfully.
  * Ensured temporary extraction files are cleaned up after failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->