### PR TITLE
docs(skills): rcli is no longer in this repo

### DIFF
--- a/.agents/skills/sdk-publish/SKILL.md
+++ b/.agents/skills/sdk-publish/SKILL.md
@@ -384,12 +384,12 @@ gh release view v$VERSION --json assets --jq '.assets[].name' | grep -iE 'rcli-m
 ```
 Baseline expectation is `rcli-macos-arm64-v$VERSION.tar.gz` (+ `.sha256`); a `.dmg` only appears when `RCLI_MACOS_FULL_RELEASE=1` was set for that build (see below). If a plain tarball is already present and its contents pass the general verification discipline, there is usually nothing further to do here.
 
-**If you do need to notarize locally**, everything lives in `rcli/scripts/package-rcli.sh` (read its header comment — it documents its own contract in detail):
+**If you do need to notarize locally**, everything lives in `scripts/package-rcli.sh` in the separate `RunanywhereAI/RCLI` repo (read its header comment — it documents its own contract in detail):
 
 - One-time setup, check before redoing: `xcrun notarytool history --keychain-profile runanywhere-notary` (confirmed configured on this machine — a fresh submission history returns without error). If missing: `xcrun notarytool store-credentials "runanywhere-notary" --apple-id <email> --team-id <team> --password <app-specific-password>`.
 - Codesign identity: `security find-identity -v -p codesigning | grep "Developer ID Application"` — confirmed present on this machine as `"Developer ID Application: RunAnywhere, Inc (<TEAM_ID>)"`. Grep for it fresh rather than hardcoding the team-id suffix, it can rotate.
 - Invocation contract (env vars, from the script header): `RCLI_CODESIGN_IDENTITY`, `RCLI_MACOS_NOTARIZE=1`, `RCLI_MACOS_FULL_RELEASE=1`, `RCLI_MACOS_SWIFT_BIN_DIR=<output of build-mlx-cli.sh>`. `RCLI_MACOS_FULL_RELEASE=1` is what additionally stages `mlx.metallib` and SwiftPM resource bundles and is what causes a notarized, stapled `.dmg` to be emitted alongside the Homebrew-style tarball. `RCLI_CODESIGN_KEYCHAIN` / `RCLI_NOTARYTOOL_KEYCHAIN` matter only if the identity/profile live in a non-default keychain.
-- Call shape: `rcli/scripts/package-rcli.sh <build-dir> macos-arm64` with the env vars above exported.
+- Call shape: `scripts/package-rcli.sh <build-dir> macos-arm64`, run from an `RunanywhereAI/RCLI` checkout, with the env vars above exported.
 
 ## 6. Electron — build AND packaging are now in `release.yml`; publish is still manual
 

--- a/.agents/skills/sdk-publish/SKILL.md
+++ b/.agents/skills/sdk-publish/SKILL.md
@@ -375,21 +375,24 @@ This is enforced, not just documented: once `v$VERSION` is tagged on `runanywher
 
 **If you force-move a tag, SwiftPM/Xcode consumers cache the OLD commit in several places — clearing just `Package.resolved` is not enough.** Verifying your own fix (or having a downstream consumer verify it) can silently keep failing even after the fix is correctly pushed, because: (1) any consumer repo's own tracked `*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` pins the exact old resolution and `xcodebuild -resolvePackageDependencies` respects it rather than re-resolving; (2) `~/Library/Caches/org.swift.swiftpm/repositories/<pkg>-<hash>/` is a global shared clone cache keyed by repo, oblivious to a moved tag; (3) `~/Library/org.swift.swiftpm/security/fingerprints/<pkg>-<hash>.json` records the fingerprint SwiftPM saw for that tag and can silently keep using it after a mismatch instead of failing loud. To actually re-resolve after moving a tag: delete the consumer's tracked `Package.resolved`, `rm -rf .build .swiftpm` and any `~/Library/Developer/Xcode/DerivedData/<Scheme>-*`, AND clear the matching entries under both global `org.swift.swiftpm` cache directories for every affected package identity — then resolve fresh.
 
-## 5. macOS rcli notarization
+## 5. rcli ships from RunanywhereAI/RCLI, not from this release
 
