### PR TITLE
fix: seed ADSP_LIBRARY_PATH for the Bonsai/Maple ternary skel on Windows Electron

### DIFF
--- a/bindings/electron/packages/qhexrt/src/QHexRT.ts
+++ b/bindings/electron/packages/qhexrt/src/QHexRT.ts
@@ -23,8 +23,12 @@
  *  1. **One flat folder.** `QnnHtp.dll`, `QnnSystem.dll`, `QnnHtpPrepare.dll`
  *     and `QnnHtpV<arch>Stub.dll` (from `lib/aarch64-windows-msvc/`) sit beside
  *     `libQnnHtpV<arch>Skel.so` **and `libqnnhtpv<arch>.cat`** (from
- *     `lib/hexagon-v<arch>/unsigned/`). There is no `ADSP_LIBRARY_PATH` on
- *     Windows — the loader resolves through the DLL's own directory.
+ *     `lib/hexagon-v<arch>/unsigned/`), plus the Bonsai/Maple ternary decoder's
+ *     own `librun_main_on_hexagon_skel.so` + `.cat`. The standard HTP graph path
+ *     resolves through the DLL's own directory (see point 3); the Bonsai/Maple
+ *     skel is loaded by a separate FastRPC mechanism that DOES read
+ *     `ADSP_LIBRARY_PATH` on Windows — `bridge.ts`'s
+ *     `addSidecarDirToDspSearchPath` sets it to this same flat folder.
  *  2. **The `.cat` is mandatory.** Without it the skel fails signature
  *     verification, and the failure surfaces with no message naming the catalog
  *     — it reads exactly like a corrupt bundle.

