### PR TITLE
docs: npm install commands pin a version that was never published

### DIFF
--- a/bindings/react-native/README.md
+++ b/bindings/react-native/README.md
@@ -34,10 +34,10 @@ Apple Silicon devices and Android phones with 6 GB+ RAM are recommended for 3B+ 
 
 ## Installation
 
-Install the core package plus the backends you need. Pin to **0.20.11**:
+Install the core package plus the backends you need. Pin to **0.20.27**:
 
 ```bash
-npm install @runanywhere/core@0.20.11 @runanywhere/llamacpp@0.20.11
+npm install @runanywhere/core@0.20.27 @runanywhere/llamacpp@0.20.27
 ```
 
 | Package | Purpose |

--- a/bindings/react-native/packages/core/README.md
+++ b/bindings/react-native/packages/core/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @runanywhere/core@0.20.11 react-native-nitro-modules
+npm install @runanywhere/core@0.20.27 react-native-nitro-modules
 ```
 
 ```bash

--- a/bindings/react-native/packages/llamacpp/README.md
+++ b/bindings/react-native/packages/llamacpp/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @runanywhere/core@0.20.11 @runanywhere/llamacpp@0.20.11
+npm install @runanywhere/core@0.20.27 @runanywhere/llamacpp@0.20.27
 cd ios && pod install && cd ..
 ```
 

--- a/bindings/react-native/packages/onnx/README.md
+++ b/bindings/react-native/packages/onnx/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @runanywhere/core@0.20.11 @runanywhere/onnx@0.20.11
+npm install @runanywhere/core@0.20.27 @runanywhere/onnx@0.20.27
 cd ios && pod install && cd ..
 ```
 

--- a/bindings/react-native/packages/qhexrt/README.md
+++ b/bindings/react-native/packages/qhexrt/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @runanywhere/core@0.20.11 @runanywhere/qhexrt@0.20.11
+npm install @runanywhere/core@0.20.19 @runanywhere/qhexrt@0.20.19
 ```
 
 See the [React Native SDK README](../../README.md) for Android setup.

--- a/bindings/web/README.md
+++ b/bindings/web/README.md
@@ -4,7 +4,7 @@ Strictly typed, on-device AI for browser applications. The Web SDK exposes a Swi
 
 The packages target ESM-aware browser bundlers such as Vite and webpack. They are not a server-side Node.js inference runtime.
 
-**Current release:** `0.20.11`
+**Current release:** `0.20.27`
 
 ## Packages
 
@@ -24,13 +24,13 @@ Install core plus only the backends your application needs. Pin compatible versi
 
 ```bash
 # Full SDK
-npm install @runanywhere/web@0.20.11 @runanywhere/web-llamacpp@0.20.11 @runanywhere/web-onnx@0.20.11
+npm install @runanywhere/web@0.20.27 @runanywhere/web-llamacpp@0.20.27 @runanywhere/web-onnx@0.20.27
 
 # LLM, GGUF embeddings, and VLM only
-npm install @runanywhere/web@0.20.11 @runanywhere/web-llamacpp@0.20.11
+npm install @runanywhere/web@0.20.27 @runanywhere/web-llamacpp@0.20.27
 
 # Speech and ONNX embeddings only
-npm install @runanywhere/web@0.20.11 @runanywhere/web-onnx@0.20.11
+npm install @runanywhere/web@0.20.27 @runanywhere/web-onnx@0.20.27
 ```
 
 Keep all three package versions aligned. Backend peer dependencies declare the supported core version range.
@@ -158,7 +158,7 @@ Threaded WebAssembly uses `SharedArrayBuffer`, which browsers only expose in cro
 No. These packages target browser bundlers with WASM and OPFS. Use the Python SDK or CLI for server-side local inference.
 
 **Which package version should I pin?**  
-Use `0.20.11` for all three packages unless release notes specify otherwise. Mismatched core/backend versions may fail peer dependency checks.
+Use `0.20.27` for all three packages unless release notes specify otherwise. Mismatched core/backend versions may fail peer dependency checks.
 
 **Where are models stored?**  
 In the browser's Origin Private File System (OPFS), scoped to your origin.

--- a/bindings/web/packages/core/README.md
+++ b/bindings/web/packages/core/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @runanywhere/web@0.20.11
+npm install @runanywhere/web@0.20.27
 ```
 
 Add `@runanywhere/web-llamacpp` and/or `@runanywhere/web-onnx` for inference backends. See the [Web SDK README](../../README.md) for COOP/COEP headers, Vite config, and bundler setup.