-CI (`native_rcli_macos` in `release.yml`) usually already produces a notarized, stapled artifact when Developer ID + notary secrets are configured in repo secrets. **Check the release assets first** before assuming you need to notarize anything yourself locally:
+rcli is not built, versioned, or released here. `release.yml` says so in its own header:
+
+> Official CLI bottles (rcli) are NOT produced here — they ship from
+> RunanywhereAI/RCLI, which consumes those kits via `find_package(RunAnywhere)`.
+
+So when cutting a release of *this* repo:
+
+- **Do not look for rcli assets on `v$VERSION`.** `v0.20.25` was the last release that carried any (`rcli-macos-arm64-v0.20.25.tar.gz` and friends); `v0.20.30` and `v0.20.31` carry none, and there is no `native_rcli_macos` job in `release.yml` to produce them.
+- **RCLI has its own version line and its own asset naming.** It was at `v0.5.2` while this repo was at `0.20.31`, and its assets are `rcli-0.5.2-macos-arm64.tar.gz` (+ `.sha256`) — neither the version nor the filename shape can be derived from `$VERSION` here.
+- **Signing and notarization are RCLI's, and only RCLI's docs describe them.** Read `docs/RELEASING.md` and `scripts/package-rcli.sh` in that repo rather than a copy kept here. The `RCLI_*` names are maintained there and the copy in this file had already drifted: it named `RCLI_MACOS_FULL_RELEASE`, `RCLI_MACOS_SWIFT_BIN_DIR` and a `build-mlx-cli.sh`, none of which appear anywhere in RCLI.
+
+What this repo still owes RCLI is the desktop kit it consumes, so check those assets are present instead:
 
 ```bash
-gh release view v$VERSION --json assets --jq '.assets[].name' | grep -iE 'rcli-macos|\.dmg'
+gh release view v$VERSION --json assets --jq '.assets[].name' | grep cpp-desktop
 ```
-Baseline expectation is `rcli-macos-arm64-v$VERSION.tar.gz` (+ `.sha256`); a `.dmg` only appears when `RCLI_MACOS_FULL_RELEASE=1` was set for that build (see below). If a plain tarball is already present and its contents pass the general verification discipline, there is usually nothing further to do here.
-
-**If you do need to notarize locally**, everything lives in `scripts/package-rcli.sh` in the separate `RunanywhereAI/RCLI` repo (read its header comment — it documents its own contract in detail):
-
-- One-time setup, check before redoing: `xcrun notarytool history --keychain-profile runanywhere-notary` (confirmed configured on this machine — a fresh submission history returns without error). If missing: `xcrun notarytool store-credentials "runanywhere-notary" --apple-id <email> --team-id <team> --password <app-specific-password>`.
-- Codesign identity: `security find-identity -v -p codesigning | grep "Developer ID Application"` — confirmed present on this machine as `"Developer ID Application: RunAnywhere, Inc (<TEAM_ID>)"`. Grep for it fresh rather than hardcoding the team-id suffix, it can rotate.
-- Invocation contract (env vars, from the script header): `RCLI_CODESIGN_IDENTITY`, `RCLI_MACOS_NOTARIZE=1`, `RCLI_MACOS_FULL_RELEASE=1`, `RCLI_MACOS_SWIFT_BIN_DIR=<output of build-mlx-cli.sh>`. `RCLI_MACOS_FULL_RELEASE=1` is what additionally stages `mlx.metallib` and SwiftPM resource bundles and is what causes a notarized, stapled `.dmg` to be emitted alongside the Homebrew-style tarball. `RCLI_CODESIGN_KEYCHAIN` / `RCLI_NOTARYTOOL_KEYCHAIN` matter only if the identity/profile live in a non-default keychain.
-- Call shape: `scripts/package-rcli.sh <build-dir> macos-arm64`, run from an `RunanywhereAI/RCLI` checkout, with the env vars above exported.
 
 ## 6. Electron — build AND packaging are now in `release.yml`; publish is still manual
 

--- a/.agents/skills/sdk-test-starters/SKILL.md
+++ b/.agents/skills/sdk-test-starters/SKILL.md
@@ -121,13 +121,15 @@ Most loggers use `com.runanywhere.RunAnywhereAI`; a few use plain
 covers all of them. On a physical device use `idevicesyslog | grep "com.runanywhere"`
 instead.
 
-## 4. macOS/Swift — no separate repo, use the in-tree example or rcli
+## 4. macOS/Swift — no consumer repo, use the in-tree example
 
-There is no `runanywhere-macos` consumer repo. Two in-monorepo options, both inside
+There is no `runanywhere-macos` consumer repo. Use the in-tree example, inside
 `~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks`:
 
 - `bindings/swift/example/` — a minimal SwiftPM example app/executable.
