### PR TITLE
fix(qhexrt): teach the prebuilt validator about win-arm64

### DIFF
--- a/scripts/build/validate-qhexrt-prebuilt.py
+++ b/scripts/build/validate-qhexrt-prebuilt.py
@@ -18,6 +18,12 @@ import sys
 
 
 ABSENT = 3
+# neurun names the MSVC/Windows-on-ARM ABI dir "win-arm64" (see its
+# QHexRT/tools/scripts/qhexrt_build_receipt.py WIN_ARM64_ABI). Receipts for it
+# differ from Android in four ways, all handled below: no `ndk` key, a Windows
+# cmake_system, a coff_reader instead of llvm_ar/llvm_readelf, and .lib names.
+WIN_ARM64_ABI = "win-arm64"
+
 SHA256 = re.compile(r"[0-9a-f]{64}\Z")
 
 
@@ -139,10 +145,17 @@ def validate(prebuilt: Path, abi: str) -> Path | None:
     ):
         raise RuntimeError("QHexRT current selection has an invalid source identity")
     build = manifest.get("build")
+    # win-arm64 is an MSVC host build: no NDK is involved, so the receipt
+    # legitimately omits that key. Keeping `ndk` unconditional here made this
+    # validator reject every valid Windows tree — latent because its only
+    # caller (build-core-android.sh) is gated on arm64-v8a.
+    _is_win = abi == WIN_ARM64_ABI
     expected_build_keys = {
         "android_abi", "build_type", "cmake_cache_sha256", "cmake_system",
-        "compiler", "ndk", "qnn_sdk", "archive_evidence",
+        "compiler", "qnn_sdk", "archive_evidence",
     }
+    if not _is_win:
+        expected_build_keys.add("ndk")
     if not isinstance(build, dict) or set(build) != expected_build_keys:
         raise RuntimeError("QHexRT current selection has an invalid build identity")
     if build.get("android_abi") != abi or not isinstance(build.get("build_type"), str):
@@ -163,11 +176,15 @@ def validate(prebuilt: Path, abi: str) -> Path | None:
     system = build.get("cmake_system")
     if not isinstance(system, dict) or set(system) != {
         "name", "processor", "crosscompiling", "state_file_sha256"
-    } or system.get("name") != "Android" or system.get("processor") not in {"aarch64", "arm64"}:
-        raise RuntimeError("QHexRT current selection has an invalid Android system identity")
+    } or system.get("name") != ("Windows" if _is_win else "Android") \
+         or system.get("processor") not in ({"ARM64", "arm64", "aarch64"} if _is_win
+                                            else {"aarch64", "arm64"}):
+        raise RuntimeError(
+            f"QHexRT current selection has an invalid "
+            f"{'Windows' if _is_win else 'Android'} system identity")
     if not isinstance(system.get("state_file_sha256"), str) or not SHA256.fullmatch(system["state_file_sha256"]):
         raise RuntimeError("QHexRT current selection has invalid CMake system-state digest")
-    for key in ("ndk", "qnn_sdk"):
+    for key in (("qnn_sdk",) if _is_win else ("ndk", "qnn_sdk")):
         identity = build.get(key)
         if not isinstance(identity, dict) or set(identity) != {"metadata_file", "metadata_sha256"}:
             raise RuntimeError(f"QHexRT current selection has invalid {key} identity")
@@ -183,11 +200,11 @@ def validate(prebuilt: Path, abi: str) -> Path | None:
         if not isinstance(identity.get("metadata_sha256"), str) or not SHA256.fullmatch(identity["metadata_sha256"]):
             raise RuntimeError(f"QHexRT current selection has invalid {key} digest")
     archive = build.get("archive_evidence")
-    if not isinstance(archive, dict) or set(archive) != {
-        "llvm_ar_sha256", "llvm_readelf_sha256", "core", "host"
-    }:
+    _expected_archive = ({"coff_reader", "core", "host"} if _is_win
+                         else {"llvm_ar_sha256", "llvm_readelf_sha256", "core", "host"})
+    if not isinstance(archive, dict) or set(archive) != _expected_archive:
         raise RuntimeError("QHexRT current selection has invalid archive evidence")
-    for key in ("llvm_ar_sha256", "llvm_readelf_sha256"):
+    for key in (() if _is_win else ("llvm_ar_sha256", "llvm_readelf_sha256")):
         if not isinstance(archive.get(key), str) or not SHA256.fullmatch(archive[key]):
             raise RuntimeError(f"QHexRT current selection has invalid archive-tool digest {key}")
     for key in ("core", "host"):
@@ -203,8 +220,8 @@ def validate(prebuilt: Path, abi: str) -> Path | None:
 
     expected = {
         "include/qhexrt/qhexrt_c.h",
-        f"lib/{abi}/libqhexrt_core.a",
-        f"lib/{abi}/libqhexrt_host.a",
+        f"lib/{abi}/qhexrt_core.lib" if _is_win else f"lib/{abi}/libqhexrt_core.a",
+        f"lib/{abi}/qhexrt_host.lib" if _is_win else f"lib/{abi}/libqhexrt_host.a",
     }
     files = manifest.get("files")
     if not isinstance(files, dict) or set(files) != expected:


### PR DESCRIPTION
`engines/qhexrt/CMakeLists.txt` has had a complete `win-arm64` contract for a long time — it
selects that ABI, expects COFF `qhexrt_core.lib` / `qhexrt_host.lib`, and even branches its
receipt validation for MSVC. But `scripts/build/validate-qhexrt-prebuilt.py` had **zero**
occurrences of `win-arm64`, so any Windows-ARM64 payload was rejected before it could be used.

That is why the SDK has only ever carried an Android prebuilt.

## What changes

Four `win-arm64` branches, matching what an MSVC build actually produces:

- **no `ndk` key** — an MSVC build binds no NDK, so requiring one is wrong there
- **`cmake_system.name == "Windows"`**, processor `ARM64`
- **archive evidence is a COFF parse** (`coff_reader`), where Android records
  `llvm-ar`/`llvm-readelf` digests
- **`.lib` filenames**, not `lib*.a`

## Verified against a real payload, not a fixture

Built on the Snapdragon X2 Elite box (`win-arm64-x2elite`) from neurun
[#70](https://github.com/RunanywhereAI/neurun/pull/70):

```
$ python3 scripts/build/validate-qhexrt-prebuilt.py --prebuilt <p> --android-abi win-arm64
/private/tmp/.../versions/37154c95d6aafa27aa6690e872c2a5042f37f814cab03493daaff94aa3c90f21
exit=0
```

Before this change the same payload failed with
`QHexRT current selection has an invalid build identity`.

The existing Android payload still validates unchanged (`exit=0`), and all **10**
`scripts/build/test_validate_qhexrt_prebuilt.py` tests pass.

## Note on the flag name

The flag stays `--android-abi` even for `win-arm64`, and the manifest key stays `android_abi`.
That is the SDK's existing schema — the engine compares that key against its selected ABI — so
renaming it here would break the contract on the other side. Kept deliberately.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added validation support for Windows on ARM (`win-arm64`) builds.
  * Windows ARM validation now checks for the expected Windows build environment and `.lib` artifacts.
* **Bug Fixes**
  * Preserved existing Android validation behavior while improving platform-specific validation for Windows ARM.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->