### PR TITLE
fix(flutter): generateStructured never renders the schema into the prompt

### DIFF
--- a/bindings/flutter/packages/runanywhere/lib/public/extensions/runanywhere_structured_output.dart
+++ b/bindings/flutter/packages/runanywhere/lib/public/extensions/runanywhere_structured_output.dart
@@ -48,7 +48,10 @@ class RunAnywhereStructuredOutput {
     if (!DartBridge.isInitialized) throw SDKException.notInitialized();
     final generation = await generateWithStructuredOutput(
       prompt: prompt,
-      structuredOutput: StructuredOutputOptions(schema: schema),
+      structuredOutput: StructuredOutputOptions(
+        schema: schema,
+        includeSchemaInPrompt: true,
+      ),
       options: options,
     );
     return RunAnywhereLLM.shared.extractStructuredOutput(


### PR DESCRIPTION
## Description

`RunAnywhereStructuredOutput.generateStructured` asks for structured output and then throws the schema away before the model sees it.

It builds the options with only the schema:

```dart
final generation = await generateWithStructuredOutput(
  prompt: prompt,
  structuredOutput: StructuredOutputOptions(schema: schema),   // includeSchemaInPrompt unset
  options: options,
);
```

and `generateWithStructuredOutput`, twenty lines below, gates the whole prompt-preparation step on that field:

```dart
if (structuredOutput.includeSchemaInPrompt) {
  final result = DartBridgeStructuredOutput.shared.preparePrompt(...);
  ...
  effectiveOptions.systemPrompt = result.systemPrompt;
}
```

`include_schema_in_prompt` is `optional bool` in `idl/structured_output.proto`, documented as "Default true (matches Apple FoundationModels includeSchemaInPrompt)" and generated with `RAC_DEFAULT_STRUCTURED_OUTPUT_OPTIONS_INCLUDE_SCHEMA_IN_PROMPT RAC_TRUE`. An unset proto3 `optional bool` reads back as `false`, so the branch is skipped: no schema is rendered into the prompt and no system prompt is set. The model is asked for JSON matching a schema it was never shown.

This is an inconsistency inside this SDK, not a judgement call. The two other places that build these options for the prepare-prompt path both pass the flag:

```dart
// lib/public/api/types/options.dart:169
StructuredOutputOptions(schema: schema, includeSchemaInPrompt: true);

// lib/public/extensions/runanywhere_structured_output.dart:113
final options = StructuredOutputOptions(
  schema: jsonSchema,
  includeSchemaInPrompt: true,
);
```

and so does every other SDK: Web `includeSchemaInPrompt: options.includeSchemaInPrompt ?? true`, Swift `includeSchemaInPrompt: Bool = true`, Kotlin `include_schema_in_prompt = true`, React Native `includeSchemaInPrompt: true`. Flutter's `generateStructured` is the one path that omits it.

The fix is to pass it, matching those siblings.

I left `DartBridgeStructuredOutput.makeParseRequest` alone even though it also omits the field: it builds requests for parse and validate, and only prepare-prompt consults the flag, so setting it there would be noise.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

**I could not build or run anything for this, and would rather say so than imply otherwise.** `dart`, `flutter` and `protoc-gen-dart` are all absent from this machine, and the generated `*.pb.dart` are gitignored, so there was no way to compile the change or exercise the path here. I am relying on this PR's `flutter-pubget` job to compile it.

What I did verify, by reading:

- The construction site omits the field and the consuming branch reads it as a value, twenty lines apart in one file.
- Two sibling construction sites in this same SDK pass `includeSchemaInPrompt: true`, so the change matches existing local convention rather than inventing one.
- The same function already uses presence accessors (`result.hasError()`, `result.hasSystemPrompt()`), so the distinction between "set" and "unset" is understood in this code; this read is the exception.

No test added: a regression test here needs the generated Dart protos plus a Flutter test host, neither of which I can produce. If you want one I am happy to add it once you tell me where Flutter-side tests for this live.

Related but independent: #825 fixes the commons side, where `rac_structured_output_prepare_prompt` returns the prompt verbatim when the flag is unset. That one is about the C ABI honouring its own default; this one is about a Flutter caller never setting it. Either fix alone leaves the other path wrong, which is why they are separate PRs.

## Labels
**SDKs:**
- [x] `Flutter SDK` - Changes to Flutter SDK (`bindings/flutter`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Structured output generation now includes the provided schema in the prompt by default, improving consistency and reliability when generating schema-conforming responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->