### PR TITLE
fix: update stale RACommons and RunAnywhereMLXRuntime checksums for v0.20.31

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -564,7 +564,7 @@ func binaryTargets() -> [Target] {
             .binaryTarget(
                 name: "RACommonsBinary",
                 url: "https://github.com/RunanywhereAI/runanywhere-sdks/releases/download/v\(sdkVersion)/RACommons-ios-v\(sdkVersion).zip",
-                checksum: "81c630305557f189df2d428dbbee167061d51c9832c5b348bde3f430b1c3fb5b"
+                checksum: "3be93cb36b5ea3a8ecfa3db93918fbce3b81165d41865bd9871e11949b903790"
             ),
             .binaryTarget(
                 name: "RABackendLlamaCPPBinary",

--- a/bindings/flutter/packages/runanywhere/ios/runanywhere/Package.swift
+++ b/bindings/flutter/packages/runanywhere/ios/runanywhere/Package.swift
@@ -23,7 +23,7 @@ func runAnywhereBinaryTarget(name: String, checksum: String) -> Target {
 
 let raCommonsTarget = runAnywhereBinaryTarget(
     name: "RACommons",
-    checksum: "81c630305557f189df2d428dbbee167061d51c9832c5b348bde3f430b1c3fb5b"
+    checksum: "3be93cb36b5ea3a8ecfa3db93918fbce3b81165d41865bd9871e11949b903790"
 )
 
 let package = Package(

--- a/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
+++ b/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
@@ -9,7 +9,7 @@
 
 mlx_checksums = {
   'RABackendMLX' => '0802fe58480c3e03e94498d46adb50fda7b9ade491807c7e0392a7fd68b83b59',
-  'RunAnywhereMLXRuntime' => '8415588141fe8d3bbb32f1eaee206cd94958c72004d0961b69b130b0c6b8ed6b',
+  'RunAnywhereMLXRuntime' => 'e2badb28a4496542a502fbfc5e019c784ed3cc109ac381586ec13c771bd0b3b5',
   'RunAnywhereMLXMetal' => '17a2f8c4ce09ef691cde5e7d04171ce749fca89315205f90eb2eed5a76b682b1',
   'RunAnywhereMLXResources' => 'ace624c5cffa32f789cd3beee8d140740daadd793b1315c3583ab670410b3ca3'
 }.freeze


### PR DESCRIPTION
## Summary
- v0.20.31's `release.yml` `publish` job failed at "Verify built Apple checksums match tagged
  package contracts": `RACommonsBinary`/`RACommons` in both `Package.swift` files still carried
  the v0.20.30 checksum. Native archives embed the version string and are never
  byte-reproducible across version bumps — the exact same failure mode as v0.20.30's own first
  release attempt (#807).
- Fixed with the real digest, independently computed via `shasum -a 256` on the just-built
  `RACommons-ios-v0.20.31.zip` (from run 33095926895's `native-ios-macos` artifact) and confirmed
  to match its own `.sha256` sidecar.
- Also proactively fixed `RunAnywhereMLXRuntime` in `runanywhere_mlx.podspec`, which carries the
  identical embedded-version-string problem but is exempted from CI verification via
  `RAC_CHECKSUM_SKIP` (the same gap #809 fixed for v0.20.30) — confirmed stale against the same
  run's real `RunAnywhereMLXRuntime-ios-v0.20.31.zip` before it could bite a Flutter consumer
  silently.

## Test plan
- [x] Both new checksums independently computed from the real build artifacts and verified
      against their `.sha256` sidecars.
- [ ] CI green, then move the `v0.20.31` tag to this fix commit and re-run `release.yml`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Updates**
  * Refreshed the iOS framework and MLX runtime release artifacts.
  * Updated package validation information to match the latest rebuilt binaries.
  * No changes to the public API, SDK version, or package configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->