### PR TITLE
fix: correct the stale RunAnywhereMLXRuntime checksum for v0.20.30

### DIFF
--- a/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
+++ b/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
@@ -9,7 +9,7 @@
 
 mlx_checksums = {
   'RABackendMLX' => '0802fe58480c3e03e94498d46adb50fda7b9ade491807c7e0392a7fd68b83b59',
-  'RunAnywhereMLXRuntime' => 'd942788f1d8f08a9c0c8cc9b7d4c212c9b35382aa90978615eccf8a7e72eac5b',
+  'RunAnywhereMLXRuntime' => '8415588141fe8d3bbb32f1eaee206cd94958c72004d0961b69b130b0c6b8ed6b',
   'RunAnywhereMLXMetal' => '17a2f8c4ce09ef691cde5e7d04171ce749fca89315205f90eb2eed5a76b682b1',
   'RunAnywhereMLXResources' => 'ace624c5cffa32f789cd3beee8d140740daadd793b1315c3583ab670410b3ca3'
 }.freeze


### PR DESCRIPTION
## Summary
- `bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec`'s `RunAnywhereMLXRuntime` checksum was still the v0.20.29-era value (`d942788f...`), which was already wrong then (see the v0.20.29 release notes/lessons).
- `sync-versions.sh` only rewrites the version string in this file, never the checksum, and `RAC_CHECKSUM_SKIP=RunAnywhereMLXRuntime` means the publish job's automated verify never checks this archive either — so nothing in CI catches a stale value here.
- Corrected to the real v0.20.30 published asset's sha256 (`8415588...`), verified directly against the GitHub Release digest for `RunAnywhereMLXRuntime-ios-v0.20.30.zip`.
- No live Flutter consumer has published against this checksum yet (pub.dev `runanywhere_mlx` was still on 0.20.27 as of the last check), so this is a proactive fix, not a hotfix for a broken release.

## Test plan
- [x] Verified all four `mlx_checksums` entries in the podspec now match the real v0.20.30 release asset digests exactly

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the integrity checksum for the iOS MLX runtime release asset to match its latest build.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->