### PR TITLE
fix(qairt): move the QAIRT runtime to the private neurun repo

### DIFF
--- a/.github/workflows/electron-native-package.yml
+++ b/.github/workflows/electron-native-package.yml
@@ -363,6 +363,8 @@ jobs:
       # pairing gate proves it is the SDK this engine was built against.
       - name: Download the pinned QAIRT runtime (win-arm64)
         shell: bash
+        env:
+          NEURUN_TOKEN: ${{ secrets.NEURUN_TOKEN }}
         run: |
           bash scripts/build/download-qairt-runtime.sh --platform win-arm64
           bash scripts/validation/gates/check_qairt_pairing.sh --platform win-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -265,14 +265,15 @@ jobs:
           fi
           [[ "$rc" -eq 0 ]] || exit "$rc"
 
-      # The QAIRT/QNN runtime the engine dlopens on device. PUBLIC assets, no
-      # token: RunAnywhere is an authorized Qualcomm partner and already ships
-      # these binaries unauthenticated on npm. Without this, build-core-android.sh
-      # correctly refuses to package a routable engine whose runtime is absent --
-      # which is what broke the first v0.20.26 candidate, since no hosted runner
-      # has a licensed QAIRT install.
+      # The QAIRT/QNN runtime the engine dlopens on device. PRIVATE, same token as
+      # the engine payload. Without it build-core-android.sh correctly refuses to
+      # package a routable engine whose runtime is absent -- which is what broke
+      # the first v0.20.26 candidate, since no hosted runner has a licensed QAIRT
+      # install.
       - name: Download the pinned QAIRT runtime (arm64-v8a only)
         if: matrix.abi == 'arm64-v8a'
+        env:
+          NEURUN_TOKEN: ${{ secrets.NEURUN_TOKEN }}
         run: bash scripts/build/download-qairt-runtime.sh --platform arm64-v8a
 
       # Two independent pins CAN drift. A drifted pair passes every other check

--- a/core/VERSIONS
+++ b/core/VERSIONS
@@ -327,13 +327,9 @@ RAC_COMMONS_VERSION=0.1.1
 # that was pinned rather than trusting the archive's claim about itself.
 #
 # QAIRT is read for HEADERS ONLY when QHexRT is built, and its runtime is dlopen'd
-# on device — both still true, and the neurun payload still carries no Qualcomm
-# binary. What is NOT true, and used to be claimed here, is that the runtime is
-# "never redistributed": RunAnywhere is an authorized Qualcomm partner and ships
-# these binaries today, publicly and unauthenticated, inside
-# @runanywhere/electron-qhexrt and @runanywhere/qhexrt on npm. The QAIRT_RUNTIME_*
-# block below makes that distribution named, versioned and checksum-pinned instead
-# of implicit.
+# on device; the neurun engine payload still carries no Qualcomm binary. The
+# runtime itself is pinned separately below and fetched from the PRIVATE neurun
+# repo with NEURUN_TOKEN, exactly like the engine payloads.
 #
 # To bump: cut a neurun release, then paste the pin block from its release notes.
 # Never compute these locally — a local build's bytes are never the published ones.
@@ -356,8 +352,11 @@ QHEXRT_WIN_ARM64_RECEIPT=073a1d0b2bd568212263d58cc45e71f2b233c30eea893a365e62bde
 # release version move independently, so these carry their own tag and are not
 # bumped by a neurun release.
 #
-# PUBLIC assets on this repo — no token — so a fork or a hosted runner can build a
-# routable Hexagon engine without a licensed QAIRT install. Produced by
+# PRIVATE assets on the neurun repo, fetched with NEURUN_TOKEN — the same
+# mechanism as NEURT_*/QHEXRT_* above, so a build that can reach one reaches all
+# three. A hosted runner with the token builds a routable Hexagon engine without a
+# licensed QAIRT install; without the token it gets the non-routable shell, which
+# is the intended public/fork outcome. Produced by
 # scripts/build/publish-qairt-runtime.sh from a licensed install (that step still
 # needs a human with the SDK) and fetched by scripts/build/download-qairt-runtime.sh.
 #

--- a/scripts/build/download-qairt-runtime.sh
+++ b/scripts/build/download-qairt-runtime.sh
@@ -1,13 +1,14 @@
 #!/usr/bin/env bash
 # Fetch the pinned QAIRT/QNN runtime redistributables for one platform.
 #
-# These are PUBLIC assets -- no token. RunAnywhere is an authorized Qualcomm
-# partner and already distributes these exact binaries unauthenticated on npm
-# (@runanywhere/electron-qhexrt ships QnnHtp.dll, libQnnHtpV81Skel.so and
-# libqnnhtpv81.cat today). Publishing them here as pinned, versioned assets makes
-# an existing distribution verifiable rather than implicit, and is what lets a
-# hosted runner -- or a fork, or an external contributor -- build a routable
-# Hexagon engine without a licensed QAIRT install.
+# PRIVATE assets on the neurun repo, fetched with NEURUN_TOKEN -- the same
+# mechanism as the NeuRT and QHexRT payloads, so a build that can reach one can
+# reach all three. Keeping them off the public repo means they cannot be pulled
+# by anyone who happens to find the URL.
+#
+# This is what lets a hosted runner build a routable Hexagon engine without a
+# licensed QAIRT install on the machine; it still requires the token, so forks and
+# external PRs get the non-routable shell (the intended public outcome).
 #
 # The engine still compiles against QAIRT HEADERS ONLY and dlopens these at
 # runtime. Shipping them beside the engine is packaging, not linking.
