### PR TITLE
fix(flutter): podspec asset_version check doesn't understand TEMP pins

### DIFF
--- a/bindings/flutter/scripts/package-sdk.sh
+++ b/bindings/flutter/scripts/package-sdk.sh
@@ -456,6 +456,18 @@ validate_public_remote_binary_contract() {
     local pkg component pkg_dir build_gradle binary_config podspec package_manifest
     local file relative expected_target expected_targets expected_count actual_count
     local actual_pubignore expected_pubignore podspec_version asset_version
+    # asset_version normally equals s.version, but check_release_version_coherence.sh
+    # (the authoritative release gate) sanctions one documented exception: when the
+    # canonical repo version leads the last published Apple archives, Package.swift
+    # carries an explicit "TEMP: pin to X until vY assets are published" marker and
+    # every podspec's asset_version pins to that same X. Recognize that exact,
+    # already-reviewed pin instead of unconditionally requiring equality -- a release
+    # that legitimately republishes non-iOS packages without cutting new iOS archives
+    # (0.20.20, 0.20.29) must not fail this check.
+    local spm_pin_version=""
+    if [ -f "$REPO_ROOT/Package.swift" ]; then
+        spm_pin_version="$(sed -nE 's/^let sdkVersion = "([^"]+)"$/\1/p' "$REPO_ROOT/Package.swift")"
+    fi
     for pkg in runanywhere runanywhere_llamacpp runanywhere_mlx runanywhere_onnx; do
         case "$pkg" in
             runanywhere)
@@ -527,7 +539,15 @@ validate_public_remote_binary_contract() {
         podspec_version="$(sed -nE "s/^[[:space:]]*s\.version[[:space:]]*=[[:space:]]*'([^']+)'$/\1/p" "$podspec")"
         asset_version="$(sed -nE "s/^[[:space:]]*asset_version[[:space:]]*=[[:space:]]*'([^']+)'$/\1/p" "$podspec")"
         [ -n "$podspec_version" ] || { echo "ERROR: $pkg podspec is missing s.version" >&2; exit 1; }
-        [ "$asset_version" = "$podspec_version" ] || { echo "ERROR: $pkg podspec asset_version must match s.version ($podspec_version)" >&2; exit 1; }
+        if [ "$asset_version" != "$podspec_version" ]; then
+            if [ -n "$spm_pin_version" ] && [ "$asset_version" = "$spm_pin_version" ] && \
+               grep -Fq "TEMP: pin to $spm_pin_version until the v$podspec_version GitHub release assets are published." "$REPO_ROOT/Package.swift"; then
+                :
+            else
+                echo "ERROR: $pkg podspec asset_version ($asset_version) must match s.version ($podspec_version), or the reviewed SwiftPM TEMP pin naming it" >&2
+                exit 1
+            fi
+        fi
         apple_archive_name_variable='$name'
         [ "$pkg" != "runanywhere_mlx" ] || apple_archive_name_variable='$asset_name'
         apple_archive_template="v#{asset_version}/${apple_archive_name_variable}-ios-v#{asset_version}.zip"


### PR DESCRIPTION
## Summary
- `validate_public_remote_binary_contract()` in `bindings/flutter/scripts/package-sdk.sh` required every public Flutter podspec's `asset_version` to exactly equal `s.version`.
- `check_release_version_coherence.sh` (the authoritative, already-reviewed release gate) explicitly sanctions a second state: when the canonical repo version leads the last published Apple archives, `Package.swift` carries a `TEMP: pin to X until vY assets are published` marker and every podspec's `asset_version` pins to that same X - a state that gate already prints `[OK]` for.
- v0.20.29 is exactly that case (`s.version = 0.20.29`, `asset_version = 0.20.28`), and this blocked `release.yml`'s `validate_consumer_flutter` job - a hard gate for `publish` - even though every version file is exactly as the reviewed release process requires.
- Fix: recognize the same reviewed TEMP pin instead of requiring bare equality.

## Test plan
- [x] `bash -n bindings/flutter/scripts/package-sdk.sh` (syntax check)
- [x] Simulated the check logic against the real v0.20.29 repo state - now passes for all four public podspecs.
- [ ] CI (`validate_consumer_flutter` job on this PR) confirms the fix in the real environment.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved SDK package validation to allow approved temporary version pins when the package metadata matches.
  * Continued rejecting unapproved version mismatches with clearer validation errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->