### PR TITLE
fix: ship libcurl.lib in Windows ARM64 C++ kits

### DIFF
--- a/cmake/PackageCppDesktop.cmake
+++ b/cmake/PackageCppDesktop.cmake
@@ -291,6 +291,13 @@ elseif(WIN32)
             string(APPEND _extra_link "\${RunAnywhere_LIBRARY_DIR}/libcurl.lib;")
         endif()
     endif()
+    if(NOT EXISTS "${RAC_KIT_OUT}/lib/libcurl.lib")
+        message(FATAL_ERROR
+            "PackageCppDesktop: Windows kit missing libcurl.lib "
+            "(http_transport_curl.cpp.obj needs it; x64-only vcpkg globs miss "
+            "arm64-windows-static). Searched vcpkg installed triplets and "
+            "${RAC_BINARY_DIR}.")
+    endif()
     # rac_commons PUBLIC-links these by bare filename on MSVC. vcpkg zlib.lib
     # does not satisfy a zlibstatic.lib DEFAULTLIB / unresolved reference.
     foreach(_need IN ITEMS zlibstatic.lib bz2_bundled.lib)

--- a/cmake/PackageCppDesktop.cmake
+++ b/cmake/PackageCppDesktop.cmake
@@ -257,17 +257,40 @@ elseif(WIN32)
     # CreateXmlReader.
     set(RUNANYWHERE_KIT_SYSTEM_LIBS "ws2_32;crypt32;bcrypt;secur32;wldap32;normaliz;advapi32;iphlpapi;xmllite;ole32")
     foreach(_root IN ITEMS "$ENV{VCPKG_INSTALLATION_ROOT}" "$ENV{VCPKG_ROOT}")
-        if(_root AND EXISTS "${_root}/installed/x64-windows-static/lib")
-            set(_vlib "${_root}/installed/x64-windows-static/lib")
+        if(NOT _root)
+            continue()
+        endif()
+        foreach(_triplet IN ITEMS
+                "${VCPKG_TARGET_TRIPLET}"
+                "arm64-windows-static"
+                "x64-windows-static")
+            if(NOT _triplet)
+                continue()
+            endif()
+            set(_vlib "${_root}/installed/${_triplet}/lib")
+            if(NOT EXISTS "${_vlib}")
+                continue()
+            endif()
             foreach(_n IN ITEMS libcurl.lib zlib.lib)
-                if(EXISTS "${_vlib}/${_n}")
+                if(EXISTS "${_vlib}/${_n}" AND NOT EXISTS "${RAC_KIT_OUT}/lib/${_n}")
                     file(COPY "${_vlib}/${_n}" DESTINATION "${RAC_KIT_OUT}/lib")
                     string(APPEND _extra_link "\${RunAnywhere_LIBRARY_DIR}/${_n};")
                 endif()
             endforeach()
-            break()
-        endif()
+        endforeach()
     endforeach()
+    # Same search as zlibstatic: curl may live in the build tree / vcpkg_installed
+    # even when VCPKG_ROOT is unset. Windows ARM64 kits previously shipped
+    # http_transport_curl.cpp.obj without libcurl.lib (x64-only vcpkg glob).
+    if(NOT EXISTS "${RAC_KIT_OUT}/lib/libcurl.lib")
+        set(_curl_hits "")
+        file(GLOB_RECURSE _curl_hits "${RAC_BINARY_DIR}/**/libcurl.lib")
+        if(_curl_hits)
+            list(GET _curl_hits 0 _curl_found)
+            file(COPY "${_curl_found}" DESTINATION "${RAC_KIT_OUT}/lib")
+            string(APPEND _extra_link "\${RunAnywhere_LIBRARY_DIR}/libcurl.lib;")
+        endif()
+    endif()
     # rac_commons PUBLIC-links these by bare filename on MSVC. vcpkg zlib.lib
     # does not satisfy a zlibstatic.lib DEFAULTLIB / unresolved reference.
     foreach(_need IN ITEMS zlibstatic.lib bz2_bundled.lib)

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -15,7 +15,7 @@ lives where it does) is [`scripts/README.md`](README.md); don't duplicate its ta
 | `release/` | version bump, artifact validation, npm/consumer-app publish helpers (see below) | `README.md` |
 | `setup/` | `doctor.sh`, `setup.sh`, `setup-toolchain.sh`, `detect-mode.sh`, `sync-skills.sh` | `README.md` |
 | `validation/` | CI gates (`gates/`), C++ commons checks (`commons/`), the seven-lane e2e harness (`e2e/`), plus root-level `verify_default_pool.sh` (cross-language default-value parity check) | [`validation/README.md`](validation/README.md) |
