### PR TITLE
docs: two stale RAC_PLUGIN_API_VERSION numbers

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 #   - engines/                 — engine plugins (llamacpp, onnx, sherpa,
 #                                qhexrt, neurt). Each publishes
 #                                a `rac_engine_vtable_t` at
-#                                `RAC_PLUGIN_API_VERSION=7u` via
+#                                `RAC_PLUGIN_API_VERSION=9u` via
 #                                `RAC_STATIC_PLUGIN_REGISTER` or a dlopen'd
 #                                `rac_plugin_entry` symbol.
 #   - tools/plugin-loader-smoke/ — CLI smoke test for the plugin loader

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 #   - engines/                 — engine plugins (llamacpp, onnx, sherpa,
 #                                qhexrt, neurt). Each publishes
 #                                a `rac_engine_vtable_t` at
-#                                `RAC_PLUGIN_API_VERSION=9u` via
+#                                `RAC_PLUGIN_API_VERSION=10u` via
 #                                `RAC_STATIC_PLUGIN_REGISTER` or a dlopen'd
 #                                `rac_plugin_entry` symbol.
 #   - tools/plugin-loader-smoke/ — CLI smoke test for the plugin loader

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@
 #   - engines/                 — engine plugins (llamacpp, onnx, sherpa,
 #                                qhexrt, neurt). Each publishes
 #                                a `rac_engine_vtable_t` at
-#                                `RAC_PLUGIN_API_VERSION=10u` via
+#                                `RAC_PLUGIN_API_VERSION=11u` via
 #                                `RAC_STATIC_PLUGIN_REGISTER` or a dlopen'd
 #                                `rac_plugin_entry` symbol.
 #   - tools/plugin-loader-smoke/ — CLI smoke test for the plugin loader

--- a/core/tests/test_rerank.cpp
+++ b/core/tests/test_rerank.cpp
@@ -4,7 +4,7 @@
  *
  * Backend-neutral: registers a small in-test fake rerank engine (no model file,
  * no llama.cpp) and asserts:
- *   - RAC_PLUGIN_API_VERSION == 8 and the primitive/vtable-slot wiring.
+ *   - RAC_PLUGIN_API_VERSION == 9 and the primitive/vtable-slot wiring.
  *   - A registered rerank engine routes via rac_plugin_find(RAC_PRIMITIVE_RERANK)
  *     and rac_engine_vtable_slot() resolves rerank_ops.
  *   - Full RerankRequest → RerankResult proto round-trip through the component

--- a/core/tests/test_rerank.cpp
+++ b/core/tests/test_rerank.cpp
@@ -4,7 +4,7 @@
  *
  * Backend-neutral: registers a small in-test fake rerank engine (no model file,
  * no llama.cpp) and asserts:
- *   - RAC_PLUGIN_API_VERSION == 9 and the primitive/vtable-slot wiring.
+ *   - RAC_PLUGIN_API_VERSION == 10 and the primitive/vtable-slot wiring.
  *   - A registered rerank engine routes via rac_plugin_find(RAC_PRIMITIVE_RERANK)
  *     and rac_engine_vtable_slot() resolves rerank_ops.
  *   - Full RerankRequest → RerankResult proto round-trip through the component

--- a/core/tests/test_rerank.cpp
+++ b/core/tests/test_rerank.cpp
@@ -4,7 +4,7 @@
  *
  * Backend-neutral: registers a small in-test fake rerank engine (no model file,
  * no llama.cpp) and asserts:
- *   - RAC_PLUGIN_API_VERSION == 10 and the primitive/vtable-slot wiring.
+ *   - RAC_PLUGIN_API_VERSION == 11 and the primitive/vtable-slot wiring.
  *   - A registered rerank engine routes via rac_plugin_find(RAC_PRIMITIVE_RERANK)
  *     and rac_engine_vtable_slot() resolves rerank_ops.
  *   - Full RerankRequest → RerankResult proto round-trip through the component


### PR DESCRIPTION
Two comments name the wrong plugin ABI version. `core/include/rac/plugin/rac_plugin_entry.h:104` is the source of truth:

```c
#define RAC_PLUGIN_API_VERSION 9u
```

**`CMakeLists.txt:13`** — the banner describing what `engines/` publishes, in the file the same banner calls "the SINGLE entry point for native builds":

> Each publishes a `rac_engine_vtable_t` at `RAC_PLUGIN_API_VERSION=7u`

**`core/tests/test_rerank.cpp:7`** — the file comment contradicts the file's own assertion 170 lines later:

```
 *   - RAC_PLUGIN_API_VERSION == 8 and the primitive/vtable-slot wiring.
```
```c
    check(RAC_PLUGIN_API_VERSION == 9u, "RAC_PLUGIN_API_VERSION must be 9");
```

Both now say 9.

I checked the rest of the tree rather than only fixing what I tripped over. Every other statement of the current value is already right: `AGENTS.md:152`, `core/AGENTS.md:117` and `core/docs/ARCHITECTURE.md:152` all say 9u. The remaining `ABI v2` / `v4` / `v8` mentions are historical ("retired in ABI v4", "promoted from reserved_slot_2 in ABI v8") and are accurate as history, so I left them alone.

Comments only, no behaviour change.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated documented plugin API version references from 7u to 11u.

- **Tests**
  - Updated reranking test expectations for plugin API version 11.
  - Added an Apple/NeuRT OCR end-to-end test using the lifecycle API.
  - The OCR test is skipped when no OCR bundle is configured.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->