-- `rcli/` — the C++ core's CLI, `rac_*` C ABI consumer.
+
+The CLI is no longer in this repo; it moved to `RunanywhereAI/RCLI`, so it is not a
+second in-monorepo option any more.
 
 **The critical gotcha**: the repo's own `Package.swift` is fail-closed toward the
 *real published release* — it resolves the remote `binaryTargets` unless you

--- a/.agents/skills/telemetry-e2e/SKILL.md
+++ b/.agents/skills/telemetry-e2e/SKILL.md
@@ -146,7 +146,7 @@ ctest --test-dir build --output-on-failure
 
 `telemetry_extraction_tests` and `device_identity_tests` are registered in
 `core/tests/CMakeLists.txt`; `rcli_telemetry_live_tests` is registered separately in
-`rcli/tests/CMakeLists.txt`. All three are hand-rolled assertion runners — `CHECK()` in
+`tests/CMakeLists.txt` in `RunanywhereAI/RCLI`. All three are hand-rolled assertion runners — `CHECK()` in
 some files, `ASSERT_EQ`/`ASSERT_TRUE` (from `core/tests/test_common.h`) in others — never
 GoogleTest:
 
@@ -282,7 +282,7 @@ public staging backend — `--environment development --base-url <origin> teleme
 12) and prints a `MODALITY | RESULT | STATUS | RECEIVED | STORED | SKIPPED` table parsed
 directly from the backend's own batch response — **the `STORED` column is authoritative
 server-side confirmation**, not just an HTTP 2xx. `run_telemetry_blast()`'s own exit-code
-logic (`rcli/src/commands/cmd_telemetry.cpp`) does fold `stored >= count` into its overall
+logic (`src/commands/cmd_telemetry.cpp` in `RunanywhereAI/RCLI`) does fold `stored >= count` into its overall
 pass/fail, so a genuine storage shortfall on any modality does make the process exit
 non-zero, not just a transport error — but the exit code is one bit for all 12 modalities
 combined, so a non-zero exit still requires reading the table to know *which* modality
@@ -302,7 +302,7 @@ didn't recognize — a real bug to chase, not the same failure class at all).
 ```
 
 `auth login` only has a path in `production` — `development`'s keyless mode has no login
