### PR TITLE
fix(gates): the deprecated-surfaces gate has a dead scan arm and two vacuous exemptions

### DIFF
--- a/scripts/validation/gates/check_deprecated_surfaces.sh
+++ b/scripts/validation/gates/check_deprecated_surfaces.sh
@@ -306,11 +306,14 @@ scan_grep "core/include" \
   "(RAC_DEPRECATED|__attribute__\\(\\(deprecated|\\[\\[deprecated)" "*.h" "cpp:deprecated-declaration"
 
 # 6d. Packaged header mirrors are public API too. A clean canonical header is
-# insufficient if SwiftPM or an AAR still advertises a retired declaration.
+# insufficient if SwiftPM still advertises a retired declaration, because that
+# mirror is committed and can drift from core/include on its own.
+# There is deliberately no React Native arm here: that package's header tree is
+# a verbatim `cp -R core/include/rac` performed by package-sdk.sh into a
+# gitignored jniLibs/include (.gitignore), so it cannot carry a declaration
+# 6c has not already seen, and it does not exist at all when this gate runs.
 scan_grep "bindings/swift/Sources/RunAnywhere/CRACommons/include" \
   "(RAC_DEPRECATED|__attribute__\\(\\(deprecated|\\[\\[deprecated)" "*.h" "swift-c:deprecated-declaration"
-scan_grep "bindings/react-native/packages/core/android/src/main/jniLibs/include" \
-  "(RAC_DEPRECATED|__attribute__\\(\\(deprecated|\\[\\[deprecated)" "*.h" "rn-c:deprecated-declaration"
 
 # 6e. Retired compatibility surfaces that must never reappear under a neutral
 # name or in one hand-maintained package mirror.
@@ -323,8 +326,7 @@ scan_git_grep \
 scan_git_grep \
   "rac_extract_archive[[:space:]]*\\(" \
   "all:retired-archive-adapter-api" "core/include" \
-  "bindings/swift/Sources/RunAnywhere/CRACommons/include" \
-  "bindings/react-native/packages/core/android/src/main/jniLibs/include"
+  "bindings/swift/Sources/RunAnywhere/CRACommons/include"
 
 # ---------------------------------------------------------------------------
 # Report

--- a/scripts/validation/gates/deprecated_surface_allowlist.txt
+++ b/scripts/validation/gates/deprecated_surface_allowlist.txt
@@ -8,7 +8,6 @@
 # Kotlin typed JSON adapters and external cloud-provider payloads.
 bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/hybrid/CloudSttProvider.kt|kotlin:org-json-usage
 bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/hybrid/Cloud.kt|kotlin:org-json-usage
-bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/LLM/StructuredOutputProtoHelpers.kt|kotlin:json-serialisation
 # Web-search tool parses the external DuckDuckGo JSON response (not an SDK DTO);
 # mirrors the already-allowlisted Swift RunAnywhere+WebSearchTool.swift.
 bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/public/extensions/LLM/RunAnywhereWebSearchTool.kt|kotlin:json-serialisation
@@ -57,7 +56,6 @@ core/include/rac/infrastructure/telemetry/rac_telemetry_manager.h|cpp:public-jso
 core/include/rac/backends/rac_llm_llamacpp.h|cpp:json-param-in-public-api
 core/include/rac/backends/rac_vlm_llamacpp.h|cpp:json-param-in-public-api
 core/include/rac/features/llm/rac_llm_service.h|cpp:json-param-in-public-api
-core/include/rac/features/llm/rac_llm_structured_output.h|cpp:json-param-in-public-api
 core/include/rac/features/embeddings/rac_embeddings_service.h|cpp:json-param-in-public-api
 core/include/rac/features/diffusion/rac_diffusion_service.h|cpp:json-param-in-public-api
 core/include/rac/features/vlm/rac_vlm_service.h|cpp:json-param-in-public-api


### PR DESCRIPTION
## Description

Two problems in the deprecated-surfaces gate. They are one concern, because the gate is one thing: `check_deprecated_surfaces.sh` and the allowlist it reads.

**1. Check 6d scans a directory that cannot match.** The check's stated principle is right:

> Packaged header mirrors are public API too. A clean canonical header is insufficient if SwiftPM or an AAR still advertises a retired declaration.

The SwiftPM arm holds, because `bindings/swift/Sources/RunAnywhere/CRACommons/include` is committed and can drift from `core/include` on its own. The React Native arm cannot:

```
$ ls -d bindings/react-native/packages/core/android/src/main/jniLibs/include
absent on HEAD

$ git check-ignore -v bindings/react-native/packages/core/android/src/main/jniLibs/include
.gitignore:365  bindings/react-native/packages/*/android/src/main/jniLibs/

$ git ls-files bindings/react-native/packages/core/android/src/main/jniLibs
(nothing tracked)
```

That tree is a verbatim `cp -R core/include/rac` performed by `package-sdk.sh`. It is gitignored, nothing is committed under it, and it does not exist when the gate runs. So it can hold no declaration check 6c has not already seen, and the scan is guaranteed to find nothing. A check that cannot fail is not coverage; it just reads like it in the gate's output. Same reasoning for that path in the `rac_extract_archive` list.

I kept the principle and rewrote the comment to say why there is deliberately no RN arm, so nobody adds it back.

**2. Two allowlist entries suppress nothing.** Neither `StructuredOutputProtoHelpers.kt|kotlin:json-serialisation` nor `rac_llm_structured_output.h|cpp:json-param-in-public-api` appears anywhere in the gate's detected-surface output, so neither is exempting a real detection. Both files still exist; they simply do not trip the patterns any more.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

Ran the gate itself, which is the only thing that can judge this:

```
before:  exit 0, "All detected surfaces match documented exceptions", allowlist 122 entries
after:   exit 0, "All detected surfaces match documented exceptions", allowlist 120 entries
```

The two removed entries do not appear in either run's detected-surface list, which is the evidence that they were vacuous rather than load-bearing.

No test added. This is a shell gate with no test harness in the repo, and the gate's own exit status is the check.

### Platform-Specific Testing (check all that apply)
None. Repository tooling only, nothing shipped.

## Labels
**SDKs:**
- [ ] `Swift SDK`
- [ ] `Kotlin SDK`
- [ ] `Flutter SDK`
- [ ] `React Native SDK`
- [ ] `Web SDK`
- [ ] `Commons`

None apply: `scripts/validation/gates/` is CI tooling, not an SDK surface.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated validation checks to focus on available committed header mirrors.
  * Clarified handling of generated React Native header files during validation.
  * Removed obsolete exceptions for retired structured-output serialization and parameter formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->