--- a/bindings/electron/src/bridge.ts
+++ b/bindings/electron/src/bridge.ts
@@ -462,7 +462,11 @@ export interface NativeAddon {
  * runtime beats a differently-versioned QAIRT already on the machine's PATH; the
  * whole flat set (QnnHtp/QnnSystem/QnnHtpPrepare/QnnHtpV<arch>Stub plus the skel
  * and its .cat) then resolves out of that one directory, which is the invariant
- * the Hexagon stack requires on Windows (there is no ADSP_LIBRARY_PATH here).
+ * the standard Hexagon HTP graph path requires on Windows. The Bonsai/Maple
+ * ternary decoder's FastRPC skel is a SEPARATE mechanism that does read an
+ * `ADSP_LIBRARY_PATH` env var on Windows (contrary to what an earlier version of
+ * this comment claimed) — see `addSidecarDirToDspSearchPath` below, which this
+ * function also calls.
  *
  * Thin-addon dual path: also prepend every registered plugin directory and the
  * directory that holds `librac_commons` / `rac_commons.dll` when present.
@@ -476,6 +480,41 @@ function addSidecarDirToDllSearch(dir: string): void {
     .some((entry) => entry && path.resolve(entry).toLowerCase() === resolved.toLowerCase());
   if (already) return;
   process.env.PATH = current ? `${dir}${path.delimiter}${current}` : dir;
+  addSidecarDirToDspSearchPath(dir);
+}
+
+/**
+ * Also make a directory reachable by the Bonsai/Maple decoder's FastRPC skel loader
+ * (QHexRT/src/bonsai/fastrpc_win.cpp), which is a SEPARATE search mechanism from the
+ * Win32 DLL loader above and does not benefit from the PATH prepend at all.
+ *
+ * That native code seeds `ADSP_LIBRARY_PATH` itself, but its only fallback is
+ * `exe_dir()` — the directory of the running EXECUTABLE. For a CLI tool the exe
+ * sits beside the flat QAIRT/skel folder, so that fallback is correct. In a
+ * packaged Electron app the executable is `RunAnywhere AI.exe`, nowhere near
+ * `node_modules/@runanywhere/electron-qhexrt/prebuilds/…` — exactly the gap
+ * `addSidecarDirToDllSearch` above exists to close for PATH. Left unset, the
+ * custom ternary/bonsai skel (`librun_main_on_hexagon_skel.so`) fails to load
+ * with a bare `HostOpFailed` at generate time — the model loads fine and only
+ * this one decode path breaks, which is what makes it easy to miss: every other
+ * QHexRT model resolves its runtime through the ordinary `LoadLibraryW`
+ * search order and never touches this second mechanism.
+ *
+ * Must run before the utility-host fork so the child inherits it — `_putenv_s`
+ * seeds a DLL's CRT at its OWN LoadLibrary time, but a forked child's env is a
+ * snapshot taken at fork(), so setting this in the parent process (here, before
+ * `require()` loads the addon that eventually forks) is what makes the timing
+ * work at all.
+ */
+function addSidecarDirToDspSearchPath(dir: string): void {
+  if (process.platform !== 'win32') return;
+  const current = process.env.ADSP_LIBRARY_PATH ?? '';
+  const resolved = path.resolve(dir);
+  const already = current
+    .split(path.delimiter)
+    .some((entry) => entry && path.resolve(entry).toLowerCase() === resolved.toLowerCase());
+  if (already) return;
+  process.env.ADSP_LIBRARY_PATH = current ? `${dir}${path.delimiter}${current}` : dir;
 }
 
 function commonsLibraryFileName(platform: NodeJS.Platform = process.platform): string {


### PR DESCRIPTION
## What this fixes

`qwen3.8-27b-1bit-npu` (the ternary "bonsai/fullnpu" decoder) failed every
generation in the packaged Windows Electron app with a bare
`qhx_generate(stream) failed: HostOpFailed` — the model loaded fine, only the
actual decode call broke.

**Root cause:** `QHexRT/src/bonsai/fastrpc_win.cpp` (neurun repo) loads its own
custom FastRPC skel (`librun_main_on_hexagon_skel.so`, separate from the
standard QNN HTP graph path) through `ADSP_LIBRARY_PATH ∪ cwd` — a real,
load-bearing search mechanism on Windows, not just an Android convention as
`bridge.ts`'s own comment incorrectly claimed. Its only fallback, `exe_dir()`,
is correct for a CLI tool (the exe sits beside the flat QAIRT/skel folder) but
wrong for Electron, where the running executable is `RunAnywhere AI.exe`,
nowhere near `node_modules/@runanywhere/electron-qhexrt/prebuilds/` — exactly
the gap `addSidecarDirToDllSearch` already closes for `PATH`, just never
extended to this second mechanism.

**Verified on the real Windows NPU device** (Snapdragon X2 Elite): the
freshly-built v0.20.29 Electron app crashed on `qwen3.8-27b-1bit-npu` with no
`ADSP_LIBRARY_PATH` override, ran clean with it manually set to the plugin's
own prebuild dir, and standard NPU models (`lfm2.5-230m-npu`) worked correctly
in both cases — isolating this to the Bonsai/Maple skel path, not a
QHexRT-wide regression.

## Fix

`addSidecarDirToDllSearch` now also calls the new `addSidecarDirToDspSearchPath`,
which extends `ADSP_LIBRARY_PATH` the same way `PATH` is already extended, for
every registered plugin directory, before the utility-host fork inherits the
environment.

## Test plan
- [x] `bridge.ts` typechecks clean (isolated — the checkout has pre-existing,
      unrelated `@runanywhere/proto-ts` module-resolution errors from missing
      local codegen, confirmed present without this change too)
- [x] Real device: `qwen3.8-27b-1bit-npu` generates a correct, coherent
      step-by-step answer in the packaged Windows ARM64 Electron app
- [x] Real device: `lfm2.5-230m-npu` (standard QNN HTP path, control) still
      generates correctly — no regression to the common case

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved Windows ARM64 runtime loading for Bonsai/Maple ternary decoding.
  - Fixed FastRPC component discovery by configuring the required runtime search path.
  - Prevented duplicate runtime paths during sidecar setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->