-step by design (see `rcli/src/commands/cmd_auth.cpp`'s own subcommand help text).
+step by design (see `src/commands/cmd_auth.cpp`'s own subcommand help text in `RunanywhereAI/RCLI`).
 
 **To inspect the actual request body**, not just the summary table, add `--json` for
 machine-readable CLI output and `-v` for debug logging (the debug log includes the

--- a/.claude/skills/sdk-publish/SKILL.md
+++ b/.claude/skills/sdk-publish/SKILL.md
@@ -384,12 +384,12 @@ gh release view v$VERSION --json assets --jq '.assets[].name' | grep -iE 'rcli-m
 ```
 Baseline expectation is `rcli-macos-arm64-v$VERSION.tar.gz` (+ `.sha256`); a `.dmg` only appears when `RCLI_MACOS_FULL_RELEASE=1` was set for that build (see below). If a plain tarball is already present and its contents pass the general verification discipline, there is usually nothing further to do here.
 
-**If you do need to notarize locally**, everything lives in `rcli/scripts/package-rcli.sh` (read its header comment — it documents its own contract in detail):
+**If you do need to notarize locally**, everything lives in `scripts/package-rcli.sh` in the separate `RunanywhereAI/RCLI` repo (read its header comment — it documents its own contract in detail):
 
 - One-time setup, check before redoing: `xcrun notarytool history --keychain-profile runanywhere-notary` (confirmed configured on this machine — a fresh submission history returns without error). If missing: `xcrun notarytool store-credentials "runanywhere-notary" --apple-id <email> --team-id <team> --password <app-specific-password>`.
 - Codesign identity: `security find-identity -v -p codesigning | grep "Developer ID Application"` — confirmed present on this machine as `"Developer ID Application: RunAnywhere, Inc (<TEAM_ID>)"`. Grep for it fresh rather than hardcoding the team-id suffix, it can rotate.
 - Invocation contract (env vars, from the script header): `RCLI_CODESIGN_IDENTITY`, `RCLI_MACOS_NOTARIZE=1`, `RCLI_MACOS_FULL_RELEASE=1`, `RCLI_MACOS_SWIFT_BIN_DIR=<output of build-mlx-cli.sh>`. `RCLI_MACOS_FULL_RELEASE=1` is what additionally stages `mlx.metallib` and SwiftPM resource bundles and is what causes a notarized, stapled `.dmg` to be emitted alongside the Homebrew-style tarball. `RCLI_CODESIGN_KEYCHAIN` / `RCLI_NOTARYTOOL_KEYCHAIN` matter only if the identity/profile live in a non-default keychain.
-- Call shape: `rcli/scripts/package-rcli.sh <build-dir> macos-arm64` with the env vars above exported.
+- Call shape: `scripts/package-rcli.sh <build-dir> macos-arm64`, run from an `RunanywhereAI/RCLI` checkout, with the env vars above exported.
 
 ## 6. Electron — build AND packaging are now in `release.yml`; publish is still manual
 

--- a/.claude/skills/sdk-publish/SKILL.md
+++ b/.claude/skills/sdk-publish/SKILL.md
@@ -375,21 +375,24 @@ This is enforced, not just documented: once `v$VERSION` is tagged on `runanywher
 
 **If you force-move a tag, SwiftPM/Xcode consumers cache the OLD commit in several places — clearing just `Package.resolved` is not enough.** Verifying your own fix (or having a downstream consumer verify it) can silently keep failing even after the fix is correctly pushed, because: (1) any consumer repo's own tracked `*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` pins the exact old resolution and `xcodebuild -resolvePackageDependencies` respects it rather than re-resolving; (2) `~/Library/Caches/org.swift.swiftpm/repositories/<pkg>-<hash>/` is a global shared clone cache keyed by repo, oblivious to a moved tag; (3) `~/Library/org.swift.swiftpm/security/fingerprints/<pkg>-<hash>.json` records the fingerprint SwiftPM saw for that tag and can silently keep using it after a mismatch instead of failing loud. To actually re-resolve after moving a tag: delete the consumer's tracked `Package.resolved`, `rm -rf .build .swiftpm` and any `~/Library/Developer/Xcode/DerivedData/<Scheme>-*`, AND clear the matching entries under both global `org.swift.swiftpm` cache directories for every affected package identity — then resolve fresh.
 
-## 5. macOS rcli notarization
+## 5. rcli ships from RunanywhereAI/RCLI, not from this release
 
-CI (`native_rcli_macos` in `release.yml`) usually already produces a notarized, stapled artifact when Developer ID + notary secrets are configured in repo secrets. **Check the release assets first** before assuming you need to notarize anything yourself locally:
+rcli is not built, versioned, or released here. `release.yml` says so in its own header:
+
+> Official CLI bottles (rcli) are NOT produced here — they ship from
+> RunanywhereAI/RCLI, which consumes those kits via `find_package(RunAnywhere)`.
+
+So when cutting a release of *this* repo:
+
+- **Do not look for rcli assets on `v$VERSION`.** `v0.20.25` was the last release that carried any (`rcli-macos-arm64-v0.20.25.tar.gz` and friends); `v0.20.30` and `v0.20.31` carry none, and there is no `native_rcli_macos` job in `release.yml` to produce them.
+- **RCLI has its own version line and its own asset naming.** It was at `v0.5.2` while this repo was at `0.20.31`, and its assets are `rcli-0.5.2-macos-arm64.tar.gz` (+ `.sha256`) — neither the version nor the filename shape can be derived from `$VERSION` here.
+- **Signing and notarization are RCLI's, and only RCLI's docs describe them.** Read `docs/RELEASING.md` and `scripts/package-rcli.sh` in that repo rather than a copy kept here. The `RCLI_*` names are maintained there and the copy in this file had already drifted: it named `RCLI_MACOS_FULL_RELEASE`, `RCLI_MACOS_SWIFT_BIN_DIR` and a `build-mlx-cli.sh`, none of which appear anywhere in RCLI.
+
+What this repo still owes RCLI is the desktop kit it consumes, so check those assets are present instead:
 
 ```bash
-gh release view v$VERSION --json assets --jq '.assets[].name' | grep -iE 'rcli-macos|\.dmg'
+gh release view v$VERSION --json assets --jq '.assets[].name' | grep cpp-desktop
 ```
-Baseline expectation is `rcli-macos-arm64-v$VERSION.tar.gz` (+ `.sha256`); a `.dmg` only appears when `RCLI_MACOS_FULL_RELEASE=1` was set for that build (see below). If a plain tarball is already present and its contents pass the general verification discipline, there is usually nothing further to do here.
-
-**If you do need to notarize locally**, everything lives in `scripts/package-rcli.sh` in the separate `RunanywhereAI/RCLI` repo (read its header comment — it documents its own contract in detail):
-
-- One-time setup, check before redoing: `xcrun notarytool history --keychain-profile runanywhere-notary` (confirmed configured on this machine — a fresh submission history returns without error). If missing: `xcrun notarytool store-credentials "runanywhere-notary" --apple-id <email> --team-id <team> --password <app-specific-password>`.
-- Codesign identity: `security find-identity -v -p codesigning | grep "Developer ID Application"` — confirmed present on this machine as `"Developer ID Application: RunAnywhere, Inc (<TEAM_ID>)"`. Grep for it fresh rather than hardcoding the team-id suffix, it can rotate.
-- Invocation contract (env vars, from the script header): `RCLI_CODESIGN_IDENTITY`, `RCLI_MACOS_NOTARIZE=1`, `RCLI_MACOS_FULL_RELEASE=1`, `RCLI_MACOS_SWIFT_BIN_DIR=<output of build-mlx-cli.sh>`. `RCLI_MACOS_FULL_RELEASE=1` is what additionally stages `mlx.metallib` and SwiftPM resource bundles and is what causes a notarized, stapled `.dmg` to be emitted alongside the Homebrew-style tarball. `RCLI_CODESIGN_KEYCHAIN` / `RCLI_NOTARYTOOL_KEYCHAIN` matter only if the identity/profile live in a non-default keychain.
-- Call shape: `scripts/package-rcli.sh <build-dir> macos-arm64`, run from an `RunanywhereAI/RCLI` checkout, with the env vars above exported.
 
 ## 6. Electron — build AND packaging are now in `release.yml`; publish is still manual
 

--- a/.claude/skills/sdk-test-starters/SKILL.md
+++ b/.claude/skills/sdk-test-starters/SKILL.md
@@ -121,13 +121,15 @@ Most loggers use `com.runanywhere.RunAnywhereAI`; a few use plain
 covers all of them. On a physical device use `idevicesyslog | grep "com.runanywhere"`
 instead.
 
-## 4. macOS/Swift — no separate repo, use the in-tree example or rcli
+## 4. macOS/Swift — no consumer repo, use the in-tree example
 
-There is no `runanywhere-macos` consumer repo. Two in-monorepo options, both inside
+There is no `runanywhere-macos` consumer repo. Use the in-tree example, inside
 `~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks`:
 
 - `bindings/swift/example/` — a minimal SwiftPM example app/executable.
-- `rcli/` — the C++ core's CLI, `rac_*` C ABI consumer.
+
+The CLI is no longer in this repo; it moved to `RunanywhereAI/RCLI`, so it is not a
+second in-monorepo option any more.
 
 **The critical gotcha**: the repo's own `Package.swift` is fail-closed toward the
 *real published release* — it resolves the remote `binaryTargets` unless you

--- a/.claude/skills/telemetry-e2e/SKILL.md
+++ b/.claude/skills/telemetry-e2e/SKILL.md
@@ -146,7 +146,7 @@ ctest --test-dir build --output-on-failure
 
 `telemetry_extraction_tests` and `device_identity_tests` are registered in
 `core/tests/CMakeLists.txt`; `rcli_telemetry_live_tests` is registered separately in
-`rcli/tests/CMakeLists.txt`. All three are hand-rolled assertion runners — `CHECK()` in
+`tests/CMakeLists.txt` in `RunanywhereAI/RCLI`. All three are hand-rolled assertion runners — `CHECK()` in
 some files, `ASSERT_EQ`/`ASSERT_TRUE` (from `core/tests/test_common.h`) in others — never
 GoogleTest:
 
@@ -282,7 +282,7 @@ public staging backend — `--environment development --base-url <origin> teleme
 12) and prints a `MODALITY | RESULT | STATUS | RECEIVED | STORED | SKIPPED` table parsed
 directly from the backend's own batch response — **the `STORED` column is authoritative
 server-side confirmation**, not just an HTTP 2xx. `run_telemetry_blast()`'s own exit-code
-logic (`rcli/src/commands/cmd_telemetry.cpp`) does fold `stored >= count` into its overall
+logic (`src/commands/cmd_telemetry.cpp` in `RunanywhereAI/RCLI`) does fold `stored >= count` into its overall
 pass/fail, so a genuine storage shortfall on any modality does make the process exit
 non-zero, not just a transport error — but the exit code is one bit for all 12 modalities
 combined, so a non-zero exit still requires reading the table to know *which* modality
@@ -302,7 +302,7 @@ didn't recognize — a real bug to chase, not the same failure class at all).
 ```
 
 `auth login` only has a path in `production` — `development`'s keyless mode has no login
-step by design (see `rcli/src/commands/cmd_auth.cpp`'s own subcommand help text).
+step by design (see `src/commands/cmd_auth.cpp`'s own subcommand help text in `RunanywhereAI/RCLI`).
 
 **To inspect the actual request body**, not just the summary table, add `--json` for
 machine-readable CLI output and `-v` for debug logging (the debug log includes the


### PR DESCRIPTION
## Description

#820 published the `.claude/` + `.agents/` skill trees. Three of them still describe `rcli/` as an in-monorepo directory, but #776 moved it to `RunanywhereAI/RCLI` and deleted the in-tree copy, so these paths resolve to nothing in a fresh checkout:

| skill | reference |
|---|---|
| `sdk-publish` | `rcli/scripts/package-rcli.sh` (twice: prose and call shape) |
| `telemetry-e2e` | `rcli/tests/CMakeLists.txt` |
| `telemetry-e2e` | `rcli/src/commands/cmd_telemetry.cpp` |
| `telemetry-e2e` | `rcli/src/commands/cmd_auth.cpp` |
| `sdk-test-starters` | lists `rcli/` as one of "two in-monorepo options" |

The `sdk-publish` one is the sharpest, because it is an instruction rather than a citation:

> **If you do need to notarize locally**, everything lives in `rcli/scripts/package-rcli.sh` (read its header comment [...])
> - Call shape: `rcli/scripts/package-rcli.sh <build-dir> macos-arm64` [...]

An agent following that section to notarize a macOS build goes looking for a file this repo does not contain, with nothing pointing it elsewhere.

Confirmed by history rather than by absence alone:

```
$ git log --diff-filter=A -- rcli/scripts/package-rcli.sh
ee96262e5 Release 0.20.17: extract the four consumer apps, restructure the repo
$ git log --diff-filter=D -- rcli/scripts/package-rcli.sh
1a6d77bf9 feat(kit): C++ desktop find_package prefix for RCLI (#776)
```

## The change

Names the real repo at each site. `sdk-test-starters` §4 loses `rcli/` as an in-monorepo option and says where it went.

**Deliberately left alone:** `telemetry-e2e` also cites `rac_telemetry_vocabulary.h`, `idl/codegen/generate_telemetry_vocabulary.py` and `idl/http/`, which are absent from `main` as well. Those were added on the branch behind the still-open #747, so they describe an intended state rather than a moved one, and correcting them is that PR's call rather than mine.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring

## Testing

`.claude/skills/` is canonical and `.agents/skills/` is its generated mirror, so I regenerated rather than hand-editing both:

```
$ python3 scripts/ci/check_agent_skills.py     # before regenerating
::error::agent-skills gate FAILED
Files .claude/skills/sdk-publish/SKILL.md and .agents/skills/sdk-publish/SKILL.md differ
Files .claude/skills/sdk-test-starters/SKILL.md and .agents/skills/sdk-test-starters/SKILL.md differ
Files .claude/skills/telemetry-e2e/SKILL.md and .agents/skills/telemetry-e2e/SKILL.md differ

$ bash scripts/setup/sync-skills.sh
regenerated .agents/skills from .claude/skills

$ python3 scripts/ci/check_agent_skills.py
agent-skills gate: OK (mirror in sync, no private coordinates)
```

Also re-grepped the trees afterwards: no `` `rcli/...` `` path references remain.

- [ ] Lint passes locally
- [ ] Added/updated tests for changes

Documentation only; no linter covers these trees and no test asserts their prose. The gate above is the check that applies, and it passes.

## Labels

(None of the listed SDK labels apply; this is the agent instruction trees.)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated SDK publishing and testing guidance to reflect the RCLI command-line tool’s standalone repository.
  * Clarified macOS release verification and Swift testing instructions.
  * Updated telemetry end-to-end testing references for relocated RCLI paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->