### PR TITLE
release: sync v0.20.27 Apple checksums (fixes publish failure)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -721,7 +721,7 @@ func binaryTargets() -> [Target] {
             .binaryTarget(
                 name: "RACommonsBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RACommons-ios-v\(sdkVersion).zip",
-                checksum: "1ae55ae456810e8115aedaf94671fc9bae280954422839bb50497da009775851"
+                checksum: "b9986796fd9e7fb3b49a5649e4749007e8b86c8421cd6cdaaf094dc3629481c5"
             ),
             .binaryTarget(
                 name: "RABackendLlamaCPPBinary",
@@ -746,7 +746,7 @@ func binaryTargets() -> [Target] {
             .binaryTarget(
                 name: "RABackendNeuRTBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RABackendNeuRT-ios-v\(sdkVersion).zip",
-                checksum: "bfdd2718523e5b2c3826d0bb18e65e107f8ede6dc615e38c5836d01e21dd69a3"
+                checksum: "57d9e8487acc77b02d07c426094ffb92719d1f0312cd2452402670c9cc6ddb39"
             ),
             .binaryTarget(
                 name: "RABackendMLXBinary",

--- a/bindings/flutter/packages/runanywhere/ios/runanywhere/Package.swift
+++ b/bindings/flutter/packages/runanywhere/ios/runanywhere/Package.swift
@@ -23,7 +23,7 @@ func runAnywhereBinaryTarget(name: String, checksum: String) -> Target {
 
 let raCommonsTarget = runAnywhereBinaryTarget(
     name: "RACommons",
-    checksum: "1ae55ae456810e8115aedaf94671fc9bae280954422839bb50497da009775851"
+    checksum: "b9986796fd9e7fb3b49a5649e4749007e8b86c8421cd6cdaaf094dc3629481c5"
 )
 
 let package = Package(

--- a/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
+++ b/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
@@ -9,7 +9,7 @@
 
 mlx_checksums = {
   'RABackendMLX' => '0802fe58480c3e03e94498d46adb50fda7b9ade491807c7e0392a7fd68b83b59',
-  'RunAnywhereMLXRuntime' => '6183c3742d6d44228cfcfe5d3d985a303de7e6f4de2ec39e0ff0e5ed2f8713bd',
+  'RunAnywhereMLXRuntime' => '1f1dcf2be55df762e9bd772f973c815d034d4e6c231f8bb2a1e41ad97d5114b3',
   'RunAnywhereMLXMetal' => '17a2f8c4ce09ef691cde5e7d04171ce749fca89315205f90eb2eed5a76b682b1',
   'RunAnywhereMLXResources' => 'ace624c5cffa32f789cd3beee8d140740daadd793b1315c3583ab670410b3ca3'
 }.freeze

--- a/bindings/flutter/packages/runanywhere_onnx/ios/runanywhere_onnx/Package.swift
+++ b/bindings/flutter/packages/runanywhere_onnx/ios/runanywhere_onnx/Package.swift
@@ -36,7 +36,7 @@ let sherpaTarget = runAnywhereBinaryTarget(
 // makes on-device image generation (diffusion.generateImage) routable.
 let coremlTarget = runAnywhereBinaryTarget(
     name: "RABackendNeuRT",
-    checksum: "bfdd2718523e5b2c3826d0bb18e65e107f8ede6dc615e38c5836d01e21dd69a3"
+    checksum: "57d9e8487acc77b02d07c426094ffb92719d1f0312cd2452402670c9cc6ddb39"
 )
 
 let package = Package(


### PR DESCRIPTION
`publish` failed on the v0.20.27 release run at **"Verify built Apple checksums match tagged package contracts"** — the exact documented failure mode from tagging without syncing checksums first (`sync-checksums.sh --check` before merge, per the release runbook).

Nothing was published — a failed `publish` dies before creating the release. `native_ios` succeeded in the same run (`32717285781`), so this reuses its artifacts rather than triggering another ~4-5h rebuild.

## Verified

- All 9 downloaded zips checked against their own `.sha256` sidecars before syncing
- `sync-checksums.sh --check` now passes clean against those same artifacts
- `RABackendNeuRT` and `RunAnywhereMLXRuntime` checksums moved — both are the known non-reproducible archives (documented), not a sign of a problem
- `check_flutter_centralization.sh` and `check_release_version_coherence.sh` both pass

## Next

Once this merges, re-tag `v0.20.27` at the new commit and dispatch a **publish-only** run (`publish_from_run_id=32717285781`) reusing the already-verified candidate rather than rebuilding.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ChXbXRyD165wGuxYUT14Dp

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated iOS and Flutter package release checksums for the latest binary archives.
  * Updated the NeuRT SDK checksum to version 0.20.27.
  * Ensured package integrity checks align with the latest released components.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->