### PR TITLE
fix(release): kit sha256 sidecars must be basenames

### DIFF
--- a/.github/workflows/cpp-desktop-kit.yml
+++ b/.github/workflows/cpp-desktop-kit.yml
@@ -65,8 +65,11 @@ jobs:
           ls -la dist/RunAnywhere-cpp-desktop-macos-arm64-v*.tar.gz
           tar=$(echo dist/RunAnywhere-cpp-desktop-macos-arm64-v*.tar.gz)
           python3 scripts/ci/verify_cpp_desktop_kit.py "$tar" --source-root . --forbid-private-engines
-          shasum -a 256 dist/RunAnywhere-cpp-desktop-macos-arm64-v*.tar.gz \
-            | tee "dist/RunAnywhere-cpp-desktop-macos-arm64-v$(tr -d '[:space:]' < core/VERSION).tar.gz.sha256"
+          (
+            cd dist
+            name="RunAnywhere-cpp-desktop-macos-arm64-v$(tr -d '[:space:]' < ../core/VERSION).tar.gz"
+            shasum -a 256 "$name" | tee "$name.sha256"
+          )
       - uses: actions/upload-artifact@v4
         with:
           name: cpp-desktop-macos-arm64

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2225,14 +2225,12 @@ jobs:
               # Sidecars must name the basename in this directory. macOS kit
               # jobs used to write `dist/foo.tar.gz`; rewrite so -c succeeds
               # and the published sidecar is consumer-usable.
-              tmp="${checksum}.basename"
-              while read -r digest path; do
-                digest="${digest%$'\r'}"
-                path="${path%$'\r'}"
-                [ -n "$digest" ] && [ -n "$path" ] || continue
-                printf '%s  %s\n' "$digest" "$(basename "$path")"
-              done < "$checksum" > "$tmp"
-              mv "$tmp" "$checksum"
+              # macOS kit sidecars used to name dist/foo.tar.gz. Strip a
+              # directory prefix only — GNU sha256sum binary lines are
+              # `hash *file` and must keep the asterisk.
+              if grep -q '  .*/' "$checksum"; then
+                sed -i -E 's|  .+/|  |' "$checksum"
+              fi
               sha256sum --check "$checksum"
             done
           )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -80,6 +80,14 @@ on:
           run's kit artifacts with this run's.
         type: boolean
         default: false
+      reuse_cpp_desktop_run_id:
+        description: >-
+          Run id whose cpp-desktop-* artifacts to attach instead of rebuilding kits
+          (skips the five kit/overlay jobs). Use with publish_from_run_id when a
+          prior rebuild_cpp_desktop run already packaged routable kits but publish
+          itself failed (e.g. sidecar path prefix).
+        required: false
+        default: ''
 
 permissions:
   contents: read
@@ -411,7 +419,7 @@ jobs:
 
   native_cpp_desktop_macos:
     needs: validate
-    if: ${{ !inputs.publish_from_run_id || inputs.rebuild_cpp_desktop }}
+    if: ${{ !inputs.publish_from_run_id || (inputs.rebuild_cpp_desktop && inputs.reuse_cpp_desktop_run_id == '') }}
     runs-on: macos-14
     timeout-minutes: 90
     steps:
@@ -432,8 +440,13 @@ jobs:
           ls -la dist/RunAnywhere-cpp-desktop-macos-arm64-v*.tar.gz
           tar=$(echo dist/RunAnywhere-cpp-desktop-macos-arm64-v*.tar.gz)
           python3 scripts/ci/verify_cpp_desktop_kit.py "$tar" --source-root . --forbid-private-engines
-          shasum -a 256 dist/RunAnywhere-cpp-desktop-macos-arm64-v*.tar.gz \
-            | tee "dist/RunAnywhere-cpp-desktop-macos-arm64-v$(tr -d '[:space:]' < core/VERSION).tar.gz.sha256"
+          # Basename only — `sha256sum -c` in publish runs inside release-flat.
+          # `shasum dist/foo.tar.gz` writes `dist/foo.tar.gz` and fails there.
+          (
+            cd dist
+            name="RunAnywhere-cpp-desktop-macos-arm64-v$(tr -d '[:space:]' < ../core/VERSION).tar.gz"
+            shasum -a 256 "$name" | tee "$name.sha256"
+          )
       - uses: actions/upload-artifact@v7
         with:
           name: cpp-desktop-macos
