### PR TITLE
chore(agents): publish .claude/ + .agents/ skill trees, gated by CI

### DIFF
--- a/.agents/skills/engine-plugin-authoring/SKILL.md
+++ b/.agents/skills/engine-plugin-authoring/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: engine-plugin-authoring
+description: Step-by-step recipe for adding a new engine plugin under runanywhere-sdks/engines/, or adding a modality (e.g. TTS) to an existing engine (llamacpp, sherpa, onnx, cloud, mlx, neurt, qhexrt). Use when the task is "add engine X", "wire up backend Y", or "make engine Z also serve <modality>".
+---
+
+# Engine plugin authoring (`engines/`)
+
+Two related runbooks: adding a brand-new engine plugin, and adding a modality to one
+that already exists. Read `engines/AGENTS.md` first for the concepts these steps
+assume (op-table vtable, manifest, the valid-engine checklist, the 4-file skeleton,
+the engine↔runtime rule). This skill is the "how", that file is the "what/why".
+
+**Invariant that applies to both procedures:** never invent a new modality just to
+ship an engine — fill an existing `rac_engine_vtable_t` slot. Adding a brand-new
+*primitive* (a new `RAC_PRIMITIVE_*` + vtable slot) is a commons ABI change, covered
+by `core/AGENTS.md` → "Adding a new capability interface", not an engine change.
+
+---
+
+## Procedure A — add a new engine
+
+Mirror **sherpa** (multi-modality, standalone `.so`) or **cloud** (single modality,
+no runtime) as your template; both are the cleanest references for the 4-file
+skeleton described in `engines/AGENTS.md`.
+
+1. **Create `engines/<name>/`** with the 4-file skeleton: `rac_plugin_entry_<name>.cpp`,
+   `rac_backend_<name>_register.cpp` (skip it if there's no extra bring-up, like
+   `neurt`), `rac_static_register_<name>.cpp`, plus your impl files.
+2. **Write the manifest** in `rac_plugin_entry_<name>.cpp`:
+   - `name` = snake_case identity (the library/framework you wrap, or your own
+     codebase unit — NEVER a modality name; see the naming rule in
+     `engines/AGENTS.md`).
+   - `primitives[]` = what you serve; fill the matching vtable slots; leave every
+     other slot explicit NULL (the all-NULL tripwire depends on this).
+   - `runtimes[]` — only devices your compute actually depends on (NULL for
+     cloud/HTTP engines) — see THE RULE in `engines/AGENTS.md`.
+   - `formats[]` = the `RAC_MODEL_FORMAT_ID_*` values you accept (NULL if there's
+     no local model file).
+   - `priority`, `availability` (PUBLIC/PRIVATE), `package_owner`/`package_name`.
+3. **Implement the op-table(s)** honoring the MODEL LIFECYCLE:
+   `create → initialize → use → cleanup → destroy` (see `engines/AGENTS.md` for the
+   exact signatures). Use `RAC_DEFINE_CREATE_ADAPTER(primitive, name)`
+   (`core/include/rac/plugin/rac_plugin_entry.h`) when `create` is a plain forward
+   onto `rac_<primitive>_<name>_create` — sherpa uses it for STT/TTS/VAD. Engines
+   with richer create flows (llamacpp, onnx, neurt, qhexrt) hand-write it.
+4. **`capability_check`** when the engine is platform- or binary-gated: use the
+   shared 3-way helper `rac_engine_unavailable_capability(platform_supported,
+   backend_present)` from `engines/common/rac_engine_unavailable.h`. When the
+   backend can be entirely absent at build time (a private prebuilt archive, a
+   sibling private repo), emit the stub with `RAC_ENGINE_UNAVAILABLE_PLUGIN(name,
+   display, cap_fn)` from the same header — see qhexrt and neurt for the two-mode
+   (ROUTABLE vs STUB) pattern this produces.
+5. **Registration carriers:** `RAC_PLUGIN_ENTRY_DEF(<name>)` returning the vtable; a
+   `rac_backend_<name>_register()`/`_unregister()` pair if you have extra bring-up
+   (called directly by SDK bridges on dynamic-link hosts); a
+   `rac_static_register_<name>.cpp` shim using `RAC_STATIC_REGISTER_BACKEND(<name>)`
+   (routes through the register fn) or `RAC_STATIC_PLUGIN_REGISTER(<name>)` (calls
+   the entry directly) for iOS/WASM static hosts.
+6. **CMake:** call `rac_add_engine_plugin(<name> SOURCES … LINK_LIBRARIES …
+   AVAILABILITY … PACKAGE_OWNER … PACKAGE_NAME …)` (`cmake/plugins.cmake`) from
+   `engines/<name>/CMakeLists.txt`, fronted by your own
+   `option(RAC_BACKEND_<NAME> "…" <default>)` + `if(NOT RAC_BACKEND_<NAME>)
+   return() endif()` self-gate (each engine owns its own option — `engines/CMakeLists.txt`
+   just unconditionally `add_subdirectory()`s and lets the child decide). Add
+   `add_subdirectory(<name>)` there. Declare `primitives`/`runtimes`/`formats` ONLY
+   in the C manifest, never in CMake, so the build graph can't drift from what the
+   router routes.
+7. **Android:** if the SDK loads the engine via `System.loadLibrary` +
+   `nativeRegister`, add a JNI bridge with `RAC_DEFINE_ENGINE_JNI_BRIDGE(...)`
+   (standalone per-engine `.so` — onnx, llamacpp) or
+   `RAC_DEFINE_ENGINE_JNI_BRIDGE_NO_ONLOAD(...)` (folded into a host lib that
+   already owns `JNI_OnLoad`, e.g. cloud → `librunanywhere_jni.so`) from
+   `engines/common/rac_engine_jni_bridge.h`. The JVM class-path token in the macro
+   call must match the Kotlin `*Bridge` class byte-for-byte.
+8. **iOS/WASM static hosts:** make sure the host force-loads the plugin —
+   `rac_force_load(<app> PLUGINS <name>)` in the host's CMakeLists — so the
+   static-init Registrar TU survives linker stripping.
+9. **If this engine ships an Electron/npm carrier package**, register it in
+   `scripts/validation/gates/check_plugin_natives.py`'s `REQUIRED_OPS` dict (the
+   ops-table symbol name(s) your entry TU references only on the routable
+   branch) — `package-sdk.sh` calls this automatically, so an unregistered
+   engine's stub/shell builds ship undetected. **Check which FILE actually
+   compiles `rac_plugin_entry_<name>.cpp`** before assuming the carrier
+   (`runanywhere_<name>`) is what to gate: sherpa/onnx/llamacpp compile it into
+   the carrier itself (an undefined symbol reference there is the evidence),
+   but neurt's `rac_add_engine_plugin()` call puts it on the ENGINE target
+   (`rac_backend_neurt`) instead — the carrier there is empty boilerplate with
+   zero symbols. Add the engine id to `EVIDENCE_IN_BACKEND_FILE` if it follows
+   neurt's shape; discovered by actually building neurt for real and running
+   `nm -a` on both files, not by reading the CMakeLists and assuming.
+
+## Procedure B — add a modality to an existing engine
+
+Multi-modality is the whole point of an identity-named engine. `cloud` and `neurt`
+are explicitly built for this and carry the recipe inline as a comment next to
+their vtable.
+
+1. Implement the new modality's op-table (e.g. a cloud TTS `g_cloud_tts_ops`,
+   typically backed by a per-modality provider adapter under `providers/`).
+2. **Fill the corresponding slot** in the engine's `rac_engine_vtable_t`
+   (`tts_ops` / `llm_ops` / `embedding_ops` / …) — every other slot must stay
+   explicit NULL.
+3. **Add the primitive** to the manifest's `primitives[]`.
+4. Update `formats[]`/`runtimes[]` only if the new modality actually needs them
+   (per THE RULE — don't declare a runtime your new op-table doesn't depend on).
+
+No new plugin, no rename, no ABI bump — the engine already owns one
+`rac_engine_vtable_t` with all ten primitive slots; you're just filling another one.
+Grep the target engine's `rac_plugin_entry_<name>.cpp` for the phrase "To add a"
+— cloud and neurt both leave a comment naming exactly which slots are still free
+and what to add to `primitives[]`.

--- a/.agents/skills/sdk-publish/SKILL.md
+++ b/.agents/skills/sdk-publish/SKILL.md
@@ -1,0 +1,444 @@
+---
+name: sdk-publish
+description: Manually publish an already-tagged, already-released (non-draft GitHub Release) RunAnywhere SDK version to every package registry (npm, Maven Central, pub.dev, Swift SPM dist repo) plus macOS rcli notarization, with heavy verification that nothing fake/stubbed/broken ships.
+---
+
+# SDK Publish
+
+Repo: `~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks` (verify with `pwd`/`git remote get-url origin` — do not assume this path is still correct, checkouts move). Version source of truth: `core/VERSION`. Throughout, `$VERSION` means the bare semver being published (e.g. `0.20.24`), never prefixed with `v` except in git tags / GitHub Release names.
+
+## THIS PROCESS IS INTENTIONALLY MANUAL
+
+**`release.yml` never publishes anywhere public.** It only builds artifacts, packages them, and creates a draft/published **GitHub Release**. It does not call `npm publish`, does not upload to Maven Central, does not call `flutter pub publish`, and does not push the Swift dist repo. Verify this is still true before trusting it — greps below should all return **zero** matches (grep the whole file, not a snippet):
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks
+grep -inE "npm publish|publishReleasePublication|publishAllPublicationsToMavenCentral|flutter pub publish" .github/workflows/release.yml
+```
+
+This is a **deliberate safety gate**, not a gap. Every step below is a human (or an agent acting on a human's explicit go-ahead) pushing a button that CI intentionally never pushes. Do not propose wiring any of this into CI as a "fix" — that would remove the gate.
+
+## Precondition check (always run first)
+
+Refuse to proceed if the release is a draft or the asset set looks incomplete.
+
+```bash
+gh release view v$VERSION --json isDraft,tagName --jq '{isDraft, tagName}'
+# isDraft MUST be false.
+
+gh release view v$VERSION --json assets --jq '.assets[].name' | sort
+```
+
+Cross-reference the listing against the `sdk-release` skill's step 8 asset-count expectations (`~/.claude/skills/sdk-release/SKILL.md`). As a second, independent check, also diff against the **previous** tagged release's asset list — same count, same name patterns, only the version token differs:
+
+```bash
+gh release view v<PREVIOUS_VERSION> --json assets --jq '.assets[].name' | sed "s/<PREVIOUS_VERSION>/$VERSION/" | sort >/tmp/expected.txt
+gh release view v$VERSION --json assets --jq '.assets[].name' | sort >/tmp/actual.txt
+diff /tmp/expected.txt /tmp/actual.txt
+```
+
+As of the last verified run (**v0.20.25, 65 assets** — up from 55 at v0.20.24 because the 5 public Electron tarballs and their sidecars joined the release; see §6), the full set is: `MANIFEST.txt`; per-platform `RACommons-{android-arm64-v8a,android-armeabi-v7a,android-x86_64,ios,linux-x86_64,web,windows-x64}-v$VERSION.{zip,tar.gz}` + `.sha256`; iOS backend zips `RABackend{LLAMACPP,MLX,NeuRT,ONNX,Sherpa}-ios-v$VERSION.zip` + `.sha256`; `RunAnywhereMLX{Metal,Resources,Runtime}-ios-v$VERSION.zip` + `.sha256`; `rcli-{linux-x86_64,macos-arm64,windows-x86_64}-v$VERSION.tar.gz`/`.zip` + `.sha256`; the 8 npm tarballs `runanywhere-{core,llamacpp,mlx,onnx,proto-ts,web,web-llamacpp,web-onnx}-$VERSION.tgz` + `.sha256`; the **5 Electron npm tarballs** `runanywhere-electron{,-llamacpp,-onnx,-sherpa,-neurt}-$VERSION.tgz` + `.sha256` (new as of v0.20.25); and `runanywhere-kotlin-maven-v$VERSION.zip` + `.sha256`. There is **no** Flutter tarball in the release (Flutter packages are staged from the native archives above, not from a dedicated release asset) and **no** `.dmg` asset in the baseline set (the macOS rcli tarball is what ships; see the notarization section for when a `.dmg` does get produced). If a `qhexrt`-named asset appears anywhere in this list, stop — that would mean `release.yml`'s own manifest assertion should have hard-failed and something is very wrong; do not publish anything from that release.
+
+## 0. MANDATORY GATE — verify the ENTIRE release before pushing anything to any registry
+
+**Run this once, in full, before the first registry push. Do not publish a single package until it passes.** Per-package spot-checks are not a substitute: they are how a bad artifact reaches a registry you cannot un-publish from. Proven end to end on v0.20.25 (2026-08-22), then independently audited and corrected: **34 payloads, 6619 files across 3 nesting levels, 282 binaries, 0 placeholder hits, 38/38 commons binaries carrying the real staging host**. The audit found 4 methodology gaps in the first pass (shallow nesting, missing `MTLB` magic, `.lib` excluded from the positive check, and a set-intersection that could pass vacuously) — every one is called out inline below, because each produced a *confident but under-covered* result.
+
+```bash
+VERSION=0.20.25                      # no leading v
+REPO=RunanywhereAI/runanywhere-sdks
+W=/tmp/relverify-$VERSION
+rm -rf "$W" && mkdir -p "$W/assets" "$W/qhexrt" "$W/x" "$W/nested"
+
+# (1) EVERY release asset — no -p filter, get the whole set.
+gh release download "v$VERSION" --repo "$REPO" -D "$W/assets"
+
+# (2) The PRIVATE QHexRT artifact is NOT a release asset — pull it from the run.
+#     Find the run that produced the release, then:
+gh run download <release-run-id> --repo "$REPO" --name sdk-electron-qhexrt-private --dir "$W/qhexrt"
+```
+
+### (3) Checksums — `cd` into the directory first
+
+Sidecars contain a **bare basename**, so `shasum -c` fails with a misleading "FAILED open or read" if run from anywhere else. This will make every artifact look broken when nothing is wrong:
+
+```bash
+cd "$W/assets"
+ok=0; bad=0
+for s in *.sha256; do
+  if shasum -a 256 -c "$s" >/dev/null 2>&1; then ok=$((ok+1)); else echo "MISMATCH: $s"; bad=$((bad+1)); fi
+done
+echo "verified=$ok mismatched=$bad"      # bad MUST be 0
+(cd "$W/qhexrt" && shasum -a 256 -c ./*.sha256)
+```
+
+### (4) Extract everything — INCLUDING nested archives
+
+**The gotcha that matters:** `runanywhere-kotlin-maven-v*.zip` contains `.aar` files, and the `.aar`s are what hold the Android `.so` binaries. A one-level extraction reports "0 binaries" for the Maven bundle and every subsequent scan passes **vacuously**.
+
+**Recurse until the tree is dry — TWO levels are required here, not one.** Each `.aar` also contains a `classes.jar`, holding ~2027 `.class` files that are doubly unreachable: inside an unopened jar *and* excluded by the `.class` suffix rule most magic-byte scanners use. Level 2 adds **2033 files** (0 placeholder hits on v0.20.25); level 3 is empty. Loop until a pass finds no new archives rather than hardcoding a depth.
+
+```bash
+cd "$W/assets"
+for f in *; do
+  case "$f" in *.sha256|MANIFEST.txt) continue;; esac
+  d="$W/x/$f"; mkdir -p "$d"
+  case "$f" in
+    *.zip)              unzip -qq -o "$f" -d "$d" || echo "EXTRACT FAILED: $f" ;;
+    *.tar.gz|*.tgz)     tar -xzf "$f" -C "$d"     || echo "EXTRACT FAILED: $f" ;;
+    *) echo "UNHANDLED TYPE: $f" ;;
+  esac
+done
+d="$W/x/$(basename "$W"/qhexrt/*.tgz)"; mkdir -p "$d"; tar -xzf "$W"/qhexrt/*.tgz -C "$d"
+
+# nested pass
+cd "$W/x"
+find . -type f \( -name '*.aar' -o -name '*.jar' -o -name '*.zip' -o -name '*.tgz' -o -name '*.tar.gz' \) \
+  | sed 's|^\./||' | while IFS= read -r a; do
+    dd="$W/nested/$(printf '%s' "$a" | tr '/' '_')"; mkdir -p "$dd"
+    case "$a" in *.aar|*.jar|*.zip) unzip -qq -o "$a" -d "$dd";; *) tar -xzf "$a" -C "$dd";; esac
+  done
+```
+
+**Prove extraction actually happened** — an empty dir makes "0 hits" meaningless:
+
+```bash
+for d in "$W"/x/*/; do
+  n=$(find "$d" -type f | wc -l)
+  [ "$n" -lt 2 ] && echo "SUSPICIOUSLY EMPTY: $d ($n files)"
+done
+```
+
+### (5) Placeholder scan — EVERY file, not just binaries
+
+The staging URL can also live in JS/JSON/TS config, so scan by content across all file types, and additionally scan the raw compressed streams in case a member never got extracted:
+
+```bash
+find "$W/x" "$W/nested" -type f | wc -l                                     # total files covered
+grep -rla "YOUR_STAGING_BASE_URL" "$W/x" "$W/nested" | tee /tmp/ph.txt | wc -l   # MUST be 0
+for f in "$W"/assets/*.tgz "$W"/assets/*.tar.gz "$W"/qhexrt/*.tgz; do
+  gzip -dc "$f" 2>/dev/null | grep -qa "YOUR_STAGING_BASE_URL" && echo "RAW HIT: $f"
+done
+```
+
+Find binaries by **magic bytes, not extension** (an unsuffixed framework binary like `RACommons.framework/RACommons` has no extension and a name-based `find` misses it). Signatures to cover:
+
+| Magic | Kind | v0.20.25 count |
+|---|---|---|
+| `7f454c46` | ELF | 177 |
+| `!<arch>` (`213c617263683e0a`) | static `.a` **and `.lib`** | 41 |
+| `MZ` | PE | 29 |
+| `cffaedfe` / `cefaedfe` | Mach-O | 19 |
+| `00 61 73 6d` | wasm | 10 |
+| **`4d544c42` (`MTLB`)** | **Metal library** — easy to miss | 5 |
+| `cafebabe` / `bebafeca` | fat Mach-O (exclude `.jar`/`.class`) | 1 |
+
+**Total: 282 binaries.** An earlier pass reported 277 because `MTLB` was absent from the signature list — `.metallib` files were invisible to the binary scan (they were still covered by the all-file `grep` in step 5, so the conclusion held, but the count was wrong). If your total comes in materially under ~282 for a comparable release, your detection is leaking.
+
+### (6) POSITIVE staging-URL check — absence of the placeholder is NOT sufficient
+
+A build with an **empty** URL baked in passes a placeholder-only check. `check_plugin_natives.py` only tests absence, so add the positive assertion yourself.
+
+Two traps that produced false confidence on the v0.20.25 pass, both worth avoiding:
+
+- **Include `.lib`.** A `MUST_HAVE` regex of `rac_commons\.(dylib|so|dll|a)$` silently skips
+  `RACommons-windows-x64/x64/rac_commons.lib` — an **89 MB** binary that then gets no positive
+  check at all. Match `(dylib|so|dll|a|lib)` plus `\.wasm$`. Correct coverage is **38** binaries,
+  not 37.
+- **Assert per binary, not by set-intersection.** Intersecting "non-public origins across all
+  files" yields more than one origin here (`hf.co` *and* the staging host), so a binary carrying
+  only `hf.co` would pass **vacuously**. Check each binary individually for the staging host.
+
+```bash
+# v0.20.25 baseline: 38 commons/wasm/lib binaries; 0 missing the staging host.
+```
+
+Never print the URL — it is a repo secret. Report a truncated SHA-256 fingerprint, or just assert presence/absence counts.
+
+### (7) Routability gate over the whole tree
+
+```bash
+python3 scripts/validation/gates/check_plugin_natives.py "$W/x" "$W/nested" > /tmp/gate.txt 2>&1
+grep -cE '^  ok ' /tmp/gate.txt; grep -E '^  FAIL' /tmp/gate.txt
+```
+
+v0.20.25 baseline: **77 ok, 1 FAIL**. The single expected FAIL is
+`RACommons-linux-x86_64/lib/librunanywhere_sherpa.so` — see the known-exception note below. **Any other FAIL blocks the publish.**
+
+### (8) Known exception — Linux sherpa is a non-routable shell (PRE-EXISTING, not a regression)
+
+`RACommons-linux-x86_64-v*.tar.gz` ships **no** `libsherpa-onnx-c-api.so` at all and its `librac_backend_sherpa.so` is a ~156 KB shell (~3 sherpa strings, vs ~31 MB / ~192 for a healthy one on Electron macOS) — the engine is not linked in, so the carrier cannot reference `g_sherpa_{stt,tts,vad}_ops` and **STT/TTS/VAD cannot work from that bundle**. Android's carriers pass on all 3 ABIs, so this is Linux-only.
+
+**Compare the CARRIER, not the backend.** The gate FAILs on `librunanywhere_sherpa.so` (the carrier); citing `librac_backend_sherpa.so` as your evidence is comparing a *different file* and is not proof. The carrier is byte-identical across releases, which is the real proof:
+
+```bash
+gh release download "v<PREV>" --repo "$REPO" -p 'RACommons-linux-x86_64-v<PREV>.tar.gz' -D /tmp/prev
+tar -xzf /tmp/prev/*.tar.gz -C /tmp/prev
+shasum -a 256 /tmp/prev/lib/librunanywhere_sherpa.so "$W"/x/RACommons-linux-*/lib/librunanywhere_sherpa.so
+# v0.20.24 and v0.20.25 both: size=15712  sha256=28ef16015b61da86...
+
+# strongest check — run the gate on the PREVIOUS bundle and confirm the identical FAIL:
+python3 scripts/validation/gates/check_plugin_natives.py /tmp/prev
+```
+
+If it ever regresses *further* (e.g. Android or macOS sherpa also goes hollow), stop and treat it as a blocking defect.
+
+### (9) Account for every payload explicitly
+
+Print a per-artifact table (checksum verdict, binary count, placeholder hits) and confirm the row count equals the payload count. Artifacts that legitimately contain **no** native binaries, and why — do not let these pass silently unexamined:
+
+| Artifact | Why it has no binaries |
+|---|---|
+| `RunAnywhereMLXResources-ios-*.zip` | 25 third-party license/notice text files |
+| `runanywhere-kotlin-maven-v*.zip` | binaries live in the **nested** `.aar`s (step 4) |
+| `runanywhere-proto-ts-*.tgz` | pure TS/JS (69 `.ts` + 69 `.js`) |
+
+Everything else must have a non-zero, plausible binary count. A platform suddenly shipping fewer binaries than the previous release is a regression signal worth chasing before publishing.
+
+### (10) Blind spot to be aware of — Windows x64 has NO routability coverage
+
+`RACommons-windows-x64-v*.zip` ships **only** a static `rac_commons.lib` (~89 MB) plus 152 `.h` / 11 `.hpp` headers — **zero backend DLLs**, where Linux/Android/Web each ship 4–5 backend carriers. That is consistent with a static-embedding bundle (consumers link the engines in themselves), but the consequence matters: **no gate can detect a missing or hollow Windows backend**, because there is no carrier to inspect. `check_plugin_natives.py` therefore reports nothing at all for this artifact rather than reporting health.
+
+Windows x64 is also *advisory* in `release.yml` (its absence does not fail the release). So a Windows regression can pass every automated check. If Windows correctness matters for a given release, verify it by actually running something on the real Windows box (see §Electron for how to reach it) — do not infer it from a green pipeline. Worth a deliberate confirmation with the repo owner that the DLL-free shape is intentional.
+
+---
+
+## General verification discipline (every artifact, every registry)
+
+Apply all three checks below to **every** file you're about to publish, before AND after the publish call. Never trust a copy cached locally earlier in the session — re-download.
+
+**(a) Download + verify the sha256 sidecar yourself:**
+
+```bash
+gh release download v$VERSION -p '<file>' -p '<file>.sha256' -D /tmp/sdk-publish-$VERSION
+cd /tmp/sdk-publish-$VERSION && shasum -a 256 -c '<file>.sha256'
+```
+
+**(b) Inspect the actual file listing inside every tarball/AAR/zip** — never assume from the filename alone:
+
+```bash
+npm pack <tgz-or-package-dir> --dry-run     # npm packages: prints the exact file list it would publish
+unzip -l  <file.zip>                        # AARs, Maven repo zip, native archives
+tar -tzf  <file.tar.gz>                     # rcli, RACommons tarballs
+```
+
+Sanity-check what comes back:
+- No suspiciously-small or empty binaries where a real native library (`.so`, `.dylib`, `.a`, `.dll`) should be — a stub or a zero-byte placeholder means the build silently failed upstream.
+- No leftover `workspace:*` or `file:` dependency specs in any `package.json` inside the tarball — those only resolve inside this monorepo and break for a real external installer.
+- Version strings inside every manifest (`package.json` `version`, AAR `pom.xml` `<version>`, `pubspec.yaml` `version:`) **exactly** match `$VERSION`.
+- **Hard rule, no exceptions:** grep the full file listing for `qhexrt` (any case) and for QNN binary names (`libQnnHtp`, `QnnHtp*.dll`, `rac_commons.dll` bundled with QHexRT, `runanywhere_qhexrt`). If any hit appears in a package meant to be public, stop and do not publish that artifact.
+
+**(c) Confirm baked-in runtime config** (e.g. a staging-vs-prod backend base URL compiled into `rac_commons` at build time) points at the real intended endpoint. This is designed to fail closed if misconfigured — a build that completed and produces working requests against prod is itself decent evidence — but if you have any doubt, `strings <binary> | grep -i "api\.\|staging\."` and eyeball it.
+
+## 1. npm — 8 packages, order matters
+
+Packages: 4 Web (`@runanywhere/proto-ts`, `@runanywhere/web`, `@runanywhere/web-llamacpp`, `@runanywhere/web-onnx`) + 4 React Native (`@runanywhere/core`, `@runanywhere/llamacpp`, `@runanywhere/mlx`, `@runanywhere/onnx`). Never `@runanywhere/qhexrt` (RN) — it exists in `bindings/react-native/packages/qhexrt/` but is excluded from the public npm train by the same policy as Maven/pub.dev QHexRT.
+
+**Publish `@runanywhere/proto-ts` FIRST.** `@runanywhere/web-onnx` deliberately does not bundle its own `proto-ts` copy and needs it resolvable from the live registry for real consumers; publish `proto-ts` before it or a fresh `npm install @runanywhere/web-onnx` fails to resolve.
+
+```bash
+gh release download v$VERSION -p 'runanywhere-proto-ts-*.tgz*' -p 'runanywhere-web-*.tgz*' \
+  -p 'runanywhere-core-*.tgz*' -p 'runanywhere-llamacpp-*.tgz*' -p 'runanywhere-mlx-*.tgz*' -p 'runanywhere-onnx-*.tgz*' \
+  -D /tmp/sdk-publish-$VERSION
+cd /tmp/sdk-publish-$VERSION
+for f in *.sha256; do shasum -a 256 -c "$f"; done
+
+npm publish runanywhere-proto-ts-$VERSION.tgz --access public   # FIRST, always
+npm publish runanywhere-web-$VERSION.tgz --access public
+npm publish runanywhere-web-llamacpp-$VERSION.tgz --access public
+npm publish runanywhere-web-onnx-$VERSION.tgz --access public
+npm publish runanywhere-core-$VERSION.tgz --access public
+npm publish runanywhere-llamacpp-$VERSION.tgz --access public
+npm publish runanywhere-mlx-$VERSION.tgz --access public
+npm publish runanywhere-onnx-$VERSION.tgz --access public
+```
+
+`npm whoami` should already show a logged-in account; if it errors, stop and tell the human rather than trying to log in non-interactively.
+
+**GOTCHA — large tarballs can silently die mid-upload.** `@runanywhere/mlx` (~50MB) and `@runanywhere/web-onnx` (unpacks to 300+MB) can exceed a short default shell/tool timeout mid-upload and get killed with no clean error. Use an explicit long timeout (5 minutes / 300000ms) on each publish call.
+
+**GOTCHA — verify via the registry API, not the npm CLI.** `npm view` can lag the CLI's own cache by several seconds right after a fresh publish and falsely report "not found". After **every** publish:
+
+```bash
+curl -s "https://registry.npmjs.org/@runanywhere/<pkg>" | python3 -c "import json,sys;print(json.load(sys.stdin)['dist-tags'])"
+```
+Confirm `latest` equals `$VERSION`.
+
+## 2. Maven Central — 3 AARs only
+
+`io.github.sanchitmonga22:{runanywhere-sdk,runanywhere-llamacpp,runanywhere-onnx}`. **Never `runanywhere-qhexrt-android`** — it was published through 0.20.19 under an earlier, since-reversed policy and is now permanently excluded; `release.yml`'s manifest assertion hard-fails if it reappears in the public asset set.
+
+Full step-by-step lives in `bindings/kotlin/docs/KOTLIN_MAVEN_CENTRAL_PUBLISHING.md`, section **"Option A: Publish with released native archives"** (line ~108 as of this writing — the doc has been corrected mid-release before, so re-read it fresh rather than trusting memory of its contents). Key points, condensed:
+
+1. Download + verify the 3 `RACommons-android-{arm64-v8a,armeabi-v7a,x86_64}-v$VERSION.zip` from the release (sha256 sidecars, per the general discipline above).
+2. Stage: `bash bindings/kotlin/scripts/package-sdk.sh --mode local --natives-from <dir-with-the-3-zips>`. This also produces a local Maven-repo zip — diff its size against `runanywhere-kotlin-maven-v$VERSION.zip` already attached to the GitHub Release as a cheap reproducibility check.
+3. Before uploading, confirm the OSSRH compatibility service has no dangling open repository for this namespace:
+   ```bash
+   CENTRAL_BEARER="$(printf '%s:%s' "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" | base64 | tr -d '\r\n')"
+   curl -s -H "Authorization: Bearer $CENTRAL_BEARER" \
+     'https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?ip=client&profile_id=io.github.sanchitmonga22'
+   ```
+   Resolve any stale repository per the doc's troubleshooting table before continuing.
+4. Source `MAVEN_CENTRAL_USERNAME`/`MAVEN_CENTRAL_PASSWORD` from `~/.gradle/gradle.properties` (`mavenCentral.username`/`mavenCentral.password` — confirmed present on this machine; never print the values) and run, from `bindings/kotlin/`:
+   ```bash
+   ./gradlew clean \
+     :publishReleasePublicationToMavenCentralRepository \
+     :modules:runanywhere-core-llamacpp:publishReleasePublicationToMavenCentralRepository \
+     :modules:runanywhere-core-onnx:publishReleasePublicationToMavenCentralRepository \
+     -Prunanywhere.useLocalNatives=true -x buildLocalJniLibs --no-daemon
+   ```
+   GPG signing (`signing.gnupg.keyName`/`signing.gnupg.passphrase` in the same properties file, key id `CC377A9928C7BB18` — confirmed importable via `gpg --list-secret-keys --keyid-format LONG` on this machine) is read from the same properties file automatically; you do not pass it separately.
+5. Transfer to Central Portal:
+   ```bash
+   curl --fail --request POST -H "Authorization: Bearer $CENTRAL_BEARER" \
+     'https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/io.github.sanchitmonga22?publishing_type=automatic'
+   ```
+   Then find the resulting `portal_deployment_id` — expect **exactly one** fresh repository; if the count isn't 1, stop and investigate rather than guessing which one is yours (see the doc for the exact `jq` filter).
+6. Poll `https://central.sonatype.com/api/v1/publisher/status?id=<id>` (POST, same bearer) until `deploymentState` is `PUBLISHED`. Automatic deployments normally go `PENDING -> VALIDATING -> PUBLISHING -> PUBLISHED` within a few minutes. **If it lands on `VALIDATED` instead of proceeding, that means Sonatype is waiting for a manual click in the Central Portal UI** — stop and tell the human; do not loop forever assuming it resolves itself. On `FAILED`, print `.errors` and stop.
+7. Verify propagation (allow 10-30 minutes for CDN propagation even after `PUBLISHED`):
+   ```bash
+   for a in runanywhere-sdk runanywhere-llamacpp runanywhere-onnx; do
+     echo "$a: $(curl -s -o /dev/null -w '%{http_code}' "https://repo1.maven.org/maven2/io/github/sanchitmonga22/$a/$VERSION/$a-$VERSION.pom")"
+   done
+   ```
+   Expect `200` for all three.
+
+## 3. pub.dev (Flutter)
+
+**Verify the current package set fresh — do not trust a hardcoded count.** As of this writing the real, non-QHexRT Flutter package set is **4**, not 3: `runanywhere`, `runanywhere_llamacpp`, `runanywhere_onnx`, and `runanywhere_mlx` (mlx was added after some earlier documentation/memory of "3 packages" was written — that assumption is stale; `runanywhere_mlx` is a real, already-published-on-pub.dev package, not new/WIP). Enumerate it yourself instead of trusting this list verbatim next time:
+```bash
+find bindings/flutter/packages -maxdepth 1 -type d -not -iname '*qhexrt*' -not -path '*/packages'
+```
+`runanywhere_qhexrt` exists in that directory too — never publish it (same exclusion policy as Maven).
+
+Stage the released iOS xcframeworks + Android `.so` into each package with the Flutter equivalent of `package-sdk.sh` (melos-based monorepo, confirmed at `bindings/flutter/scripts/package-sdk.sh`):
+
+```bash
+bash bindings/flutter/scripts/package-sdk.sh --mode local --natives-from <dir-with-xcframeworks-and-android-.so>
+```
+
+This script already runs `flutter pub publish --dry-run` internally per package as part of its own validation — but run it again yourself, per package, from each package directory, and **read the output for real, not just the exit code**:
+
+```bash
+cd bindings/flutter/packages/runanywhere && flutter pub publish --dry-run
+cd ../runanywhere_llamacpp && flutter pub publish --dry-run
+cd ../runanywhere_onnx && flutter pub publish --dry-run
+cd ../runanywhere_mlx && flutter pub publish --dry-run
+```
+
+Expect zero warnings except a benign version-gap hint. Only then run the real publish, same order (core first, since the others depend on it):
+
+```bash
+cd bindings/flutter/packages/runanywhere && flutter pub publish
+cd ../runanywhere_llamacpp && flutter pub publish
+cd ../runanywhere_onnx && flutter pub publish
+cd ../runanywhere_mlx && flutter pub publish
+```
+
+**Credential note:** pub.dev OAuth is normally cached at `~/Library/Application Support/dart/pub-credentials.json` on macOS (confirmed present on this machine). If it's missing, expired, or `flutter pub publish` prompts for an interactive browser login, **STOP and tell the human** — you cannot complete a fresh Google OAuth flow non-interactively, and forcing/guessing here is not appropriate.
+
+Verify afterward against the live API (not a cached page):
+```bash
+for p in runanywhere runanywhere_llamacpp runanywhere_onnx runanywhere_mlx; do
+  echo "$p: $(curl -s "https://pub.dev/api/packages/$p" | python3 -c "import json,sys;print(json.load(sys.stdin)['latest']['version'])")"
+done
+```
+
+## 4. Swift SPM distribution repo (`RunanywhereAI/runanywhere-swift`)
+
+A separate, **generated-only** repo mirroring `bindings/swift` (Package.swift + Sources/ + LICENSE + README) so SwiftPM consumers using `from: "<version>"` don't clone the ~340MB monorepo.
+
+**GOTCHA:** this machine may have local directories literally named `runanywhere-swift` that are just checkouts of the **monorepo's** remote, not the distribution repo. Verify before trusting any existing local directory by name:
+```bash
+git -C <candidate-dir> remote get-url origin
+```
+Must show `RunanywhereAI/runanywhere-swift`, not `runanywhere-sdks`. Always clone fresh instead of guessing:
+
+```bash
+git clone https://github.com/RunanywhereAI/runanywhere-swift.git /tmp/ra-swift
+
+bindings/swift/scripts/sync-dist-repo.sh \
+  --zips <exact-verified-Apple-archive-dir-from-the-release> --tag /tmp/ra-swift
+
+RUNANYWHERE_SWIFT_DIST_REPO=/tmp/ra-swift \
+  bash scripts/validation/gates/check_swift_dist_repo_sync.sh
+
+git -C /tmp/ra-swift push origin main --follow-tags
+```
+
+The `--zips` dir must contain the verified (sha256-checked) release archives — `RACommons-ios-v$VERSION.zip`, `RABackend{LLAMACPP,MLX,NeuRT,ONNX,Sherpa}-ios-v$VERSION.zip`, `RunAnywhereMLX{Metal,Resources,Runtime}-ios-v$VERSION.zip` — downloaded and checked exactly per the general verification discipline, not re-used from an earlier, untrusted local copy.
+
+**The tag on `runanywhere-swift` is bare semver, no `v` prefix** (SwiftPM's `from:` needs that) — do not tag it `v$VERSION` by mistake; `sync-dist-repo.sh --tag` handles this correctly, but double check the pushed tag with `git -C /tmp/ra-swift tag --points-at HEAD` before walking away.
+
+This is enforced, not just documented: once `v$VERSION` is tagged on `runanywhere-sdks`, `check_swift_dist_repo_sync.sh` fails every future PR on the monorepo until `runanywhere-swift` carries the matching bare-semver tag — so don't let this lag behind the other registries.
+
+**GATE GAP — `check_swift_dist_repo_sync.sh` does NOT catch dependency drift, only checksum/version-string drift.** `runanywhere-swift`'s `Package.swift` is manually maintained end to end — `sync-dist-repo.sh` only ever touches `sdkVersion` and the binaryTarget checksums, never the `dependencies:` block (mlx-swift, mlx-swift-lm, mlx-audio-swift, swift-crypto, etc.). If root `runanywhere-sdks/Package.swift` bumps one of those (e.g. a new fork tag), a human has to remember to mirror it into the dist repo by hand, and nothing fails CI if they forget. This exact drift shipped once (2026-08-17): the dist repo pointed `mlx-swift-lm` at unforked `ml-explore/mlx-swift-lm` instead of the `RunanywhereAI` fork, silently breaking every iOS/macOS MLX consumer of that tag until caught by an actual build failure ~40 minutes later. Before trusting a freshly-cut dist-repo tag: diff every `.package(url:` line between root `Package.swift` and the dist repo's `Package.swift` (`grep -n '\.package(url:' Package.swift` on both sides), and actually build a real product that exercises the dependency you're worried about (e.g. `cd /tmp/ra-swift && swift build --product RunAnywhereMLX`) — don't rely on the sync gate alone. If you catch drift on a tag that's only minutes old with no evidence of external consumption, fixing it in place and force-moving the tag (`git tag -f $VERSION && git push origin $VERSION --force`) is the correct call, not a shortcut — a known-broken immutable tag helps no one.
+
+**If you force-move a tag, SwiftPM/Xcode consumers cache the OLD commit in several places — clearing just `Package.resolved` is not enough.** Verifying your own fix (or having a downstream consumer verify it) can silently keep failing even after the fix is correctly pushed, because: (1) any consumer repo's own tracked `*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` pins the exact old resolution and `xcodebuild -resolvePackageDependencies` respects it rather than re-resolving; (2) `~/Library/Caches/org.swift.swiftpm/repositories/<pkg>-<hash>/` is a global shared clone cache keyed by repo, oblivious to a moved tag; (3) `~/Library/org.swift.swiftpm/security/fingerprints/<pkg>-<hash>.json` records the fingerprint SwiftPM saw for that tag and can silently keep using it after a mismatch instead of failing loud. To actually re-resolve after moving a tag: delete the consumer's tracked `Package.resolved`, `rm -rf .build .swiftpm` and any `~/Library/Developer/Xcode/DerivedData/<Scheme>-*`, AND clear the matching entries under both global `org.swift.swiftpm` cache directories for every affected package identity — then resolve fresh.
+
+## 5. macOS rcli notarization
+
+CI (`native_rcli_macos` in `release.yml`) usually already produces a notarized, stapled artifact when Developer ID + notary secrets are configured in repo secrets. **Check the release assets first** before assuming you need to notarize anything yourself locally:
+
+```bash
+gh release view v$VERSION --json assets --jq '.assets[].name' | grep -iE 'rcli-macos|\.dmg'
+```
+Baseline expectation is `rcli-macos-arm64-v$VERSION.tar.gz` (+ `.sha256`); a `.dmg` only appears when `RCLI_MACOS_FULL_RELEASE=1` was set for that build (see below). If a plain tarball is already present and its contents pass the general verification discipline, there is usually nothing further to do here.
+
+**If you do need to notarize locally**, everything lives in `rcli/scripts/package-rcli.sh` (read its header comment — it documents its own contract in detail):
+
+- One-time setup, check before redoing: `xcrun notarytool history --keychain-profile runanywhere-notary` (confirmed configured on this machine — a fresh submission history returns without error). If missing: `xcrun notarytool store-credentials "runanywhere-notary" --apple-id <email> --team-id <team> --password <app-specific-password>`.
+- Codesign identity: `security find-identity -v -p codesigning | grep "Developer ID Application"` — confirmed present on this machine as `"Developer ID Application: RunAnywhere, Inc (<TEAM_ID>)"`. Grep for it fresh rather than hardcoding the team-id suffix, it can rotate.
+- Invocation contract (env vars, from the script header): `RCLI_CODESIGN_IDENTITY`, `RCLI_MACOS_NOTARIZE=1`, `RCLI_MACOS_FULL_RELEASE=1`, `RCLI_MACOS_SWIFT_BIN_DIR=<output of build-mlx-cli.sh>`. `RCLI_MACOS_FULL_RELEASE=1` is what additionally stages `mlx.metallib` and SwiftPM resource bundles and is what causes a notarized, stapled `.dmg` to be emitted alongside the Homebrew-style tarball. `RCLI_CODESIGN_KEYCHAIN` / `RCLI_NOTARYTOOL_KEYCHAIN` matter only if the identity/profile live in a non-default keychain.
+- Call shape: `rcli/scripts/package-rcli.sh <build-dir> macos-arm64` with the env vars above exported.
+
+## 6. Electron — build AND packaging are now in `release.yml`; publish is still manual
+
+**Reversing the earlier "deliberately separate" note**: as of `fix/electron-cicd-staging-url-npu-ane` (2026-08-21), the repo owner asked for Electron to produce ready-to-publish artifacts through the real release train like every other SDK, so `release.yml` now has `native_electron` (invokes `.github/workflows/electron-native-package.yml` as a reusable `workflow_call`) and `sdk_electron` (downloads its `electron-packaged-tarballs` artifact, runs `scripts/release/prepublish_check.py` on every tarball, checksums them, and splits public vs. QHexRT-private). `publish` hard-gates on `sdk_electron` succeeding. `@runanywhere/electron`, `-llamacpp`, `-onnx`, `-sherpa`, `-neurt` land as real, `.sha256`-sidecarred GitHub Release assets, same as the Web/RN npm tarballs. `@runanywhere/electron-qhexrt` still never becomes a public Release asset (policy below) — it's produced and packaged every release, but only reachable as the `sdk-electron-qhexrt-private` workflow artifact on that run, for a human to `npm publish` by hand. Electron is **not** WIP on a branch anymore: the old root `AGENTS.md` "Active issues" section describing `smonga/electron_upgrade` as in-progress is gone entirely as of this checkout — `bindings/electron/` is a fully merged, real SDK on `main`. Re-check that section is still absent before trusting this note.
+
+`.github/workflows/electron-native-package.yml` itself is unchanged in what it builds: every backend for real (llamacpp/onnx/sherpa/neurt on their real platforms, qhexrt on a self-hosted Windows ARM64 runner) with the real `STAGING_BASE_URL` baked in, gated by `check_plugin_natives.py` (which fails closed on the staging-URL placeholder — the exact bug that shipped through `0.20.24`). What's new is that it's also invocable via `workflow_call`, and that `native_win_x64_and_package` now tolerates a failed/skipped QHexRT lane (self-hosted, single machine) rather than losing the other five real packages to one runner's outage. **`release.yml` itself still does not `npm publish` anything** — it only produces artifacts (Release assets for the public five, a workflow artifact for QHexRT) — same "build automated, publish manual" shape as every other platform. See `thoughts/shared/plans/electron_cicd_staging_url_and_npu_ane_pipeline.md` for the full history.
+
+**PROVEN END TO END on v0.20.25 (2026-08-22)** — the first release where this actually ran. Final state: 65 release assets, all 5 public Electron tarballs present with `.sha256` sidecars, zero `qhexrt`-named assets. Verified by downloading the *published* tarballs and running the repo's own gate against them:
+
+```bash
+gh release download v<version> --repo RunanywhereAI/runanywhere-sdks -p 'runanywhere-electron*.tgz' -D /tmp/verify
+python3 scripts/validation/gates/check_plugin_natives.py --expect-version <version> \
+    $(for t in /tmp/verify/*.tgz; do printf -- '--tarball %s ' "$t"; done)
+# => All 20 check(s) passed: plugin natives are routable and no staging-URL placeholder was found.
+```
+
+That single command asserts all three things you actually care about, per binary: the real `STAGING_BASE_URL` is baked in (no `YOUR_STAGING_BASE_URL`), `rac_commons` embeds the right version, and every backend is genuinely **routable** (`g_llamacpp_ops`, `g_sherpa_stt_ops`, `g_neurt_llm_ops`, `g_onnx_embeddings_ops`, …) rather than a same-sized shell. **Run it before every Electron `npm publish`** — it is the cheapest defense against exactly the class of defect that shipped `electron-sherpa` 0.20.17's NULL-vtable carrier. Expected shipped layout: entry package = `darwin-arm64` + `win32-x64` + `win32-arm64`; llamacpp/onnx/sherpa = `darwin-arm64` + `win32-x64`; neurt = `darwin-arm64` only; qhexrt = `win32-arm64` only.
+
+Where to get the QHexRT tarball for its manual publish (it is deliberately NOT a release asset):
+
+```bash
+gh run download <release-run-id> --repo RunanywhereAI/runanywhere-sdks \
+    --name sdk-electron-qhexrt-private --dir /tmp/qhexrt
+```
+
+If asked to actually publish an Electron package (still a real, separate, manual step — this skill's general discipline in §0/§General verification still applies in full):
+- Involve the Windows box for real Windows-native verification before publishing anything Windows-targeted. The team keeps a **Windows ARM64 machine reachable over SSH**; its hostname, user, key, and mesh-VPN node name are operator-specific and deliberately not recorded in this repo — read the Windows/ARM64 host entry out of the operator's `~/.ssh/config` and use that alias. If there is no such entry, the box is not configured for you: say so and ask, rather than guessing at a hostname. Check reachability **first** by asking the mesh-VPN client whether the node is up (e.g. `tailscale status`, matching on the host entry's `HostName`) — if it reports `offline, last seen ...`, the box is asleep, which is not a configuration problem: ask the human to wake it, do not debug it as broken. Only then `ssh -o ConnectTimeout=8 "$WIN_BOX" "whoami"`. That same machine is **also** registered as a GitHub Actions self-hosted runner (labels `[self-hosted, Windows, ARM64, qhexrt]`) running as a Windows service — a queued `native_win_arm64_qhexrt` job on it means the machine is busy; check `gh api repos/RunanywhereAI/runanywhere-sdks/actions/runners` for the matching runner's `busy`/`status` before assuming it's free for manual SSH work, and vice versa.
+- **`@runanywhere/electron-qhexrt` being public on npm is a CONFIRMED, settled policy decision** (repo owner, 2026-08-20) — it contains real Hexagon NPU binaries (`libQnnHtpV81Skel.so`, `QnnHtp*.dll`, `rac_commons.dll`, `runanywhere_qhexrt.dll`) on purpose. The QHexRT-stays-private policy enforced everywhere else in this skill is specifically about the **GitHub-Release-side** asset set (Android etc.), a different channel — not a contradiction. Stop treating this as an unresolved item to flag; only re-raise it if you find evidence the policy changed.
+
+## 7. Final sanity pass
+
+After every registry is done, re-view each package's public listing/API and compare against the previous version — a big unexplained drop in file count or package size is a red flag to investigate before calling the release fully published:
+
+```bash
+# npm
+for p in proto-ts web web-llamacpp web-onnx core llamacpp mlx onnx; do
+  npm pack @runanywhere/$p@$VERSION --dry-run 2>&1 | tail -5
+done
+
+# Maven — check module metadata / POM sizes are non-trivial, not near-empty
+for a in runanywhere-sdk runanywhere-llamacpp runanywhere-onnx; do
+  curl -s -o /dev/null -w "%{size_download} bytes  $a\n" \
+    "https://repo1.maven.org/maven2/io/github/sanchitmonga22/$a/$VERSION/$a-$VERSION.aar"
+done
+
+# pub.dev
+for p in runanywhere runanywhere_llamacpp runanywhere_onnx runanywhere_mlx; do
+  curl -s "https://pub.dev/api/packages/$p" | python3 -c "import json,sys;d=json.load(sys.stdin);print('$p', d['latest']['version'])"
+done
+```
+
+Only after this pass — every registry shows `$VERSION`, every artifact's contents check out, and nothing regressed in size/file-count versus the previous release — is the release fully published. Do not skip this step just because each individual publish call reported success; a successful upload is not the same claim as "the right bytes are now live."

--- a/.agents/skills/sdk-release/SKILL.md
+++ b/.agents/skills/sdk-release/SKILL.md
@@ -1,0 +1,1048 @@
+---
+name: sdk-release
+description: Cut a new RunAnywhere SDK release end-to-end in RunanywhereAI/runanywhere-sdks — version bump through a fully green, tagged, drafted-then-published GitHub Release. Stops BEFORE publishing to package registries (npm/Maven/pub.dev/SwiftPM dist) — that is the separate "sdk-publish" skill, invoked as the last step here.
+---
+
+# SDK Release (runanywhere-sdks)
+
+Repo: `~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks` (verify with `pwd`/`ls` —
+this is a workspace subfolder, not the repo root of the whole Qualcomm/ tree, and paths
+drift; re-check script paths below still exist before trusting them blindly).
+
+This is a **runbook**, not a description. Follow the steps in order. Every `gh`/`git`
+command below is meant to be run close to verbatim — adjust only the version/PR/run-id
+values for the release you're actually cutting.
+
+**THIS SKILL HAS BEEN SKIPPED THREE TIMES IN A ROW (v0.20.29, v0.20.30, v0.20.31),
+producing the IDENTICAL failure each time, DESPITE step 2/3 below documenting the exact
+fix since the v0.20.25/v0.20.29 incidents.** All three times, an agent ran
+`sync-versions.sh`, opened the PR, merged it, and pushed the tag directly — skipping the
+"dispatch a release candidate BEFORE merging, sync checksums from it, THEN merge" sequence
+in steps 2-3 — usually because the version bump was one step inside a longer autonomous
+chain (a downstream repo re-pin, a multi-repo release cascade) and felt like "just a
+version bump," not a release. **A version bump to `core/VERSION` IS a release. If you are
+about to run `scripts/release/sync-versions.sh` for ANY reason — including re-pinning this
+repo as a step in some OTHER repo's release — stop and follow this skill from step 1,
+including the candidate dispatch. Do not improvise the sequence from memory even if you
+did it correctly last time; do not skip it because "this bump is small" or "we're in a
+hurry."** v0.20.31 additionally caught a second, previously-undetected instance of the
+same class of bug in the SAME commit: `RunAnywhereMLXRuntime` in the Flutter podspec (which
+`RAC_CHECKSUM_SKIP` exempts from CI verification, so it fails silently for a consumer
+instead of failing `publish`) was ALSO stale, and had to be independently re-verified
+against the same candidate build — see step 3's checksum-location table; check every row
+in it, not just the one CI complained about.
+
+Companion skill: **sdk-publish** — invoke it at the very end (step 10) for the actual
+npm / Maven / pub.dev / SwiftPM-distribution publishing. This skill's job stops at a
+published (non-draft) GitHub Release with correct assets.
+
+---
+
+## 0. Orientation facts (confirm these still hold before relying on them)
+
+- Canonical version file: `core/VERSION` (single line, e.g. `0.20.24`). `core/VERSIONS`
+  also carries a `PROJECT_VERSION=` line that must agree — `sync-versions.sh` updates
+  both, `auto-tag.yml` reads `core/VERSIONS`, `check_release_version_coherence.sh` reads
+  `core/VERSION`. Don't hand-edit either; always go through the script.
+- `scripts/release/sync-versions.sh <version>` — bumps ~20 files (Package.swift,
+  gradle.properties, all package.json/pubspec.yaml, Kotlin/Swift/TS version constants,
+  AGENTS.md). Accepts a leading `v` and strips it.
+- `scripts/validation/gates/check_release_version_coherence.sh` — the gate that enforces
+  "PR changing VERSION must carry exactly one `release:patch|minor|major` label, and the
+  new version must be exactly base+1 for that bump type." Reads `PR_BASE_SHA` and
+  `PR_RELEASE_LABELS_JSON` env vars when run under CI; locally it only checks the
+  canonical-version-format part.
+- `.github/workflows/pr-build.yml` job **`centralization`** is what actually runs the
+  coherence gate in CI (`Release-train version coherence` step), alongside
+  `check_typescript_centralization.sh`, `check_flutter_centralization.sh`,
+  `check_gradle_centralization.sh`, `check_wasm_provenance_contract.sh`,
+  `check_swift_dist_repo_sync.sh`, `check_agents_claude_sync.sh`,
+  `check_no_hardcoded_defaults.sh`. This job's trigger types are
+  `[opened, synchronize, reopened, labeled, unlabeled]` — **adding the release label
+  after opening the PR fires a fresh run**, which is how the gate clears without a new
+  commit (see step 1).
+- `.github/workflows/release.yml` — the build/package/draft-release workflow. Triggers:
+  tag push `v*.*.*` OR `workflow_dispatch` (works on **any branch**, not just tags) with
+  inputs `version` (required), `validate_external_starters` (bool, default false),
+  `publish_from_run_id` (optional), `reuse_native_web_run_id` (optional).
+- `.github/workflows/auto-tag.yml` — fires on `pull_request: closed` to `main` when the
+  merged PR carries a `release:*` label. Verifies the version bump matches the label,
+  pushes the `v<version>` tag, and **explicitly dispatches a fresh `release.yml` run at
+  that tag** (plain `git push` of a tag with `GITHUB_TOKEN` does not auto-trigger
+  workflows, so it calls `gh workflow run release.yml --ref v<version> -f version=<version>`
+  itself). This is the redundant rebuild you must cancel — see step 7.
+- Branch protection on `main`: check
+  `gh api repos/RunanywhereAI/runanywhere-sdks/branches/main/protection` — 2 approvals +
+  code owner review required, but look for a `bypass_pull_request_allowances` (users/teams/apps)
+  list. If your `gh api user --jq .login` is on that list, `gh pr merge --squash --admin`
+  is a legitimate, pre-configured bypass — not a hack. If not on the list, stop and ask a
+  human to approve/merge.
+- Never let any `qhexrt`-named asset reach the public asset set. `release.yml`'s own
+  manifest-assertion step (`find release-flat -maxdepth 1 -type f -iname '*qhexrt*'`)
+  hard-fails the run if one is found — this is enforced, not just policy.
+- **Electron IS part of `release.yml` now** (as of `fix/electron-cicd-staging-url-npu-ane`,
+  2026-08-21) — this reverses the prior "deliberately separate" policy noted below by an
+  earlier pass; the repo owner explicitly asked for Electron to produce ready-to-publish
+  artifacts through the real release train like every other SDK. `native_electron`
+  invokes `.github/workflows/electron-native-package.yml` as a **reusable workflow**
+  (`workflow_call`) rather than duplicating its ~400 lines of hard-won native-build logic
+  inline; `sdk_electron` downloads the resulting `electron-packaged-tarballs` artifact,
+  runs `scripts/release/prepublish_check.py` on every tarball, computes checksums, and
+  splits public vs. QHexRT-private before anything reaches `release-flat`. `publish`
+  hard-gates on `sdk_electron` succeeding (same tier as `sdk_kotlin`/`sdk_web`/
+  `sdk_react_native`) but treats `native_electron`'s own result as advisory, because that
+  job's result folds in `native_win_arm64_qhexrt` — a single, personally-owned
+  self-hosted NPU runner whose outage should cost only `@runanywhere/electron-qhexrt`
+  for that release, not the whole SDK train (`native_win_x64_and_package`, the job that
+  actually produces the tarballs, tolerates a failed/skipped QHexRT lane and still packages
+  the other five real artifacts). Like every other SDK here, this still does **not**
+  `npm publish` anything — it only produces the tarballs as GitHub Release assets
+  (public ones) / a workflow artifact (the private QHexRT one) for a human to publish by
+  hand, matching the "build automated, publish manual" shape everywhere else.
+  **Electron is no longer WIP on a branch** — the old root `AGENTS.md`/`CLAUDE.md`
+  "Active issues" section describing `smonga/electron_upgrade` as in-progress is gone
+  entirely as of this checkout; `bindings/electron/` is a fully merged, real SDK on
+  `main` with its own `AGENTS.md`. Re-check that section is still absent before trusting
+  this note — if it has reappeared, something regressed.
+  See `thoughts/shared/plans/electron_cicd_staging_url_and_npu_ane_pipeline.md` for the
+  full history (this pipeline shipped the placeholder-URL bug three times before
+  `electron-native-package.yml` existed).
+  **QHexRT public/private boundary — CONFIRMED POLICY, not an open flag**: the repo
+  owner explicitly confirmed (2026-08-20) that `@runanywhere/electron-qhexrt` stays
+  public on npm intentionally (it already is, and is a real, working precedent worth
+  studying before touching QHexRT packaging elsewhere) — the QHexRT-stays-private
+  policy enforced everywhere else in this pipeline is specifically about the
+  **GitHub-Release-side** asset set (e.g. Android), a different distribution channel.
+  This is settled; stop re-flagging it as an unresolved contradiction. Only re-raise it
+  if you find evidence the policy has changed.
+
+---
+
+## 0b. NeuRT is a PINNED PREBUILT now — check this before anything else
+
+`native_ios` no longer compiles the private `neurun` repo. It downloads archives that
+repo publishes, pinned by tag + SHA-256 in `core/VERSIONS`, the same shape as sherpa-onnx:
+
+```
+NEURUN_REPO=RunanywhereAI/neurun      # shared: one repo publishes BOTH engines
+NEURT_RELEASE_TAG=v<version>          # per-engine: a release may carry one lane only
+NEURT_RAC_ABI_VERSION=9
+NEURT_MACOS_ARM64_SHA256=…
+NEURT_IOS_ARM64_SHA256=…
+NEURT_IOS_ARM64_SIMULATOR_SHA256=…
+```
+
+`NEURUN_REPO` is shared because one neurun release carries both engines. The **tags stay
+per-engine** on purpose: that repo can cut a release for one lane only, so a given tag may
+carry just one engine's assets.
+
+**Run the gate after re-pinning** — it verifies the pins against the release itself, so a
+mistyped or locally-computed value fails there instead of mid-build:
+
+```bash
+NEURUN_TOKEN="$(gh auth token)" bash scripts/validation/gates/check_engine_prebuilt_pins.sh
+```
+
+### Local engine development — there is no source mode
+
+The engine has no `NEURT_ROOT` path any more; nothing here compiles engine source. To iterate
+on NeuRT, build a slice in the neurun checkout and point the engine at it — no release, no
+tag, no pin edit:
+
+```bash
+# in neurun
+NeuRT/tools/scripts/package-rac-dist.sh --sdk-root <this repo> --version 0.0.0-dev \
+    --slice macos-arm64 --out /tmp/devdist
+mkdir -p /tmp/devslice && tar -xzf /tmp/devdist/neurt-macos-arm64-v0.0.0-dev.tar.gz \
+    -C /tmp/devslice --strip-components=1
+
+# here
+NEURT_PREBUILT_ROOT=/tmp/devslice cmake -S . -B build/dev -G Ninja \
+    -DRAC_BUILD_BACKENDS=ON -DRAC_BACKEND_NEURT=ON -DRAC_RUNTIME_COREML=ON
+# expect: Mode: PREBUILT (macos-arm64, ABI 9)
+```
+
+`NEURT_PREBUILT_ROOT` is a **single-slice** root, which is why
+`build-core-xcframework.sh` deliberately ignores it: packaging needs all three slices, so
+honouring a single-slice override there would let one staged slice satisfy the guard and
+silently package two non-routable stubs. Use an obviously-not-a-release version like
+`0.0.0-dev` so a dev slice can never be mistaken for a published one.
+
+**Why this changed, and why it matters to you specifically.** `engines/neurt/CMakeLists.txt`
+used to resolve a `NEURT_ROOT` checkout of that private repo and **regex-parse its root
+`CMakeLists.txt`** for a source list. Under that arrangement, commons widened
+`rac_llm_stream_callback_fn` with `tokens_in_delta`, the pinned neurun commit still passed
+4 arguments, and `native_ios` died with *"too few arguments to function call, expected 5,
+have 4"* on **v0.20.15, v0.20.16 and v0.20.17**. Every packaging job needs `native_ios`,
+so all three shipped **iOS-only — 18 assets where a healthy release has 55+**. That is the
+single most expensive failure this runbook exists to prevent, and it came from this seam.
+
+**Before opening the release PR**, confirm the pin is current:
+
+```bash
+grep -A5 '^NEURT_REPO' core/VERSIONS
+gh release view "$(grep '^NEURT_RELEASE_TAG=' core/VERSIONS | cut -d= -f2)" \
+    --repo RunanywhereAI/neurun --json assets --jq '.assets[].name'
+```
+
+Expect six assets — three `neurt-<slice>-v<version>.tar.gz` plus their `.sha256` sidecars.
+
+**If the plugin ABI changed this cycle** (`RAC_PLUGIN_API_VERSION` in
+`core/include/rac/plugin/rac_plugin_entry.h`), the pinned archives are invalid and
+`native_ios` will fail at the download step. Cut a neurun release first — that repo's
+`release_sdk_archives` skill is the runbook — then re-pin both `NEURT_RELEASE_TAG` and
+`NEURT_RAC_ABI_VERSION` here. The downloader refuses to run if `NEURT_RAC_ABI_VERSION`
+disagrees with the header, so this cannot be half-done.
+
+Prove it locally before trusting a tag build:
+
+```bash
+NEURUN_TOKEN="$(gh auth token)" bash scripts/build/download-neurt.sh --all
+```
+
+That verifies each tarball's SHA-256 **and** that its `RECEIPT.json` names the same ABI
+version this repo defines. Then check configure prints `Mode: PREBUILT (<slice>, ABI N)`.
+`SOURCE` means a local neurun checkout was picked up (prebuilt is meant to win, so the
+download did not land); `SHELL` means the engine is **not routable** and a release built
+now would ship an engine that registers, claims Apple availability and serves nothing.
+
+`release.yml` treats the downloader's exit **3** ("no token — degrade to the shell") as
+**fatal**. That degrade is right for a fork PR and catastrophic for a release.
+
+### The complete engine matrix — who consumes what, and how
+
+There are only **three fetch points in the entire repo**. Everything else consumes an
+sdks artifact, which is why a single fetch fix can repair five SDKs at once — and why a
+single missing fetch can silently break several.
+
+```
+neurun release (private)
+  ├─ native_ios         ──NeuRT x3 slices──►  RABackendNeuRT.xcframework
+  │                                              ├─ Swift  (Package.swift binary target)
+  │                                              ├─ Flutter / React Native (co-vendored
+  │                                              │   in the onnx package's podspec)
+  │                                              └─ rcli-macos (stages it, then GREPS
+  │                                                  `backends --json` for neurt)
+  ├─ native_android     ──QHexRT arm64-v8a──►  one build stages jniLibs into
+  │                                              Kotlin + React Native + Flutter
+  └─ electron           ──NeuRT macos-arm64 AND QHexRT win-arm64──►  its own natives
+```
+
+| target | NeuRT | QHexRT | note |
+|---|---|---|---|
+| Swift (iOS/macOS) | ✅ xcframework | — | NeuRT is Apple-only |
+| Flutter / React Native (Apple) | ✅ xcframework | — | co-vendored in the onnx package |
+| Flutter / React Native (Android) | — | ✅ jniLibs | from the same Android build as Kotlin |
+| Kotlin (Android) | — | ✅ jniLibs | arm64-v8a only; the only ABI with a Hexagon NPU |
+| Electron macOS | ✅ fetches | — | builds its own natives |
+| Electron win-arm64 | — | ✅ fetches | |
+| rcli macOS | ✅ xcframework | — | **best check in the tree** (below) |
+| rcli linux / windows-x64 | — | — | correct: NeuRT is Apple-only, QHexRT is win-arm64 |
+
+**`rcli-macos` is the strongest verification that exists here.** It greps
+`backends --json` for `"name":"neurt"` — and a non-routable shell *refuses
+registration*, so that grep proves the engine is **routable**, not merely present. Copy
+this pattern when adding an engine rather than checking for a file on disk.
+
+**Two silent-failure traps this matrix exists to prevent:**
+
+- **`RAC_BACKEND_<X>=ON` does not mean the engine works.** Without a payload the engine
+  builds as a non-routable shell and registration is refused — no build error. Android
+  shipped that way for months, and `rcli-macos-release` still sets
+  `RAC_BACKEND_NEURT: ON` regardless of whether a payload was fetched.
+- **`copy_if_exists` in `build-core-android.sh` silently no-ops** when a lib was never
+  built. That is the same guarded-copy pattern that shipped Windows with zero engines for
+  several releases. The release now asserts `librunanywhere_qhexrt.so` is really inside
+  the arm64-v8a archive.
+
+`scripts/validation/gates/check_engine_prebuilt_pins.sh` asserts all of the above plus
+the pins, the ABI, header drift against the receipt, and (with a token) the release
+contents. Run it before cutting a release; it is also wired into `pr-build` offline.
+
+### QHexRT is pinned the same way — check it too
+
+The Hexagon-NPU engine crosses the identical boundary, published by the same neurun release:
+
+```
+QHEXRT_RELEASE_TAG=v<version>
+QHEXRT_ARM64_V8A_SHA256=…      QHEXRT_ARM64_V8A_RECEIPT=…
+QHEXRT_WIN_ARM64_SHA256=…      QHEXRT_WIN_ARM64_RECEIPT=…
+```
+
+Two pins per ABI, not one: the tarball checksum **and** the payload's own build-receipt
+hash. The receipt is the directory name under `engines/qhexrt/prebuilt/versions/`, so
+pinning it is what makes the pin describe the bytes rather than trusting the archive's
+own claim about itself.
+
+```bash
+NEURUN_TOKEN="$(gh auth token)" bash scripts/build/download-qhexrt.sh --abi arm64-v8a
+NEURUN_TOKEN="$(gh auth token)" bash scripts/build/download-qhexrt.sh --abi win-arm64
+```
+
+**`current` selects ONE ABI at a time.** Both payloads can sit in `versions/` together, but
+a build targets one platform — so re-run the downloader when switching between an Android
+and a Windows build. The downloader ends by running `validate-qhexrt-prebuilt.py` itself,
+so a bad payload fails at the pin rather than mid-build.
+
+**The QHexRT lane in neurun is deliberately non-blocking.** It runs on a single
+self-hosted Snapdragon box (QAIRT is licence-gated and exists on no hosted runner). If
+that machine is offline, neurun's release publishes the Apple artifacts and **warns** that
+no QHexRT payload was produced — and the SDK simply keeps its previously pinned prebuilt.
+That is correct behaviour, not a failure: do not block an SDK release on it. Only treat it
+as blocking if this release is specifically meant to ship new NPU kernels.
+
+**Do not hand-stage `engines/qhexrt/prebuilt/`.** That was the old flow, and it is how the
+Electron win-arm64 lane once pinned a receipt staged months earlier and silently shipped
+NPU kernels from an old commit. If the tree looks stale, re-pin and re-download; never
+copy a payload in by hand.
+
+---
+
+## 1. Decide the version and open the release PR
+
+Check for an already-open release PR first — don't duplicate work:
+
+```bash
+gh pr list --repo RunanywhereAI/runanywhere-sdks --label release:patch --label release:minor
+```
+
+(gh ORs multiple `--label` flags into a single AND-filtered query per invocation is not
+guaranteed across all gh versions — if unsure, run the two label queries separately:
+`--label release:patch` then `--label release:minor`, plus `--label release:major`.)
+
+Pick a patch/minor/major bump based on the changes since the last tag. Then:
+
+```bash
+git checkout -b release/v<version>
+./scripts/release/sync-versions.sh <version>      # e.g. 0.20.25 (no 'v' needed, either works)
+bash scripts/validation/gates/check_release_version_coherence.sh
+```
+
+The coherence script may point out generated locks/changelogs that need regenerating
+(e.g. package-lock.json version bumps it expects but didn't find, or a missing CHANGELOG
+heading for the new version). Fix everything it flags, and add **explicit, human-written
+changelog entries** — the gate requires a heading for the new version to exist; it does
+not write prose for you.
+
+Open the PR and **apply exactly one `release:patch` or `release:minor` (or `release:major`)
+label** — this is required, not optional. Two failure modes to know:
+
+- If you forget the label and push a commit later, the `centralization` job's
+  `Release-train version coherence` step fails.
+- **Adding the label after the PR is already open does NOT get picked up by the run that
+  already executed.** Because `pr-build.yml`'s `centralization` job triggers on
+  `labeled`/`unlabeled` PR events, applying the label fires a **new** run of the whole
+  job — that new run is what goes green. Don't push an empty commit to "retrigger" it;
+  just add/re-add the label (or use `gh pr edit <pr> --add-label release:patch`, and if it
+  was already present, remove + re-add to force the event).
+
+---
+
+## 2. Get REAL native-artifact checksums BEFORE merging — dispatch a release candidate
+
+Do not merge on faith that native builds will succeed. `release.yml`'s
+`workflow_dispatch` trigger works on **any branch**, including your unmerged release
+branch — use it to build a full release candidate first:
+
+```bash
+gh workflow run release.yml --ref release/v<version> -f version=<version>
+```
+
+Get the run id and watch it:
+
+```bash
+gh run list --repo RunanywhereAI/runanywhere-sdks --workflow=release.yml --limit 5
+```
+
+**Do not block synchronously waiting on it.** Load the `Monitor` tool (or a background
+poll loop) to watch for completion/failure, and keep doing other release prep (changelog
+review, CodeRabbit thread triage, branch-protection check) in the meantime. Keep
+notifications to real state changes only — don't ping on every intermediate job
+completing, only on the run's overall failure or full completion.
+
+### REAL job durations — measured, not guessed. NEVER cancel a job for being "slow".
+
+Measured on the 0.20.25 train (2026-08-21/22). A release train legitimately takes
+**4-5 hours** wall-clock when `native_web` has to build.
+
+| Job | Real duration | Notes |
+|---|---|---|
+| **`native_web`** (release.yml) | **~3h51m** | The long pole, by far. Its `Vendor ONNX Runtime and Sherpa-ONNX WASM archives` step alone is **~71 minutes** — it BUILDS onnxruntime + sherpa to WASM from source; it is not a git clone. Then 4 more WASM builds: CPU core+llamacpp+onnx ~89m, WebGPU llamacpp ~37m, WebGPU onnx+sherpa ~33m. |
+| `native_ios` | ~60-75 min | XCFrameworks + MLX. No longer compiles neurun — it downloads the pinned NeuRT archives (see §0b), which is seconds, not minutes. |
+| `swift-spm` (pr-build) | **69-85 min** | `Build XCFramework` step is most of it. Measured across 6 consecutive `main` runs (2026-08-21/22): 69, 78, 75, 85, 77, 69. A run sitting at ~78 minutes is **healthy**, not hung — check this row before reaching for cancel. |
+| `kotlin-android` (pr-build) | ~40 min | |
+| `python-windows` (pr-build) | ~40 min | |
+| `electron (windows-2022)` (electron-sdk-ci) | ~40 min | |
+| `rcli-windows` | ~30 min | |
+| `native_electron / native_win_arm64_qhexrt` | ~28 min | Self-hosted; may sit **queued** for a long time first if the single runner is busy. Queued ≠ hung. |
+| `native_electron / native_win_x64_and_package` | ~35-45 min | |
+| `wasm` (pr-build) | ~12 min | **Do NOT use this as a proxy for `native_web`.** Totally different scope. |
+
+**The mistake this table exists to prevent**: `pr-build.yml`'s `wasm` job takes ~12
+minutes, so a ~50-minute `native_web` "vendor" step looks hung. It is not. On the 0.20.25
+train this misread caused two healthy `native_web` jobs to be cancelled at 2h19m and
+~55m, wasting ~3 hours and two full candidate builds. Before concluding "hung", check
+step-level progress and compare against THIS table:
+
+```bash
+gh run view <run-id> --repo RunanywhereAI/runanywhere-sdks --json jobs \
+    --jq '.jobs[] | select(.name=="native_web") | {startedAt, steps: [.steps[] | select(.status=="in_progress") | .name]}'
+```
+
+### `reuse_native_web_run_id` is the correct way to avoid re-paying that ~4 hours
+
+If a run needs redoing and **nothing under `bindings/web/wasm/`, `engines/`, or `core/`
+changed** since a run whose `native_web` succeeded, reuse it instead of rebuilding:
+
+```bash
+git diff --stat <good-run-sha> <current-sha>      # prove the scope first
+gh workflow run release.yml --ref release/<version> \
+    -f version=<version> -f reuse_native_web_run_id=<good-run-id>
+```
+
+`native_web` then shows `skipped`, and `sdk_web` + `validate_consumer_web` still run and
+pass against the reused artifact — which is also your proof the reuse was valid. Track the
+run id that **originally built** it: that is the id you keep citing (see the chaining note
+in step 7).
+
+---
+
+## 3. Sync checksums once native_ios finishes
+
+Pre-tag, `gh release download` will not work (there is no release yet) — pull the run's
+artifact directly:
+
+```bash
+gh run download <candidate-run-id> --repo RunanywhereAI/runanywhere-sdks \
+    --name native-ios-macos --dir release-artifacts/native-ios-macos
+```
+
+Verify every `.zip` against its `.sha256` sidecar **yourself** before trusting it:
+
+```bash
+cd release-artifacts/native-ios-macos
+for f in *.zip; do shasum -a 256 -c "${f}.sha256" || echo "MISMATCH: $f"; done
+cd -
+```
+
+Then sync:
+
+```bash
+bindings/swift/scripts/sync-checksums.sh release-artifacts/native-ios-macos
+```
+
+**KNOWN FACT — do not treat this as a bug**: `RunAnywhereMLXRuntime` (and occasionally
+`RACommons`) are **not byte-reproducible** between rebuilds of identical source. Expect
+their checksums to differ from any prior candidate build every single time you rebuild,
+even with zero source changes. Only investigate if a checksum for a framework that
+historically IS reproducible (e.g. plain XCFrameworks with no Swift codegen step)
+suddenly changes.
+
+**Where each checksum actually lives — these are NOT all in one file:**
+
+| Manifest | Carries |
+|---|---|
+| root `Package.swift` | `RACommons` + the 5 backend XCFrameworks (6 checksums total) |
+| nested Flutter `Package.swift` (under `bindings/flutter/`) | same 6 |
+| `bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec` → `mlx_checksums` hash | `RunAnywhereMLXRuntime`, `RunAnywhereMLXMetal`, `RunAnywhereMLXResources` — **only here**, nowhere else |
+
+After `sync-checksums.sh` runs, verify centralization didn't drift and re-run the version
+coherence gate locally:
+
+```bash
+bash scripts/validation/gates/check_flutter_centralization.sh
+bash scripts/validation/gates/check_release_version_coherence.sh
+```
+
+Commit and push the checksum-sync commit to the release branch:
+
+```bash
+git add Package.swift bindings/flutter/Package.swift \
+    bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
+git commit -m "release: sync v<version> checksums from candidate run <candidate-run-id>"
+git push
+```
+
+### THIS STEP IS NOT OPTIONAL — skipping it fails `publish` after the tag already exists
+
+**What happens if you skip it** (observed on the 0.20.25 train): every build and package
+job goes green, `publish` gets all the way past flatten and the asset-manifest assertion,
+then dies at **`Verify built Apple checksums match tagged package contracts`**:
+
+```
+mismatch: RACommonsBinary
+  Package.swift: 0609dae6...      release zip: 1ae55ae4...
+mismatch: RABackendLlamaCPPBinary
+  Package.swift: 0597442f...      release zip: 7062f7c8...
+>> Done. 8 processed, 0 missing, 4 failed.
+ERROR: built Swift archives do not match the immutable tagged manifest
+```
+
+Note `8 processed / 4 failed` is really **2 distinct archives counted twice** (root
+manifest + Flutter manifest each). On that train `RACommons` and `RABackendLLAMACPP`
+drifted while ONNX/Sherpa/NeuRT/MLX/MLXMetal/MLXResources all matched — so "6 of 8 passed"
+is a normal-looking partial failure, not evidence of something exotic.
+
+**Recovery once the tag already exists** (this is safe and was done on 0.20.25):
+
+1. Confirm nothing was actually published — a failed `publish` dies *before* creating the
+   release, so there is usually nothing to undo:
+   ```bash
+   gh release view v<version> --repo RunanywhereAI/runanywhere-sdks   # expect "release not found"
+   ```
+2. Download the **exact artifacts the release will publish** (the candidate run named in
+   `publish_from_run_id`), verify each against its sidecar, and sync on a branch off `main`.
+3. Merge that branch, then **re-point the tag** at the new commit. `git push origin --delete`
+   can hang on flaky networks; the API is more reliable:
+   ```bash
+   gh api -X DELETE repos/RunanywhereAI/runanywhere-sdks/git/refs/tags/v<version>
+   gh api -X POST   repos/RunanywhereAI/runanywhere-sdks/git/refs \
+       -f ref="refs/tags/v<version>" -f sha="<new-main-sha>"
+   ```
+   Only do this while **no release exists and nothing has been published**. If a release
+   was already published, do NOT move the tag — cut the next patch version instead.
+4. **Creating a tag via the API DOES trigger `release.yml`'s `push` trigger** (unlike a
+   `GITHUB_TOKEN` git-push of a tag, which does not). So immediately after re-tagging you
+   will have TWO runs: a full rebuild from the `push` event, and your own
+   `workflow_dispatch`. Identify by event and cancel the `push` one:
+   ```bash
+   gh run list --repo RunanywhereAI/runanywhere-sdks --workflow=release.yml --limit 3 \
+       --json databaseId,event,headBranch --jq '.[] | "\(.databaseId) \(.event) \(.headBranch)"'
+   gh api -X POST repos/RunanywhereAI/runanywhere-sdks/actions/runs/<push-run-id>/cancel
+   ```
+
+Cheapest prevention: run `sync-checksums.sh --check <zip_dir>` against the candidate's
+artifacts and require **`N processed, 0 missing, 0 failed`** before you merge the release
+PR at all.
+
+**Recurred on v0.20.30 and again on v0.20.31** — same `mismatch: RACommonsBinary` /
+`mismatch: RACommons` failure, same root cause (step 2's candidate dispatch skipped
+entirely both times), fixed the same way both times: compute the real checksum from the
+already-built release-artifact zip (`gh run download <failed-run-id> --name
+native-ios-macos`), commit it on a fix branch, merge, then move the tag (§10d) to
+re-trigger `release.yml`. On v0.20.31 this ALSO surfaced the `RunAnywhereMLXRuntime`
+podspec entry as independently stale — `RAC_CHECKSUM_SKIP` means `publish` never checks
+it, so it would have shipped broken to Flutter consumers silently. **When fixing this
+failure after the fact, check every row of the checksum-location table in step 3, not
+only the archive named in the CI error** — the ones `RAC_CHECKSUM_SKIP` exempts are
+exactly the ones that won't tell you.
+
+---
+
+## 4. Watch for the "package intentionally doesn't bundle a sibling dep" bug class
+
+This exact release hit a real bug in `bindings/web/scripts/package-sdk.sh`:
+`@runanywhere/web-onnx` deliberately does **not** bundle its own `proto-ts` copy (only
+`core`/`llamacpp` do — enforced by `bindings/web/scripts/validate_public_packages.py` and
+mirrored in `bindings/react-native/scripts/validate_public_packages.py`), but the
+packaging script's install-smoke-test (`verify_candidate_install`, around line 165 of
+`package-sdk.sh`) never supplied a resolution target for that unbundled dependency, so
+`npm install` reached out to the real npm registry for a not-yet-published version and
+failed with `ETARGET`.
+
+Fix pattern (already applied, keep it this way): the `onnx` call to
+`verify_candidate_install` passes the just-built local `proto-ts` tarball
+(`$PROTO_ARCHIVE`, built via `npm pack ../proto-ts`) as an explicit extra install arg —
+see lines ~209-233 of `bindings/web/scripts/package-sdk.sh`, where `core` and `llamacpp`
+calls omit it (they bundle proto-ts themselves) but `onnx`'s call appends `"$PROTO_ARCHIVE"`.
+
+**Generalize this as a standing check for every release**: grep for the asymmetric
+bundling flags before trusting any packaging script —
+
+```bash
+grep -n "expects_bundled_proto\|--bundle" \
+    bindings/web/scripts/package-sdk.sh bindings/react-native/scripts/package-sdk.sh
+```
+
+Whenever a package intentionally does NOT bundle a sibling first-party dependency, its
+local pre-publish verification step must supply that dependency some other way (a local
+tarball) — the real registry version genuinely does not exist yet at candidate-build
+time, and letting `npm`/`yarn` hit the real registry will `ETARGET`.
+
+**Before trusting any packaging script is bug-free, actually run it** against the real
+downloaded native artifacts and check the exit code — do not just read the code and
+assume it's fine:
+
+```bash
+cd bindings/web && ./scripts/package-sdk.sh   # then check $?
+cd bindings/react-native && ./scripts/package-sdk.sh
+```
+
+### 4b. The two Electron-specific release bugs (both fixed — know the shapes)
+
+The 0.20.25 train was the **first** release to run Electron packaging inside `release.yml`,
+and it surfaced two defects that no local test or green PR check could have caught. Both
+are fixed; recognize the shapes because they generalize.
+
+**(1) `sync-versions.sh` has a hardcoded package list, and new packages get missed.**
+`bindings/electron/packages/neurt/package.json` sat at the previous version while every
+sibling moved, because `neurt` was added (electron#734) after that list was last touched.
+Symptom: `native_win_x64_and_package` fails with
+
+```
+ERROR: npm pack did not produce .../runanywhere-electron-neurt-<version>.tgz
+```
+
+— because `npm pack` correctly produced `...-neurt-<OLD-version>.tgz` from the stale
+manifest. **Whenever you add a package anywhere, add it to `sync-versions.sh` the same
+day.** Cheap pre-flight check that catches the whole class:
+
+```bash
+grep -h '"version"' bindings/electron/package.json bindings/electron/packages/*/package.json \
+    bindings/electron/native/package.json | sort -u     # expect exactly ONE distinct version
+```
+
+**(2) `publish` downloads EVERY artifact, including intermediate hand-off bundles.**
+`publish`'s `Download all artifacts` step has no name filter. `electron-packaged-tarballs`
+is `native_win_x64_and_package`'s raw output whose only purpose is feeding `sdk_electron`,
+which re-uploads the curated public set as `sdk-electron`. Flattening both duplicated all
+5 Electron tarballs *and* dragged in the raw bundle's own `proto-ts` copy, which collided
+with `sdk_web`'s:
+
+```
+::error::flatten collision: release-flat/runanywhere-proto-ts-<v>.tgz already exists
+::error::Refusing to publish — 6 filename collision(s) detected during flatten
+```
+
+Fixed by pruning that directory in the flatten `find`
+(`-type d -name "electron-packaged-tarballs" -prune -o -type f \( ... \)`). **Standing
+rule: any new intermediate artifact must be either excluded from the flatten or named so
+it cannot collide.** When editing that `find`, test the exact expression against a fake
+`release-artifacts/` tree locally first — `-prune -o` + `-print0` is easy to get subtly
+wrong and the only other way to find out costs a full release run.
+
+---
+
+## 5. Resolve CodeRabbit (or any bot) review findings properly
+
+Do not resolve a review thread without a real, evidence-backed reply. Steps:
+
+1. Fetch unresolved threads via GraphQL:
+
+```bash
+gh api graphql -f query='
+query($owner:String!, $repo:String!, $pr:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$pr) {
+      reviewThreads(first:100) {
+        nodes { id isResolved comments(first:10) { nodes { id databaseId body } } }
+      }
+    }
+  }
+}' -f owner=RunanywhereAI -f repo=runanywhere-sdks -F pr=<pr-number>
+```
+
+2. For each unresolved thread, reply via REST with `in_reply_to` set to the comment's
+   `databaseId` (not the GraphQL node id), citing concrete evidence — a real run id,
+   a real checksum, a real commit SHA, not "looks fine":
+
+```bash
+gh api -X POST repos/RunanywhereAI/runanywhere-sdks/pulls/<pr-number>/comments \
+    -f body="Verified against candidate run <run-id>: RunAnywhereMLXRuntime checksum
+matches release-artifacts/native-ios-macos/RunAnywhereMLXRuntime-ios-v<version>.zip.sha256.
+See commit <sha>." \
+    -F in_reply_to=<comment-database-id>
+```
+
+3. Only then resolve, via GraphQL mutation on the thread id from step 1:
+
+```bash
+gh api graphql -f query='
+mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { isResolved } } }
+' -f threadId=<thread-node-id>
+```
+
+---
+
+## 6. Merge
+
+Before merging, verify:
+
+```bash
+gh pr view <pr-number> --repo RunanywhereAI/runanywhere-sdks --json mergeable,reviewDecision
+```
+
+Zero unresolved review threads (re-check the GraphQL query from step 5 — it should return
+none with `isResolved: false`), and `mergeable == "MERGEABLE"`.
+
+Confirm bypass eligibility before relying on `--admin`:
+
+```bash
+gh api repos/RunanywhereAI/runanywhere-sdks/branches/main/protection \
+    --jq '.required_pull_request_reviews.bypass_pull_request_allowances'
+gh api user --jq .login
+```
+
+If your login appears in that allowance list (users, or a team/app you belong to):
+
+```bash
+gh pr merge <pr-number> --repo RunanywhereAI/runanywhere-sdks --squash --admin
+```
+
+If not on the list, **stop** — ask a human to approve or merge instead of forcing it.
+`--admin` is a legitimate configured bypass only for allow-listed identities; do not use
+it to route around review for anyone else.
+
+---
+
+## 7. GOTCHA — cancel the auto-tag-dispatched rebuild, dispatch a publish-only run instead
+
+The moment the PR merges, `auto-tag.yml` runs, pushes the `v<version>` tag, and **itself**
+dispatches a brand-new full `release.yml` run at that tag (see orientation section — plain
+tag pushes via `GITHUB_TOKEN` don't auto-trigger, so the workflow does it explicitly).
+This is redundant — you already have a fully green, checksum-verified candidate from step
+2-3 — and wasteful, because Apple/MLX bytes will drift again for zero benefit (see the
+non-reproducibility fact in step 3).
+
+**Cancel it immediately, before it burns real compute** (ideally within the first minute
+or two, before native_ios starts real work):
+
+```bash
+gh run list --repo RunanywhereAI/runanywhere-sdks --workflow=release.yml --limit 5
+gh api -X POST repos/RunanywhereAI/runanywhere-sdks/actions/runs/<auto-triggered-run-id>/cancel
+```
+
+Then dispatch a **publish-only** run that reuses your already-verified candidate's exact
+bytes instead of rebuilding:
+
+```bash
+gh workflow run release.yml --ref v<version> \
+    -f version=<version> \
+    -f publish_from_run_id=<candidate-run-id>
+```
+
+**CRITICAL SUB-GOTCHA**: if your candidate run in step 2 itself passed
+`reuse_native_web_run_id=<X>` to skip rebuilding WASM (a packaging-only re-release), that
+candidate run **never uploaded its own copy of the `native-web` artifact** — it was
+skipped. `publish_from_run_id` alone will then fail during the release-manifest assertion
+with `"Missing or empty Web WASM payload"`, because the publish job's artifact-download
+step only pulls `reuse_native_web_run_id`'s artifact when that input is passed to *this*
+dispatch too (see `.github/workflows/release.yml` around the "Download reused Web natives"
+step — it is gated on `inputs.reuse_native_web_run_id != ''`, independent of
+`publish_from_run_id`). You must **also** pass the same original run id:
+
+```bash
+gh workflow run release.yml --ref v<version> \
+    -f version=<version> \
+    -f publish_from_run_id=<candidate-run-id> \
+    -f reuse_native_web_run_id=<X>
+```
+
+This chains forward across releases: whichever run **originally** built `native_web` is
+the run you keep citing at every subsequent `reuse_native_web_run_id`, not the most recent
+run that merely borrowed it from an earlier one. Track that original run id explicitly if
+you're doing back-to-back packaging-only releases.
+
+---
+
+## 8. Verify the draft release's asset set
+
+The publish job only creates a **draft** GitHub Release (`softprops/action-gh-release`,
+`draft: true`) with built assets attached — it does not touch npm/Maven/pub.dev at all
+(grep `release.yml` for `npm publish`, `mavenCentral`, `pub publish` — none exist there).
+
+Expected asset count for a full, non-Windows-focused release: **~65 assets** —
+
+- 9 Apple archives (iOS/macOS XCFrameworks: RACommons + 5 backends + MLX runtime/Metal/
+  resources + CoreML/NeuRT)
+- 3 Android RACommons zips (arm64-v8a, armeabi-v7a, x86_64)
+- 1 Linux RACommons tar.gz
+- 1 Windows RACommons zip (preserved as an asset, advisory — see step 9)
+- 1 Web WASM tar.gz (`RACommons-web-v<version>.tar.gz`)
+- 3 rcli tarballs (macOS arm64, Linux x86_64, Windows x86_64 — macOS may also have a
+  notarized `.dmg` if Developer ID/notary secrets are configured; this is soft-skipped
+  otherwise, not a failure)
+- 1 Kotlin Maven repo zip
+- 8 npm tarballs (proto-ts, web core, web-llamacpp, web-onnx, RN core, RN llamacpp, RN mlx,
+  RN onnx)
+- 5 Electron npm tarballs (`runanywhere-electron-<v>.tgz` core, `-llamacpp`, `-onnx`,
+  `-sherpa`, `-neurt`) — added by `sdk_electron`; each has its own `.sha256` sidecar
+  counted separately below. **`electron-qhexrt` is deliberately excluded** — it still
+  gets built and packaged, but only as the `sdk-electron-qhexrt-private` workflow
+  artifact (not a release asset); download it separately for a manual `npm publish`.
+- 1 `MANIFEST.txt`
+- **explicitly ZERO** `qhexrt`-named files (the manifest assertion step hard-fails the run
+  if it finds any — confirm the run actually reached the publish job and didn't die there)
+
+Every asset above except `MANIFEST.txt` has a `.sha256` sidecar, which is itself a
+separate asset. **v0.20.25 landed at exactly 65 assets** — use that as the concrete
+baseline rather than re-deriving the arithmetic.
+
+Cross-check every checksum's `.sha256` sidecar against what got committed to
+`Package.swift` / the flutter `Package.swift` / the MLX podspec in step 3 — they must
+match byte for byte, because this run's artifacts are exactly what step 10 (sdk-publish)
+ships to real consumers.
+
+```bash
+gh run view <publish-run-id> --repo RunanywhereAI/runanywhere-sdks --json jobs \
+    --jq '.jobs[] | {name, conclusion}'
+
+# Asset count + the Electron set + the qhexrt-leak assertion, in three commands:
+gh release view v<version> --repo RunanywhereAI/runanywhere-sdks --json assets --jq '.assets|length'
+gh release view v<version> --repo RunanywhereAI/runanywhere-sdks --json assets \
+    --jq '[.assets[].name | select(startswith("runanywhere-electron"))] | sort'
+gh release view v<version> --repo RunanywhereAI/runanywhere-sdks --json assets \
+    --jq '[.assets[].name | select(test("qhexrt";"i"))]'          # MUST be []
+```
+
+### Prove the artifacts are real — don't trust green checkmarks
+
+A green `publish` only proves the assertions ran. To prove the bytes are right, run the
+repo's own fail-closed gate against the **published** tarballs. This is the single highest
+-value verification in the whole runbook and it takes about a minute:
+
+```bash
+gh release download v<version> --repo RunanywhereAI/runanywhere-sdks \
+    -p 'runanywhere-electron*.tgz' -D /tmp/verify
+python3 scripts/validation/gates/check_plugin_natives.py --expect-version <version> \
+    $(for t in /tmp/verify/*.tgz; do printf -- '--tarball %s ' "$t"; done)
+```
+
+Expect `All N check(s) passed: plugin natives are routable and no staging-URL placeholder
+was found.` On v0.20.25 that was **20 checks** across 5 tarballs, asserting three separate
+things per binary: the real `STAGING_BASE_URL` is baked in (no `YOUR_STAGING_BASE_URL`
+placeholder), `rac_commons` embeds the right version string, and each backend is actually
+**routable** (real op tables — `g_llamacpp_ops`, `g_sherpa_stt_ops`, `g_neurt_llm_ops`,
+etc.), which is what distinguishes a real plugin from a same-sized shell.
+
+Sanity-check the shipped layout too — a tarball missing a platform is a silent regression:
+
+| Package | Expected `prebuilds/` |
+|---|---|
+| `@runanywhere/electron` | `darwin-arm64` + `win32-x64` + `win32-arm64` |
+| `-llamacpp`, `-onnx`, `-sherpa` | `darwin-arm64` + `win32-x64` |
+| `-neurt` | `darwin-arm64` only (Apple Neural Engine) |
+| `-qhexrt` (private artifact) | `win32-arm64` only (Hexagon NPU) |
+
+---
+
+## 9. Windows handling — build/preserve only, never auto-publish
+
+`native_windows` and `native_rcli_windows` run and their outputs are **preserved** as
+release assets (proving the binaries build), but nothing Windows-specific is published to
+any package registry as part of the standard flow unless a human explicitly asks for it —
+that's a deliberate, separate decision, not an oversight.
+
+For anything that needs actual execution on Windows (smoke-testing the native Windows
+build, or Electron's Windows packaging), do not assume a macOS cross-build proves
+Windows correctness — SSH to the real Windows box. The team keeps a **Windows ARM64
+machine reachable over SSH**; its hostname, user, key, and mesh-VPN node name are
+operator-specific and deliberately not recorded in this repo — read the Windows/ARM64
+host entry out of the operator's `~/.ssh/config` and use that alias. If there is no such
+entry, the box is not configured for you: say so and ask, rather than guessing.
+
+```bash
+WIN_BOX=<the ssh alias from ~/.ssh/config>
+# Ask the mesh-VPN client whether the node is up FIRST (e.g. `tailscale status`,
+# matching on that host entry's HostName) — never just try SSH and retry on timeout.
+ssh -o ConnectTimeout=8 "$WIN_BOX" "whoami"
+```
+
+If the VPN reports the node offline/asleep, **that's not a config problem** — ask the
+user to wake the box; don't debug SSH config against a machine that's simply off.
+
+---
+
+## 10. Publish the draft, then hand off
+
+Once the draft's asset set is verified complete and correct (step 8):
+
+```bash
+gh release edit v<version> --repo RunanywhereAI/runanywhere-sdks --draft=false --latest
+```
+
+This is the point where SwiftPM's `from: "<version>"` resolution and the download URLs
+baked into `Package.swift` start actually working for real external consumers — draft
+release assets are not publicly downloadable, so nothing before this line is
+externally live.
+
+**Hand off to the `sdk-publish` skill** for the actual npm / Maven Central / pub.dev /
+SwiftPM-distribution-repo publishing steps. This skill's job ends here.
+
+---
+
+## 10b. MANDATORY, and it turns `main` RED until you do it — cut runanywhere-swift
+
+The moment `v<version>` exists in this repo, `check_swift_dist_repo_sync.sh` (run by
+`pr-build.yml`'s `centralization` job) **fails on every PR and every push to `main`**:
+
+```
+[FAIL] runanywhere-swift has no 0.20.25 tag (latest: 0.20.24)
+       v0.20.25 is published here, so 'from: "0.20.25"' is broken for every
+       SwiftPM consumer of https://github.com/RunanywhereAI/runanywhere-swift.git
+```
+
+This is **by design**, not a bug, and it is the #1 reason a release looks "not green"
+after everything else succeeded. Do not go hunting for a code defect — cut the repo:
+
+```bash
+git clone https://github.com/RunanywhereAI/runanywhere-swift.git /tmp/ra-swift
+bindings/swift/scripts/sync-dist-repo.sh --zips <zip_dir> --tag /tmp/ra-swift
+# verify BEFORE pushing (content check passes locally; the tag check needs the push)
+RUNANYWHERE_SWIFT_DIST_REPO=/tmp/ra-swift \
+    bash scripts/validation/gates/check_swift_dist_repo_sync.sh
+git -C /tmp/ra-swift push origin main --follow-tags
+bash scripts/validation/gates/check_swift_dist_repo_sync.sh    # now [OK]
+```
+
+Gotchas found doing this on 0.20.25:
+
+- `--check` **cannot be combined** with `--zips`/`--commit`/`--tag` (hard error). Run a
+  bare `--check <repo>` first to preview, then the real invocation separately.
+- `--check` legitimately reports `ERROR: distribution repo is out of sync` before you
+  sync — that's the preview telling you what it will change (expect the `sdkVersion` bump,
+  ~3 changed files, `0 added / 0 removed`). Non-zero exit there is not a failure.
+- The script **never pushes**; `--tag` only creates the tag locally. The dist repo tag has
+  **no `v` prefix** (`0.20.25`, not `v0.20.25`) while the monorepo tag does.
+- Running the gate locally right after `--tag` still shows `[FAIL] ... has no <version>
+  tag` while simultaneously showing `[OK] ... checkout matches: all 6 checksums`. That is
+  expected: the content check reads your local checkout, the tag check queries the real
+  remote. It clears the moment you push.
+- It chains into `sync-checksums.sh`, so run it **after** step 3's checksums are committed,
+  or the dist manifest gets stale hashes.
+
+---
+
+## 10c. Windows + self-hosted-runner traps (read before debugging a red Windows job)
+
+These all cost a full CI cycle. The unifying fact:
+
+> The self-hosted runner service executes as `NT AUTHORITY\NETWORK SERVICE`, which has its
+> own PATH **and** its own NTFS permissions. Anything you verify over SSH on that box tells
+> you nothing about what the job can do. `native_win_arm64_qhexrt` already carries a long
+> comment about this — read it before inventing a fix, and keep it in sync with neurun's
+> equivalent lane, which runs on the *same machine*.
+
+**Environment**
+
+- **`bash: command not found`** — Git for Windows puts `Git\cmd` (git.exe) on PATH but not
+  `Git\bin` (bash.exe). `actions/checkout` still works because it calls git.exe directly,
+  which makes this look unrelated to runner setup.
+- **`pwsh` does not exist on that box** — Windows PowerShell 5.1 only. Use
+  `shell: powershell`.
+- **`gh` is not installed on that box, and must not be assumed anywhere.** A QHexRT
+  download died on `gh: command not found`. The fix is deliberately *not* to install it:
+  every fetch of a private release asset now goes through
+  `fetch_release_asset()` in `scripts/build/_release_asset.sh`, which uses `curl` + the
+  REST API. `curl` ships with Windows, macOS and every Linux image we use, so this is one
+  code path everywhere instead of a per-runner provisioning step. If you add a new
+  consumer of a private asset, source that helper — do not reach for `gh`.
+  Note the helper matches the asset name **exactly**: a prefix match picks the `.sha256`
+  sidecar (its name starts with the tarball's), and you get a 65-byte "archive" that fails
+  much later with a confusing error.
+- **Tool availability is the single most common failure class on this runner** — `bash`,
+  `python3`, `ninja`, `gh`, GNU `tar` and NDK `.exe` suffixes have each broken a lane
+  once. When a self-hosted job fails, check "does this tool exist as spelled" before
+  reading any logic.
+- **`ln -s` under Git-Bash COPIES the directory** unless `MSYS=winsymlinks:nativestrict`.
+  It does not fail, so the result looks like real content and whatever validates a
+  "must be a symlink" invariant rejects a payload that was actually fine. Never use shell
+  `ln -s` on this box — go through `scripts/build/_selection.py`.
+- **Windows selects with a JUNCTION, not a symlink, and that is deliberate.** The runner
+  service account cannot create symlinks (below), but a junction is the same kind of
+  reparse point to a directory and needs no privilege. Two traps when reading that code:
+  `Path.is_symlink()` returns **False** for a junction (`stat.S_ISLNK` is true only for
+  `IO_REPARSE_TAG_SYMLINK`) — use `_selection.is_selection()`; and a junction stores an
+  **absolute** target, so compare `_selection.read_target()`, which normalizes both
+  platforms back to `versions/<receipt>`. `Path.is_junction` is 3.12+ and that box runs
+  3.10, so the `lstat`/`st_reparse_tag` fallback is the live path there.
+
+**A green PR does not mean the win-arm64 lane passed**
+
+`native_win_arm64_qhexrt` is gated `if: github.event_name != 'pull_request'` — never run
+on a PR, fork or not, because a `pull_request` run would execute PR-controlled
+`npm install` scripts on a persistent personally-owned runner. It therefore only runs on
+`push` / `workflow_dispatch` / `workflow_call`. Consequences to plan around:
+
+- **Check the paths filter covers what you changed.** `electron-native-package.yml` watches
+  `scripts/build/**` *because* of this — a fix to `download-qhexrt.sh` used to trigger no
+  push run at all, so it would merge with the lane it was written for never having run.
+  If you add a new dependency of that workflow, add it to both paths lists.
+- To exercise the lane on an unmerged branch, `gh workflow run electron-native-package.yml
+  --ref <branch>` — `workflow_dispatch` has no paths filter and satisfies the event gate.
+- **Do not push while that dispatch run is in flight.** The concurrency group is
+  `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true` and does not
+  distinguish event types, so a push cancels the dispatch run you are waiting on.
+- Read the step list, not just the job conclusion: `skipped` on this job looks nothing like
+  `success` but sorts the same way in a rollup summary.
+- **ASCII only inside a PowerShell `run:` block.** The runner writes it to a `.ps1` with no
+  BOM and PS 5.1 decodes CP1252, so a UTF-8 em-dash ends in `0x94` — a smart closing quote —
+  and the script dies with `The string is missing the terminator` on a line that is
+  perfectly balanced. In a YAML *comment* it is harmless.
+- **The runner service caches its environment at start.** After changing machine PATH,
+  `Restart-Service` or the next job still sees the old one.
+- `cmake`/`python`/`ninja` may be pip-installed under a user profile and invisible to the
+  service account; add them to `$GITHUB_PATH` with a **concrete** path (a wildcard
+  `Get-ChildItem` there silently finds nothing, because access-denied on enumeration is
+  swallowed by `-ErrorAction SilentlyContinue`).
+
+**Batch scripts (`core/scripts/windows/*.bat`)** — both of these emit the identical, useless
+`... was unexpected at this time.` **after** an apparently successful download, which sends
+you looking in the wrong place entirely:
+
+- **`::` is a label and is ILLEGAL inside a `( )` block** — use `rem` there.
+- **Unescaped parens inside an `echo` close the block early.**
+  `echo Decompressing (7-Zip)...` is fine at top level and fatal once nested; needs
+  `^(` / `^)`.
+
+Both were introduced purely by moving existing, working lines *into* an `if`/`else` block.
+
+**`7z` is not guaranteed.** It ships on GitHub's windows runners but is not part of a stock
+Windows install. `download-sherpa-onnx.bat` now falls back to bsdtar, which handles
+`.tar.bz2` directly (measured: 2.5 s, exit 0, on Windows 11 ARM64).
+
+**CMake on Windows**
+
+- **Visual Studio is a MULTI-CONFIG generator**: `CMAKE_BUILD_TYPE` is a no-op; `--config
+  Release` at *build* time is what selects Release. Getting this wrong silently ships Debug.
+- **An Android cross-build needs `-G Ninja` explicitly.** Windows' default generator is
+  Visual Studio, which cannot drive the NDK toolchain file — and macOS/Linux pick a working
+  default, so an omitted generator breaks *only* on Windows.
+
+## 10d. Re-tagging: verify the tag actually moved
+
+`git tag -d <tag> -q` is **not valid** (`-q` is not a flag there). Guarded with `|| true`
+it fails silently, and the next `git push origin <tag>` pushes the **stale** tag. This has
+already started a release building the wrong commit. Always verify:
+
+```bash
+[ "$(git rev-parse v<version>^{commit})" = "$(git rev-parse main)" ] \
+  && echo "tag OK" || echo "STALE — delete on BOTH sides and re-tag"
+```
+
+Deleting locally is not enough; `git push origin :refs/tags/<tag>` removes the remote one.
+And if a release run already started on the stale tag, cancel it before re-tagging or you
+will race two publishes at the same tag.
+
+## 11. Non-blocking loose ends — note, don't chase
+
+- **`python-linux` no longer exists** — it was removed from `pr-build.yml` on 2026-08-22.
+  It had a chronic ~90-minute hang that tripped its own `timeout-minutes: 90` on nearly
+  every run (on both a two-version matrix and a single pinned 3.12), surfacing as a red X
+  or a whole-run "cancelled" for a job that was never a required status check and whose
+  ecosystem (PyPI) `release.yml` does not touch at all. `python-macos` and `python-windows`
+  still cover the wheel build/install/test flow. Trade-off accepted knowingly: **no CI job
+  now verifies the `requires-python = ">=3.9"` floor** declared in
+  `bindings/python/pyproject.toml`. If Python 3.9 support starts mattering, add one cheap
+  single-version job rather than resurrecting the old matrix.
+- Confirm branch protection still has **no required status checks** (so a stray red X
+  cannot silently block a merge):
+  ```bash
+  gh api repos/RunanywhereAI/runanywhere-sdks/branches/main/protection --jq '.required_status_checks'
+  gh api repos/RunanywhereAI/runanywhere-sdks/rulesets --jq '.[] | {id, name, enforcement}'
+  ```
+  As of 2026-08-22 the active `main` ruleset enforces `pull_request`,
+  `required_linear_history`, `copilot_code_review`, `deletion`, `non_fast_forward` — and
+  **zero** required status checks. Merge gating is 2 approvals + code-owner review, with
+  `bypass_pull_request_allowances` covering sanchitmonga22, shubhammalhotra28, Siddhesh2377.
+- `native_win_arm64_qhexrt` / `native_win_x64_and_package` showing **`skipping`** on any
+  `pull_request` event is intentional security gating (see the Electron section in step 0),
+  not a failure. They run on `push`/`workflow_dispatch`.
+- Transient GitHub-infra failures do happen and look alarming: on the 0.20.25 train
+  `native_ios` died once with `fatal: unable to access 'https://github.com/nlohmann/json.git/':
+  Could not resolve host: github.com` during a CMake `FetchContent` clone. Re-run the failed
+  job (`gh run rerun <id> --failed`) — but note you **cannot** re-run failed jobs while the
+  run is still in progress ("This workflow is already running"); wait for the run to finish
+  first. Distinguish this from a slow-but-healthy job using the duration table in step 2.
+- `@runanywhere/electron-qhexrt`'s npm exposure (step 0) is a confirmed, settled policy
+  decision, not an open item — no need to re-flag it every run anymore.

--- a/.agents/skills/sdk-test-starters/SKILL.md
+++ b/.agents/skills/sdk-test-starters/SKILL.md
@@ -1,0 +1,529 @@
+---
+name: sdk-test-starters
+description: Run a REAL end-to-end inference smoke test (model download + load + generate, with visible output) on every RunAnywhere starter app — iOS, macOS/Swift, Android, Web, Electron — after a runanywhere-sdks release. Build success alone is never sufficient evidence.
+---
+# SDK Test Starters
+
+Post-release validation runbook for the five RunAnywhere SDK consumer apps. This
+skill exists because "it built" has been reported as "tested" before, and that is
+not evidence of anything except that the compiler ran.
+
+## 0. The evidence bar (applies to every app, no exceptions)
+
+For each app you must produce, and be able to state explicitly:
+
+1. **Version proof** — print/log the actual resolved SDK version from inside the
+   running app (a startup log line, a version screen, an `swift package show-dependencies`
+   / `./gradlew dependencies` / `npm ls @runanywhere/...` output, etc). Never assume
+   a version bump "took" just because you edited a manifest.
+2. **Real model acquired** — a real (small) model downloaded fresh, or confirmed
+   already cached, by the app itself (not a file you hand-placed unless that IS the
+   app's supported flow).
+3. **Load** — the model actually loads (watch for a load-succeeded log/state, not
+   just "no crash").
+4. **One real inference call** — LLM `generate()` is almost always the easiest
+   modality to drive; use it unless another modality is genuinely less work for
+   that specific app.
+5. **Visible output** — capture the actual generated text (or audio/image) and
+   quote it in your report. "It responded" is not enough — show what it said.
+6. **Logs reviewed** — read the console/log stream for errors and warnings and
+   explicitly explain any that appear. Do not silently drop a stack trace because
+   the app "still produced output."
+
+Reporting an app as tested from a build/compile success alone is a skill violation.
+If you could not get past build, that is a BLOCKED report (see §8), not a PASS.
+
+## 1. Locating each app's real local checkout
+
+This machine accumulates many differently-named copies of the same repos over time
+(worktrees, experiment clones, old branches, scratch dirs). **Never trust a
+directory name.** Before touching anything in a candidate directory:
+
+```bash
+git remote get-url origin          # must be https://github.com/RunanywhereAI/<repo>.git
+git status --short --branch        # what branch, what's dirty, is it someone else's WIP?
+```
+
+As of this writing, the known-good local checkouts for this user are here (verify
+this each time — do not hardcode it further than "check this location first"):
+
+```
+~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-ios       -> RunanywhereAI/runanywhere-ios.git
+~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-android   -> RunanywhereAI/runanywhere-android.git
+~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-web       -> RunanywhereAI/runanywhere-web.git
+~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-electron  -> RunanywhereAI/runanywhere-electron.git
+```
+
+The macOS/Swift case has no separate consumer repo — see §4, it lives inside
+`~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks` (confirm with
+`git remote get-url origin` there too — this machine also has stray full-monorepo
+clones elsewhere, e.g. under `~/development/hard/ambient/`, that are NOT the one to
+use unless you've verified it's the intended checkout).
+
+These starter checkouts are commonly sitting on a feature branch, not `main` — e.g.
+at last check `runanywhere-ios` and `runanywhere-android` were on
+`add-gemma4-qwen3.6-qwen3.8-models` and `runanywhere-web` on `add-supertonic-3-tts`.
+That is fine to test FROM, but say so in your report, and do not `git checkout` away
+from a branch that has uncommitted work you didn't create — if `git status --short`
+shows dirty files you don't recognize, stop and ask rather than stashing/resetting.
+
+If genuinely unsure which directory is real, `git clone` a fresh one into the
+scratchpad rather than guessing — a wrong guess wastes far more time than a clone.
+
+## 2. Cross-repo facts this skill assumes
+
+- SDK version SoT: `core/VERSION` in `runanywhere-sdks`, bumped everywhere by
+  `scripts/release/sync-versions.sh <version>`.
+- Release publish is `.github/workflows/release.yml` (dispatch or `v*.*.*` tag).
+- **Never** treat a build success against `RUNANYWHERE_USE_LOCAL_NATIVES=1` (or any
+  monorepo-local staged artifact) as proof the *public* release works — see §4.
+- QHexRT/QNN material must never appear in a public artifact — release.yml
+  hard-fails on it. If anything you're testing surfaces a QHexRT asset in a public
+  package, stop and flag it, don't route around it.
+
+## 3. iOS — `runanywhere-ios`
+
+SDK pin lives in `Package.swift`:
+
+```swift
+.package(url: "https://github.com/RunanywhereAI/runanywhere-swift.git", from: "0.20.19")
+```
+
+This only resolves once `runanywhere-swift` (the generated Swift-only SPM
+distribution repo — see `~/.claude/skills/sdk-publish/SKILL.md` §4) is
+actually tagged at the target version. Steps:
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-ios
+# bump the `from:` version in Package.swift to the target release, then:
+swift package update            # or open in Xcode and let it resolve
+./scripts/build_and_run_ios_sample.sh simulator "iPhone 16 Pro"
+```
+
+`./scripts/verify.sh` is the CI-equivalent gate: it resolves the package remotely
+and runs a full `xcodebuild` against the iOS Simulator — use it to prove the
+resolve is clean (it fails if `Package.resolved` ends up dirty, i.e. the committed
+pin was stale). `./scripts/smoke.sh` is a fast, non-compiling grep-based check —
+it does NOT count as evidence for this skill's bar, only `build_and_run` +
+watching real output does.
+
+Drive one real `generate()` call through the app UI (or the equivalent debug
+action if the sample exposes one) against a small downloaded model, then watch the
+runtime log stream for the version line, the model download/load, the generation,
+and any errors:
+
+```bash
+log stream --predicate 'subsystem CONTAINS "com.runanywhere"' --info --debug
+```
+
+Most loggers use `com.runanywhere.RunAnywhereAI`; a few use plain
+`com.runanywhere`; the SDK logs under its own subsystem — the `CONTAINS` match
+covers all of them. On a physical device use `idevicesyslog | grep "com.runanywhere"`
+instead.
+
+## 4. macOS/Swift — no separate repo, use the in-tree example or rcli
+
+There is no `runanywhere-macos` consumer repo. Two in-monorepo options, both inside
+`~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks`:
+
+- `bindings/swift/example/` — a minimal SwiftPM example app/executable.
+- `rcli/` — the C++ core's CLI, `rac_*` C ABI consumer.
+
+**The critical gotcha**: the repo's own `Package.swift` is fail-closed toward the
+*real published release* — it resolves the remote `binaryTargets` unless you
+explicitly opt into locally staged XCFrameworks with
+`RUNANYWHERE_USE_LOCAL_NATIVES=1`. Every doc/script example in this repo sets that
+env var (because local dev wants fast iteration against in-progress binaries) —
+but that means copy-pasting those examples verbatim tests your LOCAL staged build,
+not the actual public release artifact. To prove the published release works:
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks/bindings/swift/example
+# DO NOT set RUNANYWHERE_USE_LOCAL_NATIVES — leave it unset so Package.swift
+# resolves the real remote release binaries for the target version.
+swift build
+swift run runanywhere-minimal "Name three colours."
+```
+
+If the example was previously built/run with the env var set, `swift build` may
+reuse a stale resolve — run `swift package reset` (or delete `.build/`) first if
+you're not sure which mode the last resolve used.
+
+For rcli instead (also validates the real published core):
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks
+rcli models download qwen3          # ~639MB, small enough for a quick smoke test
+rcli llm generate --model qwen3 "Reply with exactly: RCLI WORKS" --reasoning off
+```
+
+`rcli models list --all` shows the rest of the built-in catalog
+(`whisper-tiny`, `smolvlm2`, `piper`, …) if LLM generate isn't the right modality
+for what you're verifying.
+
+## 5. Android — `runanywhere-android`
+
+Version pin: `gradle/libs.versions.toml` has ONE shared catalog entry:
+
+```toml
+runanywhere = "0.20.19"
+...
+runanywhere-sdk      = { group = "io.github.sanchitmonga22", name = "runanywhere-sdk",              version.ref = "runanywhere" }
+runanywhere-llamacpp = { group = "io.github.sanchitmonga22", name = "runanywhere-llamacpp",          version.ref = "runanywhere" }
+runanywhere-onnx     = { group = "io.github.sanchitmonga22", name = "runanywhere-onnx",               version.ref = "runanywhere" }
+runanywhere-qhexrt   = { group = "io.github.sanchitmonga22", name = "runanywhere-qhexrt-android",     version.ref = "runanywhere" }
+```
+
+**CRITICAL — do not bump this block as one unit.** `runanywhere-qhexrt-android` is
+permanently frozen at whatever version it was last published at before being
+excluded from the public Maven train; by policy it can never move forward via
+public Maven again. Verify the actual frozen version FRESH every time (do not
+trust a remembered number — it doesn't change, but don't skip the check):
+
+```bash
+curl -s https://repo1.maven.org/maven2/io/github/sanchitmonga22/runanywhere-qhexrt-android/maven-metadata.xml
+```
+
+The other three artifacts (`runanywhere-sdk`, `-llamacpp`, `-onnx`) CAN and should
+move to the new release version. This means the single `runanywhere` catalog ref
+must be **split into two entries** — one at the new version for sdk/llamacpp/onnx,
+one pinned to the frozen qhexrt version — not bumped as a block.
+
+**Before trusting a mixed pin works**: verify `RAC_PLUGIN_API_VERSION` (the
+plugin ABI version constant in the C++ core, exposed identically to Kotlin) is
+unchanged between the old public SDK version and the new one. If it changed, mixing
+a newer sdk/llamacpp/onnx with the frozen qhexrt version is NOT safe — this is a
+human decision (needs either an ABI-compat shim or dropping qhexrt from this build),
+not something to force through.
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-android
+./gradlew :app:assembleDebug
+./gradlew :app:installDebug        # installs to a connected emulator/device
+adb logcat | grep -i runanywhere   # or a more specific tag if the app uses one
+```
+
+Launch the app, drive one real `generate()` call against a small downloaded model
+(the app's own model picker/download flow), confirm the resolved SDK version is
+logged, and review logcat for errors before reporting a PASS.
+
+## 6. Web — `runanywhere-web`
+
+`package.json` has 4 `@runanywhere/*` deps pinned with a caret range:
+
+```json
+"@runanywhere/proto-ts":    "^0.20.19",
+"@runanywhere/web":         "^0.20.19",
+"@runanywhere/web-llamacpp":"^0.20.19",
+"@runanywhere/web-onnx":    "^0.20.19"
+```
+
+Bump all 4 to the new version, then:
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-web
+npm install
+npm run build
+npm run dev      # vite --host localhost --port 3000 --strictPort
+```
+
+The dev/preview server is what supplies COOP/COEP headers required for
+`SharedArrayBuffer` — WASM inference will silently fail (or refuse to init
+threads) without them, so don't swap in a bare static file server.
+
+`~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks/bindings/web/AGENTS.md`
+has the authoritative Validation section (its own heading is `## Validation`) —
+full checklist:
+
+1. Fresh browser context.
+2. Example app served with COOP/COEP headers.
+3. Model download.
+4. Model load.
+5. Real browser inference for the target modality.
+6. Logs/screenshots reviewed.
+
+Its "Required release gates" (run before browser validation) from the same repo:
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks/bindings/web
+npm run typecheck && npm run lint && npm run test && npm run build
+npm run test:browser
+npm run test:browser:release
+cd example && npm run typecheck && npm run build
+```
+
+Static gates passing is not the smoke test — you still need an actual browser
+watching real inference happen against the starter app. Prefer a real browser
+automation tool (`claude-in-chrome` MCP tools, or Playwright — the maintained
+suites under `bindings/web/tests/browser/` already use `playwright.config.ts`)
+over curling the served page: WASM inference genuinely needs a browser JS engine.
+Load the served starter app, download/load a small model, trigger generate, and
+read the actual rendered output text plus the browser console — do not infer
+success from an HTTP 200 on the page load.
+
+## 7. Electron — `runanywhere-electron` (SPECIAL CASE)
+
+**Do not assume a fresh SDK publish is available for this app.** Electron's own
+npm packages (`@runanywhere/electron`, `-llamacpp`, `-onnx`, `-sherpa`, `-qhexrt`,
+`-neurt`) are on a SEPARATE, manual-publish pipeline — NOT part of `release.yml`
+(grep confirms zero mentions of these package names there). This separation is a
+**confirmed, deliberate** repo-owner decision, not a gap. Check
+`~/.claude/skills/sdk-publish/SKILL.md` §6 before assuming anything moved.
+Electron is **no longer WIP on a branch** — the old "in-progress on
+`smonga/electron_upgrade`" note is gone from the root `AGENTS.md`/`CLAUDE.md`
+entirely as of this checkout; `bindings/electron/` is a fully merged SDK on `main`.
+As of `fix/electron-cicd-staging-url-npu-ane`,
+`.github/workflows/electron-native-package.yml` builds every backend for real and
+packages every tarball — but still does not publish; verify against a live run
+rather than assuming build automation status either way.
+
+Test the starter against whatever version it is CURRENTLY pinned to unless a human
+has explicitly confirmed a newer Electron publish is ready and intended:
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-electron
+cat package.json | grep '@runanywhere/electron'   # confirm current pin before touching it
+```
+
+**`@runanywhere/electron-qhexrt` being public on npm is a CONFIRMED, settled
+policy decision** (repo owner, 2026-08-20), not a contradiction to flag — it
+contains real Hexagon NPU binaries (`libQnnHtpV81Skel.so`, `QnnHtp*.dll`,
+`rac_commons.dll`, `runanywhere_qhexrt.dll`) on purpose. The QHexRT-stays-private
+policy enforced elsewhere in this repo family is specifically about the
+GitHub-Release-side asset set (Android etc.), a different channel. Only re-raise
+this if you find evidence the policy changed.
+
+Two layers to actually exercise, do not conflate them:
+
+**(a) Cross-platform Electron JS + macOS native addon** — buildable and testable
+locally on this Mac right now:
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-electron
+npm install
+npm run build   # or the app's documented dev/start script — check package.json scripts
+npm start        # or equivalent — launch the actual Electron app
+```
+
+Drive one real `generate()` call in the running app, watch its console/log output
+for the resolved SDK version, model download, load, and generation, and read any
+errors rather than ignoring them.
+
+**(b) Genuine Windows-native behavior** — a macOS build proves NOTHING here
+regardless of how clean the cross-platform code looks; the native addon and any
+Windows-only DLLs must be exercised on real Windows.
+
+The team keeps a **Windows ARM64 test machine reachable over SSH**. Its hostname,
+user, key, and VPN/mesh node name are operator-specific and deliberately not
+recorded in this repo — read them out of the operator's own `~/.ssh/config` (look
+for the Windows/ARM64 host entry) and use that alias below wherever `$WIN_BOX`
+appears. If no such entry exists, the box is not configured for you: say so and
+ask, rather than guessing at a hostname.
+
+```bash
+WIN_BOX=<the ssh alias from ~/.ssh/config>
+```
+
+**Always check reachability first, never just try SSH and retry on timeout.** The
+box lives on a private mesh VPN and is frequently asleep, so start by asking the
+VPN client whether the node is up (e.g. `tailscale status`, matching on the host
+entry's `HostName`) rather than opening a connection.
+
+If the node reports `offline, last seen ...`, the box is asleep/powered off.
+**A connection timeout here means "device asleep," not "config is wrong."** Tell
+the human and ask them to wake it; do not loop retrying SSH. Only once the node
+shows a live/idle state, confirm with:
+
+```bash
+ssh -o ConnectTimeout=8 "$WIN_BOX" "whoami"
+```
+
+Then, with the repo already cloned there:
+
+```bash
+ssh "$WIN_BOX" "cd <repo-path-on-that-box>; git pull; npm install; npm run build"
+# then run whatever launches the Windows Electron build and drive a real generate call
+scp "$WIN_BOX":<remote-log-or-artifact-path> ./local-copy   # pull back evidence to inspect
+```
+
+Do not claim Windows-specific validation happened unless you actually obtained a
+shell on that box and ran something real there — a clean macOS build is not
+substitute evidence.
+
+**`node_modules/electron` on this box silently tracks whichever arch last ran `npm
+install`, not which Node launches the test.** The x64 (llamacpp/onnx/sherpa) and
+arm64 (QHexRT) lanes share ONE `runanywhere-electron` checkout/`node_modules` tree.
+Prepending an x64 Node to `PATH` and running `npx playwright test` does NOT make
+Electron itself x64 — `require('electron')` always resolves the single installed
+`node_modules/electron/dist/electron.exe`, and whichever arch that binary actually
+is determines which `prebuilds/win32-<arch>/` directory the running app looks in,
+regardless of `scripts/use-sdk.mjs local`'s staging (which itself is arch-aware
+based on the *launching* Node, so it can correctly report "staged win32-x64" while
+the process that will actually run is arm64 — a silent mismatch). Verify with:
+`powershell -Command "$p=[IO.File]::ReadAllBytes('...\electron.exe'); $peOff=
+[BitConverter]::ToInt32($p,60); [BitConverter]::ToUInt16($p,$peOff+4)"` — `43620`
+(`0xAA64`) is ARM64, `34404` (`0x8664`) is x64. If it's the wrong arch (e.g. a prior
+session's `npm install` for the other lane silently overwrote it), a genuine re-test
+of the other lane needs a FULLY SEPARATE checkout/`node_modules` tree installed
+under the matching-arch Node — don't assume PATH-prepending alone is sufficient, and
+don't trust `use-sdk.mjs status`'s "platform: win32-x64" output as proof the running
+Electron process is actually x64.
+
+**NPU hardware is a scarce, single-owner resource — serialize, never parallelize.**
+This box has ONE physical Hexagon NPU. `engines/qhexrt/qhexrt_session.cpp`'s
+`session_open()` has a load-bearing comment on this exact failure mode: the HTP
+exposes a small number of protection domains with a per-PD context ceiling, so a
+*second* concurrent model load fails with `RAC_ERROR_BACKEND_INIT_FAILED`
+("Backend initialization failed") — a fast (tens-of-ms), generic-looking failure
+that is easy to mistake for a real regression. Confirmed once tonight: two agents
+each independently exercising QHexRT on this box at the same time produced exactly
+this failure. Before concluding a QHexRT test genuinely failed, confirm nothing
+else (another agent, a leftover Electron process, a stuck previous test run) is
+also holding an NPU session open on this box — check for lingering `electron.exe`/
+`node.exe` processes from a prior run and kill them if orphaned, and never launch
+two NPU-touching verification passes concurrently on this machine.
+
+**"Backend initialization failed" has (at least) three distinct root causes —
+don't stop at PD exhaustion.** Confirmed on 2026-08-17 after PD-exhaustion and
+staleness were both ruled out (fresh rebuild, source-identical prebuilt, no other
+process holding a session): the *actual* bug was two compounding issues, both now
+fixed/documented —
+1. **Real source bug, fixed in PR #733**: `qhexrt_session.cpp`'s `runtime_acquire()`
+   called `qhx_runtime_create(nullptr, nullptr)` on every non-Android platform,
+   trusting the OS default DLL search order to find `QnnHtp.dll`/`QnnSystem.dll`.
+   On Windows that order never includes a dynamically-loaded sibling plugin's own
+   directory (`LOAD_WITH_ALTERED_SEARCH_PATH`, used to load `runanywhere_qhexrt.dll`
+   itself, only widens the search for *that* load call, not later `LoadLibrary`
+   calls made by code already running inside it) — so the QNN DLLs were invisible
+   even sitting right next to the plugin. Fixed by resolving the plugin's own
+   module directory (`GetModuleHandleExA`+`GetModuleFileNameA`) and passing
+   explicit paths, mirroring Android's existing `ADSP_LIBRARY_PATH` resolution in
+   the same file.
+2. **Operational staleness, NOT a script bug**: even after (1), the QNN runtime
+   DLLs actually staged into `@runanywhere/electron-qhexrt`'s
+   `prebuilds/win32-arm64` (`node_modules/.../electron-qhexrt/prebuilds/win32-arm64/`)
+   were from an old QAIRT build (~2.45.x vintage, Dec 2025 files) while the box's
+   installed QAIRT was 2.48.0.260626 — a real ABI-relevant version mismatch.
+   `bindings/electron/scripts/bundle-native.ts`'s `stageQnnRuntime()` just mirrors
+   whatever `RA_QNN_RUNTIME_DIR` points at with **no version check** — it's
+   correct-as-written; someone had pointed it at a stale neurun-side
+   `qairt-runtime-248`-named folder that was never refreshed. Fix: rebuild that
+   flat dir from the CURRENT QAIRT SDK's `lib/aarch64-windows-msvc/` (host DLLs:
+   `QnnHtp.dll`, `QnnHtpPrepare.dll`, `QnnHtpV81Stub.dll`,
+   `QnnHtpV81CalculatorStub.dll`, `QnnSystem.dll`) + `lib/hexagon-v81/unsigned/`
+   (DSP side: `libQnnHtpV81Skel.so`, `libqnnhtpv81.cat`), point
+   `RA_QNN_RUNTIME_DIR` at it, and re-run
+   `npm run bundle:native -- --package=qhexrt` from `bindings/electron/`.
+   **The already-published `@runanywhere/electron-qhexrt` npm package (as of
+   0.20.24) almost certainly ships the same stale DLLs** — this needs a
+   human decision (republish/patch) before claiming the published package works
+   on Windows NPU, separate from the source fix in PR #733.
+3. **PD exhaustion** (the pre-existing entry above) remains real and still applies
+   when two sessions genuinely contend for the one physical NPU — but it is not
+   the only explanation, and the log line to actually check first is the native
+   one: subscribe via `window.runanywhere.logging.records()` (after
+   `logging.setDebugMode(true)`) or add a temporary main-process log capture —
+   `app.process().stdout`/`stderr` do NOT carry it, because the addon runs in a
+   separate `utilityProcess.fork()` host, not the Electron main process, and
+   `RAC_LOG` is not an env var the logger reads (it does nothing). The generic
+   `[QHexRT] qhx_runtime_create failed (QNN libs unavailable?)` vs.
+   `qhx_model_load failed: ... N NPU model(s) already resident` log text is what
+   actually distinguishes cause (1)/(2) from cause (3) — always get that line
+   before diagnosing further.
+
+**Workflow gotcha:** if you orchestrate this via the Workflow tool, its agent()
+calls do NOT reliably block-wait on a long-running remote build the way a direct
+poll loop does — observed once tonight where a workflow's own agents spawned an
+internal Monitor/poller for the build log and then returned immediately,
+reporting "still waiting," which let the whole workflow finish with nothing
+actually verified. For "wait N tens-of-minutes for a real native build to
+finish," use the top-level Monitor tool yourself (a shell poll loop over SSH
+checking for a terminal BUILD_SUCCEEDED/BUILD_FAILED marker line) rather than
+delegating the wait itself into a workflow agent's own judgment.
+
+### The Windows box's actual layout, and why it's more than a cross-platform check
+
+**This is a Hexagon-NPU-equipped Windows machine** (Snapdragon-class ARM Windows
+device, Copilot+ PC), not just a generic x86 Windows box. That makes it the one
+place a QHexRT/Hexagon backend build+test can produce real device-only truth for
+Windows — matching the parent workspace's own "x86 is a simulator, device-only
+truth" rule (see the top-level `Qualcomm/CLAUDE.md` and `QHexRT/CLAUDE.md`). Don't
+treat this box as merely a Windows Electron smoke-test target; it's the only real
+Hexagon NPU test rig reachable for this platform.
+
+Per the user (2026-08-17), under `~/Downloads/RunAnywhere/` on that box there are
+three sibling repo checkouts at the same level — **verify each on connect, don't
+assume paths without checking, since this is relayed secondhand and may have
+drifted**:
+- `runanywhere-sdks` — this monorepo, presumably already cloned; `git fetch && git
+  log -1 origin/main` to see how far behind it is before doing anything.
+- `runanywhere-electron` — the Electron starter app (same repo as
+  `RunanywhereAI/runanywhere-electron` elsewhere in this skill).
+- a third repo referred to verbally as "the neuron/new-run inference engine for the
+  Hexagon NPU" — almost certainly **`neurun`**, the QHexRT/NeuRT split-out repo
+  (see memory: "neurun component split merged — QHexRT/ + NeuRT/ + shared/, root is
+  a closed 20-entry set enforced by a test"). Confirm the actual directory name and
+  remote (`git remote get-url origin`) on connect rather than guessing from the
+  transcription.
+
+**Full task on this box (per explicit user instruction, not just a smoke test):**
+1. `git pull` (or fetch+fast-forward) all three repos to latest `main`.
+2. Rebuild the QHexRT/Hexagon NPU backend from `neurun` against this device's real
+   Hexagon NPU — this is the one environment where that build+run is meaningful
+   proof, not a simulator claim.
+3. Bump Electron's native dependencies to their latest versions — llama.cpp,
+   sherpa-onnx, ONNX Runtime, and whatever else `bindings/electron` pins — across
+   the repos involved. Treat this as a real dependency-bump task (check for
+   breaking API changes, don't just edit a version string and assume it builds).
+4. Update the model catalog for **all 5 starter apps across all 4 consumer repos**
+   (iOS, Android, Web, Electron — plus whatever the "5th app" split means for
+   macOS/Swift, see the rest of this skill) so the catalog is consistent everywhere,
+   not just on this Windows box.
+5. Run a real end-to-end inference pass on this box specifically (not just build
+   success) — both the general Electron/llama.cpp path AND the Hexagon NPU path via
+   `neurun`/QHexRT.
+6. Open PRs for whatever changed, in each affected repo. Do not merge them —
+   the user explicitly said they'll review.
+
+This is real engineering work (native dependency bumps + an NPU backend rebuild),
+not a mechanical version-string edit — expect it to take real time and to
+genuinely need `QHexRT/CLAUDE.md` and `neurun`'s own docs read in full before
+touching that backend, per the parent workspace's own instructions.
+
+## 8. Reporting
+
+For each of the 5 apps (iOS, macOS/Swift, Android, Web, Electron), state exactly
+one of these two outcomes — never blur them:
+
+- **FULLY VERIFIED** — with concrete evidence: the version string actually
+  resolved/logged, the model used, and the actual output produced (quote it).
+- **BLOCKED** — with the exact concrete reason, e.g.: the Windows ARM64 box's
+  mesh-VPN node is offline; Android emulator unavailable in this environment; App Store /
+  notarization credential missing; `runanywhere-swift` not yet tagged at target
+  version so `swift package update` can't resolve; electron-qhexrt policy conflict
+  needs a human call before proceeding further.
+
+A clearly reported partial/blocked result is far more valuable than an optimistic
+summary that overstates what was actually observed. If you hit the known Electron
+qhexrt npm-publish policy conflict (§7), call it out in the report even if it
+wasn't the thing blocking your specific test — it's a standing issue every release
+night should re-surface until a human resolves it.
+
+## Credentials referenced but never printed by this skill
+
+These exist and are checked for presence only — never print their values:
+
+- Maven Central: `mavenCentral.username` / `mavenCentral.password`,
+  `signing.gnupg.keyName` / `signing.gnupg.passphrase` in `~/.gradle/gradle.properties`.
+- GPG signing key `CC377A9928C7BB18` — check with
+  `gpg --list-secret-keys --keyid-format LONG`.
+- macOS notarization profile `runanywhere-notary` — check with
+  `xcrun notarytool history --keychain-profile runanywhere-notary`; codesign
+  identity `Developer ID Application: RunAnywhere, Inc` — check with
+  `security find-identity -v -p codesigning`.
+- npm — `npm whoami` should already show a logged-in user.
+
+None of the app-level smoke tests in this skill require touching these directly;
+they matter only if a test path requires a fresh distro-repo publish (e.g.
+`runanywhere-swift` not yet tagged) — that's a separate concern of the
+`sdk-publish` skill, not this one.

--- a/.agents/skills/telemetry-e2e/SKILL.md
+++ b/.agents/skills/telemetry-e2e/SKILL.md
@@ -1,0 +1,336 @@
+---
+name: telemetry-e2e
+description: Prove that what an SDK binding EMITS on the telemetry wire is correct and that it actually arrives — vocabulary compliance, presence/absence semantics, device-id stability, and a received request body / stored row as evidence. Use when touching telemetry_json.cpp, telemetry_manager.cpp, rac_telemetry_vocabulary.h, any binding's platform-adapter telemetry bridge, or when asked to verify a telemetry field isn't silently dropping.
+---
+
+# Telemetry Wire Correctness (SDK side)
+
+This is the SDK-side counterpart to the backend's `telemetry-e2e` skill (private
+`Runanywhere-monorepo` repo — proves event-to-stored-row on the server side). This one
+proves the other half: that commons *serializes* a call correctly and that the bytes
+*leaving* a binding are the bytes a real backend accepts. It does not cover per-starter-app
+inference smoke tests — see `sdk-test-starters` for that.
+
+## 0. The evidence bar
+
+Compiling is not evidence. A green `telemetry_extraction_tests` run is not evidence that a
+real binding's real call site reaches the wire correctly — it only proves the *serializer*
+handles a hand-built payload correctly. In order of increasing strength:
+
+1. **Unit test green** (`ctest -R telemetry_extraction_tests`) — proves the JSON builder's
+   presence/vocabulary rules are still correct in isolation. Necessary, not sufficient.
+2. **Received request body** — capture the actual JSON `rcli` (or a real binding) put on
+   the wire and read it: right modality endpoint, right keys, no vocabulary values that
+   got through that shouldn't have, measured zeros kept as `0` not `null`.
+3. **Stored row matches, field-for-field** — the backend's own ingest response
+   (`events_received`/`events_stored`/`events_skipped`) or a direct DB read shows the row
+   landed with the values you actually sent, not just a 2xx. This is the only tier that
+   also proves the vocabulary/schema on both sides still agree.
+
+A PR description that says "sent telemetry, no errors" without quoting a request body or a
+stored-row count is not evidence of anything except that a socket didn't error out.
+
+## 1. The emit path
+
+Every binding funnels through the same two C ABI entry points in
+`core/src/infrastructure/telemetry/telemetry_manager.cpp`:
+
+- `rac_telemetry_manager_track` — flat-struct payload (`rac_telemetry_payload_t`), used by
+  `rcli`'s `telemetry emit`/`telemetry blast` and by hand-built events.
+- `rac_telemetry_manager_track_proto` — the real path every language binding actually uses:
+  a binding builds a protobuf `SDKEvent` (`sdk_events.pb.h`) at the real call site (e.g. an
+  LLM `generate()` completing), and `proto_event_type_string()` + the per-domain extraction
+  blocks in `telemetry_manager.cpp` turn it into the same flat payload. `framework_proto_to_string()`
+  / `framework_to_string()` / `clean_framework()` do the backend-name normalization here —
+  this is where a raw enum like `INFERENCE_FRAMEWORK_LLAMA_CPP` becomes the wire string `"llamacpp"`.
+- `stamp_live_device_state()` (same file) then overwrites the SDK-origin/device-state fields
+  (`sdk_binding`, `platform`, `battery_state`, memory, core count) from manager-owned state,
+  not from whatever the caller passed — a binding cannot inject a platform or binding value.
+- The payload is handed to `rac_telemetry_manager_payload_to_json()` in
+  `core/src/infrastructure/telemetry/telemetry_json.cpp`, which does field-by-field
+  serialization (see §2/§3 for the two contracts enforced there).
+- `send_batch_json()` batches by modality and POSTs to `/api/v2/sdk/telemetry/{modality}`
+  through whichever `rac_http_transport_ops_t` the binding registered (URLSession/OkHttp/
+  `emscripten_fetch`/curl for `rcli` — see the root `AGENTS.md`'s "HTTP is platform-provided"
+  rule). There is no `libcurl` fallback baked into commons itself.
+
+If a field is going missing on the wire, the fix is almost always in
+`telemetry_json.cpp` (a field never wired into the serializer) or in the call site's proto
+population (a field never set on the `SDKEvent`) — not in a binding's bridge code, which
+just forwards bytes.
+
+## 2. The closed vocabularies — and the silent-drop rule
+
+`core/include/rac/infrastructure/telemetry/rac_telemetry_vocabulary.h` is a **generated
+file** (see §5) holding six closed tables, each with a `RAC_TELEMETRY_<NAME>_COUNT` and a
+`RAC_TELEMETRY_<NAME>_VALUES[]` array:
+
+| Table | Count | Wire field | Values |
+|---|---|---|---|
+| `RAC_TELEMETRY_EVENT_TYPE` | 106 | `event_type` | namespaced strings, e.g. `llm.generation.completed`, `auth.succeeded`, `stt.transcription.completed` |
+| `RAC_TELEMETRY_BACKEND` | 22 | `backend` / `framework` | `onnx, sherpa, llamacpp, foundation_models, system_tts, fluid_audio, coreml, whisperkit_coreml, mlx, qhexrt, neurt, tflite, executorch, mediapipe, mlc, pico_llm, piper_tts, swift_transformers, cloud, builtin, none, unknown` |
+| `RAC_TELEMETRY_MODEL_SOURCE` | 3 | `model_source` | `catalog, builtin, user` |
+| `RAC_TELEMETRY_PLATFORM` | 9 | `platform` | `ios, android, macos, windows, linux, web, tvos, watchos, visionos` |
+| `RAC_TELEMETRY_SDK_BINDING` | 9 | `sdk_binding` | `swift, kotlin, flutter, react-native, web, electron, python, cli, cpp` |
+| `RAC_TELEMETRY_BATTERY_STATE` | 4 | `battery_state` | `charging, full, unplugged, unknown` |
+
+**The rule, verbatim from `add_vocabulary_string()` in `telemetry_json.cpp`:** if a value is
+non-null but not present in its table, the field is dropped to `null` and the *rest of the
+event still ships*. This is by design (a bad `backend` string must not cost the whole
+observation) but it means:
+
+- The backend never sees the bad value, never 422s, never quarantines anything — there is
+  no error path anywhere for this. A field just isn't there.
+- The only client-side signal is a `RAC_LOG_WARNING("Telemetry", "Dropping %s: '%s' is not
+  in the published vocabulary", ...)` log line — easy to miss unless you're specifically
+  watching debug logs.
+- `platform`, `sdk_binding`, and `battery_state` are stamped by the manager itself (§1), not
+  supplied by a binding's call site, so in practice only `backend`/`framework` (from the
+  engine/model layer) and `event_type` (only reachable via the proto path, checked at CI
+  time — see §5) are realistic places a new value can silently disappear.
+- `test_telemetry_extraction.cpp`'s vocabulary block (`"vocab-1"`/`"vocab-2"` cases) is the
+  concrete regression guard: it sends `framework = "LlamaCpp"` (a real spelling that used to
+  reach production) and asserts the string never appears on the wire while `model_id` still
+  does. If you touch `add_vocabulary_string()` or add a new vocabulary-gated field, extend
+  that test rather than trusting a manual check.
+
+Historical motivation (from the header's own comment): before this table existed, stored
+production rows had four spellings of `llama.cpp`, three of ONNX, and binding names like
+`"react-native"` recorded as a `platform` — this file exists specifically to make that class
+of drift fail in this repo instead of being discovered in a database nobody was watching.
+
+## 3. Presence vs. absence: the "measured zero" contract
+
+Before the fix documented in `telemetry_json.cpp`'s header, extractors read proto3 scalar
+fields directly — which report `0` for a field that was never set — and the old serializer
+(`add_int`/`add_double`) *skipped* zero values to keep payloads small. Result: a genuinely
+measured `output_tokens = 0` (an empty completion) and an unmeasured `tokens_per_second`
+both arrived on the wire as absent, indistinguishable from each other.
+
+The fix is `has_x`-gated serialization. Two helper families in `telemetry_json.cpp`:
+
+- `add_int_or_null(key, value, is_valid)` / `add_double_or_null(key, value, is_valid)` —
+  emit the real value (including `0`) when `is_valid` is true, else the JSON literal `null`.
+  Non-finite doubles (`NaN`/`Inf`) always degrade to `null` regardless of `is_valid`, because
+  JSON has no such literal and one bad value must not corrupt the whole batch.
+- The `is_valid` argument is a real `has_x`/sentinel check per field, not a blanket flag —
+  e.g. `payload->has_processing_time_ms != RAC_FALSE`, `payload->total_memory > 0`,
+  `payload->battery_level >= 0`.
+
+**What to check to confirm this stayed fixed** (this is exactly what
+`test_telemetry_extraction.cpp`'s presence block does — see §4): send an LLM completion
+event with `output_tokens = 0` and `input_tokens = 0` explicitly set, and
+`tokens_per_second`/`context_length` left unset. Assert the wire body contains
+`"output_tokens":0` and `"input_tokens":0` as literal numbers, and `"tokens_per_second":null`
+/ `"context_length":null` — not all four as `null`, and not all four as `0`. If a future
+refactor reverts to plain `add_int`/`add_double` for any of these fields, that regression
+test is the thing that catches it; grep `telemetry_json.cpp` for `add_int(` / `add_double(`
+(the non-`_or_null`/non-`_always` forms) if you suspect a field regressed — those two still
+silently skip zero by design and must never be used for a field where `0` is meaningful.
+
+## 4. Build, test, and what each telemetry test asserts (macOS)
+
+```bash
+cmake --preset macos-debug
+cmake --build build/macos-debug
+ctest --preset macos-debug --output-on-failure -R 'telemetry|device_identity'
+```
+
+Or the non-preset form (`core/AGENTS.md`'s documented path):
+
+```bash
+cmake -B build -DRAC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+`telemetry_extraction_tests` and `device_identity_tests` are registered in
+`core/tests/CMakeLists.txt`; `rcli_telemetry_live_tests` is registered separately in
+`rcli/tests/CMakeLists.txt`. All three are hand-rolled assertion runners — `CHECK()` in
+some files, `ASSERT_EQ`/`ASSERT_TRUE` (from `core/tests/test_common.h`) in others — never
+GoogleTest:
+
+| ctest name | Binary | What it asserts |
+|---|---|---|
+| `telemetry_extraction_tests` | `test_telemetry_extraction` | Full proto→JSON pipeline per modality (LLM token counts/`tokens_per_second`, STT NaN-confidence never leaks as the string `"nan"`, TTS `characters_per_second`, embeddings `total_tokens`/`batch_size`/`embedding_dimension`, LoRA failure-path fields, RAG retrieval counts, VLM image/timing fields, live device-state stamping); the presence/measured-zero contract (§3); the closed-vocabulary drop rule (§2); and an HTTP-retry backoff (a failed batch is re-sent only after >5s, never before). Requires `RAC_HAVE_PROTOBUF` — the test binary itself no-ops with exit 0 if commons wasn't built with protobuf support. |
+| `device_identity_tests` | `test_device_identity` | Every branch of `rac_device_get_or_create_persistent_id()`'s resolution chain (§6) against a mocked platform adapter — cache hit, vendor-ID fallback, fresh-UUID generation, and that a `secure_set` failure doesn't silently drop the ID. |
+| `rcli_telemetry_live_tests` | `test_rcli_telemetry_live` | **Opt-in, always registered but a no-op by default.** Runs only with `--live` *and* `RUNANYWHERE_BASE_URL`/`RUNANYWHERE_API_KEY` set; otherwise prints "skip" and exits 0 — a green ctest run for this target proves nothing by itself. When live, it runs `rcli::bootstrap()` (real API-key → device-register → JWT handshake), sends one real event per modality (LLM, embeddings, RAG, VLM, LoRA-failure) through the real HTTP transport, and fails on any non-2xx response — this is the test that would catch a strict-schema `422 extra_forbidden` from field drift against the real V2 endpoints. |
+
+Run it live (§7 has the full local-backend flow):
+
+```bash
+RUNANYWHERE_BASE_URL=https://<backend-origin> RUNANYWHERE_API_KEY=<key> \
+  ./build/macos-debug/rcli/tests/test_rcli_telemetry_live --live
+```
+
+`test_platform_bridge` (same `CMakeLists.txt`, adjacent target) is the wider companion
+check — "every value a binding supplies must reach the wire" — covering the platform half
+of the same two flat C structs (`rac_client_info_t`/`rac_device_registration_info_t`) for
+every SDK at once; run it alongside if you're touching client-info fields rather than
+telemetry event fields specifically.
+
+## 5. Regenerating the vocabulary header, and the drift gate
+
+`rac_telemetry_vocabulary.h` (§2) is generated from `idl/http/sdk-openapi.json` — the
+device-facing OpenAPI subset copied in from the private backend repo. **How that file gets
+updated on the backend side, and how it crosses into this repo, is the monorepo's
+`openapi-contract` skill's job — read that by name in the other repo rather than
+re-deriving the steps here.** From inside this repo, once `idl/http/sdk-openapi.json` is
+current:
+
+```bash
+python3 idl/codegen/generate_telemetry_vocabulary.py          # regenerate the header
+python3 idl/codegen/generate_telemetry_vocabulary.py --check  # CI drift check; exit 1 if stale
+```
+
+`.github/workflows/telemetry-vocabulary-drift.yml` runs three checks on every push to
+`main`/`development` and on any PR touching `idl/http/**`, the codegen script, or the
+telemetry source/header dirs:
+
+1. **Generated header is current** — the `--check` command above.
+2. **Every event type the core can emit is in the vocabulary** — a Python check that parses
+   `proto_event_type_string()`'s body out of `telemetry_manager.cpp` via regex, unions in
+   the two prefix-expansion families (`stt.model.*`/`tts.voice.*`/`llm.model.*` and
+   `llm*`/`vlm*` generation suffixes), and diffs against `TelemetryEventType`'s enum in
+   `idl/http/sdk-openapi.json`. Anything emittable but unpublished fails the job.
+3. **Every framework string the core can emit is in the vocabulary** — same technique
+   against `framework_proto_to_string()` and `framework_to_string()` vs. `TelemetryBackend`.
+
+**A documented drift you will hit if you trust the wrong file**: `idl/http/README.md`'s own
+"What it pins" table names the schema for the `framework`/`backend` field as
+`TelemetryFramework` — that's stale. The actual generator
+(`idl/codegen/generate_telemetry_vocabulary.py`'s `VOCABULARIES` dict) and the header it
+produces both say `TelemetryBackend`. Trust the generator and the generated header's own
+`// Published as X` comments over that README table.
+
+## 6. Per-binding device identity: where it's created, where it's persisted
+
+The resolution chain itself is centralized in commons —
+`core/src/infrastructure/device/device_identity.cpp`
+(`rac_device_get_or_create_persistent_id`, tested by `device_identity_tests`, §4) — and is
+the same fixed order for every binding:
+
+1. `adapter.secure_get("com.runanywhere.sdk.device.uuid")` — if found and non-empty, use it,
+   full stop.
+2. `adapter.get_vendor_id` (if the platform adapter provides one) — use it, then persist it
+   via `secure_set` so step 1 hits next boot.
+3. Generate a fresh RFC-4122 v4 UUID, persist it via `secure_set`.
+
+What differs per binding is **only** the `secure_get`/`secure_set` backing store — an
+unstable backing store (one that doesn't survive a real app restart, or that resolves to a
+different physical location than the read path expects) is exactly the bug class that
+inflates device counts, because step 3 fires again on every "cache miss":
+
+| Binding | Backing store | Where |
+|---|---|---|
+| Swift (iOS/macOS) | Keychain, service `com.runanywhere.sdk` | `bindings/swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+PlatformAdapter.swift` (`platformSecureGetCallback`/`platformSecureSetCallback`) |
+| Kotlin (Android) | Android Keystore AES-256-GCM key, ciphertext in a no-backup app file (not `SharedPreferences`) | `bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/foundation/security/AndroidKeychainManager.kt` (`NoBackupCiphertextStore`), wired through `CppBridgePlatformAdapter.PlatformSecureStorage` |
+| Flutter | Native Keychain/Keystore helper via FFI symbols `ra_flutter_secure_storage_{store,retrieve,delete}` | `bindings/flutter/packages/runanywhere/lib/native/dart_bridge_secure_storage.dart`; the device-UUID key constant is duplicated (deliberately, per its own comment) as `_keyDeviceUUID = 'com.runanywhere.sdk.device.uuid'` in `dart_bridge_device.dart` |
+| React Native (Android) | `SecureStorageManager` (native Android side) via `PlatformAdapterBridge.kt`'s `secureGet`/`secureSet` | `bindings/react-native/packages/core/android/src/main/java/com/margelo/nitro/runanywhere/PlatformAdapterBridge.kt` |
+| Web | `localStorage`, key `rac_sdk_plaintext_com.runanywhere.sdk.device.uuid` — **plaintext**, no OS-level encryption equivalent exists in a browser; restricted by convention to non-sensitive IDs | `bindings/web/packages/core/src/runtime/PlatformAdapter.ts` (`registerSecureGet`/`registerSecureSet`); also has a separate `stableVendorId()` fallback under key `rac_sdk_plaintext_vendor_id` |
+| Electron (macOS/Linux) | Flat file under a secure directory, path-traversal-guarded (`fs::path(key)` must not be absolute or contain `..`) | `bindings/electron/native/posix_platform_adapter.cpp` (`posix_secure_get`/`posix_secure_set`) |
+| Electron (Windows) | Windows DPAPI (`CryptProtectData`, current-user scope, no UI) | `bindings/electron/native/win32_platform_adapter.cpp` (`win_secure_get`/`win_secure_set`) |
+
+The key string itself — `com.runanywhere.sdk.device.uuid` — is intentionally the same
+literal across Swift, Flutter, and RN (each source comments cross-reference the other two by
+name), so grepping for it is a fast way to confirm a new binding is reading/writing the
+*same* key it thinks it is, not a typo'd sibling.
+
+**How to verify stability across a real restart** (not just "the code looks right"):
+
+1. Run the binding once, capture the emitted `device_id` from a real request body (§7) or
+   from `POST /api/v1/devices/register`'s response.
+2. Fully terminate the process (not just background it — on mobile this matters, a
+   backgrounded app can keep its in-memory device-id cache alive without ever touching
+   the read path again).
+3. Relaunch and repeat step 1.
+4. The `device_id` must be byte-identical. If it changed, the break is almost always one of:
+   the backing store not surviving process death (e.g. an in-memory-only stub used during
+   development), a key-name mismatch between the write and read paths, or (Android
+   specifically) `Context.deleteSharedPreferences` being invoked on the wrong file — see
+   `AndroidKeychainManager.kt`'s constructor, which deletes a hardcoded *legacy* prefs name
+   on every construction; if that name were ever widened to match the real store, every
+   Android launch would look like a fresh device.
+
+Two-in-one launches on the *same physical device* (e.g. two emulator instances, or a
+same-device reinstall vs. a real fresh install) are a different, real-world failure mode
+from a code bug — don't conflate an intentional reinstall's fresh ID with instability.
+
+## 7. Point a local build at a local backend and prove an event landed
+
+`rcli` is the fastest way to exercise the full wire path without a mobile/browser
+toolchain — it links `rac_commons` directly and speaks real HTTP via curl.
+
+```bash
+cmake --preset rcli-macos-release   # or rcli-linux-release on Linux
+cmake --build build/rcli-macos-release --target rcli -j "$(sysctl -n hw.logicalcpu)"
+```
+
+**Keyless (development environment) — no API key, works against any backend that allows
+anonymous V2 telemetry:**
+
+```bash
+./build/rcli-macos-release/rcli/rcli --environment development \
+  --base-url http://127.0.0.1:8000 \
+  telemetry blast --processing-ms 42.5 --session-id my-check \
+  --input-tokens 128 --output-tokens 256
+```
+
+This is exactly the shape `scripts/ci/oss_keyless_telemetry_blast.sh` runs in CI against the
+public staging backend — `--environment development --base-url <origin> telemetry blast
+...` with no `--api-key`. `telemetry blast` sends one representative event per modality (all
+12) and prints a `MODALITY | RESULT | STATUS | RECEIVED | STORED | SKIPPED` table parsed
+directly from the backend's own batch response — **the `STORED` column is authoritative
+server-side confirmation**, not just an HTTP 2xx. `run_telemetry_blast()`'s own exit-code
+logic (`rcli/src/commands/cmd_telemetry.cpp`) does fold `stored >= count` into its overall
+pass/fail, so a genuine storage shortfall on any modality does make the process exit
+non-zero, not just a transport error — but the exit code is one bit for all 12 modalities
+combined, so a non-zero exit still requires reading the table to know *which* modality
+failed and *why* (a `network error` status is a transport problem; an `HTTP 200` row with
+`STORED` under `RECEIVED` is a row-level rejection, e.g. a vocabulary value the backend
+didn't recognize — a real bug to chase, not the same failure class at all).
+
+**Authenticated (production shape) — for exercising the login handshake too:**
+
+```bash
+./build/rcli-macos-release/rcli/rcli --environment production \
+  --base-url https://<backend-origin> --api-key <key> \
+  auth login
+./build/rcli-macos-release/rcli/rcli --environment production \
+  --base-url https://<backend-origin> --api-key <key> \
+  telemetry emit --modality llm --count 3 --input-tokens 128 --output-tokens 256
+```
+
+`auth login` only has a path in `production` — `development`'s keyless mode has no login
+step by design (see `rcli/src/commands/cmd_auth.cpp`'s own subcommand help text).
+
+**To inspect the actual request body**, not just the summary table, add `--json` for
+machine-readable CLI output and `-v` for debug logging (the debug log includes the
+serialized JSON per batch before it goes on the wire) — or point `--base-url` at a throwaway
+local capture endpoint (any script that logs the raw POST body) before pointing it at a real
+backend, to sanity-check field shape offline first.
+
+**If you have the private backend repo checked out locally too**, running it yourself
+(`cd backend && uv run uvicorn main:app --reload`, per that repo's own README) and pointing
+`--base-url` at `http://127.0.0.1:8000` gets you the strongest possible evidence: query the
+SQLite/Postgres row directly after a blast and diff it field-for-field against what you sent
+— the monorepo's own `telemetry-e2e` skill (its integration suite, hermetic pytest fixtures,
+and `test_telemetry_conformance.py`'s vocabulary/presence/identity assertions against stored
+rows) is the authoritative reference for that side; don't re-implement its DB assertions
+here, just point at it.
+
+## Evidence bar, restated
+
+- Compiling `rcli` or a binding: **not evidence**.
+- `ctest -R telemetry_extraction_tests` green: **not evidence of a real call site** — only
+  of the serializer in isolation.
+- `rcli telemetry blast` exiting 0: real signal (its exit code does fold in the backend's
+  `stored >= count` check, §7) but still worth pairing with the per-modality
+  `STORED`/`SKIPPED` table in your report — the exit code can't tell you *which* modality
+  or *why* a shortfall happened.
+- A captured request body showing the right endpoint, the right keys, correct
+  presence/absence per §3, and no off-vocabulary values per §2 — **evidence of correct
+  emission**.
+- That request body's values matching a stored row (via the backend's own
+  `events_stored` count at minimum, a direct DB read at best) — **evidence of correct
+  end-to-end delivery**, the only tier worth reporting as "telemetry works."

--- a/.claude/commands/address_PR_comments.md
+++ b/.claude/commands/address_PR_comments.md
@@ -1,0 +1,524 @@
+---
+description: Fetch, triage, and act on all comments for a GitHub PR into a single source-of-truth doc.
+argument-hint: [pr-number] [optional-repo]
+---
+
+You are an assistant that triages GitHub PR comments into a single source-of-truth document and turns larger issues into GitHub issues.
+
+## ⚠️ CRITICAL: Address ALL Comments
+
+**You MUST address EVERY SINGLE COMMENT on the PR. No exceptions.**
+
+- Do NOT skip any comments, regardless of how minor they seem.
+- Do NOT assume comments are resolved without verification.
+- Do NOT stop fetching until you have retrieved ALL comments (handle pagination!).
+- The final document must account for 100% of comments on the PR.
+
+## 🚀 Parallelization Strategy: Use Task Agents
+
+**To maximize efficiency and ensure thorough analysis, use the Task tool extensively:**
+
+1. **For complexity/ranking analysis**: Launch **multiple Task agents in parallel** to analyze different comments simultaneously. Each agent should investigate the code context, assess complexity, and return a ranking score.
+
+2. **For addressing each comment**: Launch a **separate Task agent for EACH comment** to fix or investigate it. This ensures:
+   - Each comment gets dedicated attention
+   - Fixes are isolated and don't conflict
+   - Progress can be tracked independently
+   - No comments are accidentally skipped
+
+3. **Batch your Task calls**: When launching multiple agents, send them all in a **single message with multiple Task tool calls** to run them in parallel.
+
+Example pattern:
+
+```text
+# In a SINGLE message, launch multiple Task agents:
+- Task 1: "Analyze comment #1 - check file X, assess complexity, propose fix"
+- Task 2: "Analyze comment #2 - check file Y, assess complexity, propose fix"
+- Task 3: "Analyze comment #3 - check file Z, assess complexity, propose fix"
+```
+
+## Inputs
+
+- Use the **first argument** `$1` as the PR number (`PR_NUMBER`).
+- Use the **second argument** `$2` (if provided) as the repo slug `owner/name`.
+  - If `$2` is not provided, infer the repo from the current git remote / workspace.
+- All work happens on the **current branch** of the current repo.
+
+## 1. Fetch PR details and ALL comments
+
+### ⚠️ IMPORTANT: Use `gh api` directly – NOT MCP tools
+
+The GitHub MCP tools do NOT support pagination. You MUST use the `gh api` command directly via Bash to ensure you fetch ALL comments.
+
+### Step 1a: Get Total Comment Count First
+
+Before fetching comments, get the total count to know how many you need to retrieve:
+
+```bash
+# Get PR details including comment counts
+gh api repos/{owner}/{repo}/pulls/{PR_NUMBER} --jq '{
+  title: .title,
+  author: .user.login,
+  state: .state,
+  body: .body,
+  url: .html_url,
+  review_comments: .review_comments,
+  comments: .comments
+}'
+```
+
+### Step 1b: Fetch PR Metadata
+
+```bash
+gh pr view {PR_NUMBER} --repo {owner}/{repo} --json title,author,state,body,url,comments,reviewDecision
+```
+
+### Step 1c: Fetch ALL Review Comments (with pagination)
+
+Review comments are comments on specific lines of code. **You MUST paginate through ALL pages:**
+
+```bash
+# Fetch review comments - paginate until empty results
+# Page 1
+gh api repos/{owner}/{repo}/pulls/{PR_NUMBER}/comments --paginate --jq '.[] | {
+  id: .id,
+  author: .user.login,
+  body: .body,
+  path: .path,
+  line: .line,
+  created_at: .created_at,
+  updated_at: .updated_at,
+  url: .html_url,
+  in_reply_to_id: .in_reply_to_id
+}'
+```
+
+The `--paginate` flag automatically handles pagination for you, fetching ALL pages.
+
+### Step 1d: Fetch ALL Issue Comments (with pagination)
+
+Issue comments are general PR comments (not on specific lines):
+
+```bash
+# Fetch issue comments - paginate until empty results
+gh api repos/{owner}/{repo}/issues/{PR_NUMBER}/comments --paginate --jq '.[] | {
+  id: .id,
+  author: .user.login,
+  body: .body,
+  created_at: .created_at,
+  updated_at: .updated_at,
+  url: .html_url
+}'
+```
+
+### Step 1e: Verify Comment Count
+
+After fetching, **VERIFY** you have ALL comments:
+
+```bash
+# Count what you fetched
+REVIEW_COMMENTS=$(gh api repos/{owner}/{repo}/pulls/{PR_NUMBER}/comments --paginate --jq 'length')
+ISSUE_COMMENTS=$(gh api repos/{owner}/{repo}/issues/{PR_NUMBER}/comments --paginate --jq 'length')
+
+echo "Review comments fetched: $REVIEW_COMMENTS"
+echo "Issue comments fetched: $ISSUE_COMMENTS"
+echo "Total: $((REVIEW_COMMENTS + ISSUE_COMMENTS))"
+```
+
+Compare this total against the counts from Step 1a. If they don't match, investigate and re-fetch.
+
+### Step 1f: Count and Document
+
+1. Count the total number of comments (including threaded replies).
+2. **Document the count in the output file** – this is your verification that ALL comments were captured.
+
+## 2. Create / update the comments document
+
+1. In the repo root (or appropriate parent directory), ensure there is a `comments/` folder.
+2. Create or overwrite a single markdown file:
+   - Path: `comments/PR_${1}_comments.md`
+3. At the top of the file, write a header like:
+
+   ```md
+   # PR #$1 – Comment Triage
+
+   - Repo: <owner/name>
+   - PR Title: <title>
+   - PR URL: <url>
+   - Total comments (including replies): <N>
+
+   ## PR Description
+
+   <PR body/description here>
+
+   ---
+
+
+This file must be treated as the single source of truth for this PR’s comments and resolutions.
+
+Every time you do work for this command, keep updating this same file instead of creating new ones.
+
+3. Normalize and analyze each comment
+
+For each PR comment (including review comments and replies):
+
+Extract:
+
+Author
+
+Created/updated timestamps
+
+The full comment text
+
+The file + line / code context if available
+
+A permalink to the comment in GitHub
+
+Detect whether the comment:
+
+Is a true issue (bug, correctness, performance, security, missing tests, UX problem, etc.)
+
+Is a nit / style / minor suggestion
+
+Is a question or pure discussion
+
+If the comment includes an AI prompt for the fix, capture that exactly (do not rewrite) and keep it attached to that comment.
+
+4. Gut scoring and prioritization
+
+### ⚠️ Use Parallel Task Agents for Analysis
+
+**Launch multiple Task agents in parallel** to analyze comments simultaneously. For each batch of comments:
+
+1. Send a **single message with multiple Task tool calls** (one per comment)
+2. Each Task agent should:
+   - Read the relevant file(s) mentioned in the comment
+   - Understand the code context
+   - Assess the legitimacy and complexity
+   - Return a structured analysis with scores
+
+Example prompt for each Task agent:
+
+```text
+Analyze PR comment for scoring:
+- Comment: "<comment text>"
+- File: <path>:<line>
+- Task: Read the file, understand context, and return:
+  1. LUS (Legitimacy & Urgency Score): 1-5
+  2. CS (Complexity Score): 1-5
+  3. Category: bug | nit | style | docs | question | other
+  4. Brief explanation of your scoring
+```
+
+### Scoring Criteria
+
+For each comment that represents an actionable issue, assign two gut scores (simple 1–5 scale):
+
+Legitimacy & Urgency Score (LUS) – 1 (not legit / very low urgency) to 5 (definitely legit / very urgent).
+
+Complexity Score (CS) – 1 (trivial / one-liner change) to 5 (large refactor / multi-file / needs design).
+
+Then:
+
+Compute a rough priority rank:
+
+Sort primarily by LUS (descending).
+
+Ties can be broken by CS (descending) or your judgment.
+
+Use this ranking to decide if an item goes into:
+
+Section 1: Quick & Easy Fixes (LUS high, CS low–medium)
+
+Section 2: Larger / Structural Issues (LUS medium–high, CS medium–high)
+
+5. Document structure inside PR_${1}_comments.md
+
+Inside the markdown file, after the PR description, create these sections:
+
+## Section 1 – Quick & Easy Fixes
+
+(Short, low-complexity items we should fix directly in this PR.)
+
+## Section 2 – Larger / Structural Issues (Create GitHub Issues)
+
+(Items that are too big or risky to fully fix in this PR and should be tracked as issues.)
+
+## Summary & Status
+
+(High-level summary of what was addressed, what remains, and links to created issues.)
+
+Section 1 – Quick & Easy Fixes
+
+For each quick/easy item, add an entry like:
+
+### QEF-<index> – <short title>
+
+- Source comment: <GitHub permalink>
+- Author: <name>
+- File / location: `<path>:<line>` (if available)
+- LUS (Legitimacy & Urgency): <1–5>
+- CS (Complexity): <1–5>
+- Type: bug | nit | style | docs | question | other
+
+**Original Comment:**
+> <comment text>
+
+**AI Prompt (from comment, if present):**
+```text
+<prompt or "N/A">
+
+
+Plan / Notes:
+
+<your brief plan for how to fix, or what needs to be done>
+
+Status:
+
+TODO | In progress | Fixed (include commit hash / PR link if known)
+
+
+### Section 2 – Larger / Structural Issues
+
+For each larger item that should become a GitHub issue, add:
+
+```md
+### ISSUE-CANDIDATE-<index> – <short title>
+
+- Source comment: <GitHub permalink>
+- Author: <name>
+- File / location: `<path>:<line>` (if available)
+- LUS (Legitimacy & Urgency): <1–5>
+- CS (Complexity): <1–5>
+
+**Original Comment:**
+> <comment text>
+
+**Why this should be an issue:**
+- <brief explanation>
+
+**Draft Issue Title:**
+- <proposed GitHub issue title>
+
+**Draft Issue Overview:**
+- <1–3 sentence overview: what, impact, priority>
+
+**Status:**
+- TODO (not created) | Created as <issue link>
+
+6. Verifying each issue against the code
+
+Once you’ve populated the doc:
+
+For each actionable item (both quick fixes and larger issues):
+
+Make sure you are on the current branch.
+
+Use code navigation (file reads, searches, git tools, etc.) to verify:
+
+The problem truly exists.
+
+The comment is still relevant (the code may have changed).
+
+If a comment is no longer valid, mark it clearly in the doc:
+
+Example: Status: INVALID – Code has changed and this comment no longer applies (explain why).
+
+Update the LUS score if verification changes your confidence.
+
+7. Quick & easy fixes: execution guidance
+
+### ⚠️ CRITICAL: Launch a Separate Task Agent for EACH Comment
+
+**For EVERY quick fix, launch a dedicated Task agent.** Do NOT try to fix multiple comments in a single agent.
+
+Why separate agents per comment:
+- Ensures each comment gets **full, dedicated attention**
+- Prevents fixes from conflicting with each other
+- Makes it easy to track which comments are done
+- Guarantees no comment is accidentally skipped
+
+### Execution Pattern
+
+1. **Batch launch Task agents** - Send multiple Task tool calls in a single message:
+
+```text
+# Launch these in PARALLEL (single message, multiple Task calls):
+
+Task Agent for QEF-1:
+"Fix PR comment QEF-1:
+- Comment: '<comment text>'
+- File: <path>:<line>
+- Apply the fix, verify it compiles, report what you changed"
+
+Task Agent for QEF-2:
+"Fix PR comment QEF-2:
+- Comment: '<comment text>'
+- File: <path>:<line>
+- Apply the fix, verify it compiles, report what you changed"
+
+Task Agent for QEF-3:
+...
+```
+
+2. **Each Task agent should**:
+   - Read the file and understand context
+   - Apply the fix
+   - Verify the code still compiles (if practical)
+   - Report back what was changed
+
+3. **After agents complete**, update the document with results
+
+### Additional Guidelines
+
+Where the comment already includes an AI prompt for the fix, reuse it:
+
+Reference that prompt in your own reasoning.
+
+Optionally use it to generate concrete code changes.
+
+When you apply a fix:
+
+Modify the code in the appropriate files.
+
+Make sure the project still compiles / tests still pass (where practical).
+
+Update the corresponding entry in PR_${1}_comments.md:
+
+Status: Fixed
+
+Include commit hash or link to the PR update.
+
+8. Larger issues: creating GitHub issues
+
+For each item in Section 2 that truly deserves a separate issue:
+
+Create a GitHub issue in RunanywhereAI/runanywhere-sdks using `gh issue create` (prefer `gh` CLI over MCP for reliability):
+
+```bash
+gh issue create --repo RunanywhereAI/runanywhere-sdks
+```
+
+Fill out the issue content:
+
+Required Information
+
+Title – Clear, concise description of the issue (≈50–80 chars).
+
+Labels – Choose from:
+
+ios-sdk, android-sdk, ios-sample, kotlin-sample, kotlin-sdk, web-sdk, web-sample
+
+bug, enhancement, documentation, question
+
+Priority labels: P0, P1, P2
+
+Others as appropriate: good first issue, help wanted, etc.
+
+Overview Section
+
+Brief summary of the issue
+
+Impact level (Low / Medium / High)
+
+Priority (P0 / P1 / P2)
+
+Effort estimate (Small / Medium / Large)
+
+Issue Body Structure
+
+Problem Statement
+
+What’s the issue?
+
+Why does it matter?
+
+What’s broken or needs improvement?
+
+Current State
+
+What exists today?
+
+Specific file paths and line numbers
+
+Code examples showing the problem
+
+Proposed Solution
+
+How to fix it?
+
+Code examples / pseudocode
+
+File structure if creating new files
+
+Implementation Plan
+
+Step-by-step checklist
+
+Files that need changes
+
+Phased approach if applicable
+
+Success Criteria
+
+Clear checklist of what “done” means
+
+Measurable outcomes
+
+Guidelines
+
+Be specific: include file paths, line numbers, and snippets.
+
+Use markdown headings and lists.
+
+Use code blocks with syntax highlighting where appropriate.
+
+Add ⚠️ / 🔵 emojis or similar to highlight priority if useful.
+
+Add a “Related Issues” section if applicable.
+
+Use `gh issue create` with `--title`, `--label`, and `--body` flags.
+
+After creating each issue:
+
+Add the issue URL back into PR_${1}_comments.md under the corresponding ISSUE-CANDIDATE entry.
+
+Update Status to Created as <link>.
+
+9. Final summary and status update
+
+At the end of the command:
+
+Update the Summary & Status section at the bottom of PR_${1}_comments.md with:
+
+Number of comments triaged.
+
+Number of quick & easy fixes identified and how many are already fixed.
+
+Number of larger issues identified and how many have GitHub issues created (with links).
+
+Any remaining TODOs or things that still require human input / clarification.
+
+Make sure the doc reads as a single, up-to-date overview of the PR's review state:
+
+Someone new to the PR should be able to open this one file and understand:
+
+What reviewers asked for,
+
+What has been addressed,
+
+What remains, and
+
+Where to track the remaining work.
+
+## ⚠️ Final Verification Checklist
+
+Before considering this command complete, verify:
+
+- [ ] **ALL comments fetched**: Compare fetched count against PR metadata counts
+- [ ] **ALL comments documented**: Every comment appears in the markdown file
+- [ ] **ALL comments triaged**: Each comment has a status (QEF, ISSUE-CANDIDATE, or marked INVALID)
+- [ ] **ALL quick fixes addressed**: Either fixed or documented why not
+- [ ] **ALL larger issues tracked**: GitHub issues created with links in the doc
+
+**If any comment is missing from the final document, you have NOT completed this command.**

--- a/.claude/commands/copy_over_logic.md
+++ b/.claude/commands/copy_over_logic.md
@@ -1,0 +1,150 @@
+---
+description: Port RunAnywhere SDK components from one platform/framework to another.
+argument-hint: '[from] [to] [component(s)]'
+---
+
+You are RunAnywhere's SDK migration engineer.
+
+Your job is to take code from a **source** SDK / framework / platform (“from”) and implement the equivalent in a **target** SDK / framework / platform (“to”), preserving behaviour and fitting cleanly into the target architecture.
+
+Typical examples:
+- iOS SDK → Android SDK
+- Android SDK → React Native / Flutter wrapper
+- Core Kotlin lib → iOS Swift package
+- Sample app in one platform → sample app in another
+
+---
+
+## 0. Inputs & setup
+
+- Make sure the user has clearly defined: **{from} → {to}**  
+  - “From” can be a language / project / platform (e.g., “iOS SDK”, “android/app”, “KMP core lib”).
+  - “To” can be another language / project / platform (e.g., “Android SDK”, “React Native bridge”, “Web demo”).
+- Clarify *what* they want ported:
+  - A specific component (e.g., `ConversationScreen`, `VoicePipelineConfig`)
+  - A group of files or folders
+  - A feature (“the offline transcription flow”, “the onboarding wizard”)
+
+If the user mentions multiple components or features, **treat each as a separate sub-task** and process them one by one to keep context clear.
+
+---
+
+## 1. Understand the **from** side
+
+For each component/feature requested, launch a TASK for each of them:
+
+1. **Locate the code**
+   - Find all relevant files, folders, and tests.
+   - Include:
+     - Business logic
+     - UI components / views
+     - Configuration, DI wiring, routing/navigation
+     - Any RunAnywhere-specific pieces (on-device models, pipelines, config objects, telemetry)
+
+2. **Build a concise mental model**
+   - What is the responsibility and public API?
+   - What data flows through it? Where does it come from and go?
+   - What other modules does it depend on (core SDK, platform glue, third-party libs)?
+   - How are errors, edge cases, and retries handled?
+   - What constants, colors, strings, or assets does it rely on?
+
+3. **Summarize the “from” design** in a few bullets before you start coding on the “to” side.
+
+---
+
+## 2. Inspect the **to** side and launch a SINGLE task for this:
+
+1. **Find the right home**
+   - Identify the module / package / directory in the target project where this functionality should live:
+     - e.g., platform bridge, UI layer, shared core module, example app.
+
+2. **Check what already exists**
+   - If an equivalent or partial implementation already exists:
+     - Compare behaviour and responsibilities.
+     - Note gaps, mismatches, and duplication risks.
+
+3. **Align with existing architecture**
+   - Respect the target project’s:
+     - Naming conventions
+     - Layering (core vs platform-specific)
+     - DI / service location patterns
+     - Navigation / routing / state management conventions
+     - Error & logging patterns
+
+---
+
+## 3. Design the mapping ({from} → {to}) - Launch another TASK.
+
+Before writing code, plan the mapping:
+
+- How do classes, types, and functions in **from** map into **to**?
+  - E.g., Swift async/await → Kotlin coroutines; delegates → callbacks/flows; ViewControllers → Activities/Fragments/Compose.
+- Decide what should stay **shared/core** vs what must be **platform-specific**.
+  - Push cross-platform logic into shared modules when possible.
+  - Keep platform glue thin and focused on UI + system APIs.
+- Handle platform differences explicitly:
+  - Lifecycle, threading, permissions, background execution, storage, etc.
+
+Write a short mapping plan (even just bullets) before implementing.
+
+---
+
+## 4. Implement the port in the **to** project - Launch another task for implementation
+
+For each component/feature:
+
+1. **Create / update code**
+   - Implement the equivalent functionality using idiomatic patterns for the target language/framework.
+   - Keep behaviour as close as possible to the source unless platform constraints require changes.
+
+2. **Wire it into the system**
+   - Update:
+     - DI containers / service locators
+     - Routing / navigation
+     - RunAnywhere SDK configuration / initialization if needed
+     - Gradle/SPM/Pods/module exports where applicable
+
+3. **Keep the public surface consistent**
+   - Prefer keeping API names, parameter semantics, and events consistent across platforms where it makes sense for SDK consumers.
+
+4. **Avoid duplication**
+   - If you see duplicated logic, consider refactoring it into a shared/core module instead of copy-pasting.
+
+---
+
+## 5. Quality + correctness checks - Launch a verification task
+
+- Ensure the **to** project still compiles.
+  - Fix imports, types, build settings, and module wiring.
+- Run any available tests relevant to the change.
+- If there were tests on the **from** side:
+  - Re-use/adapt them for the **to** side where practical, or at least mirror the key cases.
+- Manually sanity-check:
+  - Main happy path
+  - Important edge cases (failures, timeouts, offline scenarios, permission denials, etc.)
+- Check:
+  - No obvious lint/style violations.
+  - No hard-coded values that should be shared constants or config.
+
+If something cannot be fully implemented (missing platform capability, unclear design), explicitly call that out and propose alternatives.
+
+---
+
+## 6. Summarize back to the user - Produce a final summary
+
+At the end, respond with:
+
+1. **High-level summary** (3–6 bullets) of what you did and why.
+2. **File-level summary**:
+   - New files added in {to}
+   - Existing files modified in {to} (and, if relevant, in {from})
+3. **Behavioural summary**:
+   - Confirmed behaviours that now match {from}
+   - Any intentional behaviour differences and why
+4. **Follow-ups & TODOs**:
+   - Remaining gaps
+   - Tests or refactors you recommend next
+   - Any questions that require product/architecture input
+
+Always write the summary so that another engineer on the RunAnywhere team can quickly understand the change and continue the work.
+

--- a/.claude/commands/run_and_fix_lints.md
+++ b/.claude/commands/run_and_fix_lints.md
@@ -1,0 +1,516 @@
+---
+description: Detect, run, report, and fix ALL lint errors in a project using parallel agents.
+argument-hint: [project-path]
+---
+
+You are an assistant that detects, runs, reports, and **fixes ALL lint errors** in a project using a multi-agent approach.
+
+## Critical Requirements
+
+**You MUST fix EVERY SINGLE lint error. No exceptions.**
+
+- Do NOT stop until ALL lint errors are fixed.
+- Do NOT skip any error, regardless of how minor it seems.
+- Do NOT claim an error cannot be fixed without exhausting all options.
+- PRESERVE all business logic - fixes must not change functionality.
+- The final result must be a project with ZERO lint errors.
+
+---
+
+## Multi-Agent Workflow Overview
+
+This command uses a **4-phase multi-agent approach**:
+
+```
+Phase 1: DETECTION AGENT
+    └── Identify project type(s) and lint tooling
+
+Phase 2: EXECUTION AGENT
+    └── Run all lint checks and capture outputs
+
+Phase 3: REPORT AGENT
+    └── Parse results and create structured report
+
+Phase 4: FIX AGENTS (PARALLEL)
+    └── Launch N agents to fix errors (one per file or error group)
+    └── Repeat until zero errors remain
+```
+
+---
+
+## Phase 1: Detection Agent
+
+**Launch a Task agent** to identify project types and lint tooling.
+
+### Agent Prompt Template
+
+```text
+Analyze the project at [PROJECT_PATH] and identify:
+
+1. PROJECT TYPES - Detect by scanning for canonical files:
+   - Swift/iOS: Package.swift, *.xcodeproj, *.xcworkspace, Podfile, **/*.swift
+   - Kotlin/Android: gradlew, settings.gradle(.kts), build.gradle(.kts), AndroidManifest.xml
+   - React Native/Node/TypeScript: package.json, tsconfig.json, node_modules
+   - Flutter/Dart: pubspec.yaml, lib/, analysis_options.yaml
+
+2. LINT TOOLING - For each project type, check:
+   - Swift: .swiftlint.yml, .swiftformat, .periphery.yml, Mintfile
+   - Kotlin: detekt.yml, ktlint config, Gradle lint tasks
+   - Node/TS: .eslintrc*, tsconfig.json, .prettierrc*, package.json scripts
+   - Dart: analysis_options.yaml
+
+3. TOOL RUNNERS - Detect available runners:
+   - Mint, Bundler, Gradle wrapper, npm/yarn/pnpm
+
+Return a structured report with:
+- Detected project types and evidence (files found)
+- Detected lint tools and their config paths
+- Recommended lint commands to run
+- Any missing tools or setup issues
+```
+
+### Expected Output from Detection Agent
+
+Document the findings before proceeding:
+- List of project types
+- List of configured lint tools
+- Exact commands to run for each tool
+
+---
+
+## Phase 2: Execution Agent
+
+**Launch a Task agent** to run all detected lint checks.
+
+### Agent Prompt Template
+
+```text
+Run lint checks for the project at [PROJECT_PATH].
+
+Based on the detection results:
+[INSERT DETECTION RESULTS HERE]
+
+Execute these lint commands in order, capturing ALL output:
+
+For Swift/iOS:
+- SwiftLint: mint run swiftlint swiftlint lint --reporter json (or swiftlint lint --reporter json)
+- SwiftFormat: swiftformat . --lint (if configured)
+- Periphery: periphery scan (if configured)
+
+For Kotlin/Android:
+- ./gradlew ktlintCheck --no-daemon (if ktlint configured)
+- ./gradlew detekt --no-daemon (if detekt configured)
+- ./gradlew lint --no-daemon (Android lint)
+
+For Node/TypeScript:
+- [package-manager] run lint (if lint script exists)
+- [package-manager] exec eslint . (if eslint configured)
+- [package-manager] exec tsc --noEmit (if tsconfig exists)
+
+For Flutter/Dart:
+- flutter analyze
+- dart format . --set-exit-if-changed
+
+CRITICAL RULES:
+- Capture stdout AND stderr for each tool
+- Record exit code for each tool
+- Continue even if a tool fails
+- Save raw outputs to comments/.lint_tmp/
+
+Return:
+- Commands executed with exit codes
+- Path to each raw output file
+- Initial count of errors/warnings per tool
+```
+
+---
+
+## Phase 3: Report Agent
+
+**Launch a Task agent** to parse results and create a structured report.
+
+### Agent Prompt Template
+
+```text
+Create a comprehensive lint report from the execution results.
+
+Execution results:
+[INSERT EXECUTION RESULTS HERE]
+
+Tasks:
+1. Create report directory: comments/
+2. Create report file: comments/LINT_[PROJECT_NAME]_[TIMESTAMP].md
+
+3. Parse each tool's output into severity buckets:
+   - ERRORS: Must be fixed (blocks CI, breaks builds)
+   - WARNINGS: Should be fixed (code quality issues)
+   - STYLE/INFO: Nice to fix (formatting, conventions)
+
+4. For each error/warning, extract:
+   - File path and line number
+   - Error code/rule name
+   - Error message
+   - Suggested fix (if provided by tool)
+
+5. Create the report with these sections:
+
+## Report Structure
+
+### Header
+- Project path
+- Timestamp
+- Branch and commit
+- Tools executed
+
+### Summary Table
+| Tool | Exit Code | Errors | Warnings | Style |
+|------|-----------|--------|----------|-------|
+| ...  | ...       | ...    | ...      | ...   |
+
+### Errors by File
+Group errors by file path for efficient fixing:
+
+#### File: path/to/File1.swift
+- Line 42: [E001] Error description
+- Line 87: [E002] Error description
+
+#### File: path/to/File2.kt
+- Line 15: [E003] Error description
+
+### Warnings by File
+(Same structure as errors)
+
+### Style Issues by File
+(Same structure as errors)
+
+### Raw Outputs
+<details>
+<summary>Tool Name - Raw Output</summary>
+(raw output here)
+</details>
+
+Return the full report and a summary:
+- Total errors: N
+- Total warnings: N
+- Total style issues: N
+- Files affected: N
+```
+
+---
+
+## Phase 4: Fix Agents (Parallel)
+
+**This is the most critical phase. You MUST fix ALL errors.**
+
+### Strategy: Parallel Agents per File
+
+Launch **multiple Task agents in parallel**, one for each file with errors.
+
+**Why separate agents per file:**
+- Ensures each file gets dedicated attention
+- Prevents conflicting edits
+- Makes progress trackable
+- Guarantees no error is skipped
+
+### Agent Launch Pattern
+
+In a **single message**, launch multiple Task tool calls:
+
+```text
+# Launch these in PARALLEL (single message, multiple Task calls):
+
+Task Agent for File 1:
+"Fix ALL lint errors in [path/to/File1.swift]:
+Errors to fix:
+- Line 42: [E001] Description
+- Line 87: [E002] Description
+
+RULES:
+- Fix EVERY error listed
+- PRESERVE all business logic
+- Maintain code formatting consistency
+- Report what you changed
+- Verify the file still compiles"
+
+Task Agent for File 2:
+"Fix ALL lint errors in [path/to/File2.kt]:
+Errors to fix:
+- Line 15: [E003] Description
+...
+
+Task Agent for File 3:
+...
+```
+
+### Fix Agent Detailed Prompt
+
+For each file, the fix agent must:
+
+```text
+Fix ALL lint errors in [FILE_PATH].
+
+Errors to fix:
+[LIST ALL ERRORS WITH LINE NUMBERS AND DESCRIPTIONS]
+
+## Critical Rules
+
+1. FIX EVERY ERROR - Do not skip any
+2. PRESERVE BUSINESS LOGIC - Changes must not alter functionality
+3. MAINTAIN STYLE - Keep consistent with surrounding code
+4. VERIFY COMPILATION - Ensure code still compiles after fixes
+
+## Common Fix Patterns
+
+### Swift/SwiftLint
+- trailing_whitespace: Remove trailing whitespace
+- line_length: Break long lines or refactor
+- force_unwrapping: Use optional binding or guard
+- unused_import: Remove unused imports
+- identifier_name: Rename to follow conventions
+
+### Kotlin/Detekt/Ktlint
+- max-line-length: Break long lines
+- no-wildcard-imports: Use specific imports
+- unused-imports: Remove unused imports
+- naming conventions: Rename to follow conventions
+
+### TypeScript/ESLint
+- no-unused-vars: Remove or use the variable
+- prefer-const: Change let to const
+- @typescript-eslint rules: Follow type safety recommendations
+
+## Response Format
+
+Report back:
+1. List of errors fixed (with before/after snippets)
+2. Any errors that could NOT be fixed and why
+3. Confirmation that file still compiles
+4. Any concerns about business logic preservation
+```
+
+### Iteration Until Zero Errors
+
+After the fix agents complete:
+
+1. **Re-run lint checks** to verify fixes
+2. **Count remaining errors**
+3. **If errors remain**, launch another round of fix agents
+4. **Repeat until zero errors**
+
+```text
+VERIFICATION LOOP:
+
+while (lint_errors > 0) {
+    1. Re-run lint checks
+    2. Parse new errors
+    3. Launch fix agents for remaining errors
+    4. Collect results
+}
+
+STOP only when: lint_errors == 0
+```
+
+---
+
+## Execution Flow
+
+### Step 1: Setup
+
+```bash
+PROJECT_PATH="${1:?Usage: run_and_fix_lints <project-path>}"
+
+# Get repo root
+if git rev-parse --show-toplevel >/dev/null 2>&1; then
+  REPO_ROOT="$(git rev-parse --show-toplevel)"
+else
+  REPO_ROOT="$(cd "$PROJECT_PATH" && pwd)"
+fi
+
+cd "$REPO_ROOT"
+mkdir -p comments/.lint_tmp
+
+SAFE_PROJECT_NAME="$(basename "$PROJECT_PATH" | tr -cd 'A-Za-z0-9_-')"
+TS="$(date +%Y%m%d_%H%M%S)"
+REPORT="comments/LINT_${SAFE_PROJECT_NAME}_${TS}.md"
+```
+
+### Step 2: Launch Detection Agent
+
+```text
+Task: Analyze [PROJECT_PATH] for project types and lint tooling
+Agent: Explore or general-purpose
+Return: Detection results
+```
+
+### Step 3: Launch Execution Agent
+
+```text
+Task: Run all detected lint tools on [PROJECT_PATH]
+Agent: general-purpose
+Input: Detection results from Step 2
+Return: Raw outputs and initial error counts
+```
+
+### Step 4: Launch Report Agent
+
+```text
+Task: Parse lint outputs and create structured report
+Agent: general-purpose
+Input: Execution results from Step 3
+Return: Structured report with errors grouped by file
+```
+
+### Step 5: Launch Fix Agents (Parallel)
+
+```text
+For each file with errors:
+  Launch Task agent to fix ALL errors in that file
+
+Run all fix agents in PARALLEL (single message, multiple Task calls)
+```
+
+### Step 6: Verification Loop
+
+```text
+while lint_errors > 0:
+    1. Re-run lint (same commands as Step 3)
+    2. Parse new errors
+    3. If errors remain:
+       - Update report with progress
+       - Launch new fix agents for remaining errors
+    4. If max_iterations reached:
+       - Document unfixable errors
+       - Provide manual fix guidance
+```
+
+### Step 7: Final Report Update
+
+Update the report with final status:
+- All errors that were fixed
+- Before/after error counts
+- Any warnings about business logic changes
+- Final lint status (should be PASS)
+
+---
+
+## Output Requirements
+
+### Report Location
+- Path: `comments/LINT_${PROJECT_NAME}_${TIMESTAMP}.md`
+
+### Report Must Include
+1. Detection results (project types, tools found)
+2. Commands executed with exit codes
+3. Initial error/warning/style counts
+4. Errors grouped by file
+5. Fix summary (what was changed)
+6. Final verification results
+7. Status: PASS (all errors fixed) or FAIL (with remaining issues)
+
+### Console Output
+At the end, print:
+```
+Lint Fix Complete!
+- Initial errors: X
+- Errors fixed: Y
+- Remaining errors: 0
+- Report: comments/LINT_[name]_[timestamp].md
+```
+
+---
+
+## Verification Checklist
+
+Before considering this command complete, verify:
+
+- [ ] **Detection complete**: All project types and lint tools identified
+- [ ] **Lint executed**: All configured lint tools were run
+- [ ] **Report created**: Structured report exists in comments/
+- [ ] **Errors grouped**: All errors organized by file
+- [ ] **Fix agents launched**: Parallel agents for each affected file
+- [ ] **All errors fixed**: Zero lint errors remaining
+- [ ] **Business logic preserved**: No functional changes
+- [ ] **Code compiles**: Project still builds successfully
+- [ ] **Final verification**: Re-ran lint to confirm zero errors
+
+**If ANY lint errors remain unfixed, you have NOT completed this command.**
+
+---
+
+## Edge Cases and Handling
+
+### Tool Not Found
+If a configured lint tool is not installed:
+- Document the missing tool in the report
+- Attempt to install (e.g., `brew install swiftlint`, `mint bootstrap`)
+- If install fails, note in report and continue with other tools
+
+### Unfixable Errors
+If an error genuinely cannot be auto-fixed:
+- Document why (e.g., requires architectural change)
+- Provide manual fix guidance
+- Mark as "MANUAL_FIX_REQUIRED" in report
+
+### Conflicting Rules
+If lint rules conflict with each other:
+- Document the conflict
+- Prefer the stricter/safer rule
+- Add note about potential config adjustment
+
+### Large Error Counts
+If a file has >20 errors:
+- Still create a fix agent for it
+- The agent should batch related fixes
+- May require multiple iterations
+
+---
+
+## Example Execution
+
+```text
+User: /run_and_fix_lints examples/ios/RunAnywhereAI
+
+Agent Actions:
+1. Launch Detection Agent for examples/ios/RunAnywhereAI
+   Result: iOS project, SwiftLint configured, Mint available
+
+2. Launch Execution Agent
+   Commands: mint run swiftlint swiftlint lint --reporter json
+   Result: 47 errors, 23 warnings across 12 files
+
+3. Launch Report Agent
+   Result: Structured report with errors grouped by file
+
+4. Launch Fix Agents (12 parallel agents, one per file)
+   - Agent 1: Fix 8 errors in AppDelegate.swift
+   - Agent 2: Fix 5 errors in ContentView.swift
+   - Agent 3: Fix 4 errors in VoiceService.swift
+   ...
+
+5. Re-run lint verification
+   Result: 3 remaining errors in 2 files
+
+6. Launch Fix Agents Round 2 (2 agents)
+   - Agent 1: Fix 2 errors in ContentView.swift
+   - Agent 2: Fix 1 error in VoiceService.swift
+
+7. Re-run lint verification
+   Result: 0 errors - SUCCESS!
+
+8. Final report update
+   Status: PASS - All 47 errors fixed
+```
+
+---
+
+## Summary
+
+This command ensures **comprehensive lint coverage** through:
+
+1. **Automated detection** of project types and lint tools
+2. **Systematic execution** of all configured linters
+3. **Structured reporting** with errors grouped by file
+4. **Parallel fix agents** that address each file independently
+5. **Iterative verification** until zero errors remain
+
+**The goal is simple: zero lint errors, preserved business logic.**

--- a/.claude/skills/engine-plugin-authoring/SKILL.md
+++ b/.claude/skills/engine-plugin-authoring/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: engine-plugin-authoring
+description: Step-by-step recipe for adding a new engine plugin under runanywhere-sdks/engines/, or adding a modality (e.g. TTS) to an existing engine (llamacpp, sherpa, onnx, cloud, mlx, neurt, qhexrt). Use when the task is "add engine X", "wire up backend Y", or "make engine Z also serve <modality>".
+---
+
+# Engine plugin authoring (`engines/`)
+
+Two related runbooks: adding a brand-new engine plugin, and adding a modality to one
+that already exists. Read `engines/AGENTS.md` first for the concepts these steps
+assume (op-table vtable, manifest, the valid-engine checklist, the 4-file skeleton,
+the engine↔runtime rule). This skill is the "how", that file is the "what/why".
+
+**Invariant that applies to both procedures:** never invent a new modality just to
+ship an engine — fill an existing `rac_engine_vtable_t` slot. Adding a brand-new
+*primitive* (a new `RAC_PRIMITIVE_*` + vtable slot) is a commons ABI change, covered
+by `core/AGENTS.md` → "Adding a new capability interface", not an engine change.
+
+---
+
+## Procedure A — add a new engine
+
+Mirror **sherpa** (multi-modality, standalone `.so`) or **cloud** (single modality,
+no runtime) as your template; both are the cleanest references for the 4-file
+skeleton described in `engines/AGENTS.md`.
+
+1. **Create `engines/<name>/`** with the 4-file skeleton: `rac_plugin_entry_<name>.cpp`,
+   `rac_backend_<name>_register.cpp` (skip it if there's no extra bring-up, like
+   `neurt`), `rac_static_register_<name>.cpp`, plus your impl files.
+2. **Write the manifest** in `rac_plugin_entry_<name>.cpp`:
+   - `name` = snake_case identity (the library/framework you wrap, or your own
+     codebase unit — NEVER a modality name; see the naming rule in
+     `engines/AGENTS.md`).
+   - `primitives[]` = what you serve; fill the matching vtable slots; leave every
+     other slot explicit NULL (the all-NULL tripwire depends on this).
+   - `runtimes[]` — only devices your compute actually depends on (NULL for
+     cloud/HTTP engines) — see THE RULE in `engines/AGENTS.md`.
+   - `formats[]` = the `RAC_MODEL_FORMAT_ID_*` values you accept (NULL if there's
+     no local model file).
+   - `priority`, `availability` (PUBLIC/PRIVATE), `package_owner`/`package_name`.
+3. **Implement the op-table(s)** honoring the MODEL LIFECYCLE:
+   `create → initialize → use → cleanup → destroy` (see `engines/AGENTS.md` for the
+   exact signatures). Use `RAC_DEFINE_CREATE_ADAPTER(primitive, name)`
+   (`core/include/rac/plugin/rac_plugin_entry.h`) when `create` is a plain forward
+   onto `rac_<primitive>_<name>_create` — sherpa uses it for STT/TTS/VAD. Engines
+   with richer create flows (llamacpp, onnx, neurt, qhexrt) hand-write it.
+4. **`capability_check`** when the engine is platform- or binary-gated: use the
+   shared 3-way helper `rac_engine_unavailable_capability(platform_supported,
+   backend_present)` from `engines/common/rac_engine_unavailable.h`. When the
+   backend can be entirely absent at build time (a private prebuilt archive, a
+   sibling private repo), emit the stub with `RAC_ENGINE_UNAVAILABLE_PLUGIN(name,
+   display, cap_fn)` from the same header — see qhexrt and neurt for the two-mode
+   (ROUTABLE vs STUB) pattern this produces.
+5. **Registration carriers:** `RAC_PLUGIN_ENTRY_DEF(<name>)` returning the vtable; a
+   `rac_backend_<name>_register()`/`_unregister()` pair if you have extra bring-up
+   (called directly by SDK bridges on dynamic-link hosts); a
+   `rac_static_register_<name>.cpp` shim using `RAC_STATIC_REGISTER_BACKEND(<name>)`
+   (routes through the register fn) or `RAC_STATIC_PLUGIN_REGISTER(<name>)` (calls
+   the entry directly) for iOS/WASM static hosts.
+6. **CMake:** call `rac_add_engine_plugin(<name> SOURCES … LINK_LIBRARIES …
+   AVAILABILITY … PACKAGE_OWNER … PACKAGE_NAME …)` (`cmake/plugins.cmake`) from
+   `engines/<name>/CMakeLists.txt`, fronted by your own
+   `option(RAC_BACKEND_<NAME> "…" <default>)` + `if(NOT RAC_BACKEND_<NAME>)
+   return() endif()` self-gate (each engine owns its own option — `engines/CMakeLists.txt`
+   just unconditionally `add_subdirectory()`s and lets the child decide). Add
+   `add_subdirectory(<name>)` there. Declare `primitives`/`runtimes`/`formats` ONLY
+   in the C manifest, never in CMake, so the build graph can't drift from what the
+   router routes.
+7. **Android:** if the SDK loads the engine via `System.loadLibrary` +
+   `nativeRegister`, add a JNI bridge with `RAC_DEFINE_ENGINE_JNI_BRIDGE(...)`
+   (standalone per-engine `.so` — onnx, llamacpp) or
+   `RAC_DEFINE_ENGINE_JNI_BRIDGE_NO_ONLOAD(...)` (folded into a host lib that
+   already owns `JNI_OnLoad`, e.g. cloud → `librunanywhere_jni.so`) from
+   `engines/common/rac_engine_jni_bridge.h`. The JVM class-path token in the macro
+   call must match the Kotlin `*Bridge` class byte-for-byte.
+8. **iOS/WASM static hosts:** make sure the host force-loads the plugin —
+   `rac_force_load(<app> PLUGINS <name>)` in the host's CMakeLists — so the
+   static-init Registrar TU survives linker stripping.
+9. **If this engine ships an Electron/npm carrier package**, register it in
+   `scripts/validation/gates/check_plugin_natives.py`'s `REQUIRED_OPS` dict (the
+   ops-table symbol name(s) your entry TU references only on the routable
+   branch) — `package-sdk.sh` calls this automatically, so an unregistered
+   engine's stub/shell builds ship undetected. **Check which FILE actually
+   compiles `rac_plugin_entry_<name>.cpp`** before assuming the carrier
+   (`runanywhere_<name>`) is what to gate: sherpa/onnx/llamacpp compile it into
+   the carrier itself (an undefined symbol reference there is the evidence),
+   but neurt's `rac_add_engine_plugin()` call puts it on the ENGINE target
+   (`rac_backend_neurt`) instead — the carrier there is empty boilerplate with
+   zero symbols. Add the engine id to `EVIDENCE_IN_BACKEND_FILE` if it follows
+   neurt's shape; discovered by actually building neurt for real and running
+   `nm -a` on both files, not by reading the CMakeLists and assuming.
+
+## Procedure B — add a modality to an existing engine
+
+Multi-modality is the whole point of an identity-named engine. `cloud` and `neurt`
+are explicitly built for this and carry the recipe inline as a comment next to
+their vtable.
+
+1. Implement the new modality's op-table (e.g. a cloud TTS `g_cloud_tts_ops`,
+   typically backed by a per-modality provider adapter under `providers/`).
+2. **Fill the corresponding slot** in the engine's `rac_engine_vtable_t`
+   (`tts_ops` / `llm_ops` / `embedding_ops` / …) — every other slot must stay
+   explicit NULL.
+3. **Add the primitive** to the manifest's `primitives[]`.
+4. Update `formats[]`/`runtimes[]` only if the new modality actually needs them
+   (per THE RULE — don't declare a runtime your new op-table doesn't depend on).
+
+No new plugin, no rename, no ABI bump — the engine already owns one
+`rac_engine_vtable_t` with all ten primitive slots; you're just filling another one.
+Grep the target engine's `rac_plugin_entry_<name>.cpp` for the phrase "To add a"
+— cloud and neurt both leave a comment naming exactly which slots are still free
+and what to add to `primitives[]`.

--- a/.claude/skills/sdk-publish/SKILL.md
+++ b/.claude/skills/sdk-publish/SKILL.md
@@ -1,0 +1,444 @@
+---
+name: sdk-publish
+description: Manually publish an already-tagged, already-released (non-draft GitHub Release) RunAnywhere SDK version to every package registry (npm, Maven Central, pub.dev, Swift SPM dist repo) plus macOS rcli notarization, with heavy verification that nothing fake/stubbed/broken ships.
+---
+
+# SDK Publish
+
+Repo: `~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks` (verify with `pwd`/`git remote get-url origin` — do not assume this path is still correct, checkouts move). Version source of truth: `core/VERSION`. Throughout, `$VERSION` means the bare semver being published (e.g. `0.20.24`), never prefixed with `v` except in git tags / GitHub Release names.
+
+## THIS PROCESS IS INTENTIONALLY MANUAL
+
+**`release.yml` never publishes anywhere public.** It only builds artifacts, packages them, and creates a draft/published **GitHub Release**. It does not call `npm publish`, does not upload to Maven Central, does not call `flutter pub publish`, and does not push the Swift dist repo. Verify this is still true before trusting it — greps below should all return **zero** matches (grep the whole file, not a snippet):
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks
+grep -inE "npm publish|publishReleasePublication|publishAllPublicationsToMavenCentral|flutter pub publish" .github/workflows/release.yml
+```
+
+This is a **deliberate safety gate**, not a gap. Every step below is a human (or an agent acting on a human's explicit go-ahead) pushing a button that CI intentionally never pushes. Do not propose wiring any of this into CI as a "fix" — that would remove the gate.
+
+## Precondition check (always run first)
+
+Refuse to proceed if the release is a draft or the asset set looks incomplete.
+
+```bash
+gh release view v$VERSION --json isDraft,tagName --jq '{isDraft, tagName}'
+# isDraft MUST be false.
+
+gh release view v$VERSION --json assets --jq '.assets[].name' | sort
+```
+
+Cross-reference the listing against the `sdk-release` skill's step 8 asset-count expectations (`~/.claude/skills/sdk-release/SKILL.md`). As a second, independent check, also diff against the **previous** tagged release's asset list — same count, same name patterns, only the version token differs:
+
+```bash
+gh release view v<PREVIOUS_VERSION> --json assets --jq '.assets[].name' | sed "s/<PREVIOUS_VERSION>/$VERSION/" | sort >/tmp/expected.txt
+gh release view v$VERSION --json assets --jq '.assets[].name' | sort >/tmp/actual.txt
+diff /tmp/expected.txt /tmp/actual.txt
+```
+
+As of the last verified run (**v0.20.25, 65 assets** — up from 55 at v0.20.24 because the 5 public Electron tarballs and their sidecars joined the release; see §6), the full set is: `MANIFEST.txt`; per-platform `RACommons-{android-arm64-v8a,android-armeabi-v7a,android-x86_64,ios,linux-x86_64,web,windows-x64}-v$VERSION.{zip,tar.gz}` + `.sha256`; iOS backend zips `RABackend{LLAMACPP,MLX,NeuRT,ONNX,Sherpa}-ios-v$VERSION.zip` + `.sha256`; `RunAnywhereMLX{Metal,Resources,Runtime}-ios-v$VERSION.zip` + `.sha256`; `rcli-{linux-x86_64,macos-arm64,windows-x86_64}-v$VERSION.tar.gz`/`.zip` + `.sha256`; the 8 npm tarballs `runanywhere-{core,llamacpp,mlx,onnx,proto-ts,web,web-llamacpp,web-onnx}-$VERSION.tgz` + `.sha256`; the **5 Electron npm tarballs** `runanywhere-electron{,-llamacpp,-onnx,-sherpa,-neurt}-$VERSION.tgz` + `.sha256` (new as of v0.20.25); and `runanywhere-kotlin-maven-v$VERSION.zip` + `.sha256`. There is **no** Flutter tarball in the release (Flutter packages are staged from the native archives above, not from a dedicated release asset) and **no** `.dmg` asset in the baseline set (the macOS rcli tarball is what ships; see the notarization section for when a `.dmg` does get produced). If a `qhexrt`-named asset appears anywhere in this list, stop — that would mean `release.yml`'s own manifest assertion should have hard-failed and something is very wrong; do not publish anything from that release.
+
+## 0. MANDATORY GATE — verify the ENTIRE release before pushing anything to any registry
+
+**Run this once, in full, before the first registry push. Do not publish a single package until it passes.** Per-package spot-checks are not a substitute: they are how a bad artifact reaches a registry you cannot un-publish from. Proven end to end on v0.20.25 (2026-08-22), then independently audited and corrected: **34 payloads, 6619 files across 3 nesting levels, 282 binaries, 0 placeholder hits, 38/38 commons binaries carrying the real staging host**. The audit found 4 methodology gaps in the first pass (shallow nesting, missing `MTLB` magic, `.lib` excluded from the positive check, and a set-intersection that could pass vacuously) — every one is called out inline below, because each produced a *confident but under-covered* result.
+
+```bash
+VERSION=0.20.25                      # no leading v
+REPO=RunanywhereAI/runanywhere-sdks
+W=/tmp/relverify-$VERSION
+rm -rf "$W" && mkdir -p "$W/assets" "$W/qhexrt" "$W/x" "$W/nested"
+
+# (1) EVERY release asset — no -p filter, get the whole set.
+gh release download "v$VERSION" --repo "$REPO" -D "$W/assets"
+
+# (2) The PRIVATE QHexRT artifact is NOT a release asset — pull it from the run.
+#     Find the run that produced the release, then:
+gh run download <release-run-id> --repo "$REPO" --name sdk-electron-qhexrt-private --dir "$W/qhexrt"
+```
+
+### (3) Checksums — `cd` into the directory first
+
+Sidecars contain a **bare basename**, so `shasum -c` fails with a misleading "FAILED open or read" if run from anywhere else. This will make every artifact look broken when nothing is wrong:
+
+```bash
+cd "$W/assets"
+ok=0; bad=0
+for s in *.sha256; do
+  if shasum -a 256 -c "$s" >/dev/null 2>&1; then ok=$((ok+1)); else echo "MISMATCH: $s"; bad=$((bad+1)); fi
+done
+echo "verified=$ok mismatched=$bad"      # bad MUST be 0
+(cd "$W/qhexrt" && shasum -a 256 -c ./*.sha256)
+```
+
+### (4) Extract everything — INCLUDING nested archives
+
+**The gotcha that matters:** `runanywhere-kotlin-maven-v*.zip` contains `.aar` files, and the `.aar`s are what hold the Android `.so` binaries. A one-level extraction reports "0 binaries" for the Maven bundle and every subsequent scan passes **vacuously**.
+
+**Recurse until the tree is dry — TWO levels are required here, not one.** Each `.aar` also contains a `classes.jar`, holding ~2027 `.class` files that are doubly unreachable: inside an unopened jar *and* excluded by the `.class` suffix rule most magic-byte scanners use. Level 2 adds **2033 files** (0 placeholder hits on v0.20.25); level 3 is empty. Loop until a pass finds no new archives rather than hardcoding a depth.
+
+```bash
+cd "$W/assets"
+for f in *; do
+  case "$f" in *.sha256|MANIFEST.txt) continue;; esac
+  d="$W/x/$f"; mkdir -p "$d"
+  case "$f" in
+    *.zip)              unzip -qq -o "$f" -d "$d" || echo "EXTRACT FAILED: $f" ;;
+    *.tar.gz|*.tgz)     tar -xzf "$f" -C "$d"     || echo "EXTRACT FAILED: $f" ;;
+    *) echo "UNHANDLED TYPE: $f" ;;
+  esac
+done
+d="$W/x/$(basename "$W"/qhexrt/*.tgz)"; mkdir -p "$d"; tar -xzf "$W"/qhexrt/*.tgz -C "$d"
+
+# nested pass
+cd "$W/x"
+find . -type f \( -name '*.aar' -o -name '*.jar' -o -name '*.zip' -o -name '*.tgz' -o -name '*.tar.gz' \) \
+  | sed 's|^\./||' | while IFS= read -r a; do
+    dd="$W/nested/$(printf '%s' "$a" | tr '/' '_')"; mkdir -p "$dd"
+    case "$a" in *.aar|*.jar|*.zip) unzip -qq -o "$a" -d "$dd";; *) tar -xzf "$a" -C "$dd";; esac
+  done
+```
+
+**Prove extraction actually happened** — an empty dir makes "0 hits" meaningless:
+
+```bash
+for d in "$W"/x/*/; do
+  n=$(find "$d" -type f | wc -l)
+  [ "$n" -lt 2 ] && echo "SUSPICIOUSLY EMPTY: $d ($n files)"
+done
+```
+
+### (5) Placeholder scan — EVERY file, not just binaries
+
+The staging URL can also live in JS/JSON/TS config, so scan by content across all file types, and additionally scan the raw compressed streams in case a member never got extracted:
+
+```bash
+find "$W/x" "$W/nested" -type f | wc -l                                     # total files covered
+grep -rla "YOUR_STAGING_BASE_URL" "$W/x" "$W/nested" | tee /tmp/ph.txt | wc -l   # MUST be 0
+for f in "$W"/assets/*.tgz "$W"/assets/*.tar.gz "$W"/qhexrt/*.tgz; do
+  gzip -dc "$f" 2>/dev/null | grep -qa "YOUR_STAGING_BASE_URL" && echo "RAW HIT: $f"
+done
+```
+
+Find binaries by **magic bytes, not extension** (an unsuffixed framework binary like `RACommons.framework/RACommons` has no extension and a name-based `find` misses it). Signatures to cover:
+
+| Magic | Kind | v0.20.25 count |
+|---|---|---|
+| `7f454c46` | ELF | 177 |
+| `!<arch>` (`213c617263683e0a`) | static `.a` **and `.lib`** | 41 |
+| `MZ` | PE | 29 |
+| `cffaedfe` / `cefaedfe` | Mach-O | 19 |
+| `00 61 73 6d` | wasm | 10 |
+| **`4d544c42` (`MTLB`)** | **Metal library** — easy to miss | 5 |
+| `cafebabe` / `bebafeca` | fat Mach-O (exclude `.jar`/`.class`) | 1 |
+
+**Total: 282 binaries.** An earlier pass reported 277 because `MTLB` was absent from the signature list — `.metallib` files were invisible to the binary scan (they were still covered by the all-file `grep` in step 5, so the conclusion held, but the count was wrong). If your total comes in materially under ~282 for a comparable release, your detection is leaking.
+
+### (6) POSITIVE staging-URL check — absence of the placeholder is NOT sufficient
+
+A build with an **empty** URL baked in passes a placeholder-only check. `check_plugin_natives.py` only tests absence, so add the positive assertion yourself.
+
+Two traps that produced false confidence on the v0.20.25 pass, both worth avoiding:
+
+- **Include `.lib`.** A `MUST_HAVE` regex of `rac_commons\.(dylib|so|dll|a)$` silently skips
+  `RACommons-windows-x64/x64/rac_commons.lib` — an **89 MB** binary that then gets no positive
+  check at all. Match `(dylib|so|dll|a|lib)` plus `\.wasm$`. Correct coverage is **38** binaries,
+  not 37.
+- **Assert per binary, not by set-intersection.** Intersecting "non-public origins across all
+  files" yields more than one origin here (`hf.co` *and* the staging host), so a binary carrying
+  only `hf.co` would pass **vacuously**. Check each binary individually for the staging host.
+
+```bash
+# v0.20.25 baseline: 38 commons/wasm/lib binaries; 0 missing the staging host.
+```
+
+Never print the URL — it is a repo secret. Report a truncated SHA-256 fingerprint, or just assert presence/absence counts.
+
+### (7) Routability gate over the whole tree
+
+```bash
+python3 scripts/validation/gates/check_plugin_natives.py "$W/x" "$W/nested" > /tmp/gate.txt 2>&1
+grep -cE '^  ok ' /tmp/gate.txt; grep -E '^  FAIL' /tmp/gate.txt
+```
+
+v0.20.25 baseline: **77 ok, 1 FAIL**. The single expected FAIL is
+`RACommons-linux-x86_64/lib/librunanywhere_sherpa.so` — see the known-exception note below. **Any other FAIL blocks the publish.**
+
+### (8) Known exception — Linux sherpa is a non-routable shell (PRE-EXISTING, not a regression)
+
+`RACommons-linux-x86_64-v*.tar.gz` ships **no** `libsherpa-onnx-c-api.so` at all and its `librac_backend_sherpa.so` is a ~156 KB shell (~3 sherpa strings, vs ~31 MB / ~192 for a healthy one on Electron macOS) — the engine is not linked in, so the carrier cannot reference `g_sherpa_{stt,tts,vad}_ops` and **STT/TTS/VAD cannot work from that bundle**. Android's carriers pass on all 3 ABIs, so this is Linux-only.
+
+**Compare the CARRIER, not the backend.** The gate FAILs on `librunanywhere_sherpa.so` (the carrier); citing `librac_backend_sherpa.so` as your evidence is comparing a *different file* and is not proof. The carrier is byte-identical across releases, which is the real proof:
+
+```bash
+gh release download "v<PREV>" --repo "$REPO" -p 'RACommons-linux-x86_64-v<PREV>.tar.gz' -D /tmp/prev
+tar -xzf /tmp/prev/*.tar.gz -C /tmp/prev
+shasum -a 256 /tmp/prev/lib/librunanywhere_sherpa.so "$W"/x/RACommons-linux-*/lib/librunanywhere_sherpa.so
+# v0.20.24 and v0.20.25 both: size=15712  sha256=28ef16015b61da86...
+
+# strongest check — run the gate on the PREVIOUS bundle and confirm the identical FAIL:
+python3 scripts/validation/gates/check_plugin_natives.py /tmp/prev
+```
+
+If it ever regresses *further* (e.g. Android or macOS sherpa also goes hollow), stop and treat it as a blocking defect.
+
+### (9) Account for every payload explicitly
+
+Print a per-artifact table (checksum verdict, binary count, placeholder hits) and confirm the row count equals the payload count. Artifacts that legitimately contain **no** native binaries, and why — do not let these pass silently unexamined:
+
+| Artifact | Why it has no binaries |
+|---|---|
+| `RunAnywhereMLXResources-ios-*.zip` | 25 third-party license/notice text files |
+| `runanywhere-kotlin-maven-v*.zip` | binaries live in the **nested** `.aar`s (step 4) |
+| `runanywhere-proto-ts-*.tgz` | pure TS/JS (69 `.ts` + 69 `.js`) |
+
+Everything else must have a non-zero, plausible binary count. A platform suddenly shipping fewer binaries than the previous release is a regression signal worth chasing before publishing.
+
+### (10) Blind spot to be aware of — Windows x64 has NO routability coverage
+
+`RACommons-windows-x64-v*.zip` ships **only** a static `rac_commons.lib` (~89 MB) plus 152 `.h` / 11 `.hpp` headers — **zero backend DLLs**, where Linux/Android/Web each ship 4–5 backend carriers. That is consistent with a static-embedding bundle (consumers link the engines in themselves), but the consequence matters: **no gate can detect a missing or hollow Windows backend**, because there is no carrier to inspect. `check_plugin_natives.py` therefore reports nothing at all for this artifact rather than reporting health.
+
+Windows x64 is also *advisory* in `release.yml` (its absence does not fail the release). So a Windows regression can pass every automated check. If Windows correctness matters for a given release, verify it by actually running something on the real Windows box (see §Electron for how to reach it) — do not infer it from a green pipeline. Worth a deliberate confirmation with the repo owner that the DLL-free shape is intentional.
+
+---
+
+## General verification discipline (every artifact, every registry)
+
+Apply all three checks below to **every** file you're about to publish, before AND after the publish call. Never trust a copy cached locally earlier in the session — re-download.
+
+**(a) Download + verify the sha256 sidecar yourself:**
+
+```bash
+gh release download v$VERSION -p '<file>' -p '<file>.sha256' -D /tmp/sdk-publish-$VERSION
+cd /tmp/sdk-publish-$VERSION && shasum -a 256 -c '<file>.sha256'
+```
+
+**(b) Inspect the actual file listing inside every tarball/AAR/zip** — never assume from the filename alone:
+
+```bash
+npm pack <tgz-or-package-dir> --dry-run     # npm packages: prints the exact file list it would publish
+unzip -l  <file.zip>                        # AARs, Maven repo zip, native archives
+tar -tzf  <file.tar.gz>                     # rcli, RACommons tarballs
+```
+
+Sanity-check what comes back:
+- No suspiciously-small or empty binaries where a real native library (`.so`, `.dylib`, `.a`, `.dll`) should be — a stub or a zero-byte placeholder means the build silently failed upstream.
+- No leftover `workspace:*` or `file:` dependency specs in any `package.json` inside the tarball — those only resolve inside this monorepo and break for a real external installer.
+- Version strings inside every manifest (`package.json` `version`, AAR `pom.xml` `<version>`, `pubspec.yaml` `version:`) **exactly** match `$VERSION`.
+- **Hard rule, no exceptions:** grep the full file listing for `qhexrt` (any case) and for QNN binary names (`libQnnHtp`, `QnnHtp*.dll`, `rac_commons.dll` bundled with QHexRT, `runanywhere_qhexrt`). If any hit appears in a package meant to be public, stop and do not publish that artifact.
+
+**(c) Confirm baked-in runtime config** (e.g. a staging-vs-prod backend base URL compiled into `rac_commons` at build time) points at the real intended endpoint. This is designed to fail closed if misconfigured — a build that completed and produces working requests against prod is itself decent evidence — but if you have any doubt, `strings <binary> | grep -i "api\.\|staging\."` and eyeball it.
+
+## 1. npm — 8 packages, order matters
+
+Packages: 4 Web (`@runanywhere/proto-ts`, `@runanywhere/web`, `@runanywhere/web-llamacpp`, `@runanywhere/web-onnx`) + 4 React Native (`@runanywhere/core`, `@runanywhere/llamacpp`, `@runanywhere/mlx`, `@runanywhere/onnx`). Never `@runanywhere/qhexrt` (RN) — it exists in `bindings/react-native/packages/qhexrt/` but is excluded from the public npm train by the same policy as Maven/pub.dev QHexRT.
+
+**Publish `@runanywhere/proto-ts` FIRST.** `@runanywhere/web-onnx` deliberately does not bundle its own `proto-ts` copy and needs it resolvable from the live registry for real consumers; publish `proto-ts` before it or a fresh `npm install @runanywhere/web-onnx` fails to resolve.
+
+```bash
+gh release download v$VERSION -p 'runanywhere-proto-ts-*.tgz*' -p 'runanywhere-web-*.tgz*' \
+  -p 'runanywhere-core-*.tgz*' -p 'runanywhere-llamacpp-*.tgz*' -p 'runanywhere-mlx-*.tgz*' -p 'runanywhere-onnx-*.tgz*' \
+  -D /tmp/sdk-publish-$VERSION
+cd /tmp/sdk-publish-$VERSION
+for f in *.sha256; do shasum -a 256 -c "$f"; done
+
+npm publish runanywhere-proto-ts-$VERSION.tgz --access public   # FIRST, always
+npm publish runanywhere-web-$VERSION.tgz --access public
+npm publish runanywhere-web-llamacpp-$VERSION.tgz --access public
+npm publish runanywhere-web-onnx-$VERSION.tgz --access public
+npm publish runanywhere-core-$VERSION.tgz --access public
+npm publish runanywhere-llamacpp-$VERSION.tgz --access public
+npm publish runanywhere-mlx-$VERSION.tgz --access public
+npm publish runanywhere-onnx-$VERSION.tgz --access public
+```
+
+`npm whoami` should already show a logged-in account; if it errors, stop and tell the human rather than trying to log in non-interactively.
+
+**GOTCHA — large tarballs can silently die mid-upload.** `@runanywhere/mlx` (~50MB) and `@runanywhere/web-onnx` (unpacks to 300+MB) can exceed a short default shell/tool timeout mid-upload and get killed with no clean error. Use an explicit long timeout (5 minutes / 300000ms) on each publish call.
+
+**GOTCHA — verify via the registry API, not the npm CLI.** `npm view` can lag the CLI's own cache by several seconds right after a fresh publish and falsely report "not found". After **every** publish:
+
+```bash
+curl -s "https://registry.npmjs.org/@runanywhere/<pkg>" | python3 -c "import json,sys;print(json.load(sys.stdin)['dist-tags'])"
+```
+Confirm `latest` equals `$VERSION`.
+
+## 2. Maven Central — 3 AARs only
+
+`io.github.sanchitmonga22:{runanywhere-sdk,runanywhere-llamacpp,runanywhere-onnx}`. **Never `runanywhere-qhexrt-android`** — it was published through 0.20.19 under an earlier, since-reversed policy and is now permanently excluded; `release.yml`'s manifest assertion hard-fails if it reappears in the public asset set.
+
+Full step-by-step lives in `bindings/kotlin/docs/KOTLIN_MAVEN_CENTRAL_PUBLISHING.md`, section **"Option A: Publish with released native archives"** (line ~108 as of this writing — the doc has been corrected mid-release before, so re-read it fresh rather than trusting memory of its contents). Key points, condensed:
+
+1. Download + verify the 3 `RACommons-android-{arm64-v8a,armeabi-v7a,x86_64}-v$VERSION.zip` from the release (sha256 sidecars, per the general discipline above).
+2. Stage: `bash bindings/kotlin/scripts/package-sdk.sh --mode local --natives-from <dir-with-the-3-zips>`. This also produces a local Maven-repo zip — diff its size against `runanywhere-kotlin-maven-v$VERSION.zip` already attached to the GitHub Release as a cheap reproducibility check.
+3. Before uploading, confirm the OSSRH compatibility service has no dangling open repository for this namespace:
+   ```bash
+   CENTRAL_BEARER="$(printf '%s:%s' "$MAVEN_CENTRAL_USERNAME" "$MAVEN_CENTRAL_PASSWORD" | base64 | tr -d '\r\n')"
+   curl -s -H "Authorization: Bearer $CENTRAL_BEARER" \
+     'https://ossrh-staging-api.central.sonatype.com/manual/search/repositories?ip=client&profile_id=io.github.sanchitmonga22'
+   ```
+   Resolve any stale repository per the doc's troubleshooting table before continuing.
+4. Source `MAVEN_CENTRAL_USERNAME`/`MAVEN_CENTRAL_PASSWORD` from `~/.gradle/gradle.properties` (`mavenCentral.username`/`mavenCentral.password` — confirmed present on this machine; never print the values) and run, from `bindings/kotlin/`:
+   ```bash
+   ./gradlew clean \
+     :publishReleasePublicationToMavenCentralRepository \
+     :modules:runanywhere-core-llamacpp:publishReleasePublicationToMavenCentralRepository \
+     :modules:runanywhere-core-onnx:publishReleasePublicationToMavenCentralRepository \
+     -Prunanywhere.useLocalNatives=true -x buildLocalJniLibs --no-daemon
+   ```
+   GPG signing (`signing.gnupg.keyName`/`signing.gnupg.passphrase` in the same properties file, key id `CC377A9928C7BB18` — confirmed importable via `gpg --list-secret-keys --keyid-format LONG` on this machine) is read from the same properties file automatically; you do not pass it separately.
+5. Transfer to Central Portal:
+   ```bash
+   curl --fail --request POST -H "Authorization: Bearer $CENTRAL_BEARER" \
+     'https://ossrh-staging-api.central.sonatype.com/manual/upload/defaultRepository/io.github.sanchitmonga22?publishing_type=automatic'
+   ```
+   Then find the resulting `portal_deployment_id` — expect **exactly one** fresh repository; if the count isn't 1, stop and investigate rather than guessing which one is yours (see the doc for the exact `jq` filter).
+6. Poll `https://central.sonatype.com/api/v1/publisher/status?id=<id>` (POST, same bearer) until `deploymentState` is `PUBLISHED`. Automatic deployments normally go `PENDING -> VALIDATING -> PUBLISHING -> PUBLISHED` within a few minutes. **If it lands on `VALIDATED` instead of proceeding, that means Sonatype is waiting for a manual click in the Central Portal UI** — stop and tell the human; do not loop forever assuming it resolves itself. On `FAILED`, print `.errors` and stop.
+7. Verify propagation (allow 10-30 minutes for CDN propagation even after `PUBLISHED`):
+   ```bash
+   for a in runanywhere-sdk runanywhere-llamacpp runanywhere-onnx; do
+     echo "$a: $(curl -s -o /dev/null -w '%{http_code}' "https://repo1.maven.org/maven2/io/github/sanchitmonga22/$a/$VERSION/$a-$VERSION.pom")"
+   done
+   ```
+   Expect `200` for all three.
+
+## 3. pub.dev (Flutter)
+
+**Verify the current package set fresh — do not trust a hardcoded count.** As of this writing the real, non-QHexRT Flutter package set is **4**, not 3: `runanywhere`, `runanywhere_llamacpp`, `runanywhere_onnx`, and `runanywhere_mlx` (mlx was added after some earlier documentation/memory of "3 packages" was written — that assumption is stale; `runanywhere_mlx` is a real, already-published-on-pub.dev package, not new/WIP). Enumerate it yourself instead of trusting this list verbatim next time:
+```bash
+find bindings/flutter/packages -maxdepth 1 -type d -not -iname '*qhexrt*' -not -path '*/packages'
+```
+`runanywhere_qhexrt` exists in that directory too — never publish it (same exclusion policy as Maven).
+
+Stage the released iOS xcframeworks + Android `.so` into each package with the Flutter equivalent of `package-sdk.sh` (melos-based monorepo, confirmed at `bindings/flutter/scripts/package-sdk.sh`):
+
+```bash
+bash bindings/flutter/scripts/package-sdk.sh --mode local --natives-from <dir-with-xcframeworks-and-android-.so>
+```
+
+This script already runs `flutter pub publish --dry-run` internally per package as part of its own validation — but run it again yourself, per package, from each package directory, and **read the output for real, not just the exit code**:
+
+```bash
+cd bindings/flutter/packages/runanywhere && flutter pub publish --dry-run
+cd ../runanywhere_llamacpp && flutter pub publish --dry-run
+cd ../runanywhere_onnx && flutter pub publish --dry-run
+cd ../runanywhere_mlx && flutter pub publish --dry-run
+```
+
+Expect zero warnings except a benign version-gap hint. Only then run the real publish, same order (core first, since the others depend on it):
+
+```bash
+cd bindings/flutter/packages/runanywhere && flutter pub publish
+cd ../runanywhere_llamacpp && flutter pub publish
+cd ../runanywhere_onnx && flutter pub publish
+cd ../runanywhere_mlx && flutter pub publish
+```
+
+**Credential note:** pub.dev OAuth is normally cached at `~/Library/Application Support/dart/pub-credentials.json` on macOS (confirmed present on this machine). If it's missing, expired, or `flutter pub publish` prompts for an interactive browser login, **STOP and tell the human** — you cannot complete a fresh Google OAuth flow non-interactively, and forcing/guessing here is not appropriate.
+
+Verify afterward against the live API (not a cached page):
+```bash
+for p in runanywhere runanywhere_llamacpp runanywhere_onnx runanywhere_mlx; do
+  echo "$p: $(curl -s "https://pub.dev/api/packages/$p" | python3 -c "import json,sys;print(json.load(sys.stdin)['latest']['version'])")"
+done
+```
+
+## 4. Swift SPM distribution repo (`RunanywhereAI/runanywhere-swift`)
+
+A separate, **generated-only** repo mirroring `bindings/swift` (Package.swift + Sources/ + LICENSE + README) so SwiftPM consumers using `from: "<version>"` don't clone the ~340MB monorepo.
+
+**GOTCHA:** this machine may have local directories literally named `runanywhere-swift` that are just checkouts of the **monorepo's** remote, not the distribution repo. Verify before trusting any existing local directory by name:
+```bash
+git -C <candidate-dir> remote get-url origin
+```
+Must show `RunanywhereAI/runanywhere-swift`, not `runanywhere-sdks`. Always clone fresh instead of guessing:
+
+```bash
+git clone https://github.com/RunanywhereAI/runanywhere-swift.git /tmp/ra-swift
+
+bindings/swift/scripts/sync-dist-repo.sh \
+  --zips <exact-verified-Apple-archive-dir-from-the-release> --tag /tmp/ra-swift
+
+RUNANYWHERE_SWIFT_DIST_REPO=/tmp/ra-swift \
+  bash scripts/validation/gates/check_swift_dist_repo_sync.sh
+
+git -C /tmp/ra-swift push origin main --follow-tags
+```
+
+The `--zips` dir must contain the verified (sha256-checked) release archives — `RACommons-ios-v$VERSION.zip`, `RABackend{LLAMACPP,MLX,NeuRT,ONNX,Sherpa}-ios-v$VERSION.zip`, `RunAnywhereMLX{Metal,Resources,Runtime}-ios-v$VERSION.zip` — downloaded and checked exactly per the general verification discipline, not re-used from an earlier, untrusted local copy.
+
+**The tag on `runanywhere-swift` is bare semver, no `v` prefix** (SwiftPM's `from:` needs that) — do not tag it `v$VERSION` by mistake; `sync-dist-repo.sh --tag` handles this correctly, but double check the pushed tag with `git -C /tmp/ra-swift tag --points-at HEAD` before walking away.
+
+This is enforced, not just documented: once `v$VERSION` is tagged on `runanywhere-sdks`, `check_swift_dist_repo_sync.sh` fails every future PR on the monorepo until `runanywhere-swift` carries the matching bare-semver tag — so don't let this lag behind the other registries.
+
+**GATE GAP — `check_swift_dist_repo_sync.sh` does NOT catch dependency drift, only checksum/version-string drift.** `runanywhere-swift`'s `Package.swift` is manually maintained end to end — `sync-dist-repo.sh` only ever touches `sdkVersion` and the binaryTarget checksums, never the `dependencies:` block (mlx-swift, mlx-swift-lm, mlx-audio-swift, swift-crypto, etc.). If root `runanywhere-sdks/Package.swift` bumps one of those (e.g. a new fork tag), a human has to remember to mirror it into the dist repo by hand, and nothing fails CI if they forget. This exact drift shipped once (2026-08-17): the dist repo pointed `mlx-swift-lm` at unforked `ml-explore/mlx-swift-lm` instead of the `RunanywhereAI` fork, silently breaking every iOS/macOS MLX consumer of that tag until caught by an actual build failure ~40 minutes later. Before trusting a freshly-cut dist-repo tag: diff every `.package(url:` line between root `Package.swift` and the dist repo's `Package.swift` (`grep -n '\.package(url:' Package.swift` on both sides), and actually build a real product that exercises the dependency you're worried about (e.g. `cd /tmp/ra-swift && swift build --product RunAnywhereMLX`) — don't rely on the sync gate alone. If you catch drift on a tag that's only minutes old with no evidence of external consumption, fixing it in place and force-moving the tag (`git tag -f $VERSION && git push origin $VERSION --force`) is the correct call, not a shortcut — a known-broken immutable tag helps no one.
+
+**If you force-move a tag, SwiftPM/Xcode consumers cache the OLD commit in several places — clearing just `Package.resolved` is not enough.** Verifying your own fix (or having a downstream consumer verify it) can silently keep failing even after the fix is correctly pushed, because: (1) any consumer repo's own tracked `*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` pins the exact old resolution and `xcodebuild -resolvePackageDependencies` respects it rather than re-resolving; (2) `~/Library/Caches/org.swift.swiftpm/repositories/<pkg>-<hash>/` is a global shared clone cache keyed by repo, oblivious to a moved tag; (3) `~/Library/org.swift.swiftpm/security/fingerprints/<pkg>-<hash>.json` records the fingerprint SwiftPM saw for that tag and can silently keep using it after a mismatch instead of failing loud. To actually re-resolve after moving a tag: delete the consumer's tracked `Package.resolved`, `rm -rf .build .swiftpm` and any `~/Library/Developer/Xcode/DerivedData/<Scheme>-*`, AND clear the matching entries under both global `org.swift.swiftpm` cache directories for every affected package identity — then resolve fresh.
+
+## 5. macOS rcli notarization
+
+CI (`native_rcli_macos` in `release.yml`) usually already produces a notarized, stapled artifact when Developer ID + notary secrets are configured in repo secrets. **Check the release assets first** before assuming you need to notarize anything yourself locally:
+
+```bash
+gh release view v$VERSION --json assets --jq '.assets[].name' | grep -iE 'rcli-macos|\.dmg'
+```
+Baseline expectation is `rcli-macos-arm64-v$VERSION.tar.gz` (+ `.sha256`); a `.dmg` only appears when `RCLI_MACOS_FULL_RELEASE=1` was set for that build (see below). If a plain tarball is already present and its contents pass the general verification discipline, there is usually nothing further to do here.
+
+**If you do need to notarize locally**, everything lives in `rcli/scripts/package-rcli.sh` (read its header comment — it documents its own contract in detail):
+
+- One-time setup, check before redoing: `xcrun notarytool history --keychain-profile runanywhere-notary` (confirmed configured on this machine — a fresh submission history returns without error). If missing: `xcrun notarytool store-credentials "runanywhere-notary" --apple-id <email> --team-id <team> --password <app-specific-password>`.
+- Codesign identity: `security find-identity -v -p codesigning | grep "Developer ID Application"` — confirmed present on this machine as `"Developer ID Application: RunAnywhere, Inc (<TEAM_ID>)"`. Grep for it fresh rather than hardcoding the team-id suffix, it can rotate.
+- Invocation contract (env vars, from the script header): `RCLI_CODESIGN_IDENTITY`, `RCLI_MACOS_NOTARIZE=1`, `RCLI_MACOS_FULL_RELEASE=1`, `RCLI_MACOS_SWIFT_BIN_DIR=<output of build-mlx-cli.sh>`. `RCLI_MACOS_FULL_RELEASE=1` is what additionally stages `mlx.metallib` and SwiftPM resource bundles and is what causes a notarized, stapled `.dmg` to be emitted alongside the Homebrew-style tarball. `RCLI_CODESIGN_KEYCHAIN` / `RCLI_NOTARYTOOL_KEYCHAIN` matter only if the identity/profile live in a non-default keychain.
+- Call shape: `rcli/scripts/package-rcli.sh <build-dir> macos-arm64` with the env vars above exported.
+
+## 6. Electron — build AND packaging are now in `release.yml`; publish is still manual
+
+**Reversing the earlier "deliberately separate" note**: as of `fix/electron-cicd-staging-url-npu-ane` (2026-08-21), the repo owner asked for Electron to produce ready-to-publish artifacts through the real release train like every other SDK, so `release.yml` now has `native_electron` (invokes `.github/workflows/electron-native-package.yml` as a reusable `workflow_call`) and `sdk_electron` (downloads its `electron-packaged-tarballs` artifact, runs `scripts/release/prepublish_check.py` on every tarball, checksums them, and splits public vs. QHexRT-private). `publish` hard-gates on `sdk_electron` succeeding. `@runanywhere/electron`, `-llamacpp`, `-onnx`, `-sherpa`, `-neurt` land as real, `.sha256`-sidecarred GitHub Release assets, same as the Web/RN npm tarballs. `@runanywhere/electron-qhexrt` still never becomes a public Release asset (policy below) — it's produced and packaged every release, but only reachable as the `sdk-electron-qhexrt-private` workflow artifact on that run, for a human to `npm publish` by hand. Electron is **not** WIP on a branch anymore: the old root `AGENTS.md` "Active issues" section describing `smonga/electron_upgrade` as in-progress is gone entirely as of this checkout — `bindings/electron/` is a fully merged, real SDK on `main`. Re-check that section is still absent before trusting this note.
+
+`.github/workflows/electron-native-package.yml` itself is unchanged in what it builds: every backend for real (llamacpp/onnx/sherpa/neurt on their real platforms, qhexrt on a self-hosted Windows ARM64 runner) with the real `STAGING_BASE_URL` baked in, gated by `check_plugin_natives.py` (which fails closed on the staging-URL placeholder — the exact bug that shipped through `0.20.24`). What's new is that it's also invocable via `workflow_call`, and that `native_win_x64_and_package` now tolerates a failed/skipped QHexRT lane (self-hosted, single machine) rather than losing the other five real packages to one runner's outage. **`release.yml` itself still does not `npm publish` anything** — it only produces artifacts (Release assets for the public five, a workflow artifact for QHexRT) — same "build automated, publish manual" shape as every other platform. See `thoughts/shared/plans/electron_cicd_staging_url_and_npu_ane_pipeline.md` for the full history.
+
+**PROVEN END TO END on v0.20.25 (2026-08-22)** — the first release where this actually ran. Final state: 65 release assets, all 5 public Electron tarballs present with `.sha256` sidecars, zero `qhexrt`-named assets. Verified by downloading the *published* tarballs and running the repo's own gate against them:
+
+```bash
+gh release download v<version> --repo RunanywhereAI/runanywhere-sdks -p 'runanywhere-electron*.tgz' -D /tmp/verify
+python3 scripts/validation/gates/check_plugin_natives.py --expect-version <version> \
+    $(for t in /tmp/verify/*.tgz; do printf -- '--tarball %s ' "$t"; done)
+# => All 20 check(s) passed: plugin natives are routable and no staging-URL placeholder was found.
+```
+
+That single command asserts all three things you actually care about, per binary: the real `STAGING_BASE_URL` is baked in (no `YOUR_STAGING_BASE_URL`), `rac_commons` embeds the right version, and every backend is genuinely **routable** (`g_llamacpp_ops`, `g_sherpa_stt_ops`, `g_neurt_llm_ops`, `g_onnx_embeddings_ops`, …) rather than a same-sized shell. **Run it before every Electron `npm publish`** — it is the cheapest defense against exactly the class of defect that shipped `electron-sherpa` 0.20.17's NULL-vtable carrier. Expected shipped layout: entry package = `darwin-arm64` + `win32-x64` + `win32-arm64`; llamacpp/onnx/sherpa = `darwin-arm64` + `win32-x64`; neurt = `darwin-arm64` only; qhexrt = `win32-arm64` only.
+
+Where to get the QHexRT tarball for its manual publish (it is deliberately NOT a release asset):
+
+```bash
+gh run download <release-run-id> --repo RunanywhereAI/runanywhere-sdks \
+    --name sdk-electron-qhexrt-private --dir /tmp/qhexrt
+```
+
+If asked to actually publish an Electron package (still a real, separate, manual step — this skill's general discipline in §0/§General verification still applies in full):
+- Involve the Windows box for real Windows-native verification before publishing anything Windows-targeted. The team keeps a **Windows ARM64 machine reachable over SSH**; its hostname, user, key, and mesh-VPN node name are operator-specific and deliberately not recorded in this repo — read the Windows/ARM64 host entry out of the operator's `~/.ssh/config` and use that alias. If there is no such entry, the box is not configured for you: say so and ask, rather than guessing at a hostname. Check reachability **first** by asking the mesh-VPN client whether the node is up (e.g. `tailscale status`, matching on the host entry's `HostName`) — if it reports `offline, last seen ...`, the box is asleep, which is not a configuration problem: ask the human to wake it, do not debug it as broken. Only then `ssh -o ConnectTimeout=8 "$WIN_BOX" "whoami"`. That same machine is **also** registered as a GitHub Actions self-hosted runner (labels `[self-hosted, Windows, ARM64, qhexrt]`) running as a Windows service — a queued `native_win_arm64_qhexrt` job on it means the machine is busy; check `gh api repos/RunanywhereAI/runanywhere-sdks/actions/runners` for the matching runner's `busy`/`status` before assuming it's free for manual SSH work, and vice versa.
+- **`@runanywhere/electron-qhexrt` being public on npm is a CONFIRMED, settled policy decision** (repo owner, 2026-08-20) — it contains real Hexagon NPU binaries (`libQnnHtpV81Skel.so`, `QnnHtp*.dll`, `rac_commons.dll`, `runanywhere_qhexrt.dll`) on purpose. The QHexRT-stays-private policy enforced everywhere else in this skill is specifically about the **GitHub-Release-side** asset set (Android etc.), a different channel — not a contradiction. Stop treating this as an unresolved item to flag; only re-raise it if you find evidence the policy changed.
+
+## 7. Final sanity pass
+
+After every registry is done, re-view each package's public listing/API and compare against the previous version — a big unexplained drop in file count or package size is a red flag to investigate before calling the release fully published:
+
+```bash
+# npm
+for p in proto-ts web web-llamacpp web-onnx core llamacpp mlx onnx; do
+  npm pack @runanywhere/$p@$VERSION --dry-run 2>&1 | tail -5
+done
+
+# Maven — check module metadata / POM sizes are non-trivial, not near-empty
+for a in runanywhere-sdk runanywhere-llamacpp runanywhere-onnx; do
+  curl -s -o /dev/null -w "%{size_download} bytes  $a\n" \
+    "https://repo1.maven.org/maven2/io/github/sanchitmonga22/$a/$VERSION/$a-$VERSION.aar"
+done
+
+# pub.dev
+for p in runanywhere runanywhere_llamacpp runanywhere_onnx runanywhere_mlx; do
+  curl -s "https://pub.dev/api/packages/$p" | python3 -c "import json,sys;d=json.load(sys.stdin);print('$p', d['latest']['version'])"
+done
+```
+
+Only after this pass — every registry shows `$VERSION`, every artifact's contents check out, and nothing regressed in size/file-count versus the previous release — is the release fully published. Do not skip this step just because each individual publish call reported success; a successful upload is not the same claim as "the right bytes are now live."

--- a/.claude/skills/sdk-release/SKILL.md
+++ b/.claude/skills/sdk-release/SKILL.md
@@ -1,0 +1,1048 @@
+---
+name: sdk-release
+description: Cut a new RunAnywhere SDK release end-to-end in RunanywhereAI/runanywhere-sdks — version bump through a fully green, tagged, drafted-then-published GitHub Release. Stops BEFORE publishing to package registries (npm/Maven/pub.dev/SwiftPM dist) — that is the separate "sdk-publish" skill, invoked as the last step here.
+---
+
+# SDK Release (runanywhere-sdks)
+
+Repo: `~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks` (verify with `pwd`/`ls` —
+this is a workspace subfolder, not the repo root of the whole Qualcomm/ tree, and paths
+drift; re-check script paths below still exist before trusting them blindly).
+
+This is a **runbook**, not a description. Follow the steps in order. Every `gh`/`git`
+command below is meant to be run close to verbatim — adjust only the version/PR/run-id
+values for the release you're actually cutting.
+
+**THIS SKILL HAS BEEN SKIPPED THREE TIMES IN A ROW (v0.20.29, v0.20.30, v0.20.31),
+producing the IDENTICAL failure each time, DESPITE step 2/3 below documenting the exact
+fix since the v0.20.25/v0.20.29 incidents.** All three times, an agent ran
+`sync-versions.sh`, opened the PR, merged it, and pushed the tag directly — skipping the
+"dispatch a release candidate BEFORE merging, sync checksums from it, THEN merge" sequence
+in steps 2-3 — usually because the version bump was one step inside a longer autonomous
+chain (a downstream repo re-pin, a multi-repo release cascade) and felt like "just a
+version bump," not a release. **A version bump to `core/VERSION` IS a release. If you are
+about to run `scripts/release/sync-versions.sh` for ANY reason — including re-pinning this
+repo as a step in some OTHER repo's release — stop and follow this skill from step 1,
+including the candidate dispatch. Do not improvise the sequence from memory even if you
+did it correctly last time; do not skip it because "this bump is small" or "we're in a
+hurry."** v0.20.31 additionally caught a second, previously-undetected instance of the
+same class of bug in the SAME commit: `RunAnywhereMLXRuntime` in the Flutter podspec (which
+`RAC_CHECKSUM_SKIP` exempts from CI verification, so it fails silently for a consumer
+instead of failing `publish`) was ALSO stale, and had to be independently re-verified
+against the same candidate build — see step 3's checksum-location table; check every row
+in it, not just the one CI complained about.
+
+Companion skill: **sdk-publish** — invoke it at the very end (step 10) for the actual
+npm / Maven / pub.dev / SwiftPM-distribution publishing. This skill's job stops at a
+published (non-draft) GitHub Release with correct assets.
+
+---
+
+## 0. Orientation facts (confirm these still hold before relying on them)
+
+- Canonical version file: `core/VERSION` (single line, e.g. `0.20.24`). `core/VERSIONS`
+  also carries a `PROJECT_VERSION=` line that must agree — `sync-versions.sh` updates
+  both, `auto-tag.yml` reads `core/VERSIONS`, `check_release_version_coherence.sh` reads
+  `core/VERSION`. Don't hand-edit either; always go through the script.
+- `scripts/release/sync-versions.sh <version>` — bumps ~20 files (Package.swift,
+  gradle.properties, all package.json/pubspec.yaml, Kotlin/Swift/TS version constants,
+  AGENTS.md). Accepts a leading `v` and strips it.
+- `scripts/validation/gates/check_release_version_coherence.sh` — the gate that enforces
+  "PR changing VERSION must carry exactly one `release:patch|minor|major` label, and the
+  new version must be exactly base+1 for that bump type." Reads `PR_BASE_SHA` and
+  `PR_RELEASE_LABELS_JSON` env vars when run under CI; locally it only checks the
+  canonical-version-format part.
+- `.github/workflows/pr-build.yml` job **`centralization`** is what actually runs the
+  coherence gate in CI (`Release-train version coherence` step), alongside
+  `check_typescript_centralization.sh`, `check_flutter_centralization.sh`,
+  `check_gradle_centralization.sh`, `check_wasm_provenance_contract.sh`,
+  `check_swift_dist_repo_sync.sh`, `check_agents_claude_sync.sh`,
+  `check_no_hardcoded_defaults.sh`. This job's trigger types are
+  `[opened, synchronize, reopened, labeled, unlabeled]` — **adding the release label
+  after opening the PR fires a fresh run**, which is how the gate clears without a new
+  commit (see step 1).
+- `.github/workflows/release.yml` — the build/package/draft-release workflow. Triggers:
+  tag push `v*.*.*` OR `workflow_dispatch` (works on **any branch**, not just tags) with
+  inputs `version` (required), `validate_external_starters` (bool, default false),
+  `publish_from_run_id` (optional), `reuse_native_web_run_id` (optional).
+- `.github/workflows/auto-tag.yml` — fires on `pull_request: closed` to `main` when the
+  merged PR carries a `release:*` label. Verifies the version bump matches the label,
+  pushes the `v<version>` tag, and **explicitly dispatches a fresh `release.yml` run at
+  that tag** (plain `git push` of a tag with `GITHUB_TOKEN` does not auto-trigger
+  workflows, so it calls `gh workflow run release.yml --ref v<version> -f version=<version>`
+  itself). This is the redundant rebuild you must cancel — see step 7.
+- Branch protection on `main`: check
+  `gh api repos/RunanywhereAI/runanywhere-sdks/branches/main/protection` — 2 approvals +
+  code owner review required, but look for a `bypass_pull_request_allowances` (users/teams/apps)
+  list. If your `gh api user --jq .login` is on that list, `gh pr merge --squash --admin`
+  is a legitimate, pre-configured bypass — not a hack. If not on the list, stop and ask a
+  human to approve/merge.
+- Never let any `qhexrt`-named asset reach the public asset set. `release.yml`'s own
+  manifest-assertion step (`find release-flat -maxdepth 1 -type f -iname '*qhexrt*'`)
+  hard-fails the run if one is found — this is enforced, not just policy.
+- **Electron IS part of `release.yml` now** (as of `fix/electron-cicd-staging-url-npu-ane`,
+  2026-08-21) — this reverses the prior "deliberately separate" policy noted below by an
+  earlier pass; the repo owner explicitly asked for Electron to produce ready-to-publish
+  artifacts through the real release train like every other SDK. `native_electron`
+  invokes `.github/workflows/electron-native-package.yml` as a **reusable workflow**
+  (`workflow_call`) rather than duplicating its ~400 lines of hard-won native-build logic
+  inline; `sdk_electron` downloads the resulting `electron-packaged-tarballs` artifact,
+  runs `scripts/release/prepublish_check.py` on every tarball, computes checksums, and
+  splits public vs. QHexRT-private before anything reaches `release-flat`. `publish`
+  hard-gates on `sdk_electron` succeeding (same tier as `sdk_kotlin`/`sdk_web`/
+  `sdk_react_native`) but treats `native_electron`'s own result as advisory, because that
+  job's result folds in `native_win_arm64_qhexrt` — a single, personally-owned
+  self-hosted NPU runner whose outage should cost only `@runanywhere/electron-qhexrt`
+  for that release, not the whole SDK train (`native_win_x64_and_package`, the job that
+  actually produces the tarballs, tolerates a failed/skipped QHexRT lane and still packages
+  the other five real artifacts). Like every other SDK here, this still does **not**
+  `npm publish` anything — it only produces the tarballs as GitHub Release assets
+  (public ones) / a workflow artifact (the private QHexRT one) for a human to publish by
+  hand, matching the "build automated, publish manual" shape everywhere else.
+  **Electron is no longer WIP on a branch** — the old root `AGENTS.md`/`CLAUDE.md`
+  "Active issues" section describing `smonga/electron_upgrade` as in-progress is gone
+  entirely as of this checkout; `bindings/electron/` is a fully merged, real SDK on
+  `main` with its own `AGENTS.md`. Re-check that section is still absent before trusting
+  this note — if it has reappeared, something regressed.
+  See `thoughts/shared/plans/electron_cicd_staging_url_and_npu_ane_pipeline.md` for the
+  full history (this pipeline shipped the placeholder-URL bug three times before
+  `electron-native-package.yml` existed).
+  **QHexRT public/private boundary — CONFIRMED POLICY, not an open flag**: the repo
+  owner explicitly confirmed (2026-08-20) that `@runanywhere/electron-qhexrt` stays
+  public on npm intentionally (it already is, and is a real, working precedent worth
+  studying before touching QHexRT packaging elsewhere) — the QHexRT-stays-private
+  policy enforced everywhere else in this pipeline is specifically about the
+  **GitHub-Release-side** asset set (e.g. Android), a different distribution channel.
+  This is settled; stop re-flagging it as an unresolved contradiction. Only re-raise it
+  if you find evidence the policy has changed.
+
+---
+
+## 0b. NeuRT is a PINNED PREBUILT now — check this before anything else
+
+`native_ios` no longer compiles the private `neurun` repo. It downloads archives that
+repo publishes, pinned by tag + SHA-256 in `core/VERSIONS`, the same shape as sherpa-onnx:
+
+```
+NEURUN_REPO=RunanywhereAI/neurun      # shared: one repo publishes BOTH engines
+NEURT_RELEASE_TAG=v<version>          # per-engine: a release may carry one lane only
+NEURT_RAC_ABI_VERSION=9
+NEURT_MACOS_ARM64_SHA256=…
+NEURT_IOS_ARM64_SHA256=…
+NEURT_IOS_ARM64_SIMULATOR_SHA256=…
+```
+
+`NEURUN_REPO` is shared because one neurun release carries both engines. The **tags stay
+per-engine** on purpose: that repo can cut a release for one lane only, so a given tag may
+carry just one engine's assets.
+
+**Run the gate after re-pinning** — it verifies the pins against the release itself, so a
+mistyped or locally-computed value fails there instead of mid-build:
+
+```bash
+NEURUN_TOKEN="$(gh auth token)" bash scripts/validation/gates/check_engine_prebuilt_pins.sh
+```
+
+### Local engine development — there is no source mode
+
+The engine has no `NEURT_ROOT` path any more; nothing here compiles engine source. To iterate
+on NeuRT, build a slice in the neurun checkout and point the engine at it — no release, no
+tag, no pin edit:
+
+```bash
+# in neurun
+NeuRT/tools/scripts/package-rac-dist.sh --sdk-root <this repo> --version 0.0.0-dev \
+    --slice macos-arm64 --out /tmp/devdist
+mkdir -p /tmp/devslice && tar -xzf /tmp/devdist/neurt-macos-arm64-v0.0.0-dev.tar.gz \
+    -C /tmp/devslice --strip-components=1
+
+# here
+NEURT_PREBUILT_ROOT=/tmp/devslice cmake -S . -B build/dev -G Ninja \
+    -DRAC_BUILD_BACKENDS=ON -DRAC_BACKEND_NEURT=ON -DRAC_RUNTIME_COREML=ON
+# expect: Mode: PREBUILT (macos-arm64, ABI 9)
+```
+
+`NEURT_PREBUILT_ROOT` is a **single-slice** root, which is why
+`build-core-xcframework.sh` deliberately ignores it: packaging needs all three slices, so
+honouring a single-slice override there would let one staged slice satisfy the guard and
+silently package two non-routable stubs. Use an obviously-not-a-release version like
+`0.0.0-dev` so a dev slice can never be mistaken for a published one.
+
+**Why this changed, and why it matters to you specifically.** `engines/neurt/CMakeLists.txt`
+used to resolve a `NEURT_ROOT` checkout of that private repo and **regex-parse its root
+`CMakeLists.txt`** for a source list. Under that arrangement, commons widened
+`rac_llm_stream_callback_fn` with `tokens_in_delta`, the pinned neurun commit still passed
+4 arguments, and `native_ios` died with *"too few arguments to function call, expected 5,
+have 4"* on **v0.20.15, v0.20.16 and v0.20.17**. Every packaging job needs `native_ios`,
+so all three shipped **iOS-only — 18 assets where a healthy release has 55+**. That is the
+single most expensive failure this runbook exists to prevent, and it came from this seam.
+
+**Before opening the release PR**, confirm the pin is current:
+
+```bash
+grep -A5 '^NEURT_REPO' core/VERSIONS
+gh release view "$(grep '^NEURT_RELEASE_TAG=' core/VERSIONS | cut -d= -f2)" \
+    --repo RunanywhereAI/neurun --json assets --jq '.assets[].name'
+```
+
+Expect six assets — three `neurt-<slice>-v<version>.tar.gz` plus their `.sha256` sidecars.
+
+**If the plugin ABI changed this cycle** (`RAC_PLUGIN_API_VERSION` in
+`core/include/rac/plugin/rac_plugin_entry.h`), the pinned archives are invalid and
+`native_ios` will fail at the download step. Cut a neurun release first — that repo's
+`release_sdk_archives` skill is the runbook — then re-pin both `NEURT_RELEASE_TAG` and
+`NEURT_RAC_ABI_VERSION` here. The downloader refuses to run if `NEURT_RAC_ABI_VERSION`
+disagrees with the header, so this cannot be half-done.
+
+Prove it locally before trusting a tag build:
+
+```bash
+NEURUN_TOKEN="$(gh auth token)" bash scripts/build/download-neurt.sh --all
+```
+
+That verifies each tarball's SHA-256 **and** that its `RECEIPT.json` names the same ABI
+version this repo defines. Then check configure prints `Mode: PREBUILT (<slice>, ABI N)`.
+`SOURCE` means a local neurun checkout was picked up (prebuilt is meant to win, so the
+download did not land); `SHELL` means the engine is **not routable** and a release built
+now would ship an engine that registers, claims Apple availability and serves nothing.
+
+`release.yml` treats the downloader's exit **3** ("no token — degrade to the shell") as
+**fatal**. That degrade is right for a fork PR and catastrophic for a release.
+
+### The complete engine matrix — who consumes what, and how
+
+There are only **three fetch points in the entire repo**. Everything else consumes an
+sdks artifact, which is why a single fetch fix can repair five SDKs at once — and why a
+single missing fetch can silently break several.
+
+```
+neurun release (private)
+  ├─ native_ios         ──NeuRT x3 slices──►  RABackendNeuRT.xcframework
+  │                                              ├─ Swift  (Package.swift binary target)
+  │                                              ├─ Flutter / React Native (co-vendored
+  │                                              │   in the onnx package's podspec)
+  │                                              └─ rcli-macos (stages it, then GREPS
+  │                                                  `backends --json` for neurt)
+  ├─ native_android     ──QHexRT arm64-v8a──►  one build stages jniLibs into
+  │                                              Kotlin + React Native + Flutter
+  └─ electron           ──NeuRT macos-arm64 AND QHexRT win-arm64──►  its own natives
+```
+
+| target | NeuRT | QHexRT | note |
+|---|---|---|---|
+| Swift (iOS/macOS) | ✅ xcframework | — | NeuRT is Apple-only |
+| Flutter / React Native (Apple) | ✅ xcframework | — | co-vendored in the onnx package |
+| Flutter / React Native (Android) | — | ✅ jniLibs | from the same Android build as Kotlin |
+| Kotlin (Android) | — | ✅ jniLibs | arm64-v8a only; the only ABI with a Hexagon NPU |
+| Electron macOS | ✅ fetches | — | builds its own natives |
+| Electron win-arm64 | — | ✅ fetches | |
+| rcli macOS | ✅ xcframework | — | **best check in the tree** (below) |
+| rcli linux / windows-x64 | — | — | correct: NeuRT is Apple-only, QHexRT is win-arm64 |
+
+**`rcli-macos` is the strongest verification that exists here.** It greps
+`backends --json` for `"name":"neurt"` — and a non-routable shell *refuses
+registration*, so that grep proves the engine is **routable**, not merely present. Copy
+this pattern when adding an engine rather than checking for a file on disk.
+
+**Two silent-failure traps this matrix exists to prevent:**
+
+- **`RAC_BACKEND_<X>=ON` does not mean the engine works.** Without a payload the engine
+  builds as a non-routable shell and registration is refused — no build error. Android
+  shipped that way for months, and `rcli-macos-release` still sets
+  `RAC_BACKEND_NEURT: ON` regardless of whether a payload was fetched.
+- **`copy_if_exists` in `build-core-android.sh` silently no-ops** when a lib was never
+  built. That is the same guarded-copy pattern that shipped Windows with zero engines for
+  several releases. The release now asserts `librunanywhere_qhexrt.so` is really inside
+  the arm64-v8a archive.
+
+`scripts/validation/gates/check_engine_prebuilt_pins.sh` asserts all of the above plus
+the pins, the ABI, header drift against the receipt, and (with a token) the release
+contents. Run it before cutting a release; it is also wired into `pr-build` offline.
+
+### QHexRT is pinned the same way — check it too
+
+The Hexagon-NPU engine crosses the identical boundary, published by the same neurun release:
+
+```
+QHEXRT_RELEASE_TAG=v<version>
+QHEXRT_ARM64_V8A_SHA256=…      QHEXRT_ARM64_V8A_RECEIPT=…
+QHEXRT_WIN_ARM64_SHA256=…      QHEXRT_WIN_ARM64_RECEIPT=…
+```
+
+Two pins per ABI, not one: the tarball checksum **and** the payload's own build-receipt
+hash. The receipt is the directory name under `engines/qhexrt/prebuilt/versions/`, so
+pinning it is what makes the pin describe the bytes rather than trusting the archive's
+own claim about itself.
+
+```bash
+NEURUN_TOKEN="$(gh auth token)" bash scripts/build/download-qhexrt.sh --abi arm64-v8a
+NEURUN_TOKEN="$(gh auth token)" bash scripts/build/download-qhexrt.sh --abi win-arm64
+```
+
+**`current` selects ONE ABI at a time.** Both payloads can sit in `versions/` together, but
+a build targets one platform — so re-run the downloader when switching between an Android
+and a Windows build. The downloader ends by running `validate-qhexrt-prebuilt.py` itself,
+so a bad payload fails at the pin rather than mid-build.
+
+**The QHexRT lane in neurun is deliberately non-blocking.** It runs on a single
+self-hosted Snapdragon box (QAIRT is licence-gated and exists on no hosted runner). If
+that machine is offline, neurun's release publishes the Apple artifacts and **warns** that
+no QHexRT payload was produced — and the SDK simply keeps its previously pinned prebuilt.
+That is correct behaviour, not a failure: do not block an SDK release on it. Only treat it
+as blocking if this release is specifically meant to ship new NPU kernels.
+
+**Do not hand-stage `engines/qhexrt/prebuilt/`.** That was the old flow, and it is how the
+Electron win-arm64 lane once pinned a receipt staged months earlier and silently shipped
+NPU kernels from an old commit. If the tree looks stale, re-pin and re-download; never
+copy a payload in by hand.
+
+---
+
+## 1. Decide the version and open the release PR
+
+Check for an already-open release PR first — don't duplicate work:
+
+```bash
+gh pr list --repo RunanywhereAI/runanywhere-sdks --label release:patch --label release:minor
+```
+
+(gh ORs multiple `--label` flags into a single AND-filtered query per invocation is not
+guaranteed across all gh versions — if unsure, run the two label queries separately:
+`--label release:patch` then `--label release:minor`, plus `--label release:major`.)
+
+Pick a patch/minor/major bump based on the changes since the last tag. Then:
+
+```bash
+git checkout -b release/v<version>
+./scripts/release/sync-versions.sh <version>      # e.g. 0.20.25 (no 'v' needed, either works)
+bash scripts/validation/gates/check_release_version_coherence.sh
+```
+
+The coherence script may point out generated locks/changelogs that need regenerating
+(e.g. package-lock.json version bumps it expects but didn't find, or a missing CHANGELOG
+heading for the new version). Fix everything it flags, and add **explicit, human-written
+changelog entries** — the gate requires a heading for the new version to exist; it does
+not write prose for you.
+
+Open the PR and **apply exactly one `release:patch` or `release:minor` (or `release:major`)
+label** — this is required, not optional. Two failure modes to know:
+
+- If you forget the label and push a commit later, the `centralization` job's
+  `Release-train version coherence` step fails.
+- **Adding the label after the PR is already open does NOT get picked up by the run that
+  already executed.** Because `pr-build.yml`'s `centralization` job triggers on
+  `labeled`/`unlabeled` PR events, applying the label fires a **new** run of the whole
+  job — that new run is what goes green. Don't push an empty commit to "retrigger" it;
+  just add/re-add the label (or use `gh pr edit <pr> --add-label release:patch`, and if it
+  was already present, remove + re-add to force the event).
+
+---
+
+## 2. Get REAL native-artifact checksums BEFORE merging — dispatch a release candidate
+
+Do not merge on faith that native builds will succeed. `release.yml`'s
+`workflow_dispatch` trigger works on **any branch**, including your unmerged release
+branch — use it to build a full release candidate first:
+
+```bash
+gh workflow run release.yml --ref release/v<version> -f version=<version>
+```
+
+Get the run id and watch it:
+
+```bash
+gh run list --repo RunanywhereAI/runanywhere-sdks --workflow=release.yml --limit 5
+```
+
+**Do not block synchronously waiting on it.** Load the `Monitor` tool (or a background
+poll loop) to watch for completion/failure, and keep doing other release prep (changelog
+review, CodeRabbit thread triage, branch-protection check) in the meantime. Keep
+notifications to real state changes only — don't ping on every intermediate job
+completing, only on the run's overall failure or full completion.
+
+### REAL job durations — measured, not guessed. NEVER cancel a job for being "slow".
+
+Measured on the 0.20.25 train (2026-08-21/22). A release train legitimately takes
+**4-5 hours** wall-clock when `native_web` has to build.
+
+| Job | Real duration | Notes |
+|---|---|---|
+| **`native_web`** (release.yml) | **~3h51m** | The long pole, by far. Its `Vendor ONNX Runtime and Sherpa-ONNX WASM archives` step alone is **~71 minutes** — it BUILDS onnxruntime + sherpa to WASM from source; it is not a git clone. Then 4 more WASM builds: CPU core+llamacpp+onnx ~89m, WebGPU llamacpp ~37m, WebGPU onnx+sherpa ~33m. |
+| `native_ios` | ~60-75 min | XCFrameworks + MLX. No longer compiles neurun — it downloads the pinned NeuRT archives (see §0b), which is seconds, not minutes. |
+| `swift-spm` (pr-build) | **69-85 min** | `Build XCFramework` step is most of it. Measured across 6 consecutive `main` runs (2026-08-21/22): 69, 78, 75, 85, 77, 69. A run sitting at ~78 minutes is **healthy**, not hung — check this row before reaching for cancel. |
+| `kotlin-android` (pr-build) | ~40 min | |
+| `python-windows` (pr-build) | ~40 min | |
+| `electron (windows-2022)` (electron-sdk-ci) | ~40 min | |
+| `rcli-windows` | ~30 min | |
+| `native_electron / native_win_arm64_qhexrt` | ~28 min | Self-hosted; may sit **queued** for a long time first if the single runner is busy. Queued ≠ hung. |
+| `native_electron / native_win_x64_and_package` | ~35-45 min | |
+| `wasm` (pr-build) | ~12 min | **Do NOT use this as a proxy for `native_web`.** Totally different scope. |
+
+**The mistake this table exists to prevent**: `pr-build.yml`'s `wasm` job takes ~12
+minutes, so a ~50-minute `native_web` "vendor" step looks hung. It is not. On the 0.20.25
+train this misread caused two healthy `native_web` jobs to be cancelled at 2h19m and
+~55m, wasting ~3 hours and two full candidate builds. Before concluding "hung", check
+step-level progress and compare against THIS table:
+
+```bash
+gh run view <run-id> --repo RunanywhereAI/runanywhere-sdks --json jobs \
+    --jq '.jobs[] | select(.name=="native_web") | {startedAt, steps: [.steps[] | select(.status=="in_progress") | .name]}'
+```
+
+### `reuse_native_web_run_id` is the correct way to avoid re-paying that ~4 hours
+
+If a run needs redoing and **nothing under `bindings/web/wasm/`, `engines/`, or `core/`
+changed** since a run whose `native_web` succeeded, reuse it instead of rebuilding:
+
+```bash
+git diff --stat <good-run-sha> <current-sha>      # prove the scope first
+gh workflow run release.yml --ref release/<version> \
+    -f version=<version> -f reuse_native_web_run_id=<good-run-id>
+```
+
+`native_web` then shows `skipped`, and `sdk_web` + `validate_consumer_web` still run and
+pass against the reused artifact — which is also your proof the reuse was valid. Track the
+run id that **originally built** it: that is the id you keep citing (see the chaining note
+in step 7).
+
+---
+
+## 3. Sync checksums once native_ios finishes
+
+Pre-tag, `gh release download` will not work (there is no release yet) — pull the run's
+artifact directly:
+
+```bash
+gh run download <candidate-run-id> --repo RunanywhereAI/runanywhere-sdks \
+    --name native-ios-macos --dir release-artifacts/native-ios-macos
+```
+
+Verify every `.zip` against its `.sha256` sidecar **yourself** before trusting it:
+
+```bash
+cd release-artifacts/native-ios-macos
+for f in *.zip; do shasum -a 256 -c "${f}.sha256" || echo "MISMATCH: $f"; done
+cd -
+```
+
+Then sync:
+
+```bash
+bindings/swift/scripts/sync-checksums.sh release-artifacts/native-ios-macos
+```
+
+**KNOWN FACT — do not treat this as a bug**: `RunAnywhereMLXRuntime` (and occasionally
+`RACommons`) are **not byte-reproducible** between rebuilds of identical source. Expect
+their checksums to differ from any prior candidate build every single time you rebuild,
+even with zero source changes. Only investigate if a checksum for a framework that
+historically IS reproducible (e.g. plain XCFrameworks with no Swift codegen step)
+suddenly changes.
+
+**Where each checksum actually lives — these are NOT all in one file:**
+
+| Manifest | Carries |
+|---|---|
+| root `Package.swift` | `RACommons` + the 5 backend XCFrameworks (6 checksums total) |
+| nested Flutter `Package.swift` (under `bindings/flutter/`) | same 6 |
+| `bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec` → `mlx_checksums` hash | `RunAnywhereMLXRuntime`, `RunAnywhereMLXMetal`, `RunAnywhereMLXResources` — **only here**, nowhere else |
+
+After `sync-checksums.sh` runs, verify centralization didn't drift and re-run the version
+coherence gate locally:
+
+```bash
+bash scripts/validation/gates/check_flutter_centralization.sh
+bash scripts/validation/gates/check_release_version_coherence.sh
+```
+
+Commit and push the checksum-sync commit to the release branch:
+
+```bash
+git add Package.swift bindings/flutter/Package.swift \
+    bindings/flutter/packages/runanywhere_mlx/ios/runanywhere_mlx.podspec
+git commit -m "release: sync v<version> checksums from candidate run <candidate-run-id>"
+git push
+```
+
+### THIS STEP IS NOT OPTIONAL — skipping it fails `publish` after the tag already exists
+
+**What happens if you skip it** (observed on the 0.20.25 train): every build and package
+job goes green, `publish` gets all the way past flatten and the asset-manifest assertion,
+then dies at **`Verify built Apple checksums match tagged package contracts`**:
+
+```
+mismatch: RACommonsBinary
+  Package.swift: 0609dae6...      release zip: 1ae55ae4...
+mismatch: RABackendLlamaCPPBinary
+  Package.swift: 0597442f...      release zip: 7062f7c8...
+>> Done. 8 processed, 0 missing, 4 failed.
+ERROR: built Swift archives do not match the immutable tagged manifest
+```
+
+Note `8 processed / 4 failed` is really **2 distinct archives counted twice** (root
+manifest + Flutter manifest each). On that train `RACommons` and `RABackendLLAMACPP`
+drifted while ONNX/Sherpa/NeuRT/MLX/MLXMetal/MLXResources all matched — so "6 of 8 passed"
+is a normal-looking partial failure, not evidence of something exotic.
+
+**Recovery once the tag already exists** (this is safe and was done on 0.20.25):
+
+1. Confirm nothing was actually published — a failed `publish` dies *before* creating the
+   release, so there is usually nothing to undo:
+   ```bash
+   gh release view v<version> --repo RunanywhereAI/runanywhere-sdks   # expect "release not found"
+   ```
+2. Download the **exact artifacts the release will publish** (the candidate run named in
+   `publish_from_run_id`), verify each against its sidecar, and sync on a branch off `main`.
+3. Merge that branch, then **re-point the tag** at the new commit. `git push origin --delete`
+   can hang on flaky networks; the API is more reliable:
+   ```bash
+   gh api -X DELETE repos/RunanywhereAI/runanywhere-sdks/git/refs/tags/v<version>
+   gh api -X POST   repos/RunanywhereAI/runanywhere-sdks/git/refs \
+       -f ref="refs/tags/v<version>" -f sha="<new-main-sha>"
+   ```
+   Only do this while **no release exists and nothing has been published**. If a release
+   was already published, do NOT move the tag — cut the next patch version instead.
+4. **Creating a tag via the API DOES trigger `release.yml`'s `push` trigger** (unlike a
+   `GITHUB_TOKEN` git-push of a tag, which does not). So immediately after re-tagging you
+   will have TWO runs: a full rebuild from the `push` event, and your own
+   `workflow_dispatch`. Identify by event and cancel the `push` one:
+   ```bash
+   gh run list --repo RunanywhereAI/runanywhere-sdks --workflow=release.yml --limit 3 \
+       --json databaseId,event,headBranch --jq '.[] | "\(.databaseId) \(.event) \(.headBranch)"'
+   gh api -X POST repos/RunanywhereAI/runanywhere-sdks/actions/runs/<push-run-id>/cancel
+   ```
+
+Cheapest prevention: run `sync-checksums.sh --check <zip_dir>` against the candidate's
+artifacts and require **`N processed, 0 missing, 0 failed`** before you merge the release
+PR at all.
+
+**Recurred on v0.20.30 and again on v0.20.31** — same `mismatch: RACommonsBinary` /
+`mismatch: RACommons` failure, same root cause (step 2's candidate dispatch skipped
+entirely both times), fixed the same way both times: compute the real checksum from the
+already-built release-artifact zip (`gh run download <failed-run-id> --name
+native-ios-macos`), commit it on a fix branch, merge, then move the tag (§10d) to
+re-trigger `release.yml`. On v0.20.31 this ALSO surfaced the `RunAnywhereMLXRuntime`
+podspec entry as independently stale — `RAC_CHECKSUM_SKIP` means `publish` never checks
+it, so it would have shipped broken to Flutter consumers silently. **When fixing this
+failure after the fact, check every row of the checksum-location table in step 3, not
+only the archive named in the CI error** — the ones `RAC_CHECKSUM_SKIP` exempts are
+exactly the ones that won't tell you.
+
+---
+
+## 4. Watch for the "package intentionally doesn't bundle a sibling dep" bug class
+
+This exact release hit a real bug in `bindings/web/scripts/package-sdk.sh`:
+`@runanywhere/web-onnx` deliberately does **not** bundle its own `proto-ts` copy (only
+`core`/`llamacpp` do — enforced by `bindings/web/scripts/validate_public_packages.py` and
+mirrored in `bindings/react-native/scripts/validate_public_packages.py`), but the
+packaging script's install-smoke-test (`verify_candidate_install`, around line 165 of
+`package-sdk.sh`) never supplied a resolution target for that unbundled dependency, so
+`npm install` reached out to the real npm registry for a not-yet-published version and
+failed with `ETARGET`.
+
+Fix pattern (already applied, keep it this way): the `onnx` call to
+`verify_candidate_install` passes the just-built local `proto-ts` tarball
+(`$PROTO_ARCHIVE`, built via `npm pack ../proto-ts`) as an explicit extra install arg —
+see lines ~209-233 of `bindings/web/scripts/package-sdk.sh`, where `core` and `llamacpp`
+calls omit it (they bundle proto-ts themselves) but `onnx`'s call appends `"$PROTO_ARCHIVE"`.
+
+**Generalize this as a standing check for every release**: grep for the asymmetric
+bundling flags before trusting any packaging script —
+
+```bash
+grep -n "expects_bundled_proto\|--bundle" \
+    bindings/web/scripts/package-sdk.sh bindings/react-native/scripts/package-sdk.sh
+```
+
+Whenever a package intentionally does NOT bundle a sibling first-party dependency, its
+local pre-publish verification step must supply that dependency some other way (a local
+tarball) — the real registry version genuinely does not exist yet at candidate-build
+time, and letting `npm`/`yarn` hit the real registry will `ETARGET`.
+
+**Before trusting any packaging script is bug-free, actually run it** against the real
+downloaded native artifacts and check the exit code — do not just read the code and
+assume it's fine:
+
+```bash
+cd bindings/web && ./scripts/package-sdk.sh   # then check $?
+cd bindings/react-native && ./scripts/package-sdk.sh
+```
+
+### 4b. The two Electron-specific release bugs (both fixed — know the shapes)
+
+The 0.20.25 train was the **first** release to run Electron packaging inside `release.yml`,
+and it surfaced two defects that no local test or green PR check could have caught. Both
+are fixed; recognize the shapes because they generalize.
+
+**(1) `sync-versions.sh` has a hardcoded package list, and new packages get missed.**
+`bindings/electron/packages/neurt/package.json` sat at the previous version while every
+sibling moved, because `neurt` was added (electron#734) after that list was last touched.
+Symptom: `native_win_x64_and_package` fails with
+
+```
+ERROR: npm pack did not produce .../runanywhere-electron-neurt-<version>.tgz
+```
+
+— because `npm pack` correctly produced `...-neurt-<OLD-version>.tgz` from the stale
+manifest. **Whenever you add a package anywhere, add it to `sync-versions.sh` the same
+day.** Cheap pre-flight check that catches the whole class:
+
+```bash
+grep -h '"version"' bindings/electron/package.json bindings/electron/packages/*/package.json \
+    bindings/electron/native/package.json | sort -u     # expect exactly ONE distinct version
+```
+
+**(2) `publish` downloads EVERY artifact, including intermediate hand-off bundles.**
+`publish`'s `Download all artifacts` step has no name filter. `electron-packaged-tarballs`
+is `native_win_x64_and_package`'s raw output whose only purpose is feeding `sdk_electron`,
+which re-uploads the curated public set as `sdk-electron`. Flattening both duplicated all
+5 Electron tarballs *and* dragged in the raw bundle's own `proto-ts` copy, which collided
+with `sdk_web`'s:
+
+```
+::error::flatten collision: release-flat/runanywhere-proto-ts-<v>.tgz already exists
+::error::Refusing to publish — 6 filename collision(s) detected during flatten
+```
+
+Fixed by pruning that directory in the flatten `find`
+(`-type d -name "electron-packaged-tarballs" -prune -o -type f \( ... \)`). **Standing
+rule: any new intermediate artifact must be either excluded from the flatten or named so
+it cannot collide.** When editing that `find`, test the exact expression against a fake
+`release-artifacts/` tree locally first — `-prune -o` + `-print0` is easy to get subtly
+wrong and the only other way to find out costs a full release run.
+
+---
+
+## 5. Resolve CodeRabbit (or any bot) review findings properly
+
+Do not resolve a review thread without a real, evidence-backed reply. Steps:
+
+1. Fetch unresolved threads via GraphQL:
+
+```bash
+gh api graphql -f query='
+query($owner:String!, $repo:String!, $pr:Int!) {
+  repository(owner:$owner, name:$repo) {
+    pullRequest(number:$pr) {
+      reviewThreads(first:100) {
+        nodes { id isResolved comments(first:10) { nodes { id databaseId body } } }
+      }
+    }
+  }
+}' -f owner=RunanywhereAI -f repo=runanywhere-sdks -F pr=<pr-number>
+```
+
+2. For each unresolved thread, reply via REST with `in_reply_to` set to the comment's
+   `databaseId` (not the GraphQL node id), citing concrete evidence — a real run id,
+   a real checksum, a real commit SHA, not "looks fine":
+
+```bash
+gh api -X POST repos/RunanywhereAI/runanywhere-sdks/pulls/<pr-number>/comments \
+    -f body="Verified against candidate run <run-id>: RunAnywhereMLXRuntime checksum
+matches release-artifacts/native-ios-macos/RunAnywhereMLXRuntime-ios-v<version>.zip.sha256.
+See commit <sha>." \
+    -F in_reply_to=<comment-database-id>
+```
+
+3. Only then resolve, via GraphQL mutation on the thread id from step 1:
+
+```bash
+gh api graphql -f query='
+mutation($threadId:ID!) { resolveReviewThread(input:{threadId:$threadId}) { thread { isResolved } } }
+' -f threadId=<thread-node-id>
+```
+
+---
+
+## 6. Merge
+
+Before merging, verify:
+
+```bash
+gh pr view <pr-number> --repo RunanywhereAI/runanywhere-sdks --json mergeable,reviewDecision
+```
+
+Zero unresolved review threads (re-check the GraphQL query from step 5 — it should return
+none with `isResolved: false`), and `mergeable == "MERGEABLE"`.
+
+Confirm bypass eligibility before relying on `--admin`:
+
+```bash
+gh api repos/RunanywhereAI/runanywhere-sdks/branches/main/protection \
+    --jq '.required_pull_request_reviews.bypass_pull_request_allowances'
+gh api user --jq .login
+```
+
+If your login appears in that allowance list (users, or a team/app you belong to):
+
+```bash
+gh pr merge <pr-number> --repo RunanywhereAI/runanywhere-sdks --squash --admin
+```
+
+If not on the list, **stop** — ask a human to approve or merge instead of forcing it.
+`--admin` is a legitimate configured bypass only for allow-listed identities; do not use
+it to route around review for anyone else.
+
+---
+
+## 7. GOTCHA — cancel the auto-tag-dispatched rebuild, dispatch a publish-only run instead
+
+The moment the PR merges, `auto-tag.yml` runs, pushes the `v<version>` tag, and **itself**
+dispatches a brand-new full `release.yml` run at that tag (see orientation section — plain
+tag pushes via `GITHUB_TOKEN` don't auto-trigger, so the workflow does it explicitly).
+This is redundant — you already have a fully green, checksum-verified candidate from step
+2-3 — and wasteful, because Apple/MLX bytes will drift again for zero benefit (see the
+non-reproducibility fact in step 3).
+
+**Cancel it immediately, before it burns real compute** (ideally within the first minute
+or two, before native_ios starts real work):
+
+```bash
+gh run list --repo RunanywhereAI/runanywhere-sdks --workflow=release.yml --limit 5
+gh api -X POST repos/RunanywhereAI/runanywhere-sdks/actions/runs/<auto-triggered-run-id>/cancel
+```
+
+Then dispatch a **publish-only** run that reuses your already-verified candidate's exact
+bytes instead of rebuilding:
+
+```bash
+gh workflow run release.yml --ref v<version> \
+    -f version=<version> \
+    -f publish_from_run_id=<candidate-run-id>
+```
+
+**CRITICAL SUB-GOTCHA**: if your candidate run in step 2 itself passed
+`reuse_native_web_run_id=<X>` to skip rebuilding WASM (a packaging-only re-release), that
+candidate run **never uploaded its own copy of the `native-web` artifact** — it was
+skipped. `publish_from_run_id` alone will then fail during the release-manifest assertion
+with `"Missing or empty Web WASM payload"`, because the publish job's artifact-download
+step only pulls `reuse_native_web_run_id`'s artifact when that input is passed to *this*
+dispatch too (see `.github/workflows/release.yml` around the "Download reused Web natives"
+step — it is gated on `inputs.reuse_native_web_run_id != ''`, independent of
+`publish_from_run_id`). You must **also** pass the same original run id:
+
+```bash
+gh workflow run release.yml --ref v<version> \
+    -f version=<version> \
+    -f publish_from_run_id=<candidate-run-id> \
+    -f reuse_native_web_run_id=<X>
+```
+
+This chains forward across releases: whichever run **originally** built `native_web` is
+the run you keep citing at every subsequent `reuse_native_web_run_id`, not the most recent
+run that merely borrowed it from an earlier one. Track that original run id explicitly if
+you're doing back-to-back packaging-only releases.
+
+---
+
+## 8. Verify the draft release's asset set
+
+The publish job only creates a **draft** GitHub Release (`softprops/action-gh-release`,
+`draft: true`) with built assets attached — it does not touch npm/Maven/pub.dev at all
+(grep `release.yml` for `npm publish`, `mavenCentral`, `pub publish` — none exist there).
+
+Expected asset count for a full, non-Windows-focused release: **~65 assets** —
+
+- 9 Apple archives (iOS/macOS XCFrameworks: RACommons + 5 backends + MLX runtime/Metal/
+  resources + CoreML/NeuRT)
+- 3 Android RACommons zips (arm64-v8a, armeabi-v7a, x86_64)
+- 1 Linux RACommons tar.gz
+- 1 Windows RACommons zip (preserved as an asset, advisory — see step 9)
+- 1 Web WASM tar.gz (`RACommons-web-v<version>.tar.gz`)
+- 3 rcli tarballs (macOS arm64, Linux x86_64, Windows x86_64 — macOS may also have a
+  notarized `.dmg` if Developer ID/notary secrets are configured; this is soft-skipped
+  otherwise, not a failure)
+- 1 Kotlin Maven repo zip
+- 8 npm tarballs (proto-ts, web core, web-llamacpp, web-onnx, RN core, RN llamacpp, RN mlx,
+  RN onnx)
+- 5 Electron npm tarballs (`runanywhere-electron-<v>.tgz` core, `-llamacpp`, `-onnx`,
+  `-sherpa`, `-neurt`) — added by `sdk_electron`; each has its own `.sha256` sidecar
+  counted separately below. **`electron-qhexrt` is deliberately excluded** — it still
+  gets built and packaged, but only as the `sdk-electron-qhexrt-private` workflow
+  artifact (not a release asset); download it separately for a manual `npm publish`.
+- 1 `MANIFEST.txt`
+- **explicitly ZERO** `qhexrt`-named files (the manifest assertion step hard-fails the run
+  if it finds any — confirm the run actually reached the publish job and didn't die there)
+
+Every asset above except `MANIFEST.txt` has a `.sha256` sidecar, which is itself a
+separate asset. **v0.20.25 landed at exactly 65 assets** — use that as the concrete
+baseline rather than re-deriving the arithmetic.
+
+Cross-check every checksum's `.sha256` sidecar against what got committed to
+`Package.swift` / the flutter `Package.swift` / the MLX podspec in step 3 — they must
+match byte for byte, because this run's artifacts are exactly what step 10 (sdk-publish)
+ships to real consumers.
+
+```bash
+gh run view <publish-run-id> --repo RunanywhereAI/runanywhere-sdks --json jobs \
+    --jq '.jobs[] | {name, conclusion}'
+
+# Asset count + the Electron set + the qhexrt-leak assertion, in three commands:
+gh release view v<version> --repo RunanywhereAI/runanywhere-sdks --json assets --jq '.assets|length'
+gh release view v<version> --repo RunanywhereAI/runanywhere-sdks --json assets \
+    --jq '[.assets[].name | select(startswith("runanywhere-electron"))] | sort'
+gh release view v<version> --repo RunanywhereAI/runanywhere-sdks --json assets \
+    --jq '[.assets[].name | select(test("qhexrt";"i"))]'          # MUST be []
+```
+
+### Prove the artifacts are real — don't trust green checkmarks
+
+A green `publish` only proves the assertions ran. To prove the bytes are right, run the
+repo's own fail-closed gate against the **published** tarballs. This is the single highest
+-value verification in the whole runbook and it takes about a minute:
+
+```bash
+gh release download v<version> --repo RunanywhereAI/runanywhere-sdks \
+    -p 'runanywhere-electron*.tgz' -D /tmp/verify
+python3 scripts/validation/gates/check_plugin_natives.py --expect-version <version> \
+    $(for t in /tmp/verify/*.tgz; do printf -- '--tarball %s ' "$t"; done)
+```
+
+Expect `All N check(s) passed: plugin natives are routable and no staging-URL placeholder
+was found.` On v0.20.25 that was **20 checks** across 5 tarballs, asserting three separate
+things per binary: the real `STAGING_BASE_URL` is baked in (no `YOUR_STAGING_BASE_URL`
+placeholder), `rac_commons` embeds the right version string, and each backend is actually
+**routable** (real op tables — `g_llamacpp_ops`, `g_sherpa_stt_ops`, `g_neurt_llm_ops`,
+etc.), which is what distinguishes a real plugin from a same-sized shell.
+
+Sanity-check the shipped layout too — a tarball missing a platform is a silent regression:
+
+| Package | Expected `prebuilds/` |
+|---|---|
+| `@runanywhere/electron` | `darwin-arm64` + `win32-x64` + `win32-arm64` |
+| `-llamacpp`, `-onnx`, `-sherpa` | `darwin-arm64` + `win32-x64` |
+| `-neurt` | `darwin-arm64` only (Apple Neural Engine) |
+| `-qhexrt` (private artifact) | `win32-arm64` only (Hexagon NPU) |
+
+---
+
+## 9. Windows handling — build/preserve only, never auto-publish
+
+`native_windows` and `native_rcli_windows` run and their outputs are **preserved** as
+release assets (proving the binaries build), but nothing Windows-specific is published to
+any package registry as part of the standard flow unless a human explicitly asks for it —
+that's a deliberate, separate decision, not an oversight.
+
+For anything that needs actual execution on Windows (smoke-testing the native Windows
+build, or Electron's Windows packaging), do not assume a macOS cross-build proves
+Windows correctness — SSH to the real Windows box. The team keeps a **Windows ARM64
+machine reachable over SSH**; its hostname, user, key, and mesh-VPN node name are
+operator-specific and deliberately not recorded in this repo — read the Windows/ARM64
+host entry out of the operator's `~/.ssh/config` and use that alias. If there is no such
+entry, the box is not configured for you: say so and ask, rather than guessing.
+
+```bash
+WIN_BOX=<the ssh alias from ~/.ssh/config>
+# Ask the mesh-VPN client whether the node is up FIRST (e.g. `tailscale status`,
+# matching on that host entry's HostName) — never just try SSH and retry on timeout.
+ssh -o ConnectTimeout=8 "$WIN_BOX" "whoami"
+```
+
+If the VPN reports the node offline/asleep, **that's not a config problem** — ask the
+user to wake the box; don't debug SSH config against a machine that's simply off.
+
+---
+
+## 10. Publish the draft, then hand off
+
+Once the draft's asset set is verified complete and correct (step 8):
+
+```bash
+gh release edit v<version> --repo RunanywhereAI/runanywhere-sdks --draft=false --latest
+```
+
+This is the point where SwiftPM's `from: "<version>"` resolution and the download URLs
+baked into `Package.swift` start actually working for real external consumers — draft
+release assets are not publicly downloadable, so nothing before this line is
+externally live.
+
+**Hand off to the `sdk-publish` skill** for the actual npm / Maven Central / pub.dev /
+SwiftPM-distribution-repo publishing steps. This skill's job ends here.
+
+---
+
+## 10b. MANDATORY, and it turns `main` RED until you do it — cut runanywhere-swift
+
+The moment `v<version>` exists in this repo, `check_swift_dist_repo_sync.sh` (run by
+`pr-build.yml`'s `centralization` job) **fails on every PR and every push to `main`**:
+
+```
+[FAIL] runanywhere-swift has no 0.20.25 tag (latest: 0.20.24)
+       v0.20.25 is published here, so 'from: "0.20.25"' is broken for every
+       SwiftPM consumer of https://github.com/RunanywhereAI/runanywhere-swift.git
+```
+
+This is **by design**, not a bug, and it is the #1 reason a release looks "not green"
+after everything else succeeded. Do not go hunting for a code defect — cut the repo:
+
+```bash
+git clone https://github.com/RunanywhereAI/runanywhere-swift.git /tmp/ra-swift
+bindings/swift/scripts/sync-dist-repo.sh --zips <zip_dir> --tag /tmp/ra-swift
+# verify BEFORE pushing (content check passes locally; the tag check needs the push)
+RUNANYWHERE_SWIFT_DIST_REPO=/tmp/ra-swift \
+    bash scripts/validation/gates/check_swift_dist_repo_sync.sh
+git -C /tmp/ra-swift push origin main --follow-tags
+bash scripts/validation/gates/check_swift_dist_repo_sync.sh    # now [OK]
+```
+
+Gotchas found doing this on 0.20.25:
+
+- `--check` **cannot be combined** with `--zips`/`--commit`/`--tag` (hard error). Run a
+  bare `--check <repo>` first to preview, then the real invocation separately.
+- `--check` legitimately reports `ERROR: distribution repo is out of sync` before you
+  sync — that's the preview telling you what it will change (expect the `sdkVersion` bump,
+  ~3 changed files, `0 added / 0 removed`). Non-zero exit there is not a failure.
+- The script **never pushes**; `--tag` only creates the tag locally. The dist repo tag has
+  **no `v` prefix** (`0.20.25`, not `v0.20.25`) while the monorepo tag does.
+- Running the gate locally right after `--tag` still shows `[FAIL] ... has no <version>
+  tag` while simultaneously showing `[OK] ... checkout matches: all 6 checksums`. That is
+  expected: the content check reads your local checkout, the tag check queries the real
+  remote. It clears the moment you push.
+- It chains into `sync-checksums.sh`, so run it **after** step 3's checksums are committed,
+  or the dist manifest gets stale hashes.
+
+---
+
+## 10c. Windows + self-hosted-runner traps (read before debugging a red Windows job)
+
+These all cost a full CI cycle. The unifying fact:
+
+> The self-hosted runner service executes as `NT AUTHORITY\NETWORK SERVICE`, which has its
+> own PATH **and** its own NTFS permissions. Anything you verify over SSH on that box tells
+> you nothing about what the job can do. `native_win_arm64_qhexrt` already carries a long
+> comment about this — read it before inventing a fix, and keep it in sync with neurun's
+> equivalent lane, which runs on the *same machine*.
+
+**Environment**
+
+- **`bash: command not found`** — Git for Windows puts `Git\cmd` (git.exe) on PATH but not
+  `Git\bin` (bash.exe). `actions/checkout` still works because it calls git.exe directly,
+  which makes this look unrelated to runner setup.
+- **`pwsh` does not exist on that box** — Windows PowerShell 5.1 only. Use
+  `shell: powershell`.
+- **`gh` is not installed on that box, and must not be assumed anywhere.** A QHexRT
+  download died on `gh: command not found`. The fix is deliberately *not* to install it:
+  every fetch of a private release asset now goes through
+  `fetch_release_asset()` in `scripts/build/_release_asset.sh`, which uses `curl` + the
+  REST API. `curl` ships with Windows, macOS and every Linux image we use, so this is one
+  code path everywhere instead of a per-runner provisioning step. If you add a new
+  consumer of a private asset, source that helper — do not reach for `gh`.
+  Note the helper matches the asset name **exactly**: a prefix match picks the `.sha256`
+  sidecar (its name starts with the tarball's), and you get a 65-byte "archive" that fails
+  much later with a confusing error.
+- **Tool availability is the single most common failure class on this runner** — `bash`,
+  `python3`, `ninja`, `gh`, GNU `tar` and NDK `.exe` suffixes have each broken a lane
+  once. When a self-hosted job fails, check "does this tool exist as spelled" before
+  reading any logic.
+- **`ln -s` under Git-Bash COPIES the directory** unless `MSYS=winsymlinks:nativestrict`.
+  It does not fail, so the result looks like real content and whatever validates a
+  "must be a symlink" invariant rejects a payload that was actually fine. Never use shell
+  `ln -s` on this box — go through `scripts/build/_selection.py`.
+- **Windows selects with a JUNCTION, not a symlink, and that is deliberate.** The runner
+  service account cannot create symlinks (below), but a junction is the same kind of
+  reparse point to a directory and needs no privilege. Two traps when reading that code:
+  `Path.is_symlink()` returns **False** for a junction (`stat.S_ISLNK` is true only for
+  `IO_REPARSE_TAG_SYMLINK`) — use `_selection.is_selection()`; and a junction stores an
+  **absolute** target, so compare `_selection.read_target()`, which normalizes both
+  platforms back to `versions/<receipt>`. `Path.is_junction` is 3.12+ and that box runs
+  3.10, so the `lstat`/`st_reparse_tag` fallback is the live path there.
+
+**A green PR does not mean the win-arm64 lane passed**
+
+`native_win_arm64_qhexrt` is gated `if: github.event_name != 'pull_request'` — never run
+on a PR, fork or not, because a `pull_request` run would execute PR-controlled
+`npm install` scripts on a persistent personally-owned runner. It therefore only runs on
+`push` / `workflow_dispatch` / `workflow_call`. Consequences to plan around:
+
+- **Check the paths filter covers what you changed.** `electron-native-package.yml` watches
+  `scripts/build/**` *because* of this — a fix to `download-qhexrt.sh` used to trigger no
+  push run at all, so it would merge with the lane it was written for never having run.
+  If you add a new dependency of that workflow, add it to both paths lists.
+- To exercise the lane on an unmerged branch, `gh workflow run electron-native-package.yml
+  --ref <branch>` — `workflow_dispatch` has no paths filter and satisfies the event gate.
+- **Do not push while that dispatch run is in flight.** The concurrency group is
+  `${{ github.workflow }}-${{ github.ref }}` with `cancel-in-progress: true` and does not
+  distinguish event types, so a push cancels the dispatch run you are waiting on.
+- Read the step list, not just the job conclusion: `skipped` on this job looks nothing like
+  `success` but sorts the same way in a rollup summary.
+- **ASCII only inside a PowerShell `run:` block.** The runner writes it to a `.ps1` with no
+  BOM and PS 5.1 decodes CP1252, so a UTF-8 em-dash ends in `0x94` — a smart closing quote —
+  and the script dies with `The string is missing the terminator` on a line that is
+  perfectly balanced. In a YAML *comment* it is harmless.
+- **The runner service caches its environment at start.** After changing machine PATH,
+  `Restart-Service` or the next job still sees the old one.
+- `cmake`/`python`/`ninja` may be pip-installed under a user profile and invisible to the
+  service account; add them to `$GITHUB_PATH` with a **concrete** path (a wildcard
+  `Get-ChildItem` there silently finds nothing, because access-denied on enumeration is
+  swallowed by `-ErrorAction SilentlyContinue`).
+
+**Batch scripts (`core/scripts/windows/*.bat`)** — both of these emit the identical, useless
+`... was unexpected at this time.` **after** an apparently successful download, which sends
+you looking in the wrong place entirely:
+
+- **`::` is a label and is ILLEGAL inside a `( )` block** — use `rem` there.
+- **Unescaped parens inside an `echo` close the block early.**
+  `echo Decompressing (7-Zip)...` is fine at top level and fatal once nested; needs
+  `^(` / `^)`.
+
+Both were introduced purely by moving existing, working lines *into* an `if`/`else` block.
+
+**`7z` is not guaranteed.** It ships on GitHub's windows runners but is not part of a stock
+Windows install. `download-sherpa-onnx.bat` now falls back to bsdtar, which handles
+`.tar.bz2` directly (measured: 2.5 s, exit 0, on Windows 11 ARM64).
+
+**CMake on Windows**
+
+- **Visual Studio is a MULTI-CONFIG generator**: `CMAKE_BUILD_TYPE` is a no-op; `--config
+  Release` at *build* time is what selects Release. Getting this wrong silently ships Debug.
+- **An Android cross-build needs `-G Ninja` explicitly.** Windows' default generator is
+  Visual Studio, which cannot drive the NDK toolchain file — and macOS/Linux pick a working
+  default, so an omitted generator breaks *only* on Windows.
+
+## 10d. Re-tagging: verify the tag actually moved
+
+`git tag -d <tag> -q` is **not valid** (`-q` is not a flag there). Guarded with `|| true`
+it fails silently, and the next `git push origin <tag>` pushes the **stale** tag. This has
+already started a release building the wrong commit. Always verify:
+
+```bash
+[ "$(git rev-parse v<version>^{commit})" = "$(git rev-parse main)" ] \
+  && echo "tag OK" || echo "STALE — delete on BOTH sides and re-tag"
+```
+
+Deleting locally is not enough; `git push origin :refs/tags/<tag>` removes the remote one.
+And if a release run already started on the stale tag, cancel it before re-tagging or you
+will race two publishes at the same tag.
+
+## 11. Non-blocking loose ends — note, don't chase
+
+- **`python-linux` no longer exists** — it was removed from `pr-build.yml` on 2026-08-22.
+  It had a chronic ~90-minute hang that tripped its own `timeout-minutes: 90` on nearly
+  every run (on both a two-version matrix and a single pinned 3.12), surfacing as a red X
+  or a whole-run "cancelled" for a job that was never a required status check and whose
+  ecosystem (PyPI) `release.yml` does not touch at all. `python-macos` and `python-windows`
+  still cover the wheel build/install/test flow. Trade-off accepted knowingly: **no CI job
+  now verifies the `requires-python = ">=3.9"` floor** declared in
+  `bindings/python/pyproject.toml`. If Python 3.9 support starts mattering, add one cheap
+  single-version job rather than resurrecting the old matrix.
+- Confirm branch protection still has **no required status checks** (so a stray red X
+  cannot silently block a merge):
+  ```bash
+  gh api repos/RunanywhereAI/runanywhere-sdks/branches/main/protection --jq '.required_status_checks'
+  gh api repos/RunanywhereAI/runanywhere-sdks/rulesets --jq '.[] | {id, name, enforcement}'
+  ```
+  As of 2026-08-22 the active `main` ruleset enforces `pull_request`,
+  `required_linear_history`, `copilot_code_review`, `deletion`, `non_fast_forward` — and
+  **zero** required status checks. Merge gating is 2 approvals + code-owner review, with
+  `bypass_pull_request_allowances` covering sanchitmonga22, shubhammalhotra28, Siddhesh2377.
+- `native_win_arm64_qhexrt` / `native_win_x64_and_package` showing **`skipping`** on any
+  `pull_request` event is intentional security gating (see the Electron section in step 0),
+  not a failure. They run on `push`/`workflow_dispatch`.
+- Transient GitHub-infra failures do happen and look alarming: on the 0.20.25 train
+  `native_ios` died once with `fatal: unable to access 'https://github.com/nlohmann/json.git/':
+  Could not resolve host: github.com` during a CMake `FetchContent` clone. Re-run the failed
+  job (`gh run rerun <id> --failed`) — but note you **cannot** re-run failed jobs while the
+  run is still in progress ("This workflow is already running"); wait for the run to finish
+  first. Distinguish this from a slow-but-healthy job using the duration table in step 2.
+- `@runanywhere/electron-qhexrt`'s npm exposure (step 0) is a confirmed, settled policy
+  decision, not an open item — no need to re-flag it every run anymore.

--- a/.claude/skills/sdk-test-starters/SKILL.md
+++ b/.claude/skills/sdk-test-starters/SKILL.md
@@ -1,0 +1,529 @@
+---
+name: sdk-test-starters
+description: Run a REAL end-to-end inference smoke test (model download + load + generate, with visible output) on every RunAnywhere starter app — iOS, macOS/Swift, Android, Web, Electron — after a runanywhere-sdks release. Build success alone is never sufficient evidence.
+---
+# SDK Test Starters
+
+Post-release validation runbook for the five RunAnywhere SDK consumer apps. This
+skill exists because "it built" has been reported as "tested" before, and that is
+not evidence of anything except that the compiler ran.
+
+## 0. The evidence bar (applies to every app, no exceptions)
+
+For each app you must produce, and be able to state explicitly:
+
+1. **Version proof** — print/log the actual resolved SDK version from inside the
+   running app (a startup log line, a version screen, an `swift package show-dependencies`
+   / `./gradlew dependencies` / `npm ls @runanywhere/...` output, etc). Never assume
+   a version bump "took" just because you edited a manifest.
+2. **Real model acquired** — a real (small) model downloaded fresh, or confirmed
+   already cached, by the app itself (not a file you hand-placed unless that IS the
+   app's supported flow).
+3. **Load** — the model actually loads (watch for a load-succeeded log/state, not
+   just "no crash").
+4. **One real inference call** — LLM `generate()` is almost always the easiest
+   modality to drive; use it unless another modality is genuinely less work for
+   that specific app.
+5. **Visible output** — capture the actual generated text (or audio/image) and
+   quote it in your report. "It responded" is not enough — show what it said.
+6. **Logs reviewed** — read the console/log stream for errors and warnings and
+   explicitly explain any that appear. Do not silently drop a stack trace because
+   the app "still produced output."
+
+Reporting an app as tested from a build/compile success alone is a skill violation.
+If you could not get past build, that is a BLOCKED report (see §8), not a PASS.
+
+## 1. Locating each app's real local checkout
+
+This machine accumulates many differently-named copies of the same repos over time
+(worktrees, experiment clones, old branches, scratch dirs). **Never trust a
+directory name.** Before touching anything in a candidate directory:
+
+```bash
+git remote get-url origin          # must be https://github.com/RunanywhereAI/<repo>.git
+git status --short --branch        # what branch, what's dirty, is it someone else's WIP?
+```
+
+As of this writing, the known-good local checkouts for this user are here (verify
+this each time — do not hardcode it further than "check this location first"):
+
+```
+~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-ios       -> RunanywhereAI/runanywhere-ios.git
+~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-android   -> RunanywhereAI/runanywhere-android.git
+~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-web       -> RunanywhereAI/runanywhere-web.git
+~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-electron  -> RunanywhereAI/runanywhere-electron.git
+```
+
+The macOS/Swift case has no separate consumer repo — see §4, it lives inside
+`~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks` (confirm with
+`git remote get-url origin` there too — this machine also has stray full-monorepo
+clones elsewhere, e.g. under `~/development/hard/ambient/`, that are NOT the one to
+use unless you've verified it's the intended checkout).
+
+These starter checkouts are commonly sitting on a feature branch, not `main` — e.g.
+at last check `runanywhere-ios` and `runanywhere-android` were on
+`add-gemma4-qwen3.6-qwen3.8-models` and `runanywhere-web` on `add-supertonic-3-tts`.
+That is fine to test FROM, but say so in your report, and do not `git checkout` away
+from a branch that has uncommitted work you didn't create — if `git status --short`
+shows dirty files you don't recognize, stop and ask rather than stashing/resetting.
+
+If genuinely unsure which directory is real, `git clone` a fresh one into the
+scratchpad rather than guessing — a wrong guess wastes far more time than a clone.
+
+## 2. Cross-repo facts this skill assumes
+
+- SDK version SoT: `core/VERSION` in `runanywhere-sdks`, bumped everywhere by
+  `scripts/release/sync-versions.sh <version>`.
+- Release publish is `.github/workflows/release.yml` (dispatch or `v*.*.*` tag).
+- **Never** treat a build success against `RUNANYWHERE_USE_LOCAL_NATIVES=1` (or any
+  monorepo-local staged artifact) as proof the *public* release works — see §4.
+- QHexRT/QNN material must never appear in a public artifact — release.yml
+  hard-fails on it. If anything you're testing surfaces a QHexRT asset in a public
+  package, stop and flag it, don't route around it.
+
+## 3. iOS — `runanywhere-ios`
+
+SDK pin lives in `Package.swift`:
+
+```swift
+.package(url: "https://github.com/RunanywhereAI/runanywhere-swift.git", from: "0.20.19")
+```
+
+This only resolves once `runanywhere-swift` (the generated Swift-only SPM
+distribution repo — see `~/.claude/skills/sdk-publish/SKILL.md` §4) is
+actually tagged at the target version. Steps:
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-ios
+# bump the `from:` version in Package.swift to the target release, then:
+swift package update            # or open in Xcode and let it resolve
+./scripts/build_and_run_ios_sample.sh simulator "iPhone 16 Pro"
+```
+
+`./scripts/verify.sh` is the CI-equivalent gate: it resolves the package remotely
+and runs a full `xcodebuild` against the iOS Simulator — use it to prove the
+resolve is clean (it fails if `Package.resolved` ends up dirty, i.e. the committed
+pin was stale). `./scripts/smoke.sh` is a fast, non-compiling grep-based check —
+it does NOT count as evidence for this skill's bar, only `build_and_run` +
+watching real output does.
+
+Drive one real `generate()` call through the app UI (or the equivalent debug
+action if the sample exposes one) against a small downloaded model, then watch the
+runtime log stream for the version line, the model download/load, the generation,
+and any errors:
+
+```bash
+log stream --predicate 'subsystem CONTAINS "com.runanywhere"' --info --debug
+```
+
+Most loggers use `com.runanywhere.RunAnywhereAI`; a few use plain
+`com.runanywhere`; the SDK logs under its own subsystem — the `CONTAINS` match
+covers all of them. On a physical device use `idevicesyslog | grep "com.runanywhere"`
+instead.
+
+## 4. macOS/Swift — no separate repo, use the in-tree example or rcli
+
+There is no `runanywhere-macos` consumer repo. Two in-monorepo options, both inside
+`~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks`:
+
+- `bindings/swift/example/` — a minimal SwiftPM example app/executable.
+- `rcli/` — the C++ core's CLI, `rac_*` C ABI consumer.
+
+**The critical gotcha**: the repo's own `Package.swift` is fail-closed toward the
+*real published release* — it resolves the remote `binaryTargets` unless you
+explicitly opt into locally staged XCFrameworks with
+`RUNANYWHERE_USE_LOCAL_NATIVES=1`. Every doc/script example in this repo sets that
+env var (because local dev wants fast iteration against in-progress binaries) —
+but that means copy-pasting those examples verbatim tests your LOCAL staged build,
+not the actual public release artifact. To prove the published release works:
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks/bindings/swift/example
+# DO NOT set RUNANYWHERE_USE_LOCAL_NATIVES — leave it unset so Package.swift
+# resolves the real remote release binaries for the target version.
+swift build
+swift run runanywhere-minimal "Name three colours."
+```
+
+If the example was previously built/run with the env var set, `swift build` may
+reuse a stale resolve — run `swift package reset` (or delete `.build/`) first if
+you're not sure which mode the last resolve used.
+
+For rcli instead (also validates the real published core):
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks
+rcli models download qwen3          # ~639MB, small enough for a quick smoke test
+rcli llm generate --model qwen3 "Reply with exactly: RCLI WORKS" --reasoning off
+```
+
+`rcli models list --all` shows the rest of the built-in catalog
+(`whisper-tiny`, `smolvlm2`, `piper`, …) if LLM generate isn't the right modality
+for what you're verifying.
+
+## 5. Android — `runanywhere-android`
+
+Version pin: `gradle/libs.versions.toml` has ONE shared catalog entry:
+
+```toml
+runanywhere = "0.20.19"
+...
+runanywhere-sdk      = { group = "io.github.sanchitmonga22", name = "runanywhere-sdk",              version.ref = "runanywhere" }
+runanywhere-llamacpp = { group = "io.github.sanchitmonga22", name = "runanywhere-llamacpp",          version.ref = "runanywhere" }
+runanywhere-onnx     = { group = "io.github.sanchitmonga22", name = "runanywhere-onnx",               version.ref = "runanywhere" }
+runanywhere-qhexrt   = { group = "io.github.sanchitmonga22", name = "runanywhere-qhexrt-android",     version.ref = "runanywhere" }
+```
+
+**CRITICAL — do not bump this block as one unit.** `runanywhere-qhexrt-android` is
+permanently frozen at whatever version it was last published at before being
+excluded from the public Maven train; by policy it can never move forward via
+public Maven again. Verify the actual frozen version FRESH every time (do not
+trust a remembered number — it doesn't change, but don't skip the check):
+
+```bash
+curl -s https://repo1.maven.org/maven2/io/github/sanchitmonga22/runanywhere-qhexrt-android/maven-metadata.xml
+```
+
+The other three artifacts (`runanywhere-sdk`, `-llamacpp`, `-onnx`) CAN and should
+move to the new release version. This means the single `runanywhere` catalog ref
+must be **split into two entries** — one at the new version for sdk/llamacpp/onnx,
+one pinned to the frozen qhexrt version — not bumped as a block.
+
+**Before trusting a mixed pin works**: verify `RAC_PLUGIN_API_VERSION` (the
+plugin ABI version constant in the C++ core, exposed identically to Kotlin) is
+unchanged between the old public SDK version and the new one. If it changed, mixing
+a newer sdk/llamacpp/onnx with the frozen qhexrt version is NOT safe — this is a
+human decision (needs either an ABI-compat shim or dropping qhexrt from this build),
+not something to force through.
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-android
+./gradlew :app:assembleDebug
+./gradlew :app:installDebug        # installs to a connected emulator/device
+adb logcat | grep -i runanywhere   # or a more specific tag if the app uses one
+```
+
+Launch the app, drive one real `generate()` call against a small downloaded model
+(the app's own model picker/download flow), confirm the resolved SDK version is
+logged, and review logcat for errors before reporting a PASS.
+
+## 6. Web — `runanywhere-web`
+
+`package.json` has 4 `@runanywhere/*` deps pinned with a caret range:
+
+```json
+"@runanywhere/proto-ts":    "^0.20.19",
+"@runanywhere/web":         "^0.20.19",
+"@runanywhere/web-llamacpp":"^0.20.19",
+"@runanywhere/web-onnx":    "^0.20.19"
+```
+
+Bump all 4 to the new version, then:
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-web
+npm install
+npm run build
+npm run dev      # vite --host localhost --port 3000 --strictPort
+```
+
+The dev/preview server is what supplies COOP/COEP headers required for
+`SharedArrayBuffer` — WASM inference will silently fail (or refuse to init
+threads) without them, so don't swap in a bare static file server.
+
+`~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks/bindings/web/AGENTS.md`
+has the authoritative Validation section (its own heading is `## Validation`) —
+full checklist:
+
+1. Fresh browser context.
+2. Example app served with COOP/COEP headers.
+3. Model download.
+4. Model load.
+5. Real browser inference for the target modality.
+6. Logs/screenshots reviewed.
+
+Its "Required release gates" (run before browser validation) from the same repo:
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks/bindings/web
+npm run typecheck && npm run lint && npm run test && npm run build
+npm run test:browser
+npm run test:browser:release
+cd example && npm run typecheck && npm run build
+```
+
+Static gates passing is not the smoke test — you still need an actual browser
+watching real inference happen against the starter app. Prefer a real browser
+automation tool (`claude-in-chrome` MCP tools, or Playwright — the maintained
+suites under `bindings/web/tests/browser/` already use `playwright.config.ts`)
+over curling the served page: WASM inference genuinely needs a browser JS engine.
+Load the served starter app, download/load a small model, trigger generate, and
+read the actual rendered output text plus the browser console — do not infer
+success from an HTTP 200 on the page load.
+
+## 7. Electron — `runanywhere-electron` (SPECIAL CASE)
+
+**Do not assume a fresh SDK publish is available for this app.** Electron's own
+npm packages (`@runanywhere/electron`, `-llamacpp`, `-onnx`, `-sherpa`, `-qhexrt`,
+`-neurt`) are on a SEPARATE, manual-publish pipeline — NOT part of `release.yml`
+(grep confirms zero mentions of these package names there). This separation is a
+**confirmed, deliberate** repo-owner decision, not a gap. Check
+`~/.claude/skills/sdk-publish/SKILL.md` §6 before assuming anything moved.
+Electron is **no longer WIP on a branch** — the old "in-progress on
+`smonga/electron_upgrade`" note is gone from the root `AGENTS.md`/`CLAUDE.md`
+entirely as of this checkout; `bindings/electron/` is a fully merged SDK on `main`.
+As of `fix/electron-cicd-staging-url-npu-ane`,
+`.github/workflows/electron-native-package.yml` builds every backend for real and
+packages every tarball — but still does not publish; verify against a live run
+rather than assuming build automation status either way.
+
+Test the starter against whatever version it is CURRENTLY pinned to unless a human
+has explicitly confirmed a newer Electron publish is ready and intended:
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-electron
+cat package.json | grep '@runanywhere/electron'   # confirm current pin before touching it
+```
+
+**`@runanywhere/electron-qhexrt` being public on npm is a CONFIRMED, settled
+policy decision** (repo owner, 2026-08-20), not a contradiction to flag — it
+contains real Hexagon NPU binaries (`libQnnHtpV81Skel.so`, `QnnHtp*.dll`,
+`rac_commons.dll`, `runanywhere_qhexrt.dll`) on purpose. The QHexRT-stays-private
+policy enforced elsewhere in this repo family is specifically about the
+GitHub-Release-side asset set (Android etc.), a different channel. Only re-raise
+this if you find evidence the policy changed.
+
+Two layers to actually exercise, do not conflate them:
+
+**(a) Cross-platform Electron JS + macOS native addon** — buildable and testable
+locally on this Mac right now:
+
+```bash
+cd ~/development/ODLM/MONOREPOOO/Qualcomm/starters/runanywhere-electron
+npm install
+npm run build   # or the app's documented dev/start script — check package.json scripts
+npm start        # or equivalent — launch the actual Electron app
+```
+
+Drive one real `generate()` call in the running app, watch its console/log output
+for the resolved SDK version, model download, load, and generation, and read any
+errors rather than ignoring them.
+
+**(b) Genuine Windows-native behavior** — a macOS build proves NOTHING here
+regardless of how clean the cross-platform code looks; the native addon and any
+Windows-only DLLs must be exercised on real Windows.
+
+The team keeps a **Windows ARM64 test machine reachable over SSH**. Its hostname,
+user, key, and VPN/mesh node name are operator-specific and deliberately not
+recorded in this repo — read them out of the operator's own `~/.ssh/config` (look
+for the Windows/ARM64 host entry) and use that alias below wherever `$WIN_BOX`
+appears. If no such entry exists, the box is not configured for you: say so and
+ask, rather than guessing at a hostname.
+
+```bash
+WIN_BOX=<the ssh alias from ~/.ssh/config>
+```
+
+**Always check reachability first, never just try SSH and retry on timeout.** The
+box lives on a private mesh VPN and is frequently asleep, so start by asking the
+VPN client whether the node is up (e.g. `tailscale status`, matching on the host
+entry's `HostName`) rather than opening a connection.
+
+If the node reports `offline, last seen ...`, the box is asleep/powered off.
+**A connection timeout here means "device asleep," not "config is wrong."** Tell
+the human and ask them to wake it; do not loop retrying SSH. Only once the node
+shows a live/idle state, confirm with:
+
+```bash
+ssh -o ConnectTimeout=8 "$WIN_BOX" "whoami"
+```
+
+Then, with the repo already cloned there:
+
+```bash
+ssh "$WIN_BOX" "cd <repo-path-on-that-box>; git pull; npm install; npm run build"
+# then run whatever launches the Windows Electron build and drive a real generate call
+scp "$WIN_BOX":<remote-log-or-artifact-path> ./local-copy   # pull back evidence to inspect
+```
+
+Do not claim Windows-specific validation happened unless you actually obtained a
+shell on that box and ran something real there — a clean macOS build is not
+substitute evidence.
+
+**`node_modules/electron` on this box silently tracks whichever arch last ran `npm
+install`, not which Node launches the test.** The x64 (llamacpp/onnx/sherpa) and
+arm64 (QHexRT) lanes share ONE `runanywhere-electron` checkout/`node_modules` tree.
+Prepending an x64 Node to `PATH` and running `npx playwright test` does NOT make
+Electron itself x64 — `require('electron')` always resolves the single installed
+`node_modules/electron/dist/electron.exe`, and whichever arch that binary actually
+is determines which `prebuilds/win32-<arch>/` directory the running app looks in,
+regardless of `scripts/use-sdk.mjs local`'s staging (which itself is arch-aware
+based on the *launching* Node, so it can correctly report "staged win32-x64" while
+the process that will actually run is arm64 — a silent mismatch). Verify with:
+`powershell -Command "$p=[IO.File]::ReadAllBytes('...\electron.exe'); $peOff=
+[BitConverter]::ToInt32($p,60); [BitConverter]::ToUInt16($p,$peOff+4)"` — `43620`
+(`0xAA64`) is ARM64, `34404` (`0x8664`) is x64. If it's the wrong arch (e.g. a prior
+session's `npm install` for the other lane silently overwrote it), a genuine re-test
+of the other lane needs a FULLY SEPARATE checkout/`node_modules` tree installed
+under the matching-arch Node — don't assume PATH-prepending alone is sufficient, and
+don't trust `use-sdk.mjs status`'s "platform: win32-x64" output as proof the running
+Electron process is actually x64.
+
+**NPU hardware is a scarce, single-owner resource — serialize, never parallelize.**
+This box has ONE physical Hexagon NPU. `engines/qhexrt/qhexrt_session.cpp`'s
+`session_open()` has a load-bearing comment on this exact failure mode: the HTP
+exposes a small number of protection domains with a per-PD context ceiling, so a
+*second* concurrent model load fails with `RAC_ERROR_BACKEND_INIT_FAILED`
+("Backend initialization failed") — a fast (tens-of-ms), generic-looking failure
+that is easy to mistake for a real regression. Confirmed once tonight: two agents
+each independently exercising QHexRT on this box at the same time produced exactly
+this failure. Before concluding a QHexRT test genuinely failed, confirm nothing
+else (another agent, a leftover Electron process, a stuck previous test run) is
+also holding an NPU session open on this box — check for lingering `electron.exe`/
+`node.exe` processes from a prior run and kill them if orphaned, and never launch
+two NPU-touching verification passes concurrently on this machine.
+
+**"Backend initialization failed" has (at least) three distinct root causes —
+don't stop at PD exhaustion.** Confirmed on 2026-08-17 after PD-exhaustion and
+staleness were both ruled out (fresh rebuild, source-identical prebuilt, no other
+process holding a session): the *actual* bug was two compounding issues, both now
+fixed/documented —
+1. **Real source bug, fixed in PR #733**: `qhexrt_session.cpp`'s `runtime_acquire()`
+   called `qhx_runtime_create(nullptr, nullptr)` on every non-Android platform,
+   trusting the OS default DLL search order to find `QnnHtp.dll`/`QnnSystem.dll`.
+   On Windows that order never includes a dynamically-loaded sibling plugin's own
+   directory (`LOAD_WITH_ALTERED_SEARCH_PATH`, used to load `runanywhere_qhexrt.dll`
+   itself, only widens the search for *that* load call, not later `LoadLibrary`
+   calls made by code already running inside it) — so the QNN DLLs were invisible
+   even sitting right next to the plugin. Fixed by resolving the plugin's own
+   module directory (`GetModuleHandleExA`+`GetModuleFileNameA`) and passing
+   explicit paths, mirroring Android's existing `ADSP_LIBRARY_PATH` resolution in
+   the same file.
+2. **Operational staleness, NOT a script bug**: even after (1), the QNN runtime
+   DLLs actually staged into `@runanywhere/electron-qhexrt`'s
+   `prebuilds/win32-arm64` (`node_modules/.../electron-qhexrt/prebuilds/win32-arm64/`)
+   were from an old QAIRT build (~2.45.x vintage, Dec 2025 files) while the box's
+   installed QAIRT was 2.48.0.260626 — a real ABI-relevant version mismatch.
+   `bindings/electron/scripts/bundle-native.ts`'s `stageQnnRuntime()` just mirrors
+   whatever `RA_QNN_RUNTIME_DIR` points at with **no version check** — it's
+   correct-as-written; someone had pointed it at a stale neurun-side
+   `qairt-runtime-248`-named folder that was never refreshed. Fix: rebuild that
+   flat dir from the CURRENT QAIRT SDK's `lib/aarch64-windows-msvc/` (host DLLs:
+   `QnnHtp.dll`, `QnnHtpPrepare.dll`, `QnnHtpV81Stub.dll`,
+   `QnnHtpV81CalculatorStub.dll`, `QnnSystem.dll`) + `lib/hexagon-v81/unsigned/`
+   (DSP side: `libQnnHtpV81Skel.so`, `libqnnhtpv81.cat`), point
+   `RA_QNN_RUNTIME_DIR` at it, and re-run
+   `npm run bundle:native -- --package=qhexrt` from `bindings/electron/`.
+   **The already-published `@runanywhere/electron-qhexrt` npm package (as of
+   0.20.24) almost certainly ships the same stale DLLs** — this needs a
+   human decision (republish/patch) before claiming the published package works
+   on Windows NPU, separate from the source fix in PR #733.
+3. **PD exhaustion** (the pre-existing entry above) remains real and still applies
+   when two sessions genuinely contend for the one physical NPU — but it is not
+   the only explanation, and the log line to actually check first is the native
+   one: subscribe via `window.runanywhere.logging.records()` (after
+   `logging.setDebugMode(true)`) or add a temporary main-process log capture —
+   `app.process().stdout`/`stderr` do NOT carry it, because the addon runs in a
+   separate `utilityProcess.fork()` host, not the Electron main process, and
+   `RAC_LOG` is not an env var the logger reads (it does nothing). The generic
+   `[QHexRT] qhx_runtime_create failed (QNN libs unavailable?)` vs.
+   `qhx_model_load failed: ... N NPU model(s) already resident` log text is what
+   actually distinguishes cause (1)/(2) from cause (3) — always get that line
+   before diagnosing further.
+
+**Workflow gotcha:** if you orchestrate this via the Workflow tool, its agent()
+calls do NOT reliably block-wait on a long-running remote build the way a direct
+poll loop does — observed once tonight where a workflow's own agents spawned an
+internal Monitor/poller for the build log and then returned immediately,
+reporting "still waiting," which let the whole workflow finish with nothing
+actually verified. For "wait N tens-of-minutes for a real native build to
+finish," use the top-level Monitor tool yourself (a shell poll loop over SSH
+checking for a terminal BUILD_SUCCEEDED/BUILD_FAILED marker line) rather than
+delegating the wait itself into a workflow agent's own judgment.
+
+### The Windows box's actual layout, and why it's more than a cross-platform check
+
+**This is a Hexagon-NPU-equipped Windows machine** (Snapdragon-class ARM Windows
+device, Copilot+ PC), not just a generic x86 Windows box. That makes it the one
+place a QHexRT/Hexagon backend build+test can produce real device-only truth for
+Windows — matching the parent workspace's own "x86 is a simulator, device-only
+truth" rule (see the top-level `Qualcomm/CLAUDE.md` and `QHexRT/CLAUDE.md`). Don't
+treat this box as merely a Windows Electron smoke-test target; it's the only real
+Hexagon NPU test rig reachable for this platform.
+
+Per the user (2026-08-17), under `~/Downloads/RunAnywhere/` on that box there are
+three sibling repo checkouts at the same level — **verify each on connect, don't
+assume paths without checking, since this is relayed secondhand and may have
+drifted**:
+- `runanywhere-sdks` — this monorepo, presumably already cloned; `git fetch && git
+  log -1 origin/main` to see how far behind it is before doing anything.
+- `runanywhere-electron` — the Electron starter app (same repo as
+  `RunanywhereAI/runanywhere-electron` elsewhere in this skill).
+- a third repo referred to verbally as "the neuron/new-run inference engine for the
+  Hexagon NPU" — almost certainly **`neurun`**, the QHexRT/NeuRT split-out repo
+  (see memory: "neurun component split merged — QHexRT/ + NeuRT/ + shared/, root is
+  a closed 20-entry set enforced by a test"). Confirm the actual directory name and
+  remote (`git remote get-url origin`) on connect rather than guessing from the
+  transcription.
+
+**Full task on this box (per explicit user instruction, not just a smoke test):**
+1. `git pull` (or fetch+fast-forward) all three repos to latest `main`.
+2. Rebuild the QHexRT/Hexagon NPU backend from `neurun` against this device's real
+   Hexagon NPU — this is the one environment where that build+run is meaningful
+   proof, not a simulator claim.
+3. Bump Electron's native dependencies to their latest versions — llama.cpp,
+   sherpa-onnx, ONNX Runtime, and whatever else `bindings/electron` pins — across
+   the repos involved. Treat this as a real dependency-bump task (check for
+   breaking API changes, don't just edit a version string and assume it builds).
+4. Update the model catalog for **all 5 starter apps across all 4 consumer repos**
+   (iOS, Android, Web, Electron — plus whatever the "5th app" split means for
+   macOS/Swift, see the rest of this skill) so the catalog is consistent everywhere,
+   not just on this Windows box.
+5. Run a real end-to-end inference pass on this box specifically (not just build
+   success) — both the general Electron/llama.cpp path AND the Hexagon NPU path via
+   `neurun`/QHexRT.
+6. Open PRs for whatever changed, in each affected repo. Do not merge them —
+   the user explicitly said they'll review.
+
+This is real engineering work (native dependency bumps + an NPU backend rebuild),
+not a mechanical version-string edit — expect it to take real time and to
+genuinely need `QHexRT/CLAUDE.md` and `neurun`'s own docs read in full before
+touching that backend, per the parent workspace's own instructions.
+
+## 8. Reporting
+
+For each of the 5 apps (iOS, macOS/Swift, Android, Web, Electron), state exactly
+one of these two outcomes — never blur them:
+
+- **FULLY VERIFIED** — with concrete evidence: the version string actually
+  resolved/logged, the model used, and the actual output produced (quote it).
+- **BLOCKED** — with the exact concrete reason, e.g.: the Windows ARM64 box's
+  mesh-VPN node is offline; Android emulator unavailable in this environment; App Store /
+  notarization credential missing; `runanywhere-swift` not yet tagged at target
+  version so `swift package update` can't resolve; electron-qhexrt policy conflict
+  needs a human call before proceeding further.
+
+A clearly reported partial/blocked result is far more valuable than an optimistic
+summary that overstates what was actually observed. If you hit the known Electron
+qhexrt npm-publish policy conflict (§7), call it out in the report even if it
+wasn't the thing blocking your specific test — it's a standing issue every release
+night should re-surface until a human resolves it.
+
+## Credentials referenced but never printed by this skill
+
+These exist and are checked for presence only — never print their values:
+
+- Maven Central: `mavenCentral.username` / `mavenCentral.password`,
+  `signing.gnupg.keyName` / `signing.gnupg.passphrase` in `~/.gradle/gradle.properties`.
+- GPG signing key `CC377A9928C7BB18` — check with
+  `gpg --list-secret-keys --keyid-format LONG`.
+- macOS notarization profile `runanywhere-notary` — check with
+  `xcrun notarytool history --keychain-profile runanywhere-notary`; codesign
+  identity `Developer ID Application: RunAnywhere, Inc` — check with
+  `security find-identity -v -p codesigning`.
+- npm — `npm whoami` should already show a logged-in user.
+
+None of the app-level smoke tests in this skill require touching these directly;
+they matter only if a test path requires a fresh distro-repo publish (e.g.
+`runanywhere-swift` not yet tagged) — that's a separate concern of the
+`sdk-publish` skill, not this one.

--- a/.claude/skills/telemetry-e2e/SKILL.md
+++ b/.claude/skills/telemetry-e2e/SKILL.md
@@ -1,0 +1,336 @@
+---
+name: telemetry-e2e
+description: Prove that what an SDK binding EMITS on the telemetry wire is correct and that it actually arrives — vocabulary compliance, presence/absence semantics, device-id stability, and a received request body / stored row as evidence. Use when touching telemetry_json.cpp, telemetry_manager.cpp, rac_telemetry_vocabulary.h, any binding's platform-adapter telemetry bridge, or when asked to verify a telemetry field isn't silently dropping.
+---
+
+# Telemetry Wire Correctness (SDK side)
+
+This is the SDK-side counterpart to the backend's `telemetry-e2e` skill (private
+`Runanywhere-monorepo` repo — proves event-to-stored-row on the server side). This one
+proves the other half: that commons *serializes* a call correctly and that the bytes
+*leaving* a binding are the bytes a real backend accepts. It does not cover per-starter-app
+inference smoke tests — see `sdk-test-starters` for that.
+
+## 0. The evidence bar
+
+Compiling is not evidence. A green `telemetry_extraction_tests` run is not evidence that a
+real binding's real call site reaches the wire correctly — it only proves the *serializer*
+handles a hand-built payload correctly. In order of increasing strength:
+
+1. **Unit test green** (`ctest -R telemetry_extraction_tests`) — proves the JSON builder's
+   presence/vocabulary rules are still correct in isolation. Necessary, not sufficient.
+2. **Received request body** — capture the actual JSON `rcli` (or a real binding) put on
+   the wire and read it: right modality endpoint, right keys, no vocabulary values that
+   got through that shouldn't have, measured zeros kept as `0` not `null`.
+3. **Stored row matches, field-for-field** — the backend's own ingest response
+   (`events_received`/`events_stored`/`events_skipped`) or a direct DB read shows the row
+   landed with the values you actually sent, not just a 2xx. This is the only tier that
+   also proves the vocabulary/schema on both sides still agree.
+
+A PR description that says "sent telemetry, no errors" without quoting a request body or a
+stored-row count is not evidence of anything except that a socket didn't error out.
+
+## 1. The emit path
+
+Every binding funnels through the same two C ABI entry points in
+`core/src/infrastructure/telemetry/telemetry_manager.cpp`:
+
+- `rac_telemetry_manager_track` — flat-struct payload (`rac_telemetry_payload_t`), used by
+  `rcli`'s `telemetry emit`/`telemetry blast` and by hand-built events.
+- `rac_telemetry_manager_track_proto` — the real path every language binding actually uses:
+  a binding builds a protobuf `SDKEvent` (`sdk_events.pb.h`) at the real call site (e.g. an
+  LLM `generate()` completing), and `proto_event_type_string()` + the per-domain extraction
+  blocks in `telemetry_manager.cpp` turn it into the same flat payload. `framework_proto_to_string()`
+  / `framework_to_string()` / `clean_framework()` do the backend-name normalization here —
+  this is where a raw enum like `INFERENCE_FRAMEWORK_LLAMA_CPP` becomes the wire string `"llamacpp"`.
+- `stamp_live_device_state()` (same file) then overwrites the SDK-origin/device-state fields
+  (`sdk_binding`, `platform`, `battery_state`, memory, core count) from manager-owned state,
+  not from whatever the caller passed — a binding cannot inject a platform or binding value.
+- The payload is handed to `rac_telemetry_manager_payload_to_json()` in
+  `core/src/infrastructure/telemetry/telemetry_json.cpp`, which does field-by-field
+  serialization (see §2/§3 for the two contracts enforced there).
+- `send_batch_json()` batches by modality and POSTs to `/api/v2/sdk/telemetry/{modality}`
+  through whichever `rac_http_transport_ops_t` the binding registered (URLSession/OkHttp/
+  `emscripten_fetch`/curl for `rcli` — see the root `AGENTS.md`'s "HTTP is platform-provided"
+  rule). There is no `libcurl` fallback baked into commons itself.
+
+If a field is going missing on the wire, the fix is almost always in
+`telemetry_json.cpp` (a field never wired into the serializer) or in the call site's proto
+population (a field never set on the `SDKEvent`) — not in a binding's bridge code, which
+just forwards bytes.
+
+## 2. The closed vocabularies — and the silent-drop rule
+
+`core/include/rac/infrastructure/telemetry/rac_telemetry_vocabulary.h` is a **generated
+file** (see §5) holding six closed tables, each with a `RAC_TELEMETRY_<NAME>_COUNT` and a
+`RAC_TELEMETRY_<NAME>_VALUES[]` array:
+
+| Table | Count | Wire field | Values |
+|---|---|---|---|
+| `RAC_TELEMETRY_EVENT_TYPE` | 106 | `event_type` | namespaced strings, e.g. `llm.generation.completed`, `auth.succeeded`, `stt.transcription.completed` |
+| `RAC_TELEMETRY_BACKEND` | 22 | `backend` / `framework` | `onnx, sherpa, llamacpp, foundation_models, system_tts, fluid_audio, coreml, whisperkit_coreml, mlx, qhexrt, neurt, tflite, executorch, mediapipe, mlc, pico_llm, piper_tts, swift_transformers, cloud, builtin, none, unknown` |
+| `RAC_TELEMETRY_MODEL_SOURCE` | 3 | `model_source` | `catalog, builtin, user` |
+| `RAC_TELEMETRY_PLATFORM` | 9 | `platform` | `ios, android, macos, windows, linux, web, tvos, watchos, visionos` |
+| `RAC_TELEMETRY_SDK_BINDING` | 9 | `sdk_binding` | `swift, kotlin, flutter, react-native, web, electron, python, cli, cpp` |
+| `RAC_TELEMETRY_BATTERY_STATE` | 4 | `battery_state` | `charging, full, unplugged, unknown` |
+
+**The rule, verbatim from `add_vocabulary_string()` in `telemetry_json.cpp`:** if a value is
+non-null but not present in its table, the field is dropped to `null` and the *rest of the
+event still ships*. This is by design (a bad `backend` string must not cost the whole
+observation) but it means:
+
+- The backend never sees the bad value, never 422s, never quarantines anything — there is
+  no error path anywhere for this. A field just isn't there.
+- The only client-side signal is a `RAC_LOG_WARNING("Telemetry", "Dropping %s: '%s' is not
+  in the published vocabulary", ...)` log line — easy to miss unless you're specifically
+  watching debug logs.
+- `platform`, `sdk_binding`, and `battery_state` are stamped by the manager itself (§1), not
+  supplied by a binding's call site, so in practice only `backend`/`framework` (from the
+  engine/model layer) and `event_type` (only reachable via the proto path, checked at CI
+  time — see §5) are realistic places a new value can silently disappear.
+- `test_telemetry_extraction.cpp`'s vocabulary block (`"vocab-1"`/`"vocab-2"` cases) is the
+  concrete regression guard: it sends `framework = "LlamaCpp"` (a real spelling that used to
+  reach production) and asserts the string never appears on the wire while `model_id` still
+  does. If you touch `add_vocabulary_string()` or add a new vocabulary-gated field, extend
+  that test rather than trusting a manual check.
+
+Historical motivation (from the header's own comment): before this table existed, stored
+production rows had four spellings of `llama.cpp`, three of ONNX, and binding names like
+`"react-native"` recorded as a `platform` — this file exists specifically to make that class
+of drift fail in this repo instead of being discovered in a database nobody was watching.
+
+## 3. Presence vs. absence: the "measured zero" contract
+
+Before the fix documented in `telemetry_json.cpp`'s header, extractors read proto3 scalar
+fields directly — which report `0` for a field that was never set — and the old serializer
+(`add_int`/`add_double`) *skipped* zero values to keep payloads small. Result: a genuinely
+measured `output_tokens = 0` (an empty completion) and an unmeasured `tokens_per_second`
+both arrived on the wire as absent, indistinguishable from each other.
+
+The fix is `has_x`-gated serialization. Two helper families in `telemetry_json.cpp`:
+
+- `add_int_or_null(key, value, is_valid)` / `add_double_or_null(key, value, is_valid)` —
+  emit the real value (including `0`) when `is_valid` is true, else the JSON literal `null`.
+  Non-finite doubles (`NaN`/`Inf`) always degrade to `null` regardless of `is_valid`, because
+  JSON has no such literal and one bad value must not corrupt the whole batch.
+- The `is_valid` argument is a real `has_x`/sentinel check per field, not a blanket flag —
+  e.g. `payload->has_processing_time_ms != RAC_FALSE`, `payload->total_memory > 0`,
+  `payload->battery_level >= 0`.
+
+**What to check to confirm this stayed fixed** (this is exactly what
+`test_telemetry_extraction.cpp`'s presence block does — see §4): send an LLM completion
+event with `output_tokens = 0` and `input_tokens = 0` explicitly set, and
+`tokens_per_second`/`context_length` left unset. Assert the wire body contains
+`"output_tokens":0` and `"input_tokens":0` as literal numbers, and `"tokens_per_second":null`
+/ `"context_length":null` — not all four as `null`, and not all four as `0`. If a future
+refactor reverts to plain `add_int`/`add_double` for any of these fields, that regression
+test is the thing that catches it; grep `telemetry_json.cpp` for `add_int(` / `add_double(`
+(the non-`_or_null`/non-`_always` forms) if you suspect a field regressed — those two still
+silently skip zero by design and must never be used for a field where `0` is meaningful.
+
+## 4. Build, test, and what each telemetry test asserts (macOS)
+
+```bash
+cmake --preset macos-debug
+cmake --build build/macos-debug
+ctest --preset macos-debug --output-on-failure -R 'telemetry|device_identity'
+```
+
+Or the non-preset form (`core/AGENTS.md`'s documented path):
+
+```bash
+cmake -B build -DRAC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug
+cmake --build build
+ctest --test-dir build --output-on-failure
+```
+
+`telemetry_extraction_tests` and `device_identity_tests` are registered in
+`core/tests/CMakeLists.txt`; `rcli_telemetry_live_tests` is registered separately in
+`rcli/tests/CMakeLists.txt`. All three are hand-rolled assertion runners — `CHECK()` in
+some files, `ASSERT_EQ`/`ASSERT_TRUE` (from `core/tests/test_common.h`) in others — never
+GoogleTest:
+
+| ctest name | Binary | What it asserts |
+|---|---|---|
+| `telemetry_extraction_tests` | `test_telemetry_extraction` | Full proto→JSON pipeline per modality (LLM token counts/`tokens_per_second`, STT NaN-confidence never leaks as the string `"nan"`, TTS `characters_per_second`, embeddings `total_tokens`/`batch_size`/`embedding_dimension`, LoRA failure-path fields, RAG retrieval counts, VLM image/timing fields, live device-state stamping); the presence/measured-zero contract (§3); the closed-vocabulary drop rule (§2); and an HTTP-retry backoff (a failed batch is re-sent only after >5s, never before). Requires `RAC_HAVE_PROTOBUF` — the test binary itself no-ops with exit 0 if commons wasn't built with protobuf support. |
+| `device_identity_tests` | `test_device_identity` | Every branch of `rac_device_get_or_create_persistent_id()`'s resolution chain (§6) against a mocked platform adapter — cache hit, vendor-ID fallback, fresh-UUID generation, and that a `secure_set` failure doesn't silently drop the ID. |
+| `rcli_telemetry_live_tests` | `test_rcli_telemetry_live` | **Opt-in, always registered but a no-op by default.** Runs only with `--live` *and* `RUNANYWHERE_BASE_URL`/`RUNANYWHERE_API_KEY` set; otherwise prints "skip" and exits 0 — a green ctest run for this target proves nothing by itself. When live, it runs `rcli::bootstrap()` (real API-key → device-register → JWT handshake), sends one real event per modality (LLM, embeddings, RAG, VLM, LoRA-failure) through the real HTTP transport, and fails on any non-2xx response — this is the test that would catch a strict-schema `422 extra_forbidden` from field drift against the real V2 endpoints. |
+
+Run it live (§7 has the full local-backend flow):
+
+```bash
+RUNANYWHERE_BASE_URL=https://<backend-origin> RUNANYWHERE_API_KEY=<key> \
+  ./build/macos-debug/rcli/tests/test_rcli_telemetry_live --live
+```
+
+`test_platform_bridge` (same `CMakeLists.txt`, adjacent target) is the wider companion
+check — "every value a binding supplies must reach the wire" — covering the platform half
+of the same two flat C structs (`rac_client_info_t`/`rac_device_registration_info_t`) for
+every SDK at once; run it alongside if you're touching client-info fields rather than
+telemetry event fields specifically.
+
+## 5. Regenerating the vocabulary header, and the drift gate
+
+`rac_telemetry_vocabulary.h` (§2) is generated from `idl/http/sdk-openapi.json` — the
+device-facing OpenAPI subset copied in from the private backend repo. **How that file gets
+updated on the backend side, and how it crosses into this repo, is the monorepo's
+`openapi-contract` skill's job — read that by name in the other repo rather than
+re-deriving the steps here.** From inside this repo, once `idl/http/sdk-openapi.json` is
+current:
+
+```bash
+python3 idl/codegen/generate_telemetry_vocabulary.py          # regenerate the header
+python3 idl/codegen/generate_telemetry_vocabulary.py --check  # CI drift check; exit 1 if stale
+```
+
+`.github/workflows/telemetry-vocabulary-drift.yml` runs three checks on every push to
+`main`/`development` and on any PR touching `idl/http/**`, the codegen script, or the
+telemetry source/header dirs:
+
+1. **Generated header is current** — the `--check` command above.
+2. **Every event type the core can emit is in the vocabulary** — a Python check that parses
+   `proto_event_type_string()`'s body out of `telemetry_manager.cpp` via regex, unions in
+   the two prefix-expansion families (`stt.model.*`/`tts.voice.*`/`llm.model.*` and
+   `llm*`/`vlm*` generation suffixes), and diffs against `TelemetryEventType`'s enum in
+   `idl/http/sdk-openapi.json`. Anything emittable but unpublished fails the job.
+3. **Every framework string the core can emit is in the vocabulary** — same technique
+   against `framework_proto_to_string()` and `framework_to_string()` vs. `TelemetryBackend`.
+
+**A documented drift you will hit if you trust the wrong file**: `idl/http/README.md`'s own
+"What it pins" table names the schema for the `framework`/`backend` field as
+`TelemetryFramework` — that's stale. The actual generator
+(`idl/codegen/generate_telemetry_vocabulary.py`'s `VOCABULARIES` dict) and the header it
+produces both say `TelemetryBackend`. Trust the generator and the generated header's own
+`// Published as X` comments over that README table.
+
+## 6. Per-binding device identity: where it's created, where it's persisted
+
+The resolution chain itself is centralized in commons —
+`core/src/infrastructure/device/device_identity.cpp`
+(`rac_device_get_or_create_persistent_id`, tested by `device_identity_tests`, §4) — and is
+the same fixed order for every binding:
+
+1. `adapter.secure_get("com.runanywhere.sdk.device.uuid")` — if found and non-empty, use it,
+   full stop.
+2. `adapter.get_vendor_id` (if the platform adapter provides one) — use it, then persist it
+   via `secure_set` so step 1 hits next boot.
+3. Generate a fresh RFC-4122 v4 UUID, persist it via `secure_set`.
+
+What differs per binding is **only** the `secure_get`/`secure_set` backing store — an
+unstable backing store (one that doesn't survive a real app restart, or that resolves to a
+different physical location than the read path expects) is exactly the bug class that
+inflates device counts, because step 3 fires again on every "cache miss":
+
+| Binding | Backing store | Where |
+|---|---|---|
+| Swift (iOS/macOS) | Keychain, service `com.runanywhere.sdk` | `bindings/swift/Sources/RunAnywhere/Foundation/Bridge/Extensions/CppBridge+PlatformAdapter.swift` (`platformSecureGetCallback`/`platformSecureSetCallback`) |
+| Kotlin (Android) | Android Keystore AES-256-GCM key, ciphertext in a no-backup app file (not `SharedPreferences`) | `bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/foundation/security/AndroidKeychainManager.kt` (`NoBackupCiphertextStore`), wired through `CppBridgePlatformAdapter.PlatformSecureStorage` |
+| Flutter | Native Keychain/Keystore helper via FFI symbols `ra_flutter_secure_storage_{store,retrieve,delete}` | `bindings/flutter/packages/runanywhere/lib/native/dart_bridge_secure_storage.dart`; the device-UUID key constant is duplicated (deliberately, per its own comment) as `_keyDeviceUUID = 'com.runanywhere.sdk.device.uuid'` in `dart_bridge_device.dart` |
+| React Native (Android) | `SecureStorageManager` (native Android side) via `PlatformAdapterBridge.kt`'s `secureGet`/`secureSet` | `bindings/react-native/packages/core/android/src/main/java/com/margelo/nitro/runanywhere/PlatformAdapterBridge.kt` |
+| Web | `localStorage`, key `rac_sdk_plaintext_com.runanywhere.sdk.device.uuid` — **plaintext**, no OS-level encryption equivalent exists in a browser; restricted by convention to non-sensitive IDs | `bindings/web/packages/core/src/runtime/PlatformAdapter.ts` (`registerSecureGet`/`registerSecureSet`); also has a separate `stableVendorId()` fallback under key `rac_sdk_plaintext_vendor_id` |
+| Electron (macOS/Linux) | Flat file under a secure directory, path-traversal-guarded (`fs::path(key)` must not be absolute or contain `..`) | `bindings/electron/native/posix_platform_adapter.cpp` (`posix_secure_get`/`posix_secure_set`) |
+| Electron (Windows) | Windows DPAPI (`CryptProtectData`, current-user scope, no UI) | `bindings/electron/native/win32_platform_adapter.cpp` (`win_secure_get`/`win_secure_set`) |
+
+The key string itself — `com.runanywhere.sdk.device.uuid` — is intentionally the same
+literal across Swift, Flutter, and RN (each source comments cross-reference the other two by
+name), so grepping for it is a fast way to confirm a new binding is reading/writing the
+*same* key it thinks it is, not a typo'd sibling.
+
+**How to verify stability across a real restart** (not just "the code looks right"):
+
+1. Run the binding once, capture the emitted `device_id` from a real request body (§7) or
+   from `POST /api/v1/devices/register`'s response.
+2. Fully terminate the process (not just background it — on mobile this matters, a
+   backgrounded app can keep its in-memory device-id cache alive without ever touching
+   the read path again).
+3. Relaunch and repeat step 1.
+4. The `device_id` must be byte-identical. If it changed, the break is almost always one of:
+   the backing store not surviving process death (e.g. an in-memory-only stub used during
+   development), a key-name mismatch between the write and read paths, or (Android
+   specifically) `Context.deleteSharedPreferences` being invoked on the wrong file — see
+   `AndroidKeychainManager.kt`'s constructor, which deletes a hardcoded *legacy* prefs name
+   on every construction; if that name were ever widened to match the real store, every
+   Android launch would look like a fresh device.
+
+Two-in-one launches on the *same physical device* (e.g. two emulator instances, or a
+same-device reinstall vs. a real fresh install) are a different, real-world failure mode
+from a code bug — don't conflate an intentional reinstall's fresh ID with instability.
+
+## 7. Point a local build at a local backend and prove an event landed
+
+`rcli` is the fastest way to exercise the full wire path without a mobile/browser
+toolchain — it links `rac_commons` directly and speaks real HTTP via curl.
+
+```bash
+cmake --preset rcli-macos-release   # or rcli-linux-release on Linux
+cmake --build build/rcli-macos-release --target rcli -j "$(sysctl -n hw.logicalcpu)"
+```
+
+**Keyless (development environment) — no API key, works against any backend that allows
+anonymous V2 telemetry:**
+
+```bash
+./build/rcli-macos-release/rcli/rcli --environment development \
+  --base-url http://127.0.0.1:8000 \
+  telemetry blast --processing-ms 42.5 --session-id my-check \
+  --input-tokens 128 --output-tokens 256
+```
+
+This is exactly the shape `scripts/ci/oss_keyless_telemetry_blast.sh` runs in CI against the
+public staging backend — `--environment development --base-url <origin> telemetry blast
+...` with no `--api-key`. `telemetry blast` sends one representative event per modality (all
+12) and prints a `MODALITY | RESULT | STATUS | RECEIVED | STORED | SKIPPED` table parsed
+directly from the backend's own batch response — **the `STORED` column is authoritative
+server-side confirmation**, not just an HTTP 2xx. `run_telemetry_blast()`'s own exit-code
+logic (`rcli/src/commands/cmd_telemetry.cpp`) does fold `stored >= count` into its overall
+pass/fail, so a genuine storage shortfall on any modality does make the process exit
+non-zero, not just a transport error — but the exit code is one bit for all 12 modalities
+combined, so a non-zero exit still requires reading the table to know *which* modality
+failed and *why* (a `network error` status is a transport problem; an `HTTP 200` row with
+`STORED` under `RECEIVED` is a row-level rejection, e.g. a vocabulary value the backend
+didn't recognize — a real bug to chase, not the same failure class at all).
+
+**Authenticated (production shape) — for exercising the login handshake too:**
+
+```bash
+./build/rcli-macos-release/rcli/rcli --environment production \
+  --base-url https://<backend-origin> --api-key <key> \
+  auth login
+./build/rcli-macos-release/rcli/rcli --environment production \
+  --base-url https://<backend-origin> --api-key <key> \
+  telemetry emit --modality llm --count 3 --input-tokens 128 --output-tokens 256
+```
+
+`auth login` only has a path in `production` — `development`'s keyless mode has no login
+step by design (see `rcli/src/commands/cmd_auth.cpp`'s own subcommand help text).
+
+**To inspect the actual request body**, not just the summary table, add `--json` for
+machine-readable CLI output and `-v` for debug logging (the debug log includes the
+serialized JSON per batch before it goes on the wire) — or point `--base-url` at a throwaway
+local capture endpoint (any script that logs the raw POST body) before pointing it at a real
+backend, to sanity-check field shape offline first.
+
+**If you have the private backend repo checked out locally too**, running it yourself
+(`cd backend && uv run uvicorn main:app --reload`, per that repo's own README) and pointing
+`--base-url` at `http://127.0.0.1:8000` gets you the strongest possible evidence: query the
+SQLite/Postgres row directly after a blast and diff it field-for-field against what you sent
+— the monorepo's own `telemetry-e2e` skill (its integration suite, hermetic pytest fixtures,
+and `test_telemetry_conformance.py`'s vocabulary/presence/identity assertions against stored
+rows) is the authoritative reference for that side; don't re-implement its DB assertions
+here, just point at it.
+
+## Evidence bar, restated
+
+- Compiling `rcli` or a binding: **not evidence**.
+- `ctest -R telemetry_extraction_tests` green: **not evidence of a real call site** — only
+  of the serializer in isolation.
+- `rcli telemetry blast` exiting 0: real signal (its exit code does fold in the backend's
+  `stored >= count` check, §7) but still worth pairing with the per-modality
+  `STORED`/`SKIPPED` table in your report — the exit code can't tell you *which* modality
+  or *why* a shortfall happened.
+- A captured request body showing the right endpoint, the right keys, correct
+  presence/absence per §3, and no off-vocabulary values per §2 — **evidence of correct
+  emission**.
+- That request body's values matching a stored row (via the backend's own
+  `events_stored` count at minimum, a direct DB read at best) — **evidence of correct
+  end-to-end delivery**, the only tier worth reporting as "telemetry works."

--- a/.github/workflows/agent-skills-gate.yml
+++ b/.github/workflows/agent-skills-gate.yml
@@ -1,0 +1,60 @@
+name: Agent skills gate
+
+# The agent instruction trees (`.claude/skills/`, `.claude/commands/`,
+# `.agents/skills/`) are TRACKED in this PUBLIC repo, which makes them a
+# publishing surface rather than scratch space. Two things have to be
+# machine-checked, because neither is visible in a normal diff review:
+#
+#   1. MIRROR DRIFT — `.claude/skills/` is the canonical, hand-edited tree;
+#      `.agents/skills/` is a generated copy for non-Claude tooling (a copy and
+#      not a symlink, because a checkout without core.symlinks=true materializes
+#      git symlinks as text files). Editing one and not the other publishes a
+#      stale runbook that some agents read and others don't.
+#
+#   2. PRIVATE COORDINATES CREEPING BACK IN — these skills describe real release
+#      machinery, so it is natural to paste in the Windows test box's hostname,
+#      an SSH identity file, or a runner's registered name while debugging. The
+#      standing rule is: describe the CAPABILITY ("a Windows ARM64 machine
+#      reachable over SSH; read the alias from the operator's ~/.ssh/config"),
+#      never the COORDINATES. An agent that has read the instructions can
+#      resolve the rest from the operator's own machine.
+#
+# Both checks live in scripts/ci/check_agent_skills.py so a green CI and a green
+# laptop mean the same thing. Fixing a failure locally:
+#
+#   scripts/setup/sync-skills.sh          # after editing .claude/skills/
+#   python3 scripts/ci/check_agent_skills.py
+
+on:
+  pull_request:
+    paths:
+      - '.claude/**'
+      - '.agents/**'
+      - '.gitignore'
+      - 'scripts/setup/sync-skills.sh'
+      - 'scripts/ci/check_agent_skills.py'
+      - '.github/workflows/agent-skills-gate.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.claude/**'
+      - '.agents/**'
+      - '.gitignore'
+      - 'scripts/setup/sync-skills.sh'
+      - 'scripts/ci/check_agent_skills.py'
+      - '.github/workflows/agent-skills-gate.yml'
+
+permissions:
+  contents: read
+
+jobs:
+  check:
+    name: Mirror in sync, no private coordinates
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v7
+      # No toolchain setup: the gate is stdlib-only Python plus the sync script,
+      # deliberately, so it cannot be broken by an unrelated toolchain change.
+      - name: Check agent skill trees
+        run: python3 scripts/ci/check_agent_skills.py

--- a/.gitignore
+++ b/.gitignore
@@ -156,19 +156,24 @@ bindings/kotlin/.idea/
 *.swo
 *~
 
-# Claude. Local session state stays ignored. The handoff README/scripts can
-# stay tracked, but plans and memory are local agent working notes.
+# Claude. Local session state stays ignored. The handoff README/scripts, the
+# shared slash commands, and the skill tree ARE tracked; plans, memory, local
+# permission overrides (`settings.local.json`) and worktrees are not.
 # Uses `.claude/*` rather than `.claude/` because git will not descend into
-# an excluded directory, which would make the negation below unreachable.
+# an excluded directory, which would make the negations below unreachable.
 .claude/*
 !.claude/handoff/
 .claude/handoff/plans/
 .claude/handoff/memory/
+!.claude/commands/
+!.claude/skills/
 
 # Agents. `.agents/skills/` is a generated mirror of `.claude/skills/` for non-Claude
-# tooling (see scripts/setup/sync-skills.sh) — kept local/ignored for now, same as the
-# canonical tree, until there's a decision on what's safe to publish from this public repo.
+# tooling (see scripts/setup/sync-skills.sh). Both trees are tracked and CI
+# (.github/workflows/agent-skills-gate.yml) fails if the mirror drifts or if either
+# tree grows a private hostname/credential. Everything else under .agents/ is local.
 .agents/*
+!.agents/skills/
 
 # Playwright MCP
 .playwright-mcp/

--- a/scripts/AGENTS.md
+++ b/scripts/AGENTS.md
@@ -15,7 +15,7 @@ lives where it does) is [`scripts/README.md`](README.md); don't duplicate its ta
 | `release/` | version bump, artifact validation, npm/consumer-app publish helpers (see below) | `README.md` |
 | `setup/` | `doctor.sh`, `setup.sh`, `setup-toolchain.sh`, `detect-mode.sh`, `sync-skills.sh` | `README.md` |
 | `validation/` | CI gates (`gates/`), C++ commons checks (`commons/`), the seven-lane e2e harness (`e2e/`), plus root-level `verify_default_pool.sh` (cross-language default-value parity check) | [`validation/README.md`](validation/README.md) |
-| `ci/` | `verify_cpp_desktop_kit.py` — kit tarball contract (proto headers, SCHEMA_LOCK, Windows `zlibstatic`/`bz2`/`libcurl`, sherpa routability). `oss_keyless_telemetry_blast.sh` is retired (CLI lives in RunanywhereAI/RCLI). Windows ARM64 public kits must ship `lib/libcurl.lib`; `v0.20.28` did not (packager only globbed x64-windows-static). | — |
+| `ci/` | `check_agent_skills.py` — the agent-instruction-tree gate (mirror drift + private-coordinate scan; see below). `verify_cpp_desktop_kit.py` — kit tarball contract (proto headers, SCHEMA_LOCK, Windows `zlibstatic`/`bz2`/`libcurl`, sherpa routability). `oss_keyless_telemetry_blast.sh` is retired (CLI lives in RunanywhereAI/RCLI). Windows ARM64 public kits must ship `lib/libcurl.lib`; `v0.20.28` did not (packager only globbed x64-windows-static). | — |
 | `models/` | empty on this branch — a BigVGAN ONNX exporter and a Parakeet CTC prep script have existed here on other commits/branches; a stale `__pycache__` from one of those checkouts may linger locally and is safe to delete | — |
 
 ## Path resolution: every script derives repo root from its own location, never cwd
@@ -57,13 +57,28 @@ or identity-mismatched selection.
 
 ## Skills: `.claude/skills/` is canonical, `.agents/skills/` is a generated mirror
 
-Both trees are gitignored (skill content isn't public yet), but non-Claude tooling (e.g.
-Codex, which has no native skills mechanism) reads `.agents/skills/` as plain markdown.
-Edit only `.claude/skills/`, then run `scripts/setup/sync-skills.sh` to regenerate the
-mirror (`--check` verifies it's in sync without writing, for CI/pre-commit use). Never
-hand-edit `.agents/skills/` — it's a plain `cp -R`, not a symlink, because a checkout
-without `core.symlinks=true` (common on Windows) would materialize a git symlink as a text
-file and silently break Codex's reads.
+Both trees are **tracked** and therefore **public**. Non-Claude tooling (e.g. Codex, which
+has no native skills mechanism) reads `.agents/skills/` as plain markdown, so the mirror
+has to exist as real files. Edit only `.claude/skills/`, then run
+`scripts/setup/sync-skills.sh` to regenerate the mirror (`--check` verifies it's in sync
+without writing). Never hand-edit `.agents/skills/` — it's a plain `cp -R`, not a symlink,
+because a checkout without `core.symlinks=true` (common on Windows) would materialize a git
+symlink as a text file and silently break Codex's reads.
+
+Because they're public, a skill describes the **capability**, never the **coordinates**:
+"a Windows ARM64 machine reachable over SSH; read the alias out of the operator's
+`~/.ssh/config`" — not a hostname, tailnet name, identity file, runner name, private IP, or
+`/Users/<someone>/...` path. An agent that has read the instructions can resolve the rest
+from the operator's own machine. `.claude/settings.local.json` and `.claude/worktrees/`
+stay gitignored for the same reason: they are one person's machine state.
+
+Both rules are enforced by `scripts/ci/check_agent_skills.py`, wired into CI as
+`.github/workflows/agent-skills-gate.yml`. Run it exactly as CI does:
+
+```bash
+scripts/setup/sync-skills.sh              # after editing .claude/skills/
+python3 scripts/ci/check_agent_skills.py  # mirror drift + private-coordinate scan
+```
 
 ## Release scripts: why they're this paranoid
 

--- a/scripts/ci/check_agent_skills.py
+++ b/scripts/ci/check_agent_skills.py
@@ -1,0 +1,169 @@
+#!/usr/bin/env python3
+"""Gate for the committed agent instruction trees (.claude/ + .agents/).
+
+These trees are TRACKED in a PUBLIC repo, which makes them a publishing surface,
+not scratch space. Two failure modes have to be machine-checked because neither
+shows a symptom in review:
+
+  1. MIRROR DRIFT. `.claude/skills/` is canonical (Claude Code reads it directly);
+     `.agents/skills/` is a generated copy for non-Claude tooling that cannot
+     follow a symlink. Hand-editing one and not the other publishes a stale
+     runbook that some agents read and others don't. Delegated to
+     scripts/setup/sync-skills.sh --check, so CI and a laptop run the same code.
+
+  2. PRIVATE INFRASTRUCTURE LEAKING BACK IN. The skills describe real release
+     machinery, so it is natural to paste in the hostname of the Windows test
+     box, an SSH identity file, or a runner name while debugging. A public repo
+     must not carry those. The rule is: describe the CAPABILITY ("a Windows
+     ARM64 machine reachable over SSH; read the alias from the operator's
+     ~/.ssh/config"), never the COORDINATES. An agent that has read the
+     instructions can resolve the rest from the operator's own machine.
+
+Run locally exactly as CI does:
+
+    python3 scripts/ci/check_agent_skills.py
+"""
+
+from __future__ import annotations
+
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+# Repo root by WALKING UP to a marker, never by counting parent hops — a
+# hardcoded parents[2] breaks silently the moment this file moves a level.
+def repo_root() -> Path:
+    for d in [Path(__file__).resolve().parent, *Path(__file__).resolve().parents]:
+        if (d / "CMakeLists.txt").is_file() and (d / "package.json").is_file():
+            return d
+    sys.exit("FATAL: no repo root above this script (looked for CMakeLists.txt + package.json)")
+
+
+REPO = repo_root()
+
+# The trees this gate owns. Both are tracked; see .gitignore.
+TREES = [".claude/skills", ".claude/commands", ".agents/skills"]
+
+# Each rule is (label, compiled pattern, what to write instead). Patterns are
+# deliberately about SHAPES of private coordinates rather than one team's
+# current hostnames, so the gate keeps working after the infrastructure moves.
+RULES: list[tuple[str, re.Pattern[str], str]] = [
+    (
+        "mesh-VPN / Tailscale hostname",
+        re.compile(r"\b[\w-]+\.(?:ts\.net|tailscale\.net|tailnet\.[\w-]+)\b", re.I),
+        "say 'the host entry in the operator's ~/.ssh/config'; never the tailnet name",
+    ),
+    (
+        "concrete ssh target (user@host)",
+        re.compile(r"\bssh\s+(?:-\S+\s+|\S+=\S+\s+)*[\w.-]+@[\w.-]+", re.I),
+        "use a placeholder alias, e.g. ssh \"$WIN_BOX\" ...",
+    ),
+    (
+        "~/.ssh config coordinates",
+        re.compile(r"^\s*(?:HostName|IdentityFile|ProxyJump)\s+\S", re.I | re.M),
+        "describe the host entry to look for, not its contents",
+    ),
+    (
+        "ssh private key filename",
+        re.compile(r"\bid_(?:ed25519|rsa|ecdsa|dsa)(?:_[\w-]+)?\b"),
+        "never name a key file; the operator's ssh config already selects it",
+    ),
+    (
+        "private key material",
+        re.compile(r"-----BEGIN [A-Z ]*PRIVATE KEY-----"),
+        "a key must never be in the repo at all",
+    ),
+    (
+        "self-hosted runner name",
+        # Runner *labels* stay allowed — they are how a workflow selects a
+        # runner and are already visible in .github/workflows/. Only a
+        # `runs-on:`-style concrete machine name is a coordinate.
+        re.compile(r"\brunner\s*\(`[\w-]+`", re.I),
+        "give the runner's LABELS, not the machine's registered name",
+    ),
+    (
+        "RFC1918 / link-local address",
+        re.compile(r"\b(?:10\.\d{1,3}|192\.168|172\.(?:1[6-9]|2\d|3[01])|169\.254)\.\d{1,3}\.\d{1,3}\b"),
+        "a private IP is a coordinate; describe how to discover the host instead",
+    ),
+    (
+        "absolute path into a personal home directory",
+        re.compile(r"(?:/Users/(?!<)[\w.-]+|/home/(?!<)[\w.-]+|C:\\\\Users\\\\[\w.-]+)/"),
+        "use ~ or a <placeholder>; an absolute home path names a person and a machine",
+    ),
+]
+
+
+def tracked_files() -> list[Path]:
+    """Only what git will actually publish — an untracked local scratch file
+    under these directories is the author's business, not this gate's."""
+    out = subprocess.run(
+        ["git", "-C", str(REPO), "ls-files", "-z", "--", *TREES],
+        capture_output=True, text=True, check=True,
+    ).stdout
+    return [REPO / p for p in out.split("\0") if p]
+
+
+def check_mirror() -> list[str]:
+    r = subprocess.run(
+        [str(REPO / "scripts/setup/sync-skills.sh"), "--check"],
+        capture_output=True, text=True,
+    )
+    if r.returncode == 0:
+        print(r.stdout.strip())
+        return []
+    return [(r.stdout + r.stderr).strip()]
+
+
+def check_private(files: list[Path]) -> list[str]:
+    findings: list[str] = []
+    for f in files:
+        try:
+            text = f.read_text(encoding="utf-8")
+        except (UnicodeDecodeError, OSError):
+            continue
+        lines = text.splitlines()
+        for label, pat, fix in RULES:
+            for m in pat.finditer(text):
+                lineno = text.count("\n", 0, m.start()) + 1
+                snippet = lines[lineno - 1].strip()[:120] if lineno <= len(lines) else ""
+                rel = f.relative_to(REPO)
+                findings.append(
+                    f"{rel}:{lineno}: {label}\n"
+                    f"    {snippet}\n"
+                    f"    -> {fix}"
+                )
+    return findings
+
+
+def main() -> int:
+    files = tracked_files()
+    if not files:
+        # A .gitignore edit or a directory rename can make every path above match
+        # nothing, and a gate that silently checks zero files is worse than none.
+        print("::error::agent-skills gate matched NO tracked files under "
+              + ", ".join(TREES) + " — the trees moved or became ignored.", file=sys.stderr)
+        return 1
+    print(f"agent-skills gate: {len(files)} tracked files under {', '.join(TREES)}")
+
+    problems = check_mirror() + check_private(files)
+    if problems:
+        print("\n::error::agent-skills gate FAILED\n", file=sys.stderr)
+        for p in problems:
+            print(p + "\n", file=sys.stderr)
+        print(
+            "These trees ship in a PUBLIC repo. Describe the capability, not the\n"
+            "coordinates — an agent that has read the instructions can resolve a\n"
+            "hostname from the operator's own ~/.ssh/config.\n"
+            "After editing .claude/skills/, re-run: scripts/setup/sync-skills.sh",
+            file=sys.stderr,
+        )
+        return 1
+
+    print("agent-skills gate: OK (mirror in sync, no private coordinates)")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/setup/sync-skills.sh
+++ b/scripts/setup/sync-skills.sh
@@ -9,9 +9,11 @@
 # Why a copy and not a symlink: a checkout without core.symlinks=true (common on Windows) materializes
 # git symlinks as text files, which would break Codex's reads. A generated copy + a drift check is portable.
 #
-# Both `.claude/*` and `.agents/*` are currently git-ignored in this repo (see .gitignore) — the skill
-# content is being kept local until a public/private decision is made, but the two trees still need to
-# agree with each other for whichever agent happens to read the mirror.
+# BOTH trees are TRACKED (see .gitignore: `.claude/*` / `.agents/*` are ignored except for the
+# `!.claude/skills/`, `!.claude/commands/`, `!.agents/skills/` negations). Because the mirror is
+# committed, a stale mirror is a wrong file published to a PUBLIC repo, not just local confusion —
+# so `--check` runs in CI as a required gate (.github/workflows/agent-skills-gate.yml), alongside a
+# scan that keeps private hostnames/credentials out of both trees.
 #
 # Usage:
 #   scripts/setup/sync-skills.sh            # regenerate .agents/skills from .claude/skills


### PR DESCRIPTION
## Description

The agent instruction trees (`.claude/skills/`, `.claude/commands/`, `.agents/skills/`) were **fully gitignored**, so every operator kept a private copy and they drifted apart. This tracks them — with the two things that make tracking safe in a public repo enforced by CI rather than by review.

### What was redacted before publishing

Only one class of thing in these files was genuinely private: the **Windows ARM64 test box's coordinates**.

| Removed | Kept |
|---|---|
| mesh-VPN hostname (`*.ts.net`) | "a Windows ARM64 machine reachable over SSH" |
| SSH alias, `User`, `IdentityFile` | "read the host entry out of the operator's `~/.ssh/config`" |
| the registered self-hosted runner's machine name | its **labels** — a workflow selects on those, and they're already in `.github/workflows/` |

Every operational lesson is kept verbatim: check the VPN node *before* opening a connection, a timeout means **asleep, not misconfigured**, don't loop retrying SSH, a macOS cross-build proves nothing about Windows. An agent that has read the instructions can resolve a hostname from the operator's own machine — the instructions don't need to carry it.

Also deleted `.claude/settings.local.json` (one person's permission overrides, ~20 absolute `/Users/...` paths). It and `.claude/worktrees/` stay gitignored.

**Nothing else here was new.** QHexRT / NeuRT / neurun, the QHexRT-stays-private policy, the Maven coordinates, the GPG key id, and the Sonatype publish flow already appear across the tracked tree today (309 files mention `qhexrt`; `NEURUN_TOKEN` is a named secret in `cpp-desktop-kit.yml`). Publishing the skills adds no disclosure there.

### The gate

`scripts/ci/check_agent_skills.py`, wired as `.github/workflows/agent-skills-gate.yml`, checks two things that are invisible in a normal diff review:

1. **Mirror drift.** `.claude/skills/` is canonical; `.agents/skills/` is a generated copy for non-Claude tooling (a `cp -R`, not a symlink — a checkout without `core.symlinks=true` materializes git symlinks as text files and silently breaks Codex's reads). `.agents/skills/sdk-release/SKILL.md` was **already ~40 lines stale** — regenerated here and now pinned. Delegates to `sync-skills.sh --check`, so CI and a laptop run the same code.

2. **Private coordinates creeping back in.** Tailnet hostnames, `user@host` ssh targets, `HostName`/`IdentityFile`/`ProxyJump` lines, ssh key filenames, private-key blocks, runner machine names, RFC1918 addresses, and `/Users/<name>/` paths. The patterns match **shapes**, not this team's current hostnames, so the gate keeps working after the infrastructure moves. Each finding prints what to write instead.

The gate **fails loud if it matches zero tracked files** — a `.gitignore` edit or a directory rename would otherwise make it silently check nothing and stay green forever. (This repo has been bitten by exactly that class of bug before.)

Run it exactly as CI does:

```bash
scripts/setup/sync-skills.sh              # after editing .claude/skills/
python3 scripts/ci/check_agent_skills.py
```

Stdlib-only Python plus the existing sync script — no toolchain setup, so an unrelated toolchain change can't break it.

## Type of Change
- [x] Documentation update
- [x] Refactoring

## Testing
- [x] Lint passes locally

**Negative-tested, not just run green.** Appended a file containing one instance of every blocked shape (`san@runanywhere.<tailnet>.ts.net`, an `IdentityFile` line, a `/Users/...` path, a runner machine name) and desynced the mirror. All six rule classes **and** the drift check fired, exit 1, each with the correct file:line. Then restored the file and confirmed it is byte-identical to the original (matching md5) and the gate returns exit 0.

Also verified with `git check-ignore -v --no-index` that `.claude/settings.local.json` and `.claude/worktrees/` are still ignored while the skill files are not — the `.gitignore` negations actually reach the right paths.

No platform-specific testing applies: this touches no SDK, binding, or sample-app code.

## Labels
None of the SDK/sample labels apply — this is repo tooling and agent documentation only.

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (`scripts/AGENTS.md` — the skills section said "both trees are gitignored", which is no longer true; `scripts/ci/` inventory row; the stale header comment in `sync-skills.sh`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013uCYb7mLCXaXXKAEfRQmJu


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added runbooks for engine plugin authoring, SDK releases, publishing, starter-app validation, and telemetry verification.
  * Added guidance for migrating components, addressing pull request comments, and resolving lint issues.
* **CI & Quality**
  * Added automated checks to keep mirrored guidance synchronized and prevent private infrastructure details from being committed.
* **Repository Configuration**
  * Updated tracking rules so shared agent commands and skills are included in the repository.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->