### PR TITLE
fix(qhexrt): don't force a live QNN device just to log its arch

### DIFF
--- a/engines/qhexrt/qhexrt_session.cpp
+++ b/engines/qhexrt/qhexrt_session.cpp
@@ -246,9 +246,19 @@ qhx_runtime* runtime_acquire() {
             RAC_LOG_ERROR(LOG_CAT, "qhx_runtime_create failed (QNN libs unavailable?)");
             return nullptr;
         }
-        char arch[32] = {0};
-        qhx_runtime_device(g_rt, arch, sizeof(arch), nullptr, nullptr);
-        RAC_LOG_INFO(LOG_CAT, "QHexRT runtime up (arch=%s, %s)", arch, qhx_version());
+        // Do NOT query qhx_runtime_device() here for the log line: it forces the QNN HTP
+        // device (a live DSP session) into existence before any manifest is even read.
+        // A host_only plan (the Bonsai/Maple ternary decoder — QHexRT/src/hostop/qwen38_gen.cpp)
+        // has zero QNN graphs and instead opens its own raw FastRPC session directly
+        // (fastrpc_win.cpp / run_main_on_hexagon). On Windows the two contend for the same
+        // cDSP: with a QNN device already live, the FastRPC SET_PATH/GET_PATH session
+        // controls both return a non-zero rc and the subsequent remote_handle64_open for
+        // librun_main_on_hexagon_skel.so fails (0x80000406), surfacing as a bare
+        // HostOpFailed with the model otherwise loaded fine. session_open() below still
+        // queries the real arch via qhx_runtime_device() when it actually needs it (to
+        // pick the v75/v79/v81 manifest dir), which is the only place this call is load-
+        // bearing rather than cosmetic.
+        RAC_LOG_INFO(LOG_CAT, "QHexRT runtime up (%s)", qhx_version());
     }
     ++g_rt_refs;
     return g_rt;


### PR DESCRIPTION
## Summary
- `runtime_acquire()` called `qhx_runtime_device()` right after `qhx_runtime_create()` purely to
  put the arch string in a startup log line. That call is not free — it triggers
  `Backend::ensure_device()`, which creates a real QNN HTP device / DSP session before any
  manifest is even read.
- The Bonsai/Maple ternary decoder (`qwen3.8-27b-1bit-npu`, a `host_only` manifest with zero QNN
  graphs) never uses that QNN device — it opens its own raw FastRPC session directly via
  `fastrpc_win.cpp` / `run_main_on_hexagon`. On Windows the two contend for the same cDSP.
- Traced live on a Snapdragon X2 Elite (v0.20.30 packaged Electron app + a fresh RCLI build):
  with the QNN device already live, `fastrpc_win`'s `SET_PATH`/`GET_PATH` session controls both
  return a non-zero rc (`0x14`), and the subsequent `remote_handle64_open` for
  `librun_main_on_hexagon_skel.so` fails with `0x80000406` — surfacing only as a bare
  `HostOpFailed`, with the model otherwise reporting a clean load. This reproduced identically
  whether the standard QNN HTP path fell back to "user driver path" (QAIRT 2.47 vs a 2.41 device
  skel — a separate, orthogonal version mismatch also observed) or initialized cleanly (QAIRT
  2.48, matched skel) — ruling out the version mismatch as the actual cause and isolating it to
  the eager device creation itself.
- `session_open()` already queries the real arch via `qhx_runtime_device()` when it is actually
  load-bearing (picking the `v75`/`v79`/`v81` manifest dir under `resolve_manifest()`), so this
  removes only the redundant, cosmetic-only early call.

## Test plan
- [x] Root-caused via live device tracing (stderr from a fresh `rcli.exe` build, both against the
      shipped v0.20.30 overlay's QAIRT 2.47 DLLs and a swapped-in QAIRT 2.48 set) on a Snapdragon
      X2 Elite X2E88100.
- [ ] `native_win_arm64_qhexrt` CI on this PR (same self-hosted box) — confirm it builds and, once
      an overlay is produced, re-run `qwen3.8-27b-1bit-npu` end to end with zero manual
      `ADSP_LIBRARY_PATH`/env overrides.
- [ ] Existing `lfm2.5-230m-npu` (a standard QNN-graph model) still generates correctly, to confirm
      this doesn't regress the path that legitimately needs the QNN device.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability for host-only plans by preventing premature DSP session creation.
  * Reduced FastRPC connection contention during runtime initialization.
  * Preserved device architecture detection when it is needed to select the appropriate manifest.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->