### PR TITLE
fix(build): point the Sherpa-ONNX download hints at the real script paths

### DIFF
--- a/core/cmake/FetchONNXRuntime.cmake
+++ b/core/cmake/FetchONNXRuntime.cmake
@@ -82,7 +82,7 @@ if(EMSCRIPTEN)
 
 elseif(IOS OR CMAKE_SYSTEM_NAME STREQUAL "iOS")
     # iOS: Use local ONNX Runtime xcframework from third_party
-    # Downloaded by: ./scripts/ios/download-onnx.sh
+    # Downloaded by: core/scripts/ios/download-onnx.sh
     # NOTE: Version must match what sherpa-onnx was built against
 
     set(ONNX_IOS_VERSION "${RAC_ONNX_VERSION_IOS}")
@@ -158,7 +158,7 @@ elseif(ANDROID)
     # Android: Use ONNX Runtime from Sherpa-ONNX (16KB aligned in v1.12.20+)
     # Sherpa-ONNX version is loaded from the canonical VERSIONS file.
     # Sherpa-ONNX bundles a compatible version of ONNX Runtime
-    # Downloaded by: ./scripts/android/download-sherpa-onnx.sh
+    # Downloaded by: core/scripts/android/download-sherpa-onnx.sh
     # Anchor on this module's location so the lookup is stable under the
     # single-root CMake layout, where CMAKE_SOURCE_DIR is the repo
     # root but download-sherpa-onnx.sh populates core/third_party/.
@@ -219,7 +219,9 @@ elseif(ANDROID)
         message(STATUS "ONNX Runtime Android library: ${ONNX_LIB_PATH}")
         message(STATUS "ONNX Runtime Android headers: ${ONNX_HEADER_PATH}")
     else()
-        message(FATAL_ERROR "Sherpa-ONNX not found. Please run: ./scripts/android/download-sherpa-onnx.sh")
+        message(FATAL_ERROR
+            "Sherpa-ONNX not found. Please run, from the repo root: "
+            "bash core/scripts/android/download-sherpa-onnx.sh")
     endif()
 
 elseif(APPLE)

--- a/engines/sherpa/CMakeLists.txt
+++ b/engines/sherpa/CMakeLists.txt
@@ -255,7 +255,8 @@ elseif(RAC_PLATFORM_LINUX)
 
         message(STATUS "Found Sherpa-ONNX Linux: ${SHERPA_LIB_PATH}")
     else()
-        message(STATUS "Sherpa-ONNX not found. Run: ./scripts/linux/download-sherpa-onnx.sh")
+        message(STATUS "Sherpa-ONNX not found. Run, from the repo root: "
+                   "bash core/scripts/linux/download-sherpa-onnx.sh")
     endif()
 
 elseif(RAC_PLATFORM_WINDOWS)


### PR DESCRIPTION
## What

Configuring an Android build without staging Sherpa first prints:

```
Sherpa-ONNX not found. Please run: ./scripts/android/download-sherpa-onnx.sh
```

That path does not exist. The script lives at `core/scripts/android/download-sherpa-onnx.sh`, and CMake configures from the repo root, so the suggested command fails wherever you run it from. Fixed here, along with the equivalent Linux hint in `engines/sherpa/CMakeLists.txt` and two stale `Downloaded by:` comments.

**Message and comment text only — no build logic changes.**

## What I deliberately did not change

Two paths look equally wrong and are not:

- `core/tests/scripts/run-tests-android.sh` sets `RAC_ROOT` from `SCRIPT_DIR/../..`, which is `core/`, so `${RAC_ROOT}/scripts/android/...` already resolves correctly.
- `core/AGENTS.md`'s commands are `core/`-relative by virtue of living in `core/`.

## Verification

Staged Sherpa for Android and configured `arm64-v8a` with both engines enabled:

```
Verified 12 shared libraries: every PT_LOAD alignment is >= 0x4000
Sherpa-ONNX Android 1.13.5-rac.4 installed with verified provenance
-- Sherpa Backend Configuration:
--   Sherpa-ONNX:  ON
-- QHexRT Backend Configuration:
--   Engine available: 1
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChXbXRyD165wGuxYUT14Dp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated platform setup guidance to reference the correct download script locations.
  * Improved missing Sherpa-ONNX runtime messages with accurate commands for retrieving prebuilt runtimes on Android and Linux.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->