### PR TITLE
fix(solutions): RAG vector_store and BM25/RRF settings are parsed then dropped

### DIFF
--- a/core/src/solutions/solution_converter.cpp
+++ b/core/src/solutions/solution_converter.cpp
@@ -108,6 +108,24 @@ void expand_rag(const runanywhere::v1::RAGConfig& cfg, PipelineSpec* out) {
     if (!cfg.rerank_model_id().empty()) {
         (*retrieve->mutable_params())["rerank_model_id"] = cfg.rerank_model_id();
     }
+    // vector_store selects the backend that vector_store_path points into, so
+    // forwarding the path while dropping the type left the two halves of one
+    // setting split. Retrieval tuning goes the same way: config_loader.cpp
+    // parses bm25_k1/bm25_b/rrf_k out of the solution YAML, and without these
+    // they stop at the proto.
+    if (cfg.vector_store() != runanywhere::v1::VECTOR_STORE_UNSPECIFIED) {
+        (*retrieve->mutable_params())["vector_store"] =
+            runanywhere::v1::VectorStore_Name(cfg.vector_store());
+    }
+    if (cfg.bm25_k1() > 0.0f) {
+        (*retrieve->mutable_params())["bm25_k1"] = std::to_string(cfg.bm25_k1());
+    }
+    if (cfg.bm25_b() > 0.0f) {
+        (*retrieve->mutable_params())["bm25_b"] = std::to_string(cfg.bm25_b());
+    }
+    if (cfg.rrf_k() > 0) {
+        (*retrieve->mutable_params())["rrf_k"] = std::to_string(cfg.rrf_k());
+    }
     (void)llm;
 
     add_edge(out, "query.out", "retrieve.in");

--- a/core/tests/test_solution_runner.cpp
+++ b/core/tests/test_solution_runner.cpp
@@ -1091,6 +1091,50 @@ TEST(rag_solution_compiles) {
 }
 
 // ---------------------------------------------------------------------------
+// 10b. RAG retrieval tuning knobs reach the graph.
+//      config_loader.cpp parses vector_store / bm25_k1 / bm25_b / rrf_k out of
+//      the solution YAML. vector_store is the sharpest of the four: dropping
+//      it while forwarding vector_store_path splits one setting in half.
+// ---------------------------------------------------------------------------
+TEST(rag_retrieval_params_reach_the_retrieve_operator) {
+    ScopedSolutionStandins standins;
+
+    SolutionConfig cfg;
+    auto* rag = cfg.mutable_rag();
+    rag->set_embed_model_id("bge-small");
+    rag->set_llm_model_id("qwen3-4b");
+    rag->set_vector_store(runanywhere::v1::VECTOR_STORE_USEARCH);
+    rag->set_vector_store_path("/tmp/store");
+    rag->set_bm25_k1(1.5f);
+    rag->set_bm25_b(0.6f);
+    rag->set_rrf_k(30);
+
+    SolutionRunner runner(cfg);
+    CHECK(runner.start() == RAC_SUCCESS);
+
+    const runanywhere::v1::OperatorSpec* retrieve = nullptr;
+    for (const auto& op : runner.spec().operators()) {
+        if (op.name() == "retrieve")
+            retrieve = &op;
+    }
+    CHECK(retrieve != nullptr);
+    const auto& params = retrieve->params();
+    // The path was already forwarded; assert it and the type travel together.
+    CHECK(params.find("vector_store_path") != params.end());
+    const auto store = params.find("vector_store");
+    CHECK(store != params.end());
+    CHECK(store->second == "VECTOR_STORE_USEARCH");
+    CHECK(params.find("bm25_k1") != params.end());
+    CHECK(params.find("bm25_b") != params.end());
+    const auto rrf = params.find("rrf_k");
+    CHECK(rrf != params.end());
+    CHECK(rrf->second == "30");
+
+    runner.close_input();
+    runner.wait();
+}
+
+// ---------------------------------------------------------------------------
 // 11. C ABI end-to-end: proto-bytes path.
 // ---------------------------------------------------------------------------
 TEST(c_abi_proto_bytes_lifecycle) {
@@ -1271,6 +1315,7 @@ int main() {
     run_test_context_build_builtin_applies_prompt_template();
     run_test_voice_agent_solution_compiles();
     run_test_rag_solution_compiles();
+    run_test_rag_retrieval_params_reach_the_retrieve_operator();
     run_test_c_abi_proto_bytes_lifecycle();
     run_test_c_abi_yaml_solution_lifecycle();
     run_test_c_abi_yaml_pipeline_lifecycle();

--- a/core/tests/test_solution_runner.cpp
+++ b/core/tests/test_solution_runner.cpp
@@ -1120,12 +1120,21 @@ TEST(rag_retrieval_params_reach_the_retrieve_operator) {
     CHECK(retrieve != nullptr);
     const auto& params = retrieve->params();
     // The path was already forwarded; assert it and the type travel together.
-    CHECK(params.find("vector_store_path") != params.end());
+    const auto path = params.find("vector_store_path");
+    CHECK(path != params.end());
+    CHECK(path->second == "/tmp/store");
     const auto store = params.find("vector_store");
     CHECK(store != params.end());
     CHECK(store->second == "VECTOR_STORE_USEARCH");
-    CHECK(params.find("bm25_k1") != params.end());
-    CHECK(params.find("bm25_b") != params.end());
+    // Values, not just presence: a converter that forwarded the wrong number
+    // would satisfy a presence-only check. Compared against std::to_string so
+    // the assertion tracks the converter's own float formatting.
+    const auto bm25_k1 = params.find("bm25_k1");
+    CHECK(bm25_k1 != params.end());
+    CHECK(bm25_k1->second == std::to_string(1.5f));
+    const auto bm25_b = params.find("bm25_b");
+    CHECK(bm25_b != params.end());
+    CHECK(bm25_b->second == std::to_string(0.6f));
     const auto rrf = params.find("rrf_k");
     CHECK(rrf != params.end());
     CHECK(rrf->second == "30");


### PR DESCRIPTION
## Description

Same defect as #836, in the RAG expander, four fields wide. Found by comparing every field `config_loader.cpp` parses against every field each `expand_*` forwards.

`populate_rag` parses eleven knobs. `expand_rag` forwards seven and silently drops four:

| parsed by config_loader | forwarded by expand_rag |
|---|---|
| `embed_model_id`, `llm_model_id`, `rerank_model_id` | yes |
| `retrieve_k`, `rerank_top` | yes |
| `vector_store_path` | yes |
| `prompt_template` | yes |
| `vector_store` | **no** |
| `bm25_k1` | **no** |
| `bm25_b` | **no** |
| `rrf_k` | **no** |

Operator params are the only converter-to-operator channel, so all four are read out of the YAML, stored on the proto, and discarded.

**`vector_store` is the clearest of the four.** It selects the backend that `vector_store_path` points into (`VECTOR_STORE_USEARCH` vs `VECTOR_STORE_PGVECTOR`), and the path is already forwarded on the line above it. Forwarding half of one setting and dropping the other half is not a defensible split.

The other three are retrieval tuning that the repo does implement, just not configurably:

```c
// core/src/features/rag/bm25_index.h:33
static constexpr float k1_ = 1.2f;
static constexpr float b_  = 0.75f;

// core/src/features/rag/rag_fusion.cpp:17
static constexpr float kRRFConstant = 60.0f;
```

All four now ride the `retrieve` op, beside `k` / `rerank_top` / `vector_store_path`, guarded so an unset field stays unset.

**What this does and does not claim.** It makes the four reachable on the same terms as every other knob, so a host-supplied `retrieve` factory can honour them. It does **not** make the in-tree BM25/RRF path configurable: those values are `static constexpr` above, and changing that is retrieval-math work and a separate decision. I would rather forward them and say this plainly than either drop them silently or imply I made them live.

Same reasoning as #836 on the missing in-tree consumer: this file's header states these expansions "intentionally reference engine-backed operator type names without installing factories for them", so operators are host-supplied and interpret params themselves. `prompt_template` and `rerank_top` have no in-tree reader either.

`VectorStore_Name()` is used for the enum so the param carries the canonical generated spelling rather than an integer a host would have to map back.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [x] Added/updated tests for changes

Added `rag_retrieval_params_reach_the_retrieve_operator` to `core/tests/test_solution_runner.cpp`, beside the existing `rag_solution_compiles`. It sets all four plus `vector_store_path`, then asserts the path and the type travel together and that the three tuning values land with their given values.

```
$ cmake -B build -DRAC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug && cmake --build build -j 10
build exit=0
$ ctest --test-dir build -j 10
100% tests passed out of 101
```

Fails on the unfixed code. Verified by removing only the forwarding block, with the relink confirmed first:

```
[100%] Linking CXX executable test_solution_runner
[FAIL] core/tests/test_solution_runner.cpp:1125 store != params.end()
```

On lint: unchecked because `core/scripts/lint-cpp.sh` needs the repo's pinned `clang-format` and only Apple `clang-format 21` is available here. Both files are completely clean under it (zero diff hunks).

The edited block is inside `#if defined(RAC_HAVE_PROTOBUF)`; protobuf-off builds do not compile it.

No platform boxes ticked: commons-only, exercised through the C++ suite on macOS.

## Labels
**SDKs:**
- [x] `Commons` - Changes to shared native code (`core`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - RAG retrieval configurations now correctly pass vector store and ranking settings to retrieval, including BM25 and reciprocal rank fusion parameters.
  - Non-default retrieval tuning values are preserved when solutions are expanded.
  - Configured vector store paths and ranking values are now consistently honored during retrieval, improving the accuracy and predictability of RAG results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->