### PR TITLE
fix(electron): use the shared error-category table instead of a second one

### DIFF
--- a/bindings/electron/src/errors.ts
+++ b/bindings/electron/src/errors.ts
@@ -15,8 +15,12 @@ import {
   ErrorSeverity,
   SDKError,
 } from '@runanywhere/proto-ts/errors';
+// Same reasoning one level up: the code -> category range table is shared, not
+// re-declared here. `@runanywhere/proto-ts/convenience/errors_category` is the
+// canonical table for Web, React Native and Electron, and says so.
+import { categoryForCode } from '@runanywhere/proto-ts/convenience/errors_category';
 
-export { ErrorCategory, ErrorCode, ErrorSeverity };
+export { ErrorCategory, ErrorCode, ErrorSeverity, categoryForCode };
 
 /** Strip a generated enum's `ERROR_CODE_` / `ERROR_CATEGORY_` prefix from a member name. */
 type ShortName<Key extends string, Prefix extends string> = Key extends `${Prefix}${infer Rest}`
@@ -57,32 +61,6 @@ export const ErrorCodes: Readonly<Record<ErrorCodeName, ErrorCode>> = Object.fre
 export const ErrorCategories: Readonly<Record<ErrorCategoryName, ErrorCategory>> = Object.freeze(
   shortNames(ErrorCategory, 'ERROR_CATEGORY_')
 ) as Readonly<Record<ErrorCategoryName, ErrorCategory>>;
