### PR TITLE
fix(tool-calling): honour presence on ToolCallingOptions.auto_execute

### DIFF
--- a/core/src/features/llm/tool_calling.cpp
+++ b/core/src/features/llm/tool_calling.cpp
@@ -1867,25 +1867,14 @@ tool_calling_options_from_proto(const runanywhere::v1::ToolCallingOptions& proto
     ProtoToolCallingOptions converted;
     converted.tools_json = tool_definitions_proto_to_json(proto);
 
-    // PR #605 review issue #7: `converted.options` starts from
-    // RAC_TOOL_CALLING_OPTIONS_DEFAULT (auto_execute = true); the missing
-    // `else` here meant a caller's explicit `auto_execute = false` on the
-    // wire was silently discarded and this always resolved to true. Safe to
-    // fix unconditionally: `converted.options.auto_execute` is not read by
-    // anything downstream of this function today (only `tools_json`,
-    // `system_prompt`, and `format` feed the prompt-formatting callers of
-    // `tool_calling_options_from_proto`), so trusting the wire value
-    // directly changes no observed behavior while fixing the function's own
-    // contract for whenever this does get consumed.
-    //
-    // ToolCallingOptions.auto_execute is a plain (non-optional) proto3 bool
-    // with no wire presence, unlike the sibling
-    // ToolCallingSessionCreateRequest.auto_execute (`optional`, defaults to
-    // true only when *absent* -- see tool_calling_run_loop.cpp /
-    // tool_calling_session.cpp). "Explicitly false" and "field omitted" are
-    // therefore indistinguishable on this specific field; restoring real
-    // presence would need an IDL change, out of scope here.
-    converted.options.auto_execute = proto.auto_execute() ? RAC_TRUE : RAC_FALSE;
+    // `converted.options` starts from RAC_TOOL_CALLING_OPTIONS_DEFAULT
+    // (auto_execute = true), and ToolCallingOptions.auto_execute is `optional`
+    // (idl/tool_calling.proto), so presence is what distinguishes "caller said
+    // false" from "caller said nothing". Same read as the two other consumers
+    // of this message, tool_calling_run_loop.cpp and tool_calling_session.cpp.
+    if (proto.has_auto_execute()) {
+        converted.options.auto_execute = proto.auto_execute() ? RAC_TRUE : RAC_FALSE;
+    }
     // ToolCallingOptions.temperature/max_tokens were deleted outright
     // (idl/tool_calling.proto, llm-tool-options-no-shadow): they duplicated
     // the enclosing LLMGenerationOptions.temperature/max_output_tokens in


### PR DESCRIPTION
## Description

`tool_calling_options_from_proto` reads `auto_execute` by value:

```cpp
converted.options.auto_execute = proto.auto_execute() ? RAC_TRUE : RAC_FALSE;
```

`converted.options` starts from `RAC_TOOL_CALLING_OPTIONS_DEFAULT`, whose `auto_execute` is `1`. A proto3 `optional` field that was never set reads back as `false`, so the assignment overwrites that default and "the caller said nothing" becomes "the caller said false".

What makes this worth fixing rather than a judgement call is the 8-line comment sitting directly above it, which justifies the value read like this:

> ToolCallingOptions.auto_execute is a plain (non-optional) proto3 bool with no wire presence, unlike the sibling ToolCallingSessionCreateRequest.auto_execute (`optional`, ...). "Explicitly false" and "field omitted" are therefore indistinguishable on this specific field; restoring real presence would need an IDL change, out of scope here.

That IDL change has already happened. On `main`:

```
$ grep -n auto_execute idl/tool_calling.proto
181:    optional bool auto_execute       = 3;
```

with the field's own documentation stating the opposite of the comment:

```proto
// Unset = true: the SDK runs your registered executor and closes the
// loop. Explicit false returns the parsed ToolCall without invoking it.
// Presence-tracked so "unset" is never confused with "explicitly false".
```

`auto_execute` appears in exactly one message, so the `ToolCallingSessionCreateRequest.auto_execute` the comment contrasts against no longer exists. And the two other consumers of this same `ToolCallingOptions` already read it the intended way:

```
core/src/features/llm/tool_calling_run_loop.cpp:504: ctx.auto_execute     = req_options.has_auto_execute() ? req_options.auto_execute() : true;
core/src/features/llm/tool_calling_session.cpp:890:  session->auto_execute = req_options.has_auto_execute() ? req_options.auto_execute() : true;
```

So this is one reader out of three disagreeing, on the strength of a note that documents a constraint the schema no longer has. The change guards on presence and deletes the stale note, which is a net removal of 11 lines.

Scope, stated plainly rather than dressed up: the comment's other claim, that `converted.options.auto_execute` is not consumed downstream today, still holds. I checked, and the prompt-formatting callers use `tools_json`, `system_prompt` and `format` only. So this fixes the function's contract and removes a note that would actively mislead the next person to touch it, and I am not claiming a user-visible behaviour change.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

No test added, deliberately. A test here could only assert on a value nothing currently reads, so it would pin the internals of one static function rather than any behaviour, and it would not fail for the reason the fix exists. If `converted.options.auto_execute` gains a real consumer, that consumer is where the regression test belongs.

```
$ cmake -B build -DRAC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug && cmake --build build -j 10
build exit=0, 0 errors
$ ctest --test-dir build -j 10
100% tests passed out of 103
```

Built against current `main` (`caed2daf4`, ABI v10).

On lint: left unchecked because `core/scripts/lint-cpp.sh` needs the repo's pinned `clang-format` and only Apple `clang-format 21` is available here. It reports pre-existing diffs in this file at lines 55, 1719, 2310, 2414 and 2418, none of them in the 1870-1877 range this PR touches, so the diff adds no formatting drift.

The edited lines are inside `#if defined(RAC_HAVE_PROTOBUF)`, so protobuf-off builds do not compile them.

No platform boxes ticked: commons-only, exercised through the C++ suite on macOS.

## Labels
**SDKs:**
- [x] `Commons` - Changes to shared native code (`core`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved explicitly disabled automatic tool execution settings.
  * Retained the default automatic execution behavior when no setting is provided.
  * Ensured tool-calling configuration is handled consistently across execution contexts.
  * Improved reliability when applying tool execution preferences supplied through configuration.
  * Prevented explicitly setting automatic execution to false from being overlooked.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->