### PR TITLE
fix: update stale RACommons checksum for v0.20.30

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -564,7 +564,7 @@ func binaryTargets() -> [Target] {
             .binaryTarget(
                 name: "RACommonsBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RACommons-ios-v\(sdkVersion).zip",
-                checksum: "a6c0d53f0a2ccf209d1d6354b3c5e1380d6d8a00877e44013328df80c82dcc4b"
+                checksum: "81c630305557f189df2d428dbbee167061d51c9832c5b348bde3f430b1c3fb5b"
             ),
             .binaryTarget(
                 name: "RABackendLlamaCPPBinary",

--- a/bindings/flutter/packages/runanywhere/ios/runanywhere/Package.swift
+++ b/bindings/flutter/packages/runanywhere/ios/runanywhere/Package.swift
@@ -23,7 +23,7 @@ func runAnywhereBinaryTarget(name: String, checksum: String) -> Target {
 
 let raCommonsTarget = runAnywhereBinaryTarget(
     name: "RACommons",
-    checksum: "a6c0d53f0a2ccf209d1d6354b3c5e1380d6d8a00877e44013328df80c82dcc4b"
+    checksum: "81c630305557f189df2d428dbbee167061d51c9832c5b348bde3f430b1c3fb5b"
 )
 
 let package = Package(


### PR DESCRIPTION
## Summary
- The v0.20.30 release-prep PR (#806) only bumped the version number; it never re-ran `sync-checksums.sh` against a fresh build, so `RACommons`/`RACommonsBinary` still carried the v0.20.29 checksum.
- The real v0.20.30 tag build produced different bytes (version string is baked into the XCFramework), so `release.yml`'s publish job failed at "Verify built Apple checksums match tagged package contracts".
- Corrected checksum (`81c63030...`) taken directly from that failed run's own verify-step output — no rebuild needed.

## Test plan
- [x] `grep` confirms no other file references the stale checksum
- [ ] Move the `v0.20.30` tag to this commit and re-dispatch `release.yml`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the integrity verification for the iOS binary package to support the latest SDK artifact.
  * No user-facing API changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->