-
-/**
- * Map a code to its category — a verbatim port of the canonical range table in
- * commons `rac_proto_adapters.cpp::rac_result_to_proto_category()`, including its
- * `INTERNAL` fallback. Commons reads a negative `rac_result_t`; this reads the
- * positive proto `ErrorCode`, so the bounds are compared on the magnitude.
- *
- * FALLBACK ONLY. Whenever the wire supplies a category (commons produced it with
- * the same table) that value wins and this function is not consulted.
- */
-export function categoryForCode(code: number): ErrorCategory {
-  const abs = Math.abs(Math.trunc(code));
-  if (abs === 0) return ErrorCategory.ERROR_CATEGORY_UNSPECIFIED;
-  if (abs >= 150 && abs <= 179) return ErrorCategory.ERROR_CATEGORY_NETWORK;
-  if (abs >= 250 && abs <= 279) return ErrorCategory.ERROR_CATEGORY_VALIDATION;
-  if (abs >= 110 && abs <= 129) return ErrorCategory.ERROR_CATEGORY_MODEL;
-  if ((abs >= 180 && abs <= 219) || (abs >= 280 && abs <= 299)) {
-    return ErrorCategory.ERROR_CATEGORY_IO;
-  }
-  if (abs >= 320 && abs <= 329) return ErrorCategory.ERROR_CATEGORY_AUTH;
-  if (abs >= 100 && abs <= 109) return ErrorCategory.ERROR_CATEGORY_CONFIGURATION;
-  if ((abs >= 230 && abs <= 249) || (abs >= 300 && abs <= 319)) {
-    return ErrorCategory.ERROR_CATEGORY_COMPONENT;
-  }
-  return ErrorCategory.ERROR_CATEGORY_INTERNAL;
-}
 
 export interface SDKErrorFields {
   code: ErrorCode;
@@ -288,7 +266,7 @@ type ErrorLike = {
 /**
  * Decode the `SDKError` bytes the addon attaches to every proto-path failure.
  * This is the authoritative mapping — commons produced it via
- * `rac_result_to_proto_error`, so when it is present the local `categoryForCode`
+ * `rac_result_to_proto_error`, so when it is present the shared `categoryForCode`
  * table is not consulted at all.
  */
 function fromSerializedSdkError(value: unknown): SDKException | null {


### PR DESCRIPTION
## Description

## What is wrong

`bindings/proto-ts/src/convenience/errors_category.ts` opens by naming its own scope:

> Canonical `ErrorCode` / `rac_result_t` → `ErrorCategory` range table for every TypeScript SDK (Web, React Native, Electron).
> [...] **Do not invent a second table in an SDK.**

`bindings/electron/src/errors.ts:70` invents a second table. Web and React Native both `import { categoryForCode } from '@runanywhere/proto-ts/convenience/errors_category'`; Electron declares its own, described as a port of the commons range table.

The same file already argues against this one level up, about the enums:

> `ErrorCode`, `ErrorCategory`, and `ErrorSeverity` are the GENERATED proto enums from `idl/errors.proto`, re-exported rather than re-declared [...] **A local subset would silently collapse the 115 commons codes it did not list, which is exactly the bug this file used to have.**

The category table then does the collapsing instead.

## The divergence

Evaluating both tables over codes 0..1100, they disagree on **560** of them:

| codes | shared table | Electron |
|---|---|---|
| 330-349 | AUTH | INTERNAL |
| 350-369 | IO (archive/extraction) | INTERNAL |
| 370-379 | VALIDATION (calibration) | INTERNAL |
| 400-499 | COMPONENT (module/service) | INTERNAL |
| 500-599 | CONFIGURATION (platform/adapter) | INTERNAL |
| 600-699 | COMPONENT (backend/runtime) | INTERNAL |
| 1-99, 390-399, 1000+ | UNSPECIFIED | INTERNAL |

So an Electron consumer branching on `e.category` sees INTERNAL where the identical code gives AUTH or CONFIGURATION on Web and React Native.

This is not the commons table being wrong, and the shared file says so explicitly:

> C++ commons [...] currently only maps |100|–|329| and falls through to INTERNAL — that is a known under-mapping, deliberately deferred [...] Do NOT "fix" this TS table down to match commons.

Electron's copy is that deferred under-mapping, re-introduced in the SDK layer.

It is reachable: the local table is the fallback for when the wire supplies no category, and proto3 leaves an unset enum at 0, which `fromSerializedSdkError` treats as absent.

## What this changes

Import and re-export the shared `categoryForCode`, delete the local copy. Six insertions, twenty-eight deletions, no new code. `SDKException`'s two call sites are untouched.

## Verification

Ran the codegen (`generate_ts.sh`, `generate_ts_convenience.py`, `generate_defaults_pool.py`, `generate_streams.sh`), built `proto-ts`, then built and tested the Electron package:

```
electron build: rc=0, 0 TypeScript errors
npm test:  tests 241  pass 241  fail 0
```

Both existing assertions in `test/unit/errors.test.ts` still pass **unchanged**, including `categoryForCode maps ranges like the canonical table`. That is not luck: all eight codes it pins (0, 100, 110, 130, 182, 259, 380, 804) fall in bands where the two tables already agreed, which is exactly why the divergence went unnoticed.

The behaviour change, from the built package:

```
code 340 -> AUTH           (was INTERNAL)
code 355 -> IO             (was INTERNAL)
code 372 -> VALIDATION     (was INTERNAL)
code 450 -> COMPONENT      (was INTERNAL)
code 520 -> CONFIGURATION  (was INTERNAL)
code 640 -> COMPONENT      (was INTERNAL)
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Standardized error categorization to use the shared implementation, ensuring consistent fallback behavior across the application.
* **Documentation**
  * Clarified which error-categorization behavior serves as the authoritative fallback when no more specific classification is available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally — `bindings/electron` has no `lint` script; `npm run build` (tsc, 0 errors) is the equivalent gate and passed
- [ ] Added/updated tests for changes — none added on purpose. `test/unit/errors.test.ts` already pins this function and passes unchanged; per `AGENTS.md` I do not add tests unless asked

Ran locally in `bindings/electron`, after the four IDL codegen steps and a `proto-ts` build:

```
npm run build   ->  rc=0, 0 TypeScript errors
npm test        ->  tests 241   pass 241   fail 0
```

### Platform-Specific Testing
None of the template's platform sections apply: this changes `bindings/electron`, which the matrix does not cover (Electron is also missing from the Labels list below).

## Labels
None of the listed labels matches. This is `bindings/electron`, and there is no Electron SDK label in the repo today (`ios-sdk`, `kotlin-sdk`, `web-sdk`, `flutter-sdk`, `rn-sdk`, `core`). Closest by blast radius is none of them, since no other binding is touched. Happy to relabel if you have a preference.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed) — not needed; the shared table already documents itself as canonical for Electron

## Screenshots
Not applicable, no UI surface.