@@ -65,7 +66,14 @@ for v in VERSION TAG EXPECTED_SHA; do
     [[ -n "${!v}" ]] || { echo "[ERROR] QAIRT_RUNTIME_* pin missing from core/VERSIONS ($v)" >&2; exit 2; }
 done
 
-REPO="${QAIRT_RUNTIME_REPO:-RunanywhereAI/runanywhere-sdks}"
+REPO="${QAIRT_RUNTIME_REPO:-${NEURUN_REPO:-RunanywhereAI/neurun}}"
+TOKEN="${NEURUN_TOKEN:-${GH_TOKEN:-}}"
+if [[ -z "$TOKEN" ]]; then
+    echo "[ERROR] NEURUN_TOKEN (or GH_TOKEN) is required: the QAIRT runtime is a" >&2
+    echo "        PRIVATE asset on ${REPO}." >&2
+    echo "        Without it the Hexagon engine cannot be packaged routable." >&2
+    exit 3
+fi
 ASSET="qairt-runtime-${PLATFORM}-v${VERSION}.tar.gz"
 DEST_ROOT="${REPO_ROOT}/engines/qhexrt/prebuilt/qairt-runtime/${PLATFORM}"
 DEST="${DEST_ROOT}/versions/${EXPECTED_SHA}"
@@ -88,8 +96,7 @@ fi
 if [[ "$cached_ok" -eq 0 ]]; then
     tmp="$(mktemp -d)"; trap 'rm -rf "$tmp"' EXIT
     echo "[DOWNLOAD] QAIRT runtime ${PLATFORM} <- ${REPO} ${TAG}"
-    # No token: these are public assets.
-    fetch_release_asset "$REPO" "$TAG" "$ASSET" "$tmp" "" "$PY_BIN"
+    fetch_release_asset "$REPO" "$TAG" "$ASSET" "$tmp" "$TOKEN" "$PY_BIN"
 
     actual="$("$PY_BIN" -c "
 import hashlib,sys

--- a/scripts/build/publish-qairt-runtime.sh
+++ b/scripts/build/publish-qairt-runtime.sh
@@ -13,17 +13,14 @@
 # Windows lane depended on a hand-copied directory of machine state that has
 # already gone stale once.
 #
-# RunAnywhere is an authorized Qualcomm partner and already distributes these
-# exact binaries publicly: @runanywhere/electron-qhexrt on npm ships QnnHtp.dll,
-# libQnnHtpV81Skel.so and libqnnhtpv81.cat with no authentication. This does not
-# expose anything new -- it makes an existing distribution named, versioned and
-# verifiable instead of implicit.
+# These go to the PRIVATE neurun repo, alongside the NeuRT and QHexRT payloads,
+# and are fetched with NEURUN_TOKEN. They are deliberately NOT published on the
+# public SDK repo: a public URL invites downloads we do not want to serve, and
+# nothing about the build needs them to be reachable without a token.
 #
-# The assets are published under their OWN tag (qairt-runtime-v<qairt-version>),
-# not the SDK release tag, because the QAIRT SDK version and the SDK release
-# version are independent axes. Asset names deliberately contain no "qhexrt"
-# substring so release.yml's private-leak guard (which hard-fails on any
-# *qhexrt* file reaching the public asset set) is unaffected.
+# They get their OWN tag (qairt-runtime-v<qairt-version>) rather than riding an
+# engine release, because the QAIRT SDK version and the engine version move
+# independently.
 #
 # Usage:
 #   publish-qairt-runtime.sh --qnn <QAIRT_ROOT> [--platform arm64-v8a|win-arm64|all]
@@ -36,7 +33,7 @@ set -euo pipefail
 
 REPO_ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
 MANIFEST="${REPO_ROOT}/scripts/build/qairt-runtime-manifest.json"
-PUBLISH_REPO="RunanywhereAI/runanywhere-sdks"
+PUBLISH_REPO="${NEURUN_REPO:-RunanywhereAI/neurun}"
 
 QNN_ROOT="${QNN_SDK_ROOT:-}"
 PLATFORM="all"


### PR DESCRIPTION
## What changed

The QAIRT/QNN runtime was published as a **public** release on this repo. Moved to the **private** `neurun` repo, beside the NeuRT and QHexRT payloads. The public release and its tag are deleted.

A public URL invites downloads we have no reason to serve, and nothing in the build needs the runtime reachable without a token.

## Now identical to the engine payloads

| | before | after |
|---|---|---|
| Location | public release on this repo | **private** release on `RunanywhereAI/neurun` |
| Auth | none | **`NEURUN_TOKEN`** |
| No-token behaviour | fetched anyway | **exit 3**, clear message → non-routable shell |

One credential, one access model, three payloads. Both the Android release job and the Electron win-arm64 lane now pass `secrets.NEURUN_TOKEN`.

Kept on its own tag rather than folded into an engine release — the QAIRT SDK version and the engine version move independently, and coupling them would force a QAIRT republish on every engine bump.

## Verified

- Both platforms download + validate from the private repo **with** a token
- **Without** a token: exits 3 with a clear message rather than degrading silently
- `check_engine_prebuilt_pins.sh` and `check_qairt_pairing.sh` pass
- Full `arm64-v8a` build with `QNN_SDK_ROOT` / `QAIRT_ROOT` / `QNN_ROOT` **all unset** — the CI condition:

```
exit=0
engine ROUTABLE
QNN host libs: 10   skels: 3
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChXbXRyD165wGuxYUT14Dp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Build & Release**
  * QAIRT runtime downloads now use authenticated access for supported platforms.
  * Runtime assets are fetched from the private neurun repository using configured access tokens.
  * Builds without valid authentication produce a non-routable engine.

* **Documentation**
  * Updated runtime version and publishing guidance to reflect private asset distribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->