### PR TITLE
fix(stt): report audio duration at the configured sample rate

### DIFF
--- a/core/src/features/stt/stt_module.cpp
+++ b/core/src/features/stt/stt_module.cpp
@@ -943,11 +943,16 @@ extern "C" rac_result_t rac_stt_component_transcribe(rac_handle_t handle, const 
     }
     // Lock released — safe to do long-running transcription
 
+#if defined(RAC_HAVE_PROTOBUF)
     // Estimate audio length at the component's configured rate. The 16 kHz this
     // used to hard-code is only a default: the very next event field below is
     // set from `sample_rate`, so a component at any other rate reported a
     // duration that disagreed with the rate in the same message.
+    //
+    // Guarded because every consumer is: the lifecycle events below are the only
+    // readers, and estimate_audio_length_ms itself lives inside this same guard.
     const int64_t audio_length_ms = estimate_audio_length_ms(audio_size, sample_rate);
+#endif
 
     RAC_LOG_INFO("STT.Component", "Transcribing audio");
 
@@ -1115,10 +1120,13 @@ rac_stt_component_transcribe_stream(rac_handle_t handle, const void* audio_data,
         RAC_LOG_DEBUG("STT.Component", "STT streaming transcription using model_id: %s", model_id);
     }
 
+#if defined(RAC_HAVE_PROTOBUF)
     // Calculate audio length in ms. Via the shared helper so a zero sample rate
-    // falls back to the default instead of dividing by zero.
+    // falls back to the default instead of dividing by zero. Guarded for the
+    // same reason as the batch path above.
     const int64_t audio_length_ms =
         estimate_audio_length_ms(audio_size, component->config.sample_rate);
+#endif
 
     // Generate transcription ID for tracking
     std::string transcription_id = generate_unique_id();

--- a/core/src/features/stt/stt_module.cpp
+++ b/core/src/features/stt/stt_module.cpp
@@ -943,8 +943,11 @@ extern "C" rac_result_t rac_stt_component_transcribe(rac_handle_t handle, const 
     }
     // Lock released — safe to do long-running transcription
 
-    // Estimate audio length (assuming 16kHz mono 16-bit audio)
-    double audio_length_ms = (audio_size / 2.0 / 16000.0) * 1000.0;
+    // Estimate audio length at the component's configured rate. The 16 kHz this
+    // used to hard-code is only a default: the very next event field below is
+    // set from `sample_rate`, so a component at any other rate reported a
+    // duration that disagreed with the rate in the same message.
+    const int64_t audio_length_ms = estimate_audio_length_ms(audio_size, sample_rate);
 
     RAC_LOG_INFO("STT.Component", "Transcribing audio");
 
@@ -1112,8 +1115,10 @@ rac_stt_component_transcribe_stream(rac_handle_t handle, const void* audio_data,
         RAC_LOG_DEBUG("STT.Component", "STT streaming transcription using model_id: %s", model_id);
     }
 
-    // Calculate audio length in ms (assume 16kHz, 16-bit mono)
-    double audio_length_ms = (audio_size * 1000.0) / (component->config.sample_rate * 2);
+    // Calculate audio length in ms. Via the shared helper so a zero sample rate
+    // falls back to the default instead of dividing by zero.
+    const int64_t audio_length_ms =
+        estimate_audio_length_ms(audio_size, component->config.sample_rate);
 
     // Generate transcription ID for tracking
     std::string transcription_id = generate_unique_id();


### PR DESCRIPTION
## What is wrong

`stt_module.cpp` computes `input_audio_duration_ms` for `VoiceLifecycleEvent` in two places, two different ways, and the batch path hard-codes 16 kHz:

```cpp
// batch, line 947
double audio_length_ms = (audio_size / 2.0 / 16000.0) * 1000.0;

// streaming, line 1116
double audio_length_ms = (audio_size * 1000.0) / (component->config.sample_rate * 2);
```

The batch one is wrong for any component not running at 16 kHz, and the rate it should be using is already in scope: `sample_rate` is assigned from `component->config.sample_rate` at line 916, and the same event sets it thirteen lines later via `voice.set_sample_rate(sample_rate)`. So the emitted message carries a duration and a sample rate that contradict each other.

For one second of mono 16-bit audio:

| rate | bytes | true ms | batch (947) | streaming (1116) |
|---|---|---|---|---|
| 8000 | 16000 | 1000 | **500** | 1000 |
| 16000 | 32000 | 1000 | 1000 | 1000 |
| 22050 | 44100 | 1000 | **1378** | 1000 |
| 44100 | 88200 | 1000 | **2756** | 1000 |
| 48000 | 96000 | 1000 | **3000** | 1000 |

The streaming one gets the rate right but divides by it unguarded, so a zero `sample_rate` is a division by zero and `static_cast<int64_t>` of the resulting infinity is undefined behaviour.

## The file already has the answer

`estimate_audio_length_ms(audio_size, sample_rate)` is defined at line 392 and does both things correctly: it guards the rate and uses the named constants rather than a magic `2` and a magic `16000`.

```cpp
int64_t estimate_audio_length_ms(size_t audio_size, int32_t sample_rate) {
    const int32_t rate = sample_rate > 0 ? sample_rate : RAC_STT_DEFAULT_SAMPLE_RATE;
    return static_cast<int64_t>(
        (static_cast<double>(audio_size) / static_cast<double>(RAC_STT_BYTES_PER_SAMPLE) /
         static_cast<double>(rate)) * 1000.0);
}
```

Four other call sites already use it (lines 432 and 1481, plus a three-argument overload at 1706 used at 1841 and 2052). These two were the ones that open-coded it.

## What this changes

Both sites now call the helper. Nine insertions, four deletions, no new code.

I left the four `static_cast<int64_t>(audio_length_ms)` at the consumers alone: the variable is now already `int64_t`, so those casts are no-ops, and removing them would grow the diff without changing behaviour.

## Scope

I swept the rest of `core/src` for the same shape rather than only fixing what I tripped over. Every other hard-coded `16000` is a legitimate fallback default (`param_int_or(spec, "sample_rate_hz", 16000)`, `options.sample_rate > 0 ? options.sample_rate : 16000`) rather than a computation ignoring a rate it already has. `rac_vad_stream.cpp`'s equivalent position math is fine: `audio_samples` is `uint64_t` so the `* 1000U` widens, and it already guards `sample_rate <= 0`.

## Verification

Built commons with `-DRAC_BUILD_TESTS=ON` (clean, zero compile errors) and ran the suite:

```
100% tests passed out of 100
```

The table above is both formulas evaluated directly, not an estimate.

Reachability, since a hard-coded default is only a bug if the value can differ: `sample_rate` is a caller-settable proto field (`idl/stt_options.proto:29`), reaching the component through `config->sample_rate` and `request.audio().sample_rate()`.

Note on overlap: #747 also edits this file, at `rac_stt_component_load_model` around line 826. It does not touch `audio_length_ms`, `sample_rate` or `16000`, and a trial merge of this branch with it is clean.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved audio-duration reporting for batch and streaming transcription.
  * Duration estimates now reflect configured sample rates and safely use a default when needed.
  * Telemetry duration calculations are now limited to supported protobuf-enabled configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->