### PR TITLE
docs(abi): the plugin ABI history stops at 9u but the define says 11u

### DIFF
--- a/core/include/rac/plugin/rac_plugin_entry.h
+++ b/core/include/rac/plugin/rac_plugin_entry.h
@@ -100,6 +100,19 @@ extern "C" {
  *                 Engines compiled against v8 are rejected until rebuilt;
  *                 NULL `get_stream_token_counts` means counts must be marked
  *                 estimated. Engine-vtable reserved_slot_3 is unchanged.
+ *  10u — promoted reserved primitive wire value 12 to image embedding
+ *                 (`RAC_PRIMITIVE_EMBED_IMAGE`) and renamed engine-vtable
+ *                 reserved_slot_3 -> `image_embedding_ops`, same binary
+ *                 offset, exactly as rerank_ops was promoted in v8. Engines
+ *                 compiled against v9 are rejected until rebuilt; a NULL
+ *                 `image_embedding_ops` means the engine does not serve the
+ *                 primitive.
+ *  11u — promoted reserved primitive wire value 13 to optical character
+ *                 recognition (`RAC_PRIMITIVE_OCR`) and renamed engine-vtable
+ *                 reserved_slot_4 -> `ocr_ops`, same binary offset, so the
+ *                 17-pointer tail is unchanged and only the ABI version gates
+ *                 it. Engines compiled against v10 are rejected until
+ *                 rebuilt.
  */
 #define RAC_PLUGIN_API_VERSION 11u
 


### PR DESCRIPTION
## Description

`rac_plugin_entry.h` carries a version-by-version ABI history above the define. Every bump from `3u` to `9u` has an entry saying what changed and, crucially, why a plugin built against the previous version is now rejected:

```
 *   8u — revived reranking as a first-class primitive: promoted reserved
 *                 primitive wire value 11 to `RAC_PRIMITIVE_RERANK` and
 *                 renamed vtable reserved_slot_2 -> `rerank_ops` ...
 *   9u — LLM streaming token accounting: ... Engines compiled against v8
 *                 are rejected until rebuilt ...
 */
#define RAC_PLUGIN_API_VERSION 10u
```

v0.20.32 bumped the define to `10u` and did not add the matching entry, so the list runs 3, 4, 5, 6, 7, 8, 9 and then stops one short of the current value.

That is worth a line because of what this block is for. When an engine fails to register with `RAC_ERROR_ABI_VERSION_MISMATCH`, this is the file that tells its author what the new version requires. Right now a v9 engine is rejected and the document explaining every previous rejection is silent about this one.

The entry describes the v10 change and is sourced from the repo, not written from memory. `rac_engine_vtable.h:184` already documents the slot side of it:

```c
/** Image embedding (`RAC_PRIMITIVE_EMBED_IMAGE`). Promoted from reserved_slot_3 in ABI v10 —
 *  occupies the same binary offset, so the struct layout stayed stable across the promotion,
 *  exactly as rerank_ops did in v8. */
const struct rac_image_embedding_service_ops* image_embedding_ops;
```

and `rac_primitive.h:57` the wire side (`RAC_PRIMITIVE_EMBED_IMAGE = 12`, "Promoted from RAC_PRIMITIVE_RESERVED_12 in ABI v10").

Comment only, no code. I deliberately did not touch anything else: the functional side of the v10 promotion is complete, the `RAC_PRIMITIVE_TABLE` X-macro already carries its `X(RAC_PRIMITIVE_EMBED_IMAGE, image_embedding_ops, "embed_image")` row, so dispatch, capability reporting and manifest validation are all generated correctly. Only the history note was missing.

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

No test: this changes a block comment. Built anyway to confirm the header still compiles everywhere it is included.

```
$ cmake --build build -j 10
build exit=0, 0 errors
```

On lint: unchecked because `core/scripts/lint-cpp.sh` requires the repo's pinned `clang-format` and only Apple `clang-format 21` is available here.

## Labels
**SDKs:**
- [x] `Commons` - Changes to shared native code (`core`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added support for image embedding and optical character recognition primitives in API versions 10u and 11u.
  * Engines may omit either capability when the corresponding operations are unavailable.

* **Bug Fixes**
  * Updated registration compatibility requirements: engines built against API versions 9u or 10u must be rebuilt to work with API version 11u.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->