### PR TITLE
fix(rag): RAC_ENABLE_PROTOBUF=OFF cannot compile the RAG backend

### DIFF
--- a/core/src/features/rag/rac_rag_proto_abi.cpp
+++ b/core/src/features/rag/rac_rag_proto_abi.cpp
@@ -27,7 +27,6 @@
 #include <vector>
 
 #include "../embeddings/embeddings_service_internal.h"
-#include "features/llm/llm_thinking_tags_internal.h"
 #include "rac/core/rac_core.h"
 #include "rac/core/rac_error.h"
 #include "rac/core/rac_logger.h"
@@ -46,6 +45,7 @@
 #include "rag.pb.h"
 #include "sdk_events.pb.h"
 
+#include "features/llm/llm_thinking_tags_internal.h"
 #include "foundation/rac_proto_marshal_internal.h"
 #include "infrastructure/events/sdk_event_publish.h"
 #endif


### PR DESCRIPTION
## Description

`cmake -B build -DRAC_ENABLE_PROTOBUF=OFF` does not build. It stops here:

```
core/src/features/rag/rac_rag_proto_abi.cpp:30:10: fatal error:
      'features/llm/llm_thinking_tags_internal.h' file not found
```

`RAC_ENABLE_PROTOBUF` is a real supported option (`core/CMakeLists.txt:1417`) with its own documented `else()` branch — *"RAC_ENABLE_PROTOBUF=OFF — exported proto ABI functions use unavailable stubs"* — and it is the EMSCRIPTEN default. `RAC_BACKEND_RAG` defaults `ON`, so the flag on its own is enough to reproduce.

The cause is an include on the wrong side of a guard. `rac_rag_proto_abi.cpp` pulls in three commons-internal headers by a path relative to the `src/` root, but only two of them are inside the `RAC_HAVE_PROTOBUF` guard:

```cpp
#include "features/llm/llm_thinking_tags_internal.h"   // line 30 — OUTSIDE the guard
...
#if defined(RAC_HAVE_PROTOBUF)
#include "foundation/rac_proto_marshal_internal.h"     // line 49 — inside
#include "infrastructure/events/sdk_event_publish.h"   // line 50 — inside
```

That matters because the `src/` root only joins the target's include path inside the protobuf branch of `core/src/features/rag/CMakeLists.txt:120`:

```cmake
if(RAC_PROTOBUF_RUNTIME_ENABLED OR (...))
    target_compile_definitions(rac_backend_rag PRIVATE RAC_HAVE_PROTOBUF=1)
    target_include_directories(rac_backend_rag PRIVATE
        ${CMAKE_CURRENT_SOURCE_DIR}/../../../src        # <-- only here
```

With protobuf off, that directory is never added and the unguarded include cannot resolve. The other two never had the problem because they sit where the include path exists.

The header's only use is `model_thinking_tags_from_registry` at line 497, which is itself inside the guard, so the include belongs there too. This moves that one line down beside its siblings — no new include directory, no CMake change, and nothing new compiled in either configuration.

Why CI is green today: no workflow configures `RAC_ENABLE_PROTOBUF=OFF`, and `bindings/web/wasm/scripts/build.sh:416` passes `-DRAC_ENABLE_PROTOBUF=ON` explicitly, so the WASM build overrides the EMSCRIPTEN default and never hits it.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

No test added: this is a build-configuration failure, so the build in each configuration *is* the check, and there is no runtime behaviour to assert. Both directions verified.

Protobuf off, which is the failure this fixes:

```
$ cmake -B build-noproto -DRAC_ENABLE_PROTOBUF=OFF -DRAC_BUILD_TESTS=OFF -DCMAKE_BUILD_TYPE=Debug
$ cmake --build build-noproto --target rac_commons -j 8
# before: core/src/features/rag/rac_rag_proto_abi.cpp:30:10: fatal error: ... file not found
# after:
[100%] Linking CXX static library librac_commons.a
[100%] Built target rac_commons
exit=0
```

Protobuf on, unchanged:

```
$ cmake -B build -DRAC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug && cmake --build build -j 10
exit=0, 0 errors
$ ctest --test-dir build -j 10
100% tests passed out of 101
```

On lint: left unchecked rather than imply more than I checked. `core/scripts/lint-cpp.sh` wants the repo's pinned `clang-format` and only Apple `clang-format 21` is available here, which reports pre-existing diffs in this file at lines 343/551/575/601/605/609/668 — none of them my two lines (29 and 48). I did not reformat anything.

No platform boxes ticked: commons-only, verified through the two CMake configurations and the C++ suite on macOS.

## Labels
**SDKs:**
- [x] `Commons` - Changes to shared native code (`core`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved build compatibility by limiting an internal component to configurations with protobuf support enabled.
  * No user-facing features or behavior have changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


---

**CI note:** the red `centralization` is not from this diff. Its only failing step is *"Swift distribution repo (runanywhere-swift) is cut at this release"* — that repo is tagged `0.20.30` while this one has published `v0.20.31`, which `scripts/release/sync-versions.sh:616` documents as failing every PR until the tag is cut. Every other step in that job, including the C++ gates, passed. Nothing to push here; the remedy is cutting the distribution repo.