### PR TITLE
fix(gate): address CodeRabbit review on #781

### DIFF
--- a/scripts/build/_release_asset.sh
+++ b/scripts/build/_release_asset.sh
@@ -16,10 +16,12 @@ fetch_release_asset() {
 
     # Every current caller (download-neurt.sh, download-qhexrt.sh,
     # download-qairt-runtime.sh, check_engine_prebuilt_pins.sh) requires a real
-    # NEURUN_TOKEN and exits before reaching here without one -- NeuRT, QHexRT and
-    # the QAIRT runtime are all private assets on the neurun repo. This guard just
-    # avoids ever sending a literally empty Bearer header (GitHub rejects that
-    # outright) if a future caller legitimately has none.
+    # NEURUN_TOKEN (or GH_TOKEN as a fallback -- see each caller's own
+    # TOKEN="${NEURUN_TOKEN:-${GH_TOKEN:-}}") and exits before reaching here
+    # without one -- NeuRT, QHexRT and the QAIRT runtime are all private assets
+    # on the neurun repo. This guard just avoids ever sending a literally empty
+    # Bearer header (GitHub rejects that outright) if a future caller
+    # legitimately has none.
     local auth=()
     [[ -n "$token" ]] && auth=(-H "Authorization: Bearer ${token}")
 

--- a/scripts/validation/gates/check_engine_prebuilt_pins.sh
+++ b/scripts/validation/gates/check_engine_prebuilt_pins.sh
@@ -146,7 +146,7 @@ echo "== no hand-staged payload paths =="
 # Also covers QAIRT: RA_QNN_RUNTIME_DIR pointing at a literal Windows path is
 # exactly the C:\actions-runner-state\qhexrt-qnn-runtime-flat regression --
 # that directory carried no version info and had already gone stale once.
-HANDSTAGE_RE="QHEXRT_ROOT: *['\"][A-Za-z]:\\\\|NEURT_ROOT: *['\"]?[A-Za-z]:\\\\|QAIRT_ROOT: *['\"][A-Za-z]:\\\\|RA_QNN_RUNTIME_DIR: *['\"][A-Za-z]:\\\\|qhexrt-prebuilt\\\\versions|qairt-runtime\\\\versions"
+HANDSTAGE_RE="QHEXRT_ROOT: *['\"][A-Za-z]:\\\\|NEURT_ROOT: *['\"]?[A-Za-z]:\\\\|QAIRT_ROOT: *['\"][A-Za-z]:\\\\|RA_QNN_RUNTIME_DIR: *['\"][A-Za-z]:\\\\|qhexrt-prebuilt\\\\versions|qairt-runtime\\\\(arm64-v8a|win-arm64)\\\\versions"
 if grep -rnE "$HANDSTAGE_RE" "${REPO_ROOT}/.github/workflows/" >/dev/null 2>&1; then
     bad "a workflow pins an engine or QAIRT payload by absolute path; use the downloader"
     grep -rnE "$HANDSTAGE_RE" "${REPO_ROOT}/.github/workflows/" | sed 's/^/         /' >&2
@@ -231,6 +231,11 @@ if [[ "$OFFLINE" -eq 1 || -z "$TOKEN" ]]; then
     note "Local pin checks above still ran."
 else
     repo="${NEURUN_REPO:-RunanywhereAI/neurun}"
+    # Same precedence as scripts/build/download-qairt-runtime.sh -- if a future
+    # QAIRT_RUNTIME_REPO override ever points QAIRT at a different repo than the
+    # engine payloads, this gate must validate the same release the downloader
+    # actually fetches, not silently fall back to the engine repo.
+    qairt_repo="${QAIRT_RUNTIME_REPO:-${NEURUN_REPO:-RunanywhereAI/neurun}}"
     # curl, not `gh`: a self-hosted runner may not have the CLI at all.
     listing="$(curl -sSL -H "Authorization: Bearer ${TOKEN}" \
                  -H "Accept: application/vnd.github+json" \
@@ -259,12 +264,12 @@ for a in rel.get('assets',[]): print(a['name'])" 2>/dev/null || true)"
         # move independently, so it is fetched from a separate release listing.
         qairt_listing="$(curl -sSL -H "Authorization: Bearer ${TOKEN}" \
                      -H "Accept: application/vnd.github+json" \
-                     "https://api.github.com/repos/${repo}/releases/tags/${QAIRT_RUNTIME_RELEASE_TAG}" \
+                     "https://api.github.com/repos/${qairt_repo}/releases/tags/${QAIRT_RUNTIME_RELEASE_TAG}" \
                    | python3 -c "import json,sys
 rel=json.load(sys.stdin)
 for a in rel.get('assets',[]): print(a['name'])" 2>/dev/null || true)"
         if [[ -z "$qairt_listing" ]]; then
-            bad "could not read release ${QAIRT_RUNTIME_RELEASE_TAG} from $repo"
+            bad "could not read release ${QAIRT_RUNTIME_RELEASE_TAG} from $qairt_repo"
         else
             qairt_want=()
             for p in "${QAIRT_PLATFORMS[@]}"; do
@@ -306,7 +311,6 @@ for a in rel.get('assets',[]): print(a['name'])" 2>/dev/null || true)"
         done
         for p in "${QAIRT_PLATFORMS[@]}"; do
             var="QAIRT_RUNTIME_$(echo "$p" | tr 'a-z-' 'A-Z_')_SHA256"
-            qairt_repo="${NEURUN_REPO:-$repo}"
             aname="qairt-runtime-${p}-v${QAIRT_RUNTIME_VERSION}.tar.gz"
             if ! fetch_release_asset "$qairt_repo" "$QAIRT_RUNTIME_RELEASE_TAG" \
                     "${aname}.sha256" "$tmp" "$TOKEN" python3 2>/dev/null; then


### PR DESCRIPTION
#781 squash-merged before I checked for unresolved review threads. Three existed, two Major. Fixing here.

1. **Hand-staged-path guard couldn't match the real staged path.** It looked for `qairt-runtime\versions`, but `download-qairt-runtime.sh` stages under `qairt-runtime/<platform>/versions/<sha>` — the platform directory sits between the two words the regex required adjacent, so a hardcoded workflow path would pass undetected. Now `qairt-runtime\(arm64-v8a|win-arm64)\versions`.

2. **`QAIRT_RUNTIME_REPO` was silently ignored by the gate.** The downloader honors it; the gate's QAIRT sections never read it and always validated the NeuRT/QHexRT repo instead. A future QAIRT-specific repo would have the downloader and gate checking two different releases. Fixed with identical precedence to the downloader.

3. Documented the `GH_TOKEN` fallback in `_release_asset.sh`'s comment.

## Verified

- New regex catches a hardcoded `win-arm64`/`arm64-v8a` path, no false positive on the real downloader call
- `QAIRT_RUNTIME_REPO` pointed at a nonexistent repo now correctly fails the gate (previously silently passed)
- Full gate still passes clean against the actual pins

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChXbXRyD165wGuxYUT14Dp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation for platform-specific runtime paths and release checks.
  * Release validation now consistently uses the configured runtime source when available.

* **Documentation**
  * Clarified authentication guidance for release asset access, including token fallback behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->