--- a/bindings/web/packages/llamacpp/README.md
+++ b/bindings/web/packages/llamacpp/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @runanywhere/web@0.20.11 @runanywhere/web-llamacpp@0.20.11
+npm install @runanywhere/web@0.20.27 @runanywhere/web-llamacpp@0.20.27
 ```
 
 See the [Web SDK README](../../README.md) for bundler configuration and cross-origin isolation headers.

--- a/bindings/web/packages/onnx/README.md
+++ b/bindings/web/packages/onnx/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @runanywhere/web@0.20.11 @runanywhere/web-onnx@0.20.11
+npm install @runanywhere/web@0.20.27 @runanywhere/web-onnx@0.20.27
 ```
 
 See the [Web SDK README](../../README.md) for bundler configuration and cross-origin isolation headers.


### PR DESCRIPTION
## Description

Every Web and React Native README pins its install command to `0.20.11`:

```
npm install @runanywhere/web@0.20.11 @runanywhere/web-llamacpp@0.20.11 @runanywhere/web-onnx@0.20.11
```

That version does not exist on npm. `@runanywhere/web` went `0.20.10` straight to `0.20.16`, so this command has never worked for anyone who copied it:

```
$ npm view @runanywhere/web@0.20.11 version
npm error code E404
npm error 404 No match found for version 0.20.11
```

Published `0.20.x` versions: `0.20.9, 0.20.10, 0.20.16, 0.20.17, 0.20.18, 0.20.19, 0.20.24, 0.20.27`.

This is not ordinary staleness. These nine files sit outside both `check_release_version_coherence.sh`'s doc list and `sync-versions.sh`'s rewrite set, so no release has ever moved them and none will.

Repins to `0.20.27`, the current latest for every affected package.

`packages/qhexrt/README.md` is the one exception: `@runanywhere/qhexrt` last published `0.20.19`, so that file pins core and qhexrt together at `0.20.19` rather than pairing `core@0.20.27` with a qhexrt version that does not exist. The Web README's own guidance is that "mismatched core/backend versions may fail peer dependency checks."

Root `README.md` is deliberately untouched — #798 is already refreshing its version line, and I did not want to collide with it.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring

## Testing

Docs only, no code paths touched. Verified every version this PR documents actually resolves:

```
@runanywhere/web@0.20.27           -> 0.20.27
@runanywhere/web-llamacpp@0.20.27  -> 0.20.27
@runanywhere/web-onnx@0.20.27      -> 0.20.27
@runanywhere/core@0.20.27          -> 0.20.27
@runanywhere/llamacpp@0.20.27      -> 0.20.27
@runanywhere/onnx@0.20.27          -> 0.20.27
@runanywhere/core@0.20.19          -> 0.20.19
@runanywhere/qhexrt@0.20.19        -> 0.20.19
```

- [ ] Lint passes locally
- [ ] Added/updated tests for changes

No linter covers these files and no test asserts README contents, so neither box is ticked rather than claiming a check I did not run.

## Labels
- [x] `React Native SDK`
- [x] `Web SDK`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Updated React Native and Web SDK installation instructions to reference the latest package versions.
  - Updated package-specific setup examples for Core, Llama.cpp, ONNX, and QHexRT integrations.
  - Refreshed Web SDK FAQ version guidance to match the current release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->