### PR TITLE
chore(gates): drop two deprecated-surface exemptions that no longer apply

### DIFF
--- a/scripts/validation/gates/deprecated_surface_allowlist.txt
+++ b/scripts/validation/gates/deprecated_surface_allowlist.txt
@@ -8,7 +8,6 @@
 # Kotlin typed JSON adapters and external cloud-provider payloads.
 bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/hybrid/CloudSttProvider.kt|kotlin:org-json-usage
 bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/hybrid/Cloud.kt|kotlin:org-json-usage
-bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/LLM/StructuredOutputProtoHelpers.kt|kotlin:json-serialisation
 # Web-search tool parses the external DuckDuckGo JSON response (not an SDK DTO);
 # mirrors the already-allowlisted Swift RunAnywhere+WebSearchTool.swift.
 bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/LLM/RunAnywhereWebSearchTool.kt|kotlin:json-serialisation
@@ -57,7 +56,6 @@ core/include/rac/infrastructure/telemetry/rac_telemetry_manager.h|cpp:public-jso
 core/include/rac/backends/rac_llm_llamacpp.h|cpp:json-param-in-public-api
 core/include/rac/backends/rac_vlm_llamacpp.h|cpp:json-param-in-public-api
 core/include/rac/features/llm/rac_llm_service.h|cpp:json-param-in-public-api
-core/include/rac/features/llm/rac_llm_structured_output.h|cpp:json-param-in-public-api
 core/include/rac/features/embeddings/rac_embeddings_service.h|cpp:json-param-in-public-api
 core/include/rac/features/diffusion/rac_diffusion_service.h|cpp:json-param-in-public-api
 core/include/rac/features/vlm/rac_vlm_service.h|cpp:json-param-in-public-api


### PR DESCRIPTION
## Description

`deprecated_surface_allowlist.txt` carries 120 entries; only 118 of them still correspond to a real detection. These two are vacuous:

```
bindings/kotlin/.../LLM/StructuredOutputProtoHelpers.kt|kotlin:json-serialisation
core/include/rac/features/llm/rac_llm_structured_output.h|cpp:json-param-in-public-api
```

Neither is a moved or deleted file. Both still exist; they simply no longer match the rule they are exempted from:

```
$ grep -cE "(toJson|fromJson|JsonObject)" .../StructuredOutputProtoHelpers.kt
0
$ grep -cE "(config_json|out_json|out_stats_json)" core/include/rac/features/llm/rac_llm_structured_output.h
0
```

That matters because of what an entry in this file means. The gate's own message calls each one a "narrowly scoped exception", and its header says it "Exits 1 when NEW (non-allowlisted) violations are found". An exemption for a surface that is already gone is not narrow, it is a standing pre-approval: put `toJson` back into that Kotlin helper, or a `config_json` parameter back into that header, and the gate stays silent on exactly the regression it exists to catch.

Both are structured-output paths, so this looks like the residue of that migration finishing rather than anything going wrong.

## How I found them

Ran the gate with the allowlist temporarily moved aside, which makes it report every detection rather than only unlisted ones, then diffed that set against the file:

```
detected:     118
allowlisted:  120
STALE (allowlisted, no longer detected):  the two above
detected but unlisted:                    none
```

The empty second set is the part worth stating: the gate is not hiding anything today, so this is purely about the two entries that have stopped doing work.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring

## Testing
- [x] Lint passes locally — `check_deprecated_surfaces.sh` exits 0 with the two entries removed: "All detected surfaces match documented exceptions. No new regressions."
- [ ] Added/updated tests for changes — not applicable to removing two allowlist lines

Also confirmed the removal does not flip the gate: it passed before and after, and no previously-listed path became a new violation.

### Platform-Specific Testing
Not applicable, no platform code changed.

## Labels
Closest is `core` by path, though the change is to a validation allowlist rather than to shipped code.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed) — the file documents itself through its entries

## Screenshots
Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Removed validation allowlist entries for Kotlin and C++ structured-output JSON APIs.
  * Added validation allowlist entries for C++ image-embedding and OCR service headers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->