### PR TITLE
docs: Windows install command for rcli, and refresh the version line

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,12 +398,18 @@ $ rcli serve qwen3        # OpenAI-compatible API on :8080
 
 Also: `rcli run --image photo.jpg` (VLM), `rcli vad`, `rcli embed`, `rcli image` (diffusion, Apple), `rcli lora`, and `--json` on everything.
 
-Install (macOS Apple Silicon, Linux x86_64/aarch64, Windows x86_64):
+Install (macOS Apple Silicon, Linux x86_64/aarch64):
 
 ```bash
 brew install runanywhereai/tap/rcli
 # or
 curl -fsSL https://raw.githubusercontent.com/RunanywhereAI/RCLI/main/install.sh | sh
+```
+
+Windows (x64):
+
+```powershell
+irm https://raw.githubusercontent.com/RunanywhereAI/RCLI/main/install.ps1 | iex
 ```
 
 [CLI README](https://github.com/RunanywhereAI/RCLI)
@@ -425,7 +431,7 @@ curl -fsSL https://raw.githubusercontent.com/RunanywhereAI/RCLI/main/install.sh 
 | **Python** | Windows, macOS, Linux | Alpha | pip (`runanywhere`) | [SDK README](bindings/python/) |
 | **rcli** | macOS, Linux, Windows | Stable | Homebrew / install script | [RCLI](https://github.com/RunanywhereAI/RCLI) |
 
-All SDKs ship on one version line, currently **0.20.11**, from a single C++ core. Pin the same version across the core package and its backends. See [Releases](https://github.com/RunanywhereAI/runanywhere-sdks/releases) for what is published today.
+All SDKs ship on one version line, currently **0.20.28**, from a single C++ core. Pin the same version across the core package and its backends. See [Releases](https://github.com/RunanywhereAI/runanywhere-sdks/releases) for what is published today.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -398,7 +398,7 @@ $ rcli serve qwen3        # OpenAI-compatible API on :8080
 
 Also: `rcli run --image photo.jpg` (VLM), `rcli vad`, `rcli embed`, `rcli image` (diffusion, Apple), `rcli lora`, and `--json` on everything.
 
-Install (macOS Apple Silicon, Linux x86_64/aarch64):
+Install (macOS Apple Silicon, Linux x86_64):
 
 ```bash
 brew install runanywhereai/tap/rcli
@@ -431,7 +431,7 @@ irm https://raw.githubusercontent.com/RunanywhereAI/RCLI/main/install.ps1 | iex
 | **Python** | Windows, macOS, Linux | Alpha | pip (`runanywhere`) | [SDK README](bindings/python/) |
 | **rcli** | macOS, Linux, Windows | Stable | Homebrew / install script | [RCLI](https://github.com/RunanywhereAI/RCLI) |
 
-All SDKs ship on one version line, currently **0.20.28**, from a single C++ core. Pin the same version across the core package and its backends. See [Releases](https://github.com/RunanywhereAI/runanywhere-sdks/releases) for what is published today.
+All SDKs ship on one version line, currently **0.20.29**, from a single C++ core. Pin the same version across the core package and its backends. See [Releases](https://github.com/RunanywhereAI/runanywhere-sdks/releases) for what is published today.
 
 ---
 


### PR DESCRIPTION
## The problem

The rcli install block is headed:

> Install (macOS Apple Silicon, Linux x86_64/aarch64, Windows x86_64):

and then offers only `brew install runanywhereai/tap/rcli` and `curl -fsSL ... install.sh | sh`. Neither runs natively on Windows — Homebrew has no Windows build, and the curl pipe needs a POSIX shell. A Windows reader following that heading gets two commands that cannot work.

The correct path already exists: `install.ps1` ships in `RunanywhereAI/RCLI` and that repo's README documents the PowerShell one-liner. It just never made it onto this page.

## The change

Narrows the existing heading to the platforms its two commands actually cover, and adds a `Windows (x64)` block with the `irm ... install.ps1 | iex` line, matching how the RCLI README presents it.

Also updates the version line from `0.20.11` to `0.20.28`. Latest release is v0.20.28 (published 2026-08-25), and `rcli info` reports `commons 0.20.28`.

## Verification

Docs only, no code paths touched. The PowerShell installer was not executed as part of this change; the command is copied from the RCLI README and `install.ps1` is confirmed present at the repo root of RunanywhereAI/RCLI.

Found while running `rcli-0.5.1-windows-x86_64.zip` cold on Windows 11 Pro x64.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated RCLI installation instructions to support macOS Apple Silicon and Linux x86_64, while retaining Windows PowerShell guidance and excluding Linux aarch64.
  * Updated the documented unified SDK version from `0.20.11` to `0.20.29`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->