### PR TITLE
fix(llamacpp): stop discarding gpu_layers=-1, the "offload every layer" request

### DIFF
--- a/engines/llamacpp/llamacpp_backend.cpp
+++ b/engines/llamacpp/llamacpp_backend.cpp
@@ -426,9 +426,14 @@ bool LlamaCppTextGeneration::load_model(const std::string& model_path,
     model_params.load_mode = LLAMA_LOAD_MODE_NONE;
 #endif
 
-    // If common_fit_params aborts, use the user-provided value
-    int user_gpu_layers = -1;  // -1 = not set by user
-    if (config.contains("gpu_layers")) {
+    // If common_fit_params aborts, use the user-provided value.
+    // Presence of the key is the signal, not a sentinel value: -1 is a real
+    // request ("offload every layer"), which is what rac_llm_llamacpp_create
+    // emits for ACCELERATOR_POLICY_GPU. It omits the key entirely when the
+    // caller has no opinion, so `contains` is exactly "the caller asked".
+    const bool have_user_gpu_layers = config.contains("gpu_layers");
+    int user_gpu_layers = 0;
+    if (have_user_gpu_layers) {
         user_gpu_layers = config["gpu_layers"].get<int>();
         RAC_LOG_INFO("LLM.LlamaCpp", "User-provided GPU layers: %d (will apply after fit)",
                      user_gpu_layers);
@@ -558,7 +563,7 @@ bool LlamaCppTextGeneration::load_model(const std::string& model_path,
                      "GPU memory but no GPU backend active. "
                      "Applying conservative CPU defaults.");
     }
-    if (user_gpu_layers > 0) {
+    if (have_user_gpu_layers && user_gpu_layers != 0) {
         RAC_LOG_INFO("LLM.LlamaCpp",
                      "CPU-only build: ignoring user gpu_layers=%d (no GPU backend "
                      "available)",
@@ -570,7 +575,7 @@ bool LlamaCppTextGeneration::load_model(const std::string& model_path,
         RAC_LOG_INFO("LLM.LlamaCpp", "CPU-only: capping context to %u", ctx_params.n_ctx);
     }
 #else
-    if (user_gpu_layers >= 0) {
+    if (have_user_gpu_layers) {
         // common_fit_params fell back to n_gpu_layers=0 for non-SUCCESS outcomes;
         // honouring the user override here reinstates the OOM risk the fit call
         // was supposed to prevent. Log a warning so it's visible in the event of

--- a/engines/llamacpp/llamacpp_backend.cpp
+++ b/engines/llamacpp/llamacpp_backend.cpp
@@ -21,6 +21,7 @@
 #include <cstdint>
 #include <cstring>
 #include <fstream>
+#include <optional>
 #include <string>
 #include <sys/stat.h>
 #include <vector>
@@ -431,12 +432,11 @@ bool LlamaCppTextGeneration::load_model(const std::string& model_path,
     // request ("offload every layer"), which is what rac_llm_llamacpp_create
     // emits for ACCELERATOR_POLICY_GPU. It omits the key entirely when the
     // caller has no opinion, so `contains` is exactly "the caller asked".
-    const bool have_user_gpu_layers = config.contains("gpu_layers");
-    int user_gpu_layers = 0;
-    if (have_user_gpu_layers) {
+    std::optional<int> user_gpu_layers;
+    if (config.contains("gpu_layers")) {
         user_gpu_layers = config["gpu_layers"].get<int>();
         RAC_LOG_INFO("LLM.LlamaCpp", "User-provided GPU layers: %d (will apply after fit)",
-                     user_gpu_layers);
+                     *user_gpu_layers);
     }
 
     // Set up context params early for common_fit_params
@@ -563,11 +563,11 @@ bool LlamaCppTextGeneration::load_model(const std::string& model_path,
                      "GPU memory but no GPU backend active. "
                      "Applying conservative CPU defaults.");
     }
-    if (have_user_gpu_layers && user_gpu_layers != 0) {
+    if (user_gpu_layers.has_value() && *user_gpu_layers != 0) {
         RAC_LOG_INFO("LLM.LlamaCpp",
                      "CPU-only build: ignoring user gpu_layers=%d (no GPU backend "
                      "available)",
-                     user_gpu_layers);
+                     *user_gpu_layers);
     }
     model_params.n_gpu_layers = 0;
     if (ctx_params.n_ctx == 0 || ctx_params.n_ctx > 4096) {
@@ -575,7 +575,7 @@ bool LlamaCppTextGeneration::load_model(const std::string& model_path,
         RAC_LOG_INFO("LLM.LlamaCpp", "CPU-only: capping context to %u", ctx_params.n_ctx);
     }
 #else
-    if (have_user_gpu_layers) {
+    if (user_gpu_layers.has_value()) {
         // common_fit_params fell back to n_gpu_layers=0 for non-SUCCESS outcomes;
         // honouring the user override here reinstates the OOM risk the fit call
         // was supposed to prevent. Log a warning so it's visible in the event of
@@ -586,10 +586,11 @@ bool LlamaCppTextGeneration::load_model(const std::string& model_path,
             RAC_LOG_WARNING("LLM.LlamaCpp",
                             "Applying user gpu_layers=%d override despite "
                             "common_fit_params %s — risk of OOM",
-                            user_gpu_layers, fit_label);
+                            *user_gpu_layers, fit_label);
         }
-        model_params.n_gpu_layers = user_gpu_layers;
-        RAC_LOG_INFO("LLM.LlamaCpp", "Applying user GPU layers override: %d", user_gpu_layers);
+        model_params.n_gpu_layers = *user_gpu_layers;
+        RAC_LOG_INFO("LLM.LlamaCpp", "Applying user GPU layers override: %d",
+                     *user_gpu_layers);
     }
 #endif
 


### PR DESCRIPTION
## Description

`a46517cf1` ("honour accelerator_policy and context_length instead of dropping them") made the load knobs reach the llama.cpp backend. They reach it, and then the backend drops the GPU case anyway.

`rac_llm_llamacpp_create` emits `gpu_layers = -1` for `ACCELERATOR_POLICY_GPU`, and omits the key entirely when the caller has no opinion:

```cpp
// AUTO means "no opinion"; every other value, INCLUDING 0, is an
// explicit placement request and must reach the backend.
if (config->gpu_layers != RAC_LLM_LLAMACPP_GPU_LAYERS_AUTO) {
    model_config["gpu_layers"] = config->gpu_layers;
}
```

`LlamaCppTextGeneration::load_model` then re-uses `-1` as its own local "not set" sentinel:

```cpp
int user_gpu_layers = -1;  // -1 = not set by user
if (config.contains("gpu_layers")) {
    user_gpu_layers = config["gpu_layers"].get<int>();
}
...
if (user_gpu_layers >= 0) {
    model_params.n_gpu_layers = user_gpu_layers;
}
```

The two meanings of `-1` collide. In the public API `-1` is "offload every layer" (`RAC_LLM_LLAMACPP_CONFIG_DEFAULT` documents it as *All layers on GPU*); here it means "the caller said nothing". An explicit GPU request therefore never survives the `>= 0` guard.

`ACCELERATOR_POLICY_CPU` maps to `0`, which passes `>= 0` and applies correctly. That asymmetry is what hides this: pinning to CPU works, asking for GPU silently does not.

This is not only a lost hint. For any non-`SUCCESS` `common_fit_params` outcome the fit has already fallen back to `n_gpu_layers = 0`, and applying the override is precisely what reinstates the offload — the comment directly below the guard says so ("honouring the user override here reinstates the OOM risk the fit call was supposed to prevent ... keep honouring the user's explicit request"). So a caller who asked for GPU gets a fully CPU-resident model.

## The change

Uses **presence of the JSON key** as the signal rather than a sentinel value. The producer already omits the key when the caller has no opinion, so `contains("gpu_layers")` is exactly "the caller asked for something". That removes the collision by construction instead of trading `-1` for another magic number.

The CPU-only-build warning is widened the same way (`> 0` → `!= 0` with the presence flag), so a `-1` GPU request on a build with no GPU backend now reports that it is being ignored instead of staying silent.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing

Both preprocessor arms of the edited region were compiled, since the two guards select different code on different CI targets:

```
cmake --preset macos-debug -DRAC_BUILD_BACKENDS=ON
ninja engines/llamacpp/CMakeFiles/rac_backend_llamacpp.dir/llamacpp_backend.cpp.o   # exit 0
```

That build defines neither `GGML_USE_METAL`/`CUDA`/`VULKAN`/`WEBGPU`, so it compiles the CPU-only arm. I re-ran the same compile command with `-DGGML_USE_METAL` added to cover the `#else` arm — also exit 0.

- [ ] Lint passes locally
- [ ] Added/updated tests for changes

No test added: the affected code is inside `load_model`, which needs a real GGUF model and a live llama.cpp context, and the existing `core/tests/test_llm.cpp` cases skip themselves when no model is present. A test that cannot fail on the unfixed code is not worth adding. Happy to add one if you have a fixture for this.

## Labels
- [ ] `Commons`

(The change is in `engines/llamacpp`, which none of the listed labels cover exactly.)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GPU-layer override handling so omitted settings, zero, and unlimited-layer values are interpreted distinctly.
  * CPU-only builds now clearly report when explicit nonzero GPU-layer overrides are ignored.
  * GPU-capable builds consistently apply configured overrides, including unlimited-layer settings, and warn when they replace a failed or errored automatic fit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->