-| `ci/` | `verify_cpp_desktop_kit.py` — kit tarball contract (proto headers, SCHEMA_LOCK, Windows zlibstatic/bz2). `oss_keyless_telemetry_blast.sh` is retired (CLI lives in RunanywhereAI/RCLI). | — |
+| `ci/` | `verify_cpp_desktop_kit.py` — kit tarball contract (proto headers, SCHEMA_LOCK, Windows `zlibstatic`/`bz2`/`libcurl`, sherpa routability). `oss_keyless_telemetry_blast.sh` is retired (CLI lives in RunanywhereAI/RCLI). Windows ARM64 public kits must ship `lib/libcurl.lib`; `v0.20.28` did not (packager only globbed x64-windows-static). | — |
 | `models/` | empty on this branch — a BigVGAN ONNX exporter and a Parakeet CTC prep script have existed here on other commits/branches; a stale `__pycache__` from one of those checkouts may linger locally and is safe to delete | — |
 
 ## Path resolution: every script derives repo root from its own location, never cwd

--- a/scripts/ci/verify_cpp_desktop_kit.py
+++ b/scripts/ci/verify_cpp_desktop_kit.py
@@ -4,7 +4,8 @@
 Public kits:
   - every checked-in generated *.pb.h is in include/runanywhere/proto/
   - share/runanywhere/SCHEMA_LOCK is present
-  - on Windows, zlibstatic.lib / bz2_bundled.lib / onnxruntime.lib + DLL
+  - on Windows, zlibstatic.lib / bz2_bundled.lib / libcurl.lib /
+    onnxruntime.lib + DLL (ARM64 OSS kits skip ONNX, never libcurl)
   - --forbid-private-engines: no neurt/qhexrt paths
   - if a sherpa backend archive is present, rac_plugin_entry_sherpa must
     reference g_sherpa_stt_ops (RAC_SHERPA_ROUTABLE=1). Ops symbols in a
@@ -142,7 +143,7 @@ def main() -> int:
         missing.append("share/runanywhere/SCHEMA_LOCK")
 
     if args.windows:
-        for lib in ("zlibstatic.lib", "bz2_bundled.lib"):
+        for lib in ("zlibstatic.lib", "bz2_bundled.lib", "libcurl.lib"):
             if not any(n.endswith(lib) for n in names):
                 missing.append(f"lib/{lib}")
         if not args.allow_missing_onnxruntime:


### PR DESCRIPTION
## Summary
- `package-cpp-desktop` only copied `libcurl.lib` from `vcpkg/installed/x64-windows-static`, so Windows ARM64 kits contained `http_transport_curl.cpp.obj` with no import lib.
- Linking RCLI against that kit failed with LNK2019 on `curl_*`. Copy `arm64-windows-static` and any build-tree `libcurl.lib` as well.

## Test plan
- [x] Copied on-device `arm64-windows-static/libcurl.lib` into a 0.20.28 ARM64 kit prefix; RCLI linked and `rcli backends` listed **qhexrt**
- [ ] Next `cpp-desktop-windows-arm64` kit job includes `lib/libcurl.lib` without a manual copy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows packaging to include required curl and zlib libraries across supported architectures.
  - Added fallback detection for curl libraries when unavailable through standard package locations.
  - Prevented missing curl libraries in Windows ARM64 kits.
  - Packaging now reports an error when the required curl library cannot be found.
- **Validation**
  - Updated desktop kit checks to verify required Windows libraries and runtime components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->