### PR TITLE
chore: un-pin Apple/Android release manifests, v0.20.29 real archives

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ import Foundation
 // This is the SINGLE Package.swift for both local development and SPM consumption.
 //
 // FOR EXTERNAL USERS (consuming via GitHub):
-//   .package(url: "https://github.com/RunanywhereAI/runanywhere-swift.git", from: "0.20.28")
+//   .package(url: "https://github.com/RunanywhereAI/runanywhere-swift.git", from: "0.20.29")
 //
 //   Consume the SWIFT DISTRIBUTION REPO, never this monorepo. Two reasons, and
 //   the first one is fatal:
@@ -115,12 +115,7 @@ let mlxRuntimeDistributionSwiftSettings: [SwiftSetting] = buildMLXDistributionFr
 
 // Version for remote XCFrameworks (used unless local natives are explicitly enabled).
 // Updated by scripts/release/sync-versions.sh during release preparation.
-// TEMP: pin to 0.20.28 until the v0.20.29 GitHub release assets are published.
-// This release is a Windows QHexRT engine fix (see knowledge/findings/
-// win-arm64-release-never-enabled-bonsai.yaml in the neurun repo); no new iOS
-// archives were built for it, so the remote binaryTargets must keep resolving
-// 0.20.28 until a release that actually publishes v0.20.29 iOS archives lands.
-let sdkVersion = "0.20.28"
+let sdkVersion = "0.20.29"
 
 let homebrewPrefix = ProcessInfo.processInfo.environment["RUNANYWHERE_HOMEBREW_PREFIX"]
     ?? ProcessInfo.processInfo.environment["HOMEBREW_PREFIX"]
