### PR TITLE
fix(structured-output): an unset include_schema_in_prompt drops the schema from the prompt

### DIFF
--- a/core/src/features/llm/structured_output.cpp
+++ b/core/src/features/llm/structured_output.cpp
@@ -337,8 +337,15 @@ static ProtoStructuredOutputConfig
 structured_output_config_from_options(const runanywhere::v1::StructuredOutputOptions& options) {
     ProtoStructuredOutputConfig converted;
     converted.json_schema = json_schema_from_options(options);
-    converted.config.include_schema_in_prompt =
-        options.include_schema_in_prompt() ? RAC_TRUE : RAC_FALSE;
+    // include_schema_in_prompt is `optional` with rac_default "true", and
+    // converted.config already carries that default from
+    // RAC_STRUCTURED_OUTPUT_DEFAULT. Reading the value unconditionally turned
+    // an absent field into RAC_FALSE and threw the default away, which makes
+    // rac_structured_output_prepare_prompt hand back the prompt untouched.
+    if (options.has_include_schema_in_prompt()) {
+        converted.config.include_schema_in_prompt =
+            options.include_schema_in_prompt() ? RAC_TRUE : RAC_FALSE;
+    }
     refresh_proto_structured_output_config(&converted);
     return converted;
 }

--- a/core/tests/test_structured_output.cpp
+++ b/core/tests/test_structured_output.cpp
@@ -189,6 +189,42 @@ int test_prepare_prompt_proto_uses_generated_contract() {
     return 0;
 }
 
+int test_prepare_prompt_proto_defaults_schema_into_prompt() {
+    // include_schema_in_prompt is `optional bool` with rac_default "true"
+    // (idl/structured_output.proto), so a request that constrains decoding but
+    // says nothing about the prompt must still get the schema rendered in.
+    // Reading the field by value makes an absent one look like an explicit
+    // false, and prepare_prompt then returns `text` verbatim.
+    runanywhere::v1::StructuredOutputParseRequest request;
+    request.set_text("Return a status");
+    auto* options = request.mutable_options();
+    options->set_schema(
+        "{\"type\":\"object\",\"required\":[\"status\"],"
+        "\"properties\":{\"status\":{\"type\":\"string\"}}}");
+    ASSERT_TRUE(!options->has_include_schema_in_prompt());
+
+    std::string bytes;
+    ASSERT_TRUE(request.SerializeToString(&bytes));
+
+    rac_proto_buffer_t result_bytes{};
+    rac_proto_buffer_init(&result_bytes);
+    const rac_result_t rc = rac_structured_output_prepare_prompt_proto(
+        reinterpret_cast<const uint8_t*>(bytes.data()), bytes.size(), &result_bytes);
+    ASSERT_EQ_INT(rc, RAC_SUCCESS);
+    ASSERT_EQ_INT(result_bytes.status, RAC_SUCCESS);
+    ASSERT_TRUE(result_bytes.data != nullptr);
+
+    runanywhere::v1::StructuredOutputPromptResult result;
+    ASSERT_TRUE(result.ParseFromArray(result_bytes.data, static_cast<int>(result_bytes.size)));
+    ASSERT_EQ_INT(result.error().c_abi_code(), RAC_SUCCESS);
+    ASSERT_SUBSTR(result.prepared_prompt().c_str(), "Return a status");
+    ASSERT_SUBSTR(result.prepared_prompt().c_str(), "\"status\"");
+    ASSERT_TRUE(result.prepared_prompt() != "Return a status");
+
+    rac_proto_buffer_free(&result_bytes);
+    return 0;
+}
+
 int test_validate_proto_uses_generated_contract() {
     // StructuredOutputValidationRequest was deleted outright — the sole
     // request envelope shared by parse/validate/prepare-prompt is now
@@ -262,6 +298,8 @@ int main() {
          .fn = test_parse_proto_extracts_array_with_brace_in_string},
         {.name = "prepare_prompt_proto_uses_generated_contract",
          .fn = test_prepare_prompt_proto_uses_generated_contract},
+        {.name = "prepare_prompt_proto_defaults_schema_into_prompt",
+         .fn = test_prepare_prompt_proto_defaults_schema_into_prompt},
         {.name = "validate_proto_uses_generated_contract",
          .fn = test_validate_proto_uses_generated_contract},
     };


### PR DESCRIPTION
## Description

`structured_output_config_from_options` (`core/src/features/llm/structured_output.cpp:337`) throws away the default it was just given:

```cpp
ProtoStructuredOutputConfig converted;                       // config = RAC_STRUCTURED_OUTPUT_DEFAULT
converted.json_schema = json_schema_from_options(options);
converted.config.include_schema_in_prompt =
    options.include_schema_in_prompt() ? RAC_TRUE : RAC_FALSE;   // unset -> RAC_FALSE
```

