### PR TITLE
fix(solutions): an explicit temperature of 0.0 never survives expansion

### DIFF
--- a/core/src/solutions/operators/op_engine_backed.cpp
+++ b/core/src/solutions/operators/op_engine_backed.cpp
@@ -48,6 +48,7 @@
 #include "rac/core/rac_platform_adapter.h"
 #include "rac/foundation/rac_proto_buffer.h"
 #include "rac/graph/pipeline_node.hpp"
+#include "rac/rac_defaults_generated.h"
 #include "rac/solutions/operator_registry.hpp"
 
 #if defined(RAC_HAVE_PROTOBUF)
@@ -192,7 +193,10 @@ class GenerateTextNode final : public OperatorNode {
         : PipelineNode(std::move(name), /*input*/ 8, /*output*/ 8, OverflowPolicy::BlockProducer),
           model_id_(spec.model_id()),
           max_tokens_(param_int_or(spec, "max_tokens", 0)),
-          temperature_(param_float_or(spec, "temperature", 0.0f)) {
+          // param_float_or already supplies this when the key is absent, so an
+          // explicit "0" in the spec stays 0 (greedy) instead of being re-read as unset.
+          temperature_(param_float_or(spec, "temperature",
+                                      RAC_DEFAULT_LLM_GENERATION_OPTIONS_TEMPERATURE)) {
         if (const std::string* p = find_param(spec, "system_prompt"); p) {
             system_prompt_ = *p;
         }
@@ -214,7 +218,7 @@ class GenerateTextNode final : public OperatorNode {
         message->set_role(runanywhere::v1::MESSAGE_ROLE_USER);
         message->set_content(item.text());
         auto* options = request.mutable_options();
-        options->set_temperature(temperature_ > 0.0f ? temperature_ : 0.8f);
+        options->set_temperature(temperature_);
         options->set_top_p(1.0f);
         if (!system_prompt_.empty()) {
             options->set_system_prompt(system_prompt_);

--- a/core/src/solutions/solution_converter.cpp
+++ b/core/src/solutions/solution_converter.cpp
@@ -65,7 +65,10 @@ void expand_voice_agent(const runanywhere::v1::VoiceAgentConfig& cfg, PipelineSp
     if (cfg.max_context_tokens() > 0) {
         (*llm->mutable_params())["max_context_tokens"] = std::to_string(cfg.max_context_tokens());
     }
-    if (cfg.has_generation() && cfg.generation().temperature() != 0.0f) {
+    // Presence, not value: llm_options.proto documents "0.0 = greedy decoding, and
+    // is honoured as an explicit request", so a caller asking for 0.0 must reach the
+    // operator rather than look identical to a caller who set nothing.
+    if (cfg.has_generation() && cfg.generation().has_temperature()) {
         (*llm->mutable_params())["temperature"] = std::to_string(cfg.generation().temperature());
     }
     (*tts->mutable_params())["emit_partials"] = cfg.emit_partials() ? "true" : "false";

--- a/core/tests/test_solution_runner.cpp
+++ b/core/tests/test_solution_runner.cpp
@@ -4,6 +4,7 @@
 
 #include <cstdio>
 #include <cstring>
+#include <string>
 
 #if defined(RAC_HAVE_PROTOBUF)
 #include "pipeline.pb.h"
@@ -1067,6 +1068,41 @@ TEST(voice_agent_solution_compiles) {
 }
 
 // ---------------------------------------------------------------------------
+// 9b. An explicit temperature of 0.0 is greedy decoding. llm_options.proto
+//     documents it as "honoured as an explicit request", so it has to reach
+//     the llm operator instead of looking identical to an unset field.
+// ---------------------------------------------------------------------------
+TEST(voice_agent_explicit_zero_temperature_reaches_llm_operator) {
+    SolutionConfig cfg;
+    auto* va = cfg.mutable_voice_agent();
+    va->set_llm_model_id("qwen3-4b");
+    va->set_stt_model_id("whisper");
+    va->set_tts_model_id("kokoro");
+    va->set_vad_model_id("silero");
+    va->mutable_generation()->set_temperature(0.0f);
+
+    runanywhere::v1::PipelineSpec spec;
+    CHECK(rac::solutions::convert_solution_to_pipeline(cfg, &spec) == RAC_SUCCESS);
+
+    const runanywhere::v1::OperatorSpec* llm = nullptr;
+    for (const auto& op : spec.operators()) {
+        if (op.name() == "llm") {
+            llm = &op;
+            break;
+        }
+    }
+    CHECK(llm != nullptr);
+    if (llm == nullptr) {
+        return;
+    }
+    const auto it = llm->params().find("temperature");
+    CHECK(it != llm->params().end());
+    if (it != llm->params().end()) {
+        CHECK(std::stof(it->second) == 0.0f);
+    }
+}
+
+// ---------------------------------------------------------------------------
 // 10. SolutionConfig (RAG) expands + compiles with explicit stand-ins.
 //     Topology: query (source) → retrieve → context → llm. The retrieve
 //     operator owns the embedding lookup via the host-supplied RAG
@@ -1270,6 +1306,7 @@ int main() {
     run_test_time_series_solution_compiles_with_builtin_window();
     run_test_context_build_builtin_applies_prompt_template();
     run_test_voice_agent_solution_compiles();
+    run_test_voice_agent_explicit_zero_temperature_reaches_llm_operator();
     run_test_rag_solution_compiles();
     run_test_c_abi_proto_bytes_lifecycle();
     run_test_c_abi_yaml_solution_lifecycle();


### PR DESCRIPTION
## Description

`idl/llm_options.proto` states the contract on the field itself:

```proto
// 0.0 = greedy decoding, and is honoured as an explicit request.
optional float temperature = 2 [
    (runanywhere.v1.rac_default) = "0.7",
    ...
];
```

The solutions path breaks it twice, on the same value, at both ends of the same hop.

**Writer** — `core/src/solutions/solution_converter.cpp`:

```cpp
if (cfg.has_generation() && cfg.generation().temperature() != 0.0f) {
    (*llm->mutable_params())["temperature"] = std::to_string(cfg.generation().temperature());
}
```

This uses the value as a presence test. `temperature` is `optional`, so `has_temperature()` exists and is the question actually being asked. An explicit `0.0` is indistinguishable from a caller who set nothing, and the param is never written into the operator spec. `core/src/foundation/rac_proto_adapters.cpp:351` already does this correctly with `if (in.has_temperature())`.

**Reader** — `core/src/solutions/operators/op_engine_backed.cpp`:

```cpp
options->set_temperature(temperature_ > 0.0f ? temperature_ : 0.8f);
```

Even when the param *is* present, a spec carrying `"temperature" = "0"` was re-read as unset and replaced. So both ends had to change for `0.0` to survive.

Net effect today: a caller asking for deterministic decoding through a voice-agent solution silently gets sampled decoding instead.

## The change

The reader now lets `param_float_or` supply the default, which it already does when the key is absent, and passes the parsed value through untouched. No sentinel value is involved on either side.

That also replaces a hardcoded `0.8f` with `RAC_DEFAULT_LLM_GENERATION_OPTIONS_TEMPERATURE`. **This changes the unset-case default from 0.8 to 0.7.** 0.7 is the canonical value in `llm_options.proto` and what every other temperature default in `core/src` uses (`rac_backend_platform_register.cpp:59,92`, `vlm_module.cpp:80`); this operator was the only `0.8` in the tree. Happy to restore the 0.8 if it was deliberate.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing

Regression test added in `core/tests/test_solution_runner.cpp`, beside the existing voice-agent converter case rather than in a new file.

**Confirmed it fails on the unfixed code** by reverting only the converter guard and rebuilding:

```
[RUN ] voice_agent_explicit_zero_temperature_reaches_llm_operator
[FAIL] core/tests/test_solution_runner.cpp:1099 it != llm->params().end()
```

With the fix in place:

```
cmake --preset macos-debug -DRAC_BUILD_BACKENDS=ON && ninja
ctest  ->  100% tests passed out of 130
```

Both preprocessor configurations of the edited region were compiled, since `op_engine_backed.cpp` guards its body on `RAC_HAVE_PROTOBUF`: the normal build (define present) plus a re-run of the same compile command with `-DRAC_HAVE_PROTOBUF` stripped. Both exit 0.

- [ ] Lint passes locally
- [x] Added/updated tests for changes

`clang-format` is not installed on this machine, so I matched surrounding style by hand and checked no added line exceeds the column limit rather than claiming a formatter run.

## Labels
- [x] `Commons`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed VoiceAgent configurations with an explicit temperature of `0.0` so the setting is preserved and correctly applied during text generation.
  * Unspecified temperature settings continue to use the default generation temperature.

* **Tests**
  * Added coverage to verify that an explicit zero temperature reaches the language model operator.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->