### PR TITLE
fix: correct the RunAnywhereMLXRuntime checksum for v0.20.31

### DIFF
--- a/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
+++ b/bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
@@ -9,7 +9,7 @@
 
 mlx_checksums = {
   'RABackendMLX' => '0802fe58480c3e03e94498d46adb50fda7b9ade491807c7e0392a7fd68b83b59',
-  'RunAnywhereMLXRuntime' => 'e2badb28a4496542a502fbfc5e019c784ed3cc109ac381586ec13c771bd0b3b5',
+  'RunAnywhereMLXRuntime' => '7a24b950a53fe0e972584a6df016d700a246db69bae2285a2d3ce28ce4bafdbd',
   'RunAnywhereMLXMetal' => '17a2f8c4ce09ef691cde5e7d04171ce749fca89315205f90eb2eed5a76b682b1',
   'RunAnywhereMLXResources' => 'ace624c5cffa32f789cd3beee8d140740daadd793b1315c3583ab670410b3ca3'
 }.freeze


### PR DESCRIPTION
## Description

`bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec` pins a checksum that does not match the archive v0.20.31 actually published:

```
committed  e2badb28a4496542a502fbfc5e019c784ed3cc109ac381586ec13c771bd0b3b5
published  7a24b950a53fe0e972584a6df016d700a246db69bae2285a2d3ce28ce4bafdbd
```

`git log -S` puts the committed value in #817, which synced checksums for v0.20.31. `RACommons` was fixed by that same PR and still matches, because it is byte-reproducible for a given source tree. `RunAnywhereMLXRuntime` is not, which is the whole reason `RAC_CHECKSUM_SKIP` exists, so when the release was re-run after #817 merged its archive got a new hash and the committed value went stale again. That is the superseded-build failure `AGENTS.md` describes, now on its fourth occurrence across 0.20.29 through 0.20.31.

**Nothing catches this.** `RAC_CHECKSUM_SKIP=RunAnywhereMLXRuntime` exempts this exact archive from `publish`'s `sync-checksums.sh --check`, which `AGENTS.md` already notes means it "would have shipped broken to Flutter consumers with no CI signal at all". pub.dev is still on 0.20.27, so it has not shipped yet, but the repo is wrong now and the next publish of `runanywhere_mlx` carries it.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing

I did not trust the `.sha256` sidecar on its own. I downloaded the release asset and hashed it locally; both agree:

```
$ curl -sL -o mlxrt.zip .../v0.20.31/RunAnywhereMLXRuntime-ios-v0.20.31.zip
$ shasum -a 256 mlxrt.zip
7a24b950a53fe0e972584a6df016d700a246db69bae2285a2d3ce28ce4bafdbd
```

Per the "check every row of the checksum-location table, not only the one the CI error names" note in `AGENTS.md`, I checked the whole table against v0.20.31 rather than just this row:

```
Package.swift    RACommons / RABackendLLAMACPP / RABackendONNX
                 RABackendSherpa / RABackendNeuRT / RABackendMLX    all OK
mlx podspec      RABackendMLX                                       OK
                 RunAnywhereMLXRuntime                              MISMATCH  <-- this PR
                 RunAnywhereMLXMetal                                OK
                 RunAnywhereMLXResources                            OK
```

After the change all four MLX entries and all six SwiftPM targets resolve against v0.20.31. `scripts/validation/gates/check_release_version_coherence.sh` exits 0 (`[OK] release version coherence: 0.20.31`).

- [ ] Lint passes locally
- [ ] Added/updated tests for changes

No test: this is a single checksum literal whose correctness is the artifact comparison above, and there is no fixture that could assert it without network access to the release.

## Labels
- [x] `Flutter SDK`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the integrity verification for the iOS MLX runtime package.
  * No changes to download behavior or user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->