`include_schema_in_prompt` is `optional` in `idl/structured_output.proto` and its default is documented and generated, not implied:

```proto
// Default true (matches Apple FoundationModels includeSchemaInPrompt).
optional bool include_schema_in_prompt = 1 [(runanywhere.v1.rac_default) = "true"];
```

```c
#define RAC_DEFAULT_STRUCTURED_OUTPUT_OPTIONS_INCLUDE_SCHEMA_IN_PROMPT RAC_TRUE
static const rac_structured_output_config_t RAC_STRUCTURED_OUTPUT_DEFAULT = {
    .json_schema = RAC_NULL, .include_schema_in_prompt = RAC_TRUE};
```

Reading the field by value cannot distinguish "absent" from "explicitly false", so the unconditional assignment replaces that `RAC_TRUE` with `RAC_FALSE` whenever the caller did not set the flag. That is not a cosmetic difference, because it is exactly the flag `rac_structured_output_prepare_prompt` branches on:

```cpp
// If no config or schema not included in prompt, return original
if (config == nullptr || config->include_schema_in_prompt == 0) {
    ... memcpy(result, original_prompt, len + 1);   // prompt returned verbatim
```

So `rac_structured_output_prepare_prompt_proto` given `options { schema: "..." }` and no `include_schema_in_prompt` hands the prompt straight back: no JSON instructions, no schema, no error. The one call whose entire job is to render the schema into the prompt silently does nothing.

The same field is read correctly one file over, on the generate path, which is what makes this an inconsistency rather than a judgement call:

```cpp
// llm_module.cpp:2443
structured_config.include_schema_in_prompt =
    so.has_include_schema_in_prompt() ? (so.include_schema_in_prompt() ? RAC_TRUE : RAC_FALSE)
                                      : RAC_TRUE;
```

The fix guards on presence and lets `RAC_STRUCTURED_OUTPUT_DEFAULT` stand when the field is absent, so an explicit `false` is still honoured.

Scope, stated plainly: every bundled SDK sets this flag explicitly today (`MappingOptions.kt:125` `= true`, Swift `StructuredOutputProto+Helpers.swift:21` default `true`, Web `RunAnywhere+StructuredOutput.ts:119` `?? true`, RN `Options.ts:135`), so I am not claiming a user-visible regression through the SDK surfaces. This is the exported C/proto ABI disagreeing with its own generated default and with its sibling reader, which is reachable for any host calling the ABI directly and is what the three call sites inside `structured_output.cpp` pass through.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [x] Added/updated tests for changes

Added `prepare_prompt_proto_defaults_schema_into_prompt` to `core/tests/test_structured_output.cpp`, alongside the existing `prepare_prompt_proto_uses_generated_contract` which covers the explicit-`true` case. It sets a schema, asserts the flag really is absent, and asserts the prepared prompt is not the input echoed back.

```
$ cmake -B build -DRAC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug && cmake --build build -j 10
$ ctest --test-dir build -j 10
100% tests passed out of 101
```

Fails on the unfixed code. Verified by reverting only the presence guard and confirming the relink happened first:

```
[100%] Linking CXX executable test_structured_output
[structured_output] prepare_prompt_proto_defaults_schema_into_prompt ... ASSERT FAIL @
  core/tests/test_structured_output.cpp:221: '"status"' not found in 'Return a status'
```

That failure message is the bug in one line: the returned prompt is the input, unchanged.

On lint: left unchecked because `core/scripts/lint-cpp.sh` needs the repo's pinned `clang-format` and only Apple `clang-format 21` is available here. Both files this PR touches happen to be completely clean under it (zero diff hunks), so there is no formatting drift either way.

Both changed lines sit inside `#if defined(RAC_HAVE_PROTOBUF)`. I could not complete a `-DRAC_ENABLE_PROTOBUF=OFF` build to confirm the other configuration, because that configuration is broken on current `main` for an unrelated reason in the RAG backend (`rac_rag_proto_abi.cpp:30`, fatal include error). That is #824, filed separately rather than folded in here.

No platform boxes ticked: commons-only, exercised through the C++ suite on macOS.

## Labels
**SDKs:**
- [x] `Commons` - Changes to shared native code (`core`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)



---

**CI note:** the red `centralization` is not from this diff. Its only failing step is *"Swift distribution repo (runanywhere-swift) is cut at this release"* — that repo is tagged `0.20.30` while this one has published `v0.20.31`, which `scripts/release/sync-versions.sh:616` documents as failing every PR until the tag is cut. Every other step in that job, including the C++ gates, passed. Nothing to push here; the remedy is cutting the distribution repo.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved the default behavior of including schemas in structured-output prompts when the option is not explicitly specified.
  * Structured-output requests now correctly include schema details in prepared prompts by default.

* **Tests**
  * Added coverage verifying schema inclusion when the corresponding option is omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->