### PR TITLE
chore(pre-commit): let periphery read its own config instead of re-listing targets

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -107,7 +107,7 @@ repos:
 
       - id: ios-sdk-periphery
         name: iOS SDK Periphery (Unused Code)
-        entry: bash -c 'cd bindings/swift && if which periphery >/dev/null; then OUTPUT=$(periphery scan --targets RunAnywhere --targets ONNXRuntime --targets LlamaCPPRuntime 2>&1); WARNINGS=$(echo "$OUTPUT" | grep "warning:" | grep -v "Associatedtype .* is unused"); if [ -n "$WARNINGS" ]; then echo "$WARNINGS"; echo "Periphery found unused code"; exit 1; fi; exit 0; else echo "Periphery not installed"; exit 0; fi'
+        entry: bash -c 'cd bindings/swift && if which periphery >/dev/null; then OUTPUT=$(periphery scan 2>&1); WARNINGS=$(echo "$OUTPUT" | grep "warning:" | grep -v "Associatedtype .* is unused"); if [ -n "$WARNINGS" ]; then echo "$WARNINGS"; echo "Periphery found unused code"; exit 1; fi; exit 0; else echo "Periphery not installed"; exit 0; fi'
         language: system
         files: ^bindings/swift/.*\.swift$
         pass_filenames: false


### PR DESCRIPTION
## Description

The Periphery target list is specified in two places, and only one of them is the checked-in config.

`bindings/swift/.periphery.yml`:

```yaml
targets:
  - RunAnywhere
  - ONNXRuntime
  - LlamaCPPRuntime
```

`.pre-commit-config.yaml:110` then passes the same three as flags, which override that block:

```
cd bindings/swift && ... periphery scan --targets RunAnywhere --targets ONNXRuntime --targets LlamaCPPRuntime ...
```

So adding a target to `.periphery.yml` silently does nothing for anyone committing locally; the hook keeps scanning the old three.

`pr-build.yml:457` already does it the other way:

```yaml
      - name: Periphery unused-code scan (advisory)
        working-directory: bindings/swift
        run: |
          ...
            periphery scan --quiet
```

No `--targets`, because the config supplies them. That step's own comment says Periphery stays advisory "until the runner image ships it and the repository has a checked-in, reproducible scan configuration" — the repo does have one, and CI uses it. The hook is the one place bypassing it.

Both invocations already `cd bindings/swift`, so Periphery discovers `.periphery.yml` identically in each. Dropping the flags makes the hook read it too.

**No behaviour change today**: the flag list and the config list are currently the same three targets. This removes the way they come apart.

I deliberately did not also change *which* targets are scanned. `bindings/swift/Sources/` holds six (`MLXRuntime`, `MLXRuntimeDistribution` and `NeuRTRuntime` are not scanned by either path), and adding them would change how much unused code gets reported, which is a judgement call for you rather than a drive-by. Worth a look separately, and easier to make once the list lives in one file.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [ ] Documentation update
- [x] Refactoring

## Testing
- [x] Lint passes locally — `.pre-commit-config.yaml` still parses (12 hooks), and the hook's inlined shell passes `bash -n`
- [ ] Added/updated tests for changes — not applicable to a pre-commit invocation

I could not execute the hook end to end: Periphery is not installed on this machine, and the hook is written to self-skip in that case (`if which periphery >/dev/null; ... else echo "Periphery not installed"; exit 0`). What I verified is that the two target lists are identical today, that both call sites run from `bindings/swift`, and that the edited entry is still valid YAML and valid shell.

### Platform-Specific Testing
Not applicable, no platform code changed.

## Labels
Closest is `ios-sdk`, since the hook only scans `bindings/swift`.

## Checklist
- [x] Code follows project style guidelines — matches the flagless invocation `pr-build.yml` already uses
- [x] Self-review completed
- [ ] Documentation updated (if needed) — none references the flags

## Screenshots
Not applicable.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated iOS SDK code scanning to cover all default targets, improving consistency and coverage across the project.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->