@@ -569,7 +564,7 @@ func binaryTargets() -> [Target] {
             .binaryTarget(
                 name: "RACommonsBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RACommons-ios-v\(sdkVersion).zip",
-                checksum: "f7f58b1b8cf1274268046b5dbf4d805ce3fd11a5e6b11f21b74a3ca87f424aa1"
+                checksum: "a6c0d53f0a2ccf209d1d6354b3c5e1380d6d8a00877e44013328df80c82dcc4b"
             ),
             .binaryTarget(
                 name: "RABackendLlamaCPPBinary",

--- a/bindings/flutter/packages/runanywhere/ios/runanywhere.podspec
+++ b/bindings/flutter/packages/runanywhere/ios/runanywhere.podspec
@@ -26,9 +26,9 @@ Pod::Spec.new do |s|
   # scripts/release/sync-versions.sh rewrites it and
   # check_release_version_coherence.sh requires the exact string. It only
   # diverges when a version republishes non-iOS packages without cutting iOS
-  # archives (0.20.20, and now 0.20.29, did that) -- then pin the last
+  # archives (0.20.20 did that) -- then pin the last
   # release that has them.
-  asset_version      = '0.20.28'
+  asset_version      = '0.20.29'
   s.summary          = 'RunAnywhere: Privacy-first, on-device AI SDK for Flutter'
   s.description      = <<-DESC
 Privacy-first, on-device AI SDK for Flutter. This package provides the core

--- a/bindings/flutter/packages/runanywhere/ios/runanywhere/Package.swift
+++ b/bindings/flutter/packages/runanywhere/ios/runanywhere/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 import Foundation
 
-let sdkVersion = "0.20.28"
+let sdkVersion = "0.20.29"
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 
 func runAnywhereBinaryTarget(name: String, checksum: String) -> Target {
@@ -23,7 +23,7 @@ func runAnywhereBinaryTarget(name: String, checksum: String) -> Target {
 
 let raCommonsTarget = runAnywhereBinaryTarget(
     name: "RACommons",
-    checksum: "f7f58b1b8cf1274268046b5dbf4d805ce3fd11a5e6b11f21b74a3ca87f424aa1"
+    checksum: "a6c0d53f0a2ccf209d1d6354b3c5e1380d6d8a00877e44013328df80c82dcc4b"
 )
 
 let package = Package(

--- a/bindings/flutter/packages/runanywhere_llamacpp/ios/runanywhere_llamacpp.podspec
+++ b/bindings/flutter/packages/runanywhere_llamacpp/ios/runanywhere_llamacpp.podspec
@@ -26,9 +26,9 @@ Pod::Spec.new do |s|
   # scripts/release/sync-versions.sh rewrites it and
   # check_release_version_coherence.sh requires the exact string. It only
   # diverges when a version republishes non-iOS packages without cutting iOS
-  # archives (0.20.20, and now 0.20.29, did that) -- then pin the last
+  # archives (0.20.20 did that) -- then pin the last
   # release that has them.
-  asset_version      = '0.20.28'
+  asset_version      = '0.20.29'
   s.summary          = 'RunAnywhere LlamaCPP: LLM text generation for Flutter'
   s.description      = <<-DESC
 LlamaCPP backend for RunAnywhere Flutter SDK. Provides LLM text generation

--- a/bindings/flutter/packages/runanywhere_llamacpp/ios/runanywhere_llamacpp/Package.swift
+++ b/bindings/flutter/packages/runanywhere_llamacpp/ios/runanywhere_llamacpp/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 import Foundation
 
-let sdkVersion = "0.20.28"
+let sdkVersion = "0.20.29"
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 
 func runAnywhereBinaryTarget(name: String, checksum: String) -> Target {

--- a/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
+++ b/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
@@ -9,7 +9,7 @@
 
 mlx_checksums = {
   'RABackendMLX' => '0802fe58480c3e03e94498d46adb50fda7b9ade491807c7e0392a7fd68b83b59',
-  'RunAnywhereMLXRuntime' => '99678b329a456d0529d2f6e8a051639537cc8dc79346591d2ae9f91ce279c308',
+  'RunAnywhereMLXRuntime' => 'd942788f1d8f08a9c0c8cc9b7d4c212c9b35382aa90978615eccf8a7e72eac5b',
   'RunAnywhereMLXMetal' => '17a2f8c4ce09ef691cde5e7d04171ce749fca89315205f90eb2eed5a76b682b1',
   'RunAnywhereMLXResources' => 'ace624c5cffa32f789cd3beee8d140740daadd793b1315c3583ab670410b3ca3'
 }.freeze
@@ -31,9 +31,9 @@ Pod::Spec.new do |s|
   # scripts/release/sync-versions.sh rewrites it and
   # check_release_version_coherence.sh requires the exact string. It only
   # diverges when a version republishes non-iOS packages without cutting iOS
-  # archives (0.20.20, and now 0.20.29, did that) -- then pin the last
+  # archives (0.20.20 did that) -- then pin the last
   # release that has them.
-  asset_version      = '0.20.28'
+  asset_version      = '0.20.29'
   s.summary          = 'RunAnywhere MLX backend for physical iOS devices'
   s.description      = <<-DESC
 Apple MLX backend for the RunAnywhere Flutter SDK. Provides on-device LLM,

--- a/bindings/flutter/packages/runanywhere_onnx/ios/runanywhere_onnx.podspec
+++ b/bindings/flutter/packages/runanywhere_onnx/ios/runanywhere_onnx.podspec
@@ -31,7 +31,7 @@ Pod::Spec.new do |s|
   # check_release_version_coherence.sh requires the exact string. It only
   # diverges when a version republishes non-iOS packages without cutting iOS
   # archives (0.20.20 did that) -- then pin the last release that has them.
-  asset_version      = '0.20.28'
+  asset_version      = '0.20.29'
   s.summary          = 'RunAnywhere ONNX: STT, TTS, VAD for Flutter'
   s.description      = <<-DESC
 ONNX Runtime backend for RunAnywhere Flutter SDK. Provides speech-to-text (STT),

--- a/bindings/flutter/packages/runanywhere_onnx/ios/runanywhere_onnx/Package.swift
+++ b/bindings/flutter/packages/runanywhere_onnx/ios/runanywhere_onnx/Package.swift
@@ -3,7 +3,7 @@
 import PackageDescription
 import Foundation
 
-let sdkVersion = "0.20.28"
+let sdkVersion = "0.20.29"
 let packageRoot = URL(fileURLWithPath: #filePath).deletingLastPathComponent()
 
 func runAnywhereBinaryTarget(name: String, checksum: String) -> Target {

--- a/bindings/kotlin/gradle.properties
+++ b/bindings/kotlin/gradle.properties
@@ -16,7 +16,7 @@ runanywhere.rebuildCommons=false
 # NOT the package version. 0.20.20 republished only the Electron npm packages, so
 # no v0.20.20 tag or android archives exist and the download 404s. Keep this at the
 # last release that actually has assets; move it with the next real release train.
-runanywhere.nativeLibVersion=0.20.28
+runanywhere.nativeLibVersion=0.20.29
 
 # Enabled parallel sync for Gradle 9.4+
 org.gradle.tooling.parallel=true

--- a/bindings/react-native/packages/core/RunAnywhereCore.podspec
+++ b/bindings/react-native/packages/core/RunAnywhereCore.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   # `pod install` fails outright. Mirrors asset_version in the Flutter
   # podspecs. Bump back in step with the SwiftPM pin once a matching release
   # exists; check_release_version_coherence.sh enforces that they agree.
-  source_tag_version = '0.20.28'
+  source_tag_version = '0.20.29'
   s.source       = { :git => "https://github.com/RunanywhereAI/runanywhere-sdks.git", :tag => "v#{source_tag_version}" }
 
   # =============================================================================

--- a/bindings/react-native/packages/llamacpp/RunAnywhereLlama.podspec
+++ b/bindings/react-native/packages/llamacpp/RunAnywhereLlama.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   # `pod install` fails outright. Mirrors asset_version in the Flutter
   # podspecs. Bump back in step with the SwiftPM pin once a matching release
   # exists; check_release_version_coherence.sh enforces that they agree.
-  source_tag_version = '0.20.28'
+  source_tag_version = '0.20.29'
   s.source       = { :git => "https://github.com/RunanywhereAI/runanywhere-sdks.git", :tag => "v#{source_tag_version}" }
 
   # =============================================================================

--- a/bindings/react-native/packages/mlx/RunAnywhereMLX.podspec
+++ b/bindings/react-native/packages/mlx/RunAnywhereMLX.podspec
@@ -19,7 +19,7 @@ Pod::Spec.new do |s|
   # `pod install` fails outright. Mirrors asset_version in the Flutter
   # podspecs. Bump back in step with the SwiftPM pin once a matching release
   # exists; check_release_version_coherence.sh enforces that they agree.
-  source_tag_version = '0.20.28'
+  source_tag_version = '0.20.29'
   s.source        = { :git => "https://github.com/RunanywhereAI/runanywhere-sdks.git", :tag => "v#{source_tag_version}" }
 
   # All three binaries are required. RABackendMLX owns the commons backend

--- a/bindings/react-native/packages/onnx/RunAnywhereONNX.podspec
+++ b/bindings/react-native/packages/onnx/RunAnywhereONNX.podspec
@@ -20,7 +20,7 @@ Pod::Spec.new do |s|
   # `pod install` fails outright. Mirrors asset_version in the Flutter
   # podspecs. Bump back in step with the SwiftPM pin once a matching release
   # exists; check_release_version_coherence.sh enforces that they agree.
-  source_tag_version = '0.20.28'
+  source_tag_version = '0.20.29'
   s.source       = { :git => "https://github.com/RunanywhereAI/runanywhere-sdks.git", :tag => "v#{source_tag_version}" }
 
   # =============================================================================


### PR DESCRIPTION
## Summary
- v0.20.29's SwiftPM `sdkVersion`, the four Flutter podspecs' `asset_version`, and Kotlin's `nativeLibVersion` were TEMP-pinned at 0.20.28 on the assumption this release doesn't cut new iOS archives. That assumption was false: `native_ios`/`native_android` rebuild fresh archives on every `release.yml` run unconditionally (no reuse/skip mechanism exists for either), and this release genuinely produced new content in `RACommons-ios` and `RunAnywhereMLXRuntime-ios` (confirmed by downloading and hashing the real artifacts from run 32967338598).
- This made `publish`'s "Verify built Apple checksums match tagged package contracts" step permanently unsatisfiable while pinned — it looks up files by the pinned version, but the freshly-built `release-flat` only ever contains files labeled at the current release version.
- Fixed by running the real release-prep sequence: `scripts/release/sync-versions.sh 0.20.29` (removes the pin) then `bindings/swift/scripts/sync-checksums.sh` against the actual built artifacts (9 processed, 0 missing, 0 failed — only 2 of 9 archives needed a checksum update, the rest were byte-identical).
- Cleaned up three stale comments that incorrectly cited 0.20.29 as an example of a release needing no new iOS archives.

## Test plan
- [x] `bash scripts/validation/gates/check_release_version_coherence.sh` passes cleanly (no pin exceptions needed)
- [x] `bindings/swift/scripts/sync-checksums.sh --check <real-artifacts>` passes cleanly (0 missing, 0 failed)
- [x] Verified `package-sdk.sh`'s (already-fixed) podspec version check also passes trivially in this state

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
  - Updated the SDK and native library release version to **0.20.29** across supported iOS, Flutter, Kotlin, and React Native integrations.
  - Updated release archives, download references, source tags, and integrity checksums for the latest runtime packages.
  - iOS integrations now use the 0.20.29 release assets without older-version fallbacks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->