### PR TITLE
fix(rag): an unset temperature or top_k collapses to 0 on the RAG query path

### DIFF
--- a/core/src/features/rag/rac_rag_proto_abi.cpp
+++ b/core/src/features/rag/rac_rag_proto_abi.cpp
@@ -422,11 +422,18 @@ rac_result_t execute_rag_query(const std::shared_ptr<Session>& s,
     // Base off RAC_LLM_OPTIONS_DEFAULT, then apply the embedded generation
     // knobs with the RAG pipeline defaults (max 512 tokens, top_p 0.9) when
     // unset.
+    //
+    // temperature and top_k are `optional` in llm_options.proto, so presence
+    // is what "unset" means: reading the value instead yields 0, which is a
+    // legal explicit setting for both (greedy / top-k disabled) and therefore
+    // cannot double as a sentinel. has_generation() is not a substitute -- a
+    // caller that sets any other generation knob makes the submessage present
+    // while leaving these two absent.
     rac_llm_options_t opts = RAC_LLM_OPTIONS_DEFAULT;
     opts.max_tokens = gen.max_output_tokens() > 0 ? gen.max_output_tokens() : 512;
-    opts.temperature = query_proto.has_generation() ? gen.temperature() : opts.temperature;
+    opts.temperature = gen.has_temperature() ? gen.temperature() : opts.temperature;
     opts.top_p = gen.top_p() > 0.0f ? gen.top_p() : 0.9f;
-    opts.top_k = gen.top_k();
+    opts.top_k = gen.has_top_k() ? gen.top_k() : opts.top_k;
     opts.disable_thinking =
         (gen.has_reasoning() && gen.reasoning().mode() == runanywhere::v1::REASONING_MODE_OFF)
             ? RAC_TRUE

--- a/core/tests/test_advanced_modality_proto_abi.cpp
+++ b/core/tests/test_advanced_modality_proto_abi.cpp
@@ -103,6 +103,7 @@ std::atomic<bool> g_dummy_embeddings_started{false};
 std::atomic<bool> g_dummy_embeddings_release{false};
 float g_dummy_llm_last_temperature = -1.0f;
 int32_t g_dummy_llm_last_max_tokens = 0;
+int32_t g_dummy_llm_last_top_k = -1;
 rac_bool_t g_dummy_llm_last_disable_thinking = RAC_FALSE;
 std::string g_dummy_llm_stream_response;
 
@@ -380,6 +381,7 @@ rac_result_t dummy_llm_stream(void* impl, const char*, const rac_llm_options_t* 
     if (options) {
         g_dummy_llm_last_temperature = options->temperature;
         g_dummy_llm_last_max_tokens = options->max_tokens;
+        g_dummy_llm_last_top_k = options->top_k;
         g_dummy_llm_last_disable_thinking = options->disable_thinking;
     }
     if (g_dummy_llm_block_stream.load(std::memory_order_acquire)) {
@@ -1111,6 +1113,30 @@ int test_rag_ingest_query_mocked_path() {
           "RAG query publishes RAG_QUERY_STARTED");
     CHECK(poll_capability(runanywhere::v1::CAPABILITY_OPERATION_EVENT_KIND_RAG_QUERY_COMPLETED),
           "RAG query publishes RAG_QUERY_COMPLETED");
+
+    // temperature and top_k are `optional` in llm_options.proto, so a
+    // generation submessage that sets neither must leave the
+    // RAC_LLM_OPTIONS_DEFAULT values in place rather than collapse to the
+    // proto3 zero -- 0.0f and 0 are both legal explicit settings here
+    // (greedy sampling / top-k disabled), so neither can act as a sentinel.
+    runanywhere::v1::RAGQueryOptions unset_sampling_query;
+    unset_sampling_query.set_query("Where does RAG live?");
+    unset_sampling_query.mutable_generation()->set_max_output_tokens(32);
+    std::vector<uint8_t> unset_sampling_bytes;
+    CHECK(serialize(unset_sampling_query, &unset_sampling_bytes),
+          "RAGQueryOptions with no sampling knobs serializes");
+    g_dummy_llm_last_temperature = -1.0f;
+    g_dummy_llm_last_top_k = -1;
+    rac_proto_buffer_init(&out);
+    rc = rac_rag_query_proto(session, unset_sampling_bytes.data(), unset_sampling_bytes.size(),
+                             &out);
+    CHECK(rc == RAC_SUCCESS, "RAG query with no sampling knobs succeeds");
+    CHECK(g_dummy_llm_last_temperature == RAC_LLM_OPTIONS_DEFAULT.temperature,
+          "RAG query keeps the default temperature when the field is unset");
+    CHECK(g_dummy_llm_last_top_k == RAC_LLM_OPTIONS_DEFAULT.top_k,
+          "RAG query keeps the default top_k when the field is unset");
+    rac_proto_buffer_free(&out);
+    rac_sdk_event_clear_queue();
 
     // A token-limited thinking phase may omit its closing tag. The RAG result
     // must keep that private content out of answer while retaining typed

--- a/core/tests/test_advanced_modality_proto_abi.cpp
+++ b/core/tests/test_advanced_modality_proto_abi.cpp
@@ -1138,6 +1138,27 @@ int test_rag_ingest_query_mocked_path() {
     rac_proto_buffer_free(&out);
     rac_sdk_event_clear_queue();
 
+    // The other half of the same contract: 0 is a legal explicit top_k
+    // (top-k filtering disabled), so it has to survive rather than be read as
+    // "unset". This is what stops the bug from being "fixed" with a
+    // value-based sentinel such as `gen.top_k() > 0 ? gen.top_k() : default`,
+    // which would satisfy the unset case above while silently discarding a
+    // caller's explicit 0.
+    runanywhere::v1::RAGQueryOptions explicit_zero_query;
+    explicit_zero_query.set_query("Where does RAG live?");
+    explicit_zero_query.mutable_generation()->set_max_output_tokens(32);
+    explicit_zero_query.mutable_generation()->set_top_k(0);
+    std::vector<uint8_t> explicit_zero_bytes;
+    CHECK(serialize(explicit_zero_query, &explicit_zero_bytes),
+          "RAGQueryOptions with an explicit top_k of 0 serializes");
+    g_dummy_llm_last_top_k = -1;
+    rac_proto_buffer_init(&out);
+    rc = rac_rag_query_proto(session, explicit_zero_bytes.data(), explicit_zero_bytes.size(), &out);
+    CHECK(rc == RAC_SUCCESS, "RAG query with an explicit top_k of 0 succeeds");
+    CHECK(g_dummy_llm_last_top_k == 0, "RAG query honours an explicit top_k of 0");
+    rac_proto_buffer_free(&out);
+    rac_sdk_event_clear_queue();
+
     // A token-limited thinking phase may omit its closing tag. The RAG result
     // must keep that private content out of answer while retaining typed
     // thinking_content for non-UI consumers.


### PR DESCRIPTION
## Description

`execute_rag_query` (`core/src/features/rag/rac_rag_proto_abi.cpp`) starts from `RAC_LLM_OPTIONS_DEFAULT` and then overwrites the sampling knobs from the request's `generation` submessage:

```cpp
rac_llm_options_t opts = RAC_LLM_OPTIONS_DEFAULT;
opts.max_tokens = gen.max_output_tokens() > 0 ? gen.max_output_tokens() : 512;
opts.temperature = query_proto.has_generation() ? gen.temperature() : opts.temperature;
opts.top_p = gen.top_p() > 0.0f ? gen.top_p() : 0.9f;
opts.top_k = gen.top_k();
```

Two of those four lines lose the default they just set up.

`temperature` and `top_k` are both `optional` in `idl/llm_options.proto`, with declared defaults:

```proto
optional float temperature = 2 [(runanywhere.v1.rac_default) = "0.7", ...];
optional int32 top_k       = 4 [(runanywhere.v1.rac_default) = "40",  (runanywhere.v1.rac_min) = 0];
```

and `RAC_LLM_OPTIONS_DEFAULT` is generated straight from those annotations (`rac_llm_types.h:166`, `RAC_DEFAULT_LLM_GENERATION_OPTIONS_{TEMPERATURE,TOP_K}` = `0.7f` / `40`).

- **`top_k` has no presence check at all.** An absent field reads back as the proto3 zero, so `opts.top_k` becomes `0` and the default `40` is gone. `top_k = 0` is not a no-op, it means top-k filtering disabled.
- **`temperature` is guarded on the wrong presence bit.** `has_generation()` only tells you the submessage exists. A caller that sets any other knob (say `max_output_tokens`) makes `generation` present while leaving `temperature` absent, and then gets `0.0f`, i.e. greedy decoding instead of `0.7`.

So a RAG query carrying `generation { max_output_tokens: 32 }` samples at temperature 0 with top-k disabled, rather than at the documented defaults. Neither zero can serve as an "unset" sentinel here, because both are legal explicit settings a caller may want.

The fix guards each field on its own presence bit, which is what the sibling readers of the same options already do (`tool_calling_run_loop.cpp:504`, `tool_calling_session.cpp:890`, and `has_system_prompt()` four lines up in this very function):

```cpp
opts.temperature = gen.has_temperature() ? gen.temperature() : opts.temperature;
opts.top_k       = gen.has_top_k()       ? gen.top_k()       : opts.top_k;
```

`max_tokens` and `top_p` are deliberately left alone: the surrounding comment documents `top_p 0.9` as an intentional RAG-pipeline default distinct from the global `1.0`, and changing it is a separate decision from this bug.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [x] Added/updated tests for changes

`core/tests/test_advanced_modality_proto_abi.cpp` already drives `rac_rag_query_proto` against a mock LLM that records the `rac_llm_options_t` it receives, so the new case is four asserts in that existing harness plus a `top_k` capture alongside the `temperature` and `max_tokens` ones already there.

```
$ cmake -B build -DRAC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug && cmake --build build -j 10
$ ctest --test-dir build -j 10
100% tests passed out of 101
```

The new asserts fail on the unfixed code. Verified by reverting only the two source lines and confirming the relink actually happened:

```
[100%] Linking CXX executable test_advanced_modality_proto_abi
FAIL: RAG query keeps the default temperature when the field is unset (...:1135)
      g_dummy_llm_last_temperature == RAC_LLM_OPTIONS_DEFAULT.temperature
FAIL: RAG query keeps the default top_k when the field is unset (...:1137)
      g_dummy_llm_last_top_k == RAC_LLM_OPTIONS_DEFAULT.top_k
```

On lint: I left that box unchecked rather than imply more than I checked. `core/scripts/lint-cpp.sh` needs the repo's pinned `clang-format` and only Apple `clang-format 21` is available here, which reports pre-existing diffs in regions this PR does not touch. What I did verify is that none of its hunks overlap my changed line ranges, so this diff adds no new formatting drift, and I did not reformat unrelated lines.

The edited block sits inside `#if defined(RAC_HAVE_PROTOBUF)` (the guard opens at line 63), so it is compiled only in protobuf-enabled configurations.

I tried to confirm that against a `-DRAC_ENABLE_PROTOBUF=OFF` build and could not, because that configuration does not compile this file on current `main` either:

```
core/src/features/rag/rac_rag_proto_abi.cpp:30:10: fatal error:
      'features/llm/llm_thinking_tags_internal.h' file not found
```

That is a pre-existing include-path gap in the protobuf-off configuration, not something this diff introduces: I reproduced it with `main`'s unmodified copy of the file and the error is identical. So the protobuf-off claim rests on the guard placement rather than on a clean build, and I would rather say that than imply a check I did not get.

No platform-specific boxes ticked: this is commons-only and was exercised through the C++ test suite on macOS, not through any SDK sample.

## Labels
**SDKs:**
- [x] `Commons` - Changes to shared native code (`core`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved RAG query handling for optional LLM sampling settings.
  * Preserved default temperature and top-k values when these options are omitted, preventing unintended zero-value overrides.
  * Ensured explicitly setting top-k to 0 is honored correctly.

* **Tests**
  * Added coverage verifying omitted sampling options retain their configured defaults.
  * Added regression coverage for explicitly configured zero values.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

**CI note:** the red `centralization` is not from this diff. Its only failing step is *"Swift distribution repo (runanywhere-swift) is cut at this release"* — that repo is tagged `0.20.30` while this one has published `v0.20.31`, which `scripts/release/sync-versions.sh:616` documents as failing every PR until the tag is cut. Every other step in that job, including the C++ gates, passed. Nothing to push here; the remedy is cutting the distribution repo.