### PR TITLE
fix(models): an unknown storage probe marks every model incompatible

### DIFF
--- a/core/src/infrastructure/model_management/model_compatibility.cpp
+++ b/core/src/infrastructure/model_management/model_compatibility.cpp
@@ -56,13 +56,19 @@ rac_result_t rac_model_check_compatibility(rac_model_registry_handle_t registry_
     // can_run:  available RAM >= required memory (or requirement is 0/unknown).
     //           available_ram <= 0 means UNKNOWN (device_info.proto: 0 = UNKNOWN) —
     //           never refuse a load because the platform could not probe free RAM.
-    // can_fit:  available storage >= required storage (or requirement is 0/unknown)
+    // can_fit:  available storage >= required storage (or requirement is 0/unknown).
+    //           available_storage <= 0 means UNKNOWN too (model_types.proto documents
+    //           ModelCompatibilityRequest.available_storage_bytes as "0 = unknown",
+    //           exactly like available_ram_bytes) — a platform that cannot probe free
+    //           disk must not have every model reported as too large.
     rac_bool_t can_run =
         (required_memory <= 0 || available_ram <= 0 || available_ram >= required_memory)
             ? RAC_TRUE
             : RAC_FALSE;
     rac_bool_t can_fit =
-        (required_storage <= 0 || available_storage >= required_storage) ? RAC_TRUE : RAC_FALSE;
+        (required_storage <= 0 || available_storage <= 0 || available_storage >= required_storage)
+            ? RAC_TRUE
+            : RAC_FALSE;
 
     // Populate result
     out_result->can_run = can_run;

--- a/core/tests/test_model_registry_proto.cpp
+++ b/core/tests/test_model_registry_proto.cpp
@@ -10,6 +10,7 @@
 #include <vector>
 
 #include "rac/core/rac_error.h"
+#include "rac/infrastructure/model_management/rac_model_compatibility.h"
 #include "rac/infrastructure/model_management/rac_model_registry.h"
 
 #ifdef RAC_HAVE_PROTOBUF
@@ -637,6 +638,39 @@ int test_remove_proto() {
     return 0;
 }
 
+// model_types.proto documents BOTH probe inputs the same way:
+//   available_ram_bytes      "0 = unknown -- commons will treat the requirement as satisfied"
+//   available_storage_bytes  "0 = unknown"
+// A platform that cannot probe free disk must therefore not have every model
+// reported as too large.
+int test_unknown_probe_values_do_not_block_compatibility() {
+    rac_model_registry_handle_t registry = create_registry();
+    ASSERT_TRUE(registry != nullptr);
+    ASSERT_TRUE(register_model_proto(
+        registry, build_full_model_proto("llama.compat", "Compat", "/models/llama.compat")));
+
+    // Both probes unknown.
+    rac_model_compatibility_result_t unknown = {};
+    ASSERT_EQ(rac_model_check_compatibility(registry, "llama.compat", /*available_ram=*/0,
+                                            /*available_storage=*/0, &unknown),
+              RAC_SUCCESS);
+    ASSERT_EQ(unknown.can_run, RAC_TRUE);
+    ASSERT_EQ(unknown.can_fit, RAC_TRUE);
+    ASSERT_EQ(unknown.is_compatible, RAC_TRUE);
+
+    // A real probe that is genuinely too small must still refuse, so the
+    // unknown-handling above cannot be mistaken for "always compatible".
+    rac_model_compatibility_result_t tight = {};
+    ASSERT_EQ(rac_model_check_compatibility(registry, "llama.compat", /*available_ram=*/0,
+                                            /*available_storage=*/1, &tight),
+              RAC_SUCCESS);
+    ASSERT_EQ(tight.can_fit, RAC_FALSE);
+    ASSERT_EQ(tight.is_compatible, RAC_FALSE);
+
+    rac_model_registry_destroy(registry);
+    return 0;
+}
+
 int test_canonical_result_shapes_and_typed_errors() {
     rac_model_registry_handle_t registry = create_registry();
     ASSERT_TRUE(registry != nullptr);
@@ -860,6 +894,7 @@ int main() {
         RUN(test_register_proto_preserves_proto_only_fields_on_resave);
         RUN(test_query_filters_and_downloaded_list_proto);
         RUN(test_remove_proto);
+        RUN(test_unknown_probe_values_do_not_block_compatibility);
         RUN(test_canonical_result_shapes_and_typed_errors);
         RUN(test_update_missing_and_invalid_bytes);
 #else


### PR DESCRIPTION
## Description

`idl/model_types.proto` documents both probe inputs the same way:

```proto
// Available RAM in bytes (from device probe). 0 = unknown — commons
// will treat the requirement as satisfied.
int64 available_ram_bytes = 2;

// Available storage in bytes (from filesystem probe). 0 = unknown.
int64 available_storage_bytes = 3;
```

`rac_model_check_compatibility` honours that for RAM and not for storage:

```cpp
can_run = (required_memory  <= 0 || available_ram <= 0 || available_ram     >= required_memory)
can_fit = (required_storage <= 0 ||                       available_storage >= required_storage)
```

The `can_run` line even carries a comment citing `device_info.proto`'s "0 = UNKNOWN" and saying never to refuse a load because the platform could not probe free RAM. The line directly below it does exactly that for disk.

**0 is a reachable value here, not a hypothetical.** `rac_file_manager_get_storage_info` zero-initializes its result and then fills `device_free` only when the adapter supplies the callback:

```cpp
std::memset(out_info, 0, sizeof(rac_file_manager_storage_info_t));
...
if (cb->get_available_space != nullptr) {
    out_info->device_free = cb->get_available_space(cb->user_data);
}
```

So any platform whose adapter leaves `get_available_space` null reports `0`, and then every model comes back `can_fit = false` and `is_compatible = false`.

## The change

Adds the same `<= 0` unknown guard the RAM branch already has, and extends the comment to name the storage contract too.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing

Regression test added to `core/tests/test_model_registry_proto.cpp`, reusing the existing `create_registry` / `build_full_model_proto` helpers rather than adding a fixture (that model already carries `download_size_bytes = 42`).

It asserts both halves, so the fix cannot be mistaken for "always compatible":
- both probes unknown (`0`, `0`) → `can_run`, `can_fit`, `is_compatible` all true
- a genuinely too-small probe (`storage = 1` against a 42-byte model) → still `can_fit = false`

**Confirmed it fails on the unfixed code** by reverting only the `can_fit` expression and rebuilding (verified the binary actually relinked):

```
ASSERT FAILED: unknown.can_fit == RAC_TRUE @ core/tests/test_model_registry_proto.cpp:658
[ FAIL ] test_unknown_probe_values_do_not_block_compatibility
```

With the fix:

```
cmake --preset macos-debug -DRAC_BUILD_BACKENDS=ON && ninja
ctest  ->  100% tests passed out of 130
```

`model_compatibility.cpp` has no preprocessor guards, and I also compiled it with `-DRAC_HAVE_PROTOBUF` stripped (exit 0). The new test function sits inside the file's existing `#ifdef RAC_HAVE_PROTOBUF` block (lines 46-870) and its `RUN` inside the matching guarded block, so the no-protobuf build is unaffected.

- [ ] Lint passes locally
- [x] Added/updated tests for changes

`clang-format` is not installed here, so I matched surrounding style by hand and checked no added line exceeds the column limit rather than claiming a formatter run.

## Labels
- [x] `Commons`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved model compatibility checks when available RAM or storage cannot be measured.
  * Models are no longer incorrectly rejected as too large when system resource information is unavailable.
  * Models are still rejected when a confirmed storage limit is insufficient.
  * Compatibility results now better distinguish unavailable resource information from genuine capacity limits.

* **Tests**
  * Added coverage for unknown resource values and confirmed insufficient storage scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->