### PR TITLE
fix: package the QHexRT skel files into the private RCLI overlay

### DIFF
--- a/scripts/build/package-private-engine-overlay.sh
+++ b/scripts/build/package-private-engine-overlay.sh
@@ -157,12 +157,16 @@ case "$ENGINE" in
       echo "python3/python required to copy QAIRT DLLs off a Windows junction" >&2
       exit 1
     fi
+    # .dll/.lib is the QNN HTP graph path; .so/.cat is the standard HTP skel + its
+    # signing catalog (see docs/MAPLE_WINDOWS_SIGNING.md) — dropping them here left
+    # RCLI's own overlay with no skel at all next to a real DLL set, since exe_dir()
+    # (QHexRT/src/bonsai/fastrpc_win.cpp) only finds a skel that is actually staged.
     "$PY_BIN" -c 'import shutil, sys
 from pathlib import Path
 src, dst = Path(sys.argv[1]), Path(sys.argv[2])
 n = 0
 for p in src.rglob("*"):
-    if p.is_file() and p.suffix.lower() in {".dll", ".lib"}:
+    if p.is_file() and p.suffix.lower() in {".dll", ".lib", ".so", ".cat"}:
         shutil.copy2(p, dst / p.name)
         n += 1
 if n == 0:
@@ -175,6 +179,22 @@ print(f"copied {n} QAIRT runtime files")
     if [[ ${#dlls[@]} -eq 0 ]]; then
       echo "QAIRT runtime at $qairt produced no DLLs; refusing a stub overlay" >&2
       exit 1
+    fi
+    # The Bonsai/Maple ternary decoder's own FastRPC skel (librun_main_on_hexagon_skel.so
+    # + .cat) is a separate artifact from the QAIRT runtime above — staged the same way
+    # bindings/electron/scripts/bundle-native.ts's stageQhexrtDspSkel() already does for
+    # the Electron package, flat into the same directory as the QNN DLLs. Optional: an
+    # older QHexRT prebuilt predating this directory, or a build with no Bonsai payload,
+    # still produces a usable (non-ternary) overlay.
+    dsp_dir="$PRE/dsp/win-arm64"
+    if [[ -d "$dsp_dir" ]]; then
+      dsp_n=0
+      for f in "$dsp_dir"/*; do
+        [[ -f "$f" ]] || continue
+        cp "$f" "$stage/bin/"
+        dsp_n=$((dsp_n + 1))
+      done
+      echo "copied $dsp_n Bonsai DSP skel file(s) from $dsp_dir"
     fi
     printf 'qhexrt\n' > "$stage/share/runanywhere/private/ENGINE"
     OS_ARCH="windows-arm64"


### PR DESCRIPTION
## What this fixes

\`package-private-engine-overlay.sh\`'s QAIRT-runtime copy step filtered on
\`{".dll", ".lib"}\` only, silently dropping the standard HTP skel
(\`libQnnHtpV81Skel.so\` + \`libqnnhtpv81.cat\`) that ships alongside the DLLs
in every \`qairt-runtime-*.tar.gz\` release. It also never looked at
\`engines/qhexrt/prebuilt/current/dsp/win-arm64/\` at all — the directory
\`bindings/electron/scripts/bundle-native.ts\`'s \`stageQhexrtDspSkel()\`
already reads to stage the Bonsai/Maple ternary decoder's own FastRPC skel
(\`librun_main_on_hexagon_skel.so\` + \`.cat\`) for the Electron package.

**Net effect:** every RCLI build using this overlay shipped a real QNN DLL
set with NO skel next to it at all. Confirmed while validating v0.20.29: a
fresh kit + qhexrt private overlay straight off this script produced a
\`build/\` with \`QnnHtp.dll\` etc. but zero \`.so\`/\`.cat\` files — \`rcli\`
could not have run ANY QHexRT model, standard or Bonsai, without
hand-copying them in (which is what this validation had to do).

## Fix

Widen the QAIRT-runtime filter to include \`.so\`/\`.cat\`, and add an
optional copy pass from \`dsp/win-arm64/\` (same graceful no-op as
\`bundle-native.ts\` when that directory doesn't exist, so older prebuilts
still produce a usable non-Bonsai overlay).

## Test plan
- [x] \`bash -n\` on the modified script — syntax clean
- [ ] Full \`RCLI_PRIVATE_OVERLAY\`/kit build on the Windows ARM64 self-hosted
      runner, confirming the overlay now contains the skel files without a
      manual copy step

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Improvements**
  - Improved QHexRT packaging compatibility across supported platforms by including additional runtime and metadata files.
  - Added support for staging required DSP components, improving compatibility with Bonsai and Maple workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->