@@ -445,7 +458,7 @@ jobs:
 
   native_cpp_desktop_windows:
     needs: validate
-    if: ${{ !inputs.publish_from_run_id || inputs.rebuild_cpp_desktop }}
+    if: ${{ !inputs.publish_from_run_id || (inputs.rebuild_cpp_desktop && inputs.reuse_cpp_desktop_run_id == '') }}
     runs-on: windows-2022
     timeout-minutes: 120
     steps:
@@ -490,7 +503,7 @@ jobs:
 
   native_cpp_desktop_windows_arm64:
     needs: validate
-    if: ${{ !inputs.publish_from_run_id || inputs.rebuild_cpp_desktop }}
+    if: ${{ !inputs.publish_from_run_id || (inputs.rebuild_cpp_desktop && inputs.reuse_cpp_desktop_run_id == '') }}
     runs-on: windows-11-arm
     timeout-minutes: 90
     steps:
@@ -541,7 +554,7 @@ jobs:
 
   native_cpp_desktop_macos_neurt_private:
     needs: validate
-    if: ${{ !inputs.publish_from_run_id || inputs.rebuild_cpp_desktop }}
+    if: ${{ !inputs.publish_from_run_id || (inputs.rebuild_cpp_desktop && inputs.reuse_cpp_desktop_run_id == '') }}
     runs-on: macos-14
     timeout-minutes: 90
     steps:
@@ -582,7 +595,7 @@ jobs:
 
   native_cpp_desktop_windows_qhexrt_private:
     needs: validate
-    if: ${{ !inputs.publish_from_run_id || inputs.rebuild_cpp_desktop }}
+    if: ${{ !inputs.publish_from_run_id || (inputs.rebuild_cpp_desktop && inputs.reuse_cpp_desktop_run_id == '') }}
     runs-on: windows-11-arm
     timeout-minutes: 120
     steps:
@@ -2045,18 +2058,18 @@ jobs:
           run-id: ${{ inputs.reuse_native_web_run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       # Stub kits from the reused candidate must not ship. Drop them, then
-      # take this run's rebuilt tarballs (same artifact names).
+      # take rebuilt tarballs (this run, or reuse_cpp_desktop_run_id).
       - name: Drop stub C++ desktop kits from the reused run
-        if: ${{ inputs.publish_from_run_id != '' && inputs.rebuild_cpp_desktop }}
+        if: ${{ inputs.publish_from_run_id != '' && (inputs.rebuild_cpp_desktop || inputs.reuse_cpp_desktop_run_id != '') }}
         run: rm -rf release-artifacts/cpp-desktop-*
       - name: Replace C++ desktop kits from this run
-        if: ${{ inputs.publish_from_run_id != '' && inputs.rebuild_cpp_desktop }}
+        if: ${{ inputs.publish_from_run_id != '' && (inputs.rebuild_cpp_desktop || inputs.reuse_cpp_desktop_run_id != '') }}
         uses: actions/download-artifact@v8
         with:
           pattern: cpp-desktop-*
           path: release-artifacts
           merge-multiple: false
-          run-id: ${{ github.run_id }}
+          run-id: ${{ inputs.reuse_cpp_desktop_run_id || github.run_id }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
       - name: Flatten + index assets
         # Collision-detecting flatten. The previous `find ... -exec cp` form
@@ -2209,6 +2222,15 @@ jobs:
           (
             cd release-flat
             for checksum in *.sha256; do
+              # Sidecars must name the basename in this directory. macOS kit
+              # jobs used to write `dist/foo.tar.gz`; rewrite so -c succeeds
+              # and the published sidecar is consumer-usable.
+              tmp="${checksum}.basename"
+              while read -r digest _ path; do
+                [ -n "$digest" ] || continue
+                printf '%s  %s\n' "$digest" "$(basename "$path")"
+              done < "$checksum" > "$tmp"
+              mv "$tmp" "$checksum"
               sha256sum --check "$checksum"
             done
           )

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2226,8 +2226,10 @@ jobs:
               # jobs used to write `dist/foo.tar.gz`; rewrite so -c succeeds
               # and the published sidecar is consumer-usable.
               tmp="${checksum}.basename"
-              while read -r digest _ path; do
-                [ -n "$digest" ] || continue
+              while read -r digest path; do
+                digest="${digest%$'\r'}"
+                path="${path%$'\r'}"
+                [ -n "$digest" ] && [ -n "$path" ] || continue
                 printf '%s  %s\n' "$digest" "$(basename "$path")"
               done < "$checksum" > "$tmp"
               mv "$tmp" "$checksum"

--- a/cmake/PackageCppDesktop.cmake
+++ b/cmake/PackageCppDesktop.cmake
@@ -289,21 +289,34 @@ else()
 endif()
 
 # macOS Sherpa-ONNX is STATIC IMPORTED from third_party; `ar` of
-# rac_backend_sherpa does not absorb those objects. Copy them into the kit
-# (skip libonnxruntime.a — the kit already ships the ORT dylib of the same
-# pin). Windows uses SHARED DLLs staged above.
+# rac_backend_sherpa does not absorb those objects. Copy them into the kit,
+# including libonnxruntime.a (CI prefetch uses the static sherpa inventory;
+# there is no ORT dylib in the build tree to glob). Windows uses SHARED DLLs
+# staged above.
 if(APPLE)
     set(_sherpa_mac "${RAC_SOURCE_DIR}/core/third_party/sherpa-onnx-macos/lib")
     if(EXISTS "${_sherpa_mac}")
         file(GLOB _sherpa_as "${_sherpa_mac}/*.a")
         foreach(_a IN LISTS _sherpa_as)
             get_filename_component(_n "${_a}" NAME)
-            if(_n MATCHES "onnxruntime")
-                continue()
-            endif()
             file(COPY "${_a}" DESTINATION "${RAC_KIT_OUT}/lib")
             string(APPEND _extra_link "\${RunAnywhere_LIBRARY_DIR}/${_n};")
+            if(_n MATCHES "onnxruntime")
+                set(_kit_has_ort_static TRUE)
+            endif()
         endforeach()
+    endif()
+    if(EXISTS "${RAC_KIT_OUT}/lib/librac_backend_sherpa.a"
+       AND NOT EXISTS "${RAC_KIT_OUT}/lib/libonnxruntime.a"
+       AND NOT EXISTS "${RAC_KIT_OUT}/third_party/libonnxruntime.dylib")
+        message(FATAL_ERROR
+            "PackageCppDesktop: macOS kit has rac_backend_sherpa but no ONNX Runtime "
+            "(libonnxruntime.a from sherpa-onnx-macos, or libonnxruntime.dylib). "
+            "Prefetch with core/scripts/macos/download-sherpa-onnx.sh.")
+    endif()
+    if(EXISTS "${RAC_KIT_OUT}/lib/libonnxruntime.a"
+       AND EXISTS "${RAC_KIT_OUT}/third_party/libonnxruntime.dylib")
+        file(REMOVE "${RAC_KIT_OUT}/third_party/libonnxruntime.dylib")
     endif()
 endif()
 

--- a/cmake/PackageCppDesktop.cmake
+++ b/cmake/PackageCppDesktop.cmake
@@ -187,6 +187,20 @@ if(RAC_BINARY_DIR)
             foreach(_dll IN LISTS _sherpa_dlls)
                 file(COPY "${_dll}" DESTINATION "${RAC_KIT_OUT}/third_party")
             endforeach()
+            # Import libs must be on the consumer link line (MSVC is one-pass).
+            # Never pass the DLLs to link.exe (LNK1107).
+            file(GLOB _sherpa_implibs "${_sherpa_win}/*.lib")
+            foreach(_implib IN LISTS _sherpa_implibs)
+                file(COPY "${_implib}" DESTINATION "${RAC_KIT_OUT}/lib")
+                get_filename_component(_n "${_implib}" NAME)
+                string(APPEND _extra_link "\${RunAnywhere_LIBRARY_DIR}/${_n};")
+            endforeach()
+            if(EXISTS "${RAC_KIT_OUT}/lib/rac_backend_sherpa.lib"
+               AND NOT EXISTS "${RAC_KIT_OUT}/lib/sherpa-onnx-c-api.lib")
+                message(FATAL_ERROR
+                    "PackageCppDesktop: Windows kit has rac_backend_sherpa.lib but no "
+                    "sherpa-onnx-c-api.lib. Prefetch with download-sherpa-onnx.bat.")
+            endif()
         endif()
     endif()
     if(APPLE AND EXISTS "${RAC_KIT_OUT}/third_party/libonnxruntime.dylib")

--- a/cmake/RunAnywhereConfig.cmake.in
+++ b/cmake/RunAnywhereConfig.cmake.in
@@ -86,6 +86,16 @@ if(NOT TARGET RunAnywhere::commons)
             endif()
         endif()
     endforeach()
+    # Transitive SHARED deps of whole-archived backends must follow them on
+    # MSVC (one-pass). Apple ld is more forgiving but the same order is correct.
+    if(WIN32)
+        file(GLOB _sherpa_implibs "${RunAnywhere_LIBRARY_DIR}/sherpa-onnx*.lib")
+        list(APPEND _runanywhere_kit_extra ${_sherpa_implibs})
+    endif()
+    if(APPLE AND EXISTS "${RunAnywhere_LIBRARY_DIR}/libonnxruntime.a")
+        list(APPEND _runanywhere_kit_extra
+            "${RunAnywhere_LIBRARY_DIR}/libonnxruntime.a")
+    endif()
     # Unix: link the unversioned ORT dylib. Versioned copies
     # (libonnxruntime.1.dylib) are Mach-O stubs and fail to load.
     # Windows: never pass onnxruntime.dll to link.exe (LNK1107). The import

--- a/scripts/build/package-private-engine-overlay.sh
+++ b/scripts/build/package-private-engine-overlay.sh
@@ -197,10 +197,14 @@ if [[ -z "$OUT" ]]; then
 fi
 # include/ is present for NeuRT (plugin entry header); QHexRT overlays have none.
 tar -C "$stage" -czf "$OUT" lib bin share include
-if command -v shasum >/dev/null 2>&1; then
-  shasum -a 256 "$OUT" | tee "${OUT}.sha256"
-elif command -v sha256sum >/dev/null 2>&1; then
-  sha256sum "$OUT" | tee "${OUT}.sha256"
-fi
+(
+  cd "$(dirname "$OUT")"
+  base="$(basename "$OUT")"
+  if command -v shasum >/dev/null 2>&1; then
+    shasum -a 256 "$base" | tee "$base.sha256"
+  elif command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "$base" | tee "$base.sha256"
+  fi
+)
 echo "private overlay: $OUT"
 ls -la "$stage/lib" "$stage/bin"

--- a/scripts/ci/verify_cpp_desktop_kit.py
+++ b/scripts/ci/verify_cpp_desktop_kit.py
@@ -188,6 +188,12 @@ def main() -> int:
                 missing.append("third_party/sherpa-onnx-c-api.dll")
         elif not any(n.replace("\\", "/").endswith("libsherpa-onnx-c-api.a") for n in canon):
             missing.append("lib/libsherpa-onnx-c-api.a")
+        if not any(
+            n.replace("\\", "/").endswith("libonnxruntime.a")
+            or n.replace("\\", "/").endswith("third_party/libonnxruntime.dylib")
+            for n in canon
+        ):
+            missing.append("lib/libonnxruntime.a (or third_party/libonnxruntime.dylib)")
 
     private_hits = [n for n in canon if "neurt" in n.lower() or "qhexrt" in n.lower()]
     if args.forbid_private_engines and private_hits:

--- a/scripts/ci/verify_cpp_desktop_kit.py
+++ b/scripts/ci/verify_cpp_desktop_kit.py
@@ -186,6 +186,8 @@ def main() -> int:
         if args.windows:
             if not any("sherpa-onnx-c-api.dll" in n.replace("\\", "/") for n in canon):
                 missing.append("third_party/sherpa-onnx-c-api.dll")
+            if not any(n.replace("\\", "/").endswith("sherpa-onnx-c-api.lib") for n in canon):
+                missing.append("lib/sherpa-onnx-c-api.lib")
         elif not any(n.replace("\\", "/").endswith("libsherpa-onnx-c-api.a") for n in canon):
             missing.append("lib/libsherpa-onnx-c-api.a")
         if not any(

--- a/scripts/ci/verify_cpp_desktop_kit.py
+++ b/scripts/ci/verify_cpp_desktop_kit.py
@@ -188,14 +188,17 @@ def main() -> int:
                 missing.append("third_party/sherpa-onnx-c-api.dll")
             if not any(n.replace("\\", "/").endswith("sherpa-onnx-c-api.lib") for n in canon):
                 missing.append("lib/sherpa-onnx-c-api.lib")
-        elif not any(n.replace("\\", "/").endswith("libsherpa-onnx-c-api.a") for n in canon):
-            missing.append("lib/libsherpa-onnx-c-api.a")
-        if not any(
-            n.replace("\\", "/").endswith("libonnxruntime.a")
-            or n.replace("\\", "/").endswith("third_party/libonnxruntime.dylib")
-            for n in canon
-        ):
-            missing.append("lib/libonnxruntime.a (or third_party/libonnxruntime.dylib)")
+            # Windows Sherpa-ONNX is SHARED: ORT is onnxruntime.dll +
+            # onnxruntime.lib (checked above), never libonnxruntime.a.
+        else:
+            if not any(n.replace("\\", "/").endswith("libsherpa-onnx-c-api.a") for n in canon):
+                missing.append("lib/libsherpa-onnx-c-api.a")
+            if not any(
+                n.replace("\\", "/").endswith("libonnxruntime.a")
+                or n.replace("\\", "/").endswith("third_party/libonnxruntime.dylib")
+                for n in canon
+            ):
+                missing.append("lib/libonnxruntime.a (or third_party/libonnxruntime.dylib)")
 
     private_hits = [n for n in canon if "neurt" in n.lower() or "qhexrt" in n.lower()]
     if args.forbid_private_engines and private_hits:


### PR DESCRIPTION
## Summary
- macOS C++ desktop kit `.sha256` sidecars named `dist/foo.tar.gz`, so `sha256sum -c` in `release-flat` failed after every other 0.20.28 asset verified (`32804627702`).
- Write sidecars as basenames; rewrite any leftover path prefix at publish time; add `reuse_cpp_desktop_run_id` to republish without rebuilding kits.

## Test plan
- [x] Local rewrite of the failed sidecar then `shasum -c` against the tarball
- [ ] Publish dispatch `32806053758` creates draft `v0.20.28` with three public kits and zero `*qhexrt*` / `*neurt-private*`

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an option to reuse previously built C++ desktop artifacts during release rebuilds.
  * C++ desktop kits now include required Sherpa-ONNX and ONNX Runtime libraries for supported platforms.
* **Bug Fixes**
  * Improved checksum generation and validation for desktop kits and private engine overlays.
  * Ensured checksum files remain portable and compatible with legacy formats.
  * Added validation to detect incomplete or incompatible desktop kits.
* **Release Improvements**
  * Rebuilds can skip unnecessary desktop and overlay jobs when reusable artifacts are provided.
  * Publishing can use artifacts from the current release or a specified prior run.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->