### PR TITLE
fix(embeddings): an explicit normalize=false never reaches the engine

### DIFF
--- a/core/src/foundation/rac_proto_adapters.cpp
+++ b/core/src/foundation/rac_proto_adapters.cpp
@@ -849,11 +849,13 @@ bool rac_embeddings_options_from_proto(const ::runanywhere::v1::EmbeddingsOption
         return false;
     *out = RAC_EMBEDDINGS_OPTIONS_DEFAULT;
 
-    // EmbeddingsOptions.normalize is a plain proto3 bool with no unset sentinel;
-    // the backends default to L2 unit vectors (EmbeddingsConfiguration.normalize
-    // rac_default = true), so an explicit true and the proto default both resolve
-    // to L2 here. Disabling normalization is a component-configuration concern.
-    out->normalize = RAC_EMBEDDINGS_NORMALIZE_L2;
+    // EmbeddingsOptions.normalize is `optional` with rac_default "true", so
+    // presence separates "caller said false" from "caller said nothing"
+    // (embeddings_options.proto: "Unset = true. false returns the raw pooled
+    // vector"). Unset keeps the L2 that RAC_EMBEDDINGS_OPTIONS_DEFAULT already
+    // set; an explicit false is the only way to ask for the raw vector.
+    out->normalize = (!in.has_normalize() || in.normalize()) ? RAC_EMBEDDINGS_NORMALIZE_L2
+                                                             : RAC_EMBEDDINGS_NORMALIZE_NONE;
 
     switch (in.pooling()) {
         case ::runanywhere::v1::EMBEDDINGS_POOLING_STRATEGY_UNSPECIFIED:

--- a/core/tests/test_advanced_modality_proto_abi.cpp
+++ b/core/tests/test_advanced_modality_proto_abi.cpp
@@ -922,6 +922,25 @@ int test_embeddings_options_mapping() {
     CHECK(raw.truncate == 0, "explicit truncate=false maps exactly");
     CHECK(raw.batch_size == 32, "embedding batch size maps exactly");
 
+    // normalize is `optional` with rac_default "true": "Unset = true. false
+    // returns the raw pooled vector" (embeddings_options.proto). Explicit false
+    // is the only way to ask for the raw vector, so it has to survive the hop.
+    runanywhere::v1::EmbeddingsOptions no_normalize;
+    no_normalize.set_normalize(false);
+    raw = RAC_EMBEDDINGS_OPTIONS_DEFAULT;
+    CHECK(rac::foundation::rac_embeddings_options_from_proto(no_normalize, &raw),
+          "EmbeddingsOptions with normalize=false maps");
+    CHECK(raw.normalize == RAC_EMBEDDINGS_NORMALIZE_NONE,
+          "an explicit normalize=false reaches the C ABI as NONE");
+
+    runanywhere::v1::EmbeddingsOptions yes_normalize;
+    yes_normalize.set_normalize(true);
+    raw = RAC_EMBEDDINGS_OPTIONS_DEFAULT;
+    CHECK(rac::foundation::rac_embeddings_options_from_proto(yes_normalize, &raw),
+          "EmbeddingsOptions with normalize=true maps");
+    CHECK(raw.normalize == RAC_EMBEDDINGS_NORMALIZE_L2,
+          "an explicit normalize=true stays L2");
+
     runanywhere::v1::EmbeddingsOptions defaults;
     raw = RAC_EMBEDDINGS_OPTIONS_DEFAULT;
     CHECK(rac::foundation::rac_embeddings_options_from_proto(defaults, &raw),


### PR DESCRIPTION
## Description

`rac_embeddings_options_from_proto` cannot express "do not normalize", so a caller asking for raw pooled vectors gets L2-normalized ones instead.

The adapter hardcodes the mode:

```cpp
// EmbeddingsOptions.normalize is a plain proto3 bool with no unset sentinel;
// the backends default to L2 unit vectors ...
// Disabling normalization is a component-configuration concern.
out->normalize = RAC_EMBEDDINGS_NORMALIZE_L2;
```

The premise in that comment is not true of the current schema. `normalize` is `optional`, so it is presence-tracked and `has_normalize()` separates "caller said false" from "caller said nothing":

```proto
// L2-normalize every vector to unit length (what cosine search expects).
// Unset = true. false returns the raw pooled vector.
optional bool normalize = 4 [(runanywhere.v1.rac_default) = "true"];
```

"false returns the raw pooled vector" is a documented behaviour with no way to reach it: every `EmbeddingsOptions` that crosses this adapter comes out as L2. The C ABI is not the limitation either, since the enum already carries the value the adapter never emits:

```c
RAC_EMBEDDINGS_NORMALIZE_NONE = 0, /**< No normalization */
```

The fix reads presence and leaves the default alone:

```cpp
out->normalize = (!in.has_normalize() || in.normalize()) ? RAC_EMBEDDINGS_NORMALIZE_L2
                                                         : RAC_EMBEDDINGS_NORMALIZE_NONE;
```

Unset stays L2, which is both `RAC_EMBEDDINGS_OPTIONS_DEFAULT.normalize` (already assigned two lines above) and the documented "Unset = true", so nothing changes for callers that do not set the field. Only an explicit `false` behaves differently, which is the point.

This is the same shape as #828: a value read justified by a comment describing a schema that has since changed, with the neighbouring line in this very function already doing it correctly (`out->truncate = in.has_truncate() ? ... : -1`).

I have not touched the second half of that comment, that disabling normalization is "a component-configuration concern". If the intent is genuinely that this knob should only exist at component-configuration level, then the field and its documentation are the things to change, and I would rather you make that call than have me delete a per-call option that reads as supported.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [x] Added/updated tests for changes

Extended `test_embeddings_options_mapping` in `core/tests/test_advanced_modality_proto_abi.cpp` with both explicit cases. The two assertions already there never set `normalize`, so they only ever covered the unset path and still pass unchanged.

```
$ cmake -B build -DRAC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug && cmake --build build -j 10
build exit=0
$ ctest --test-dir build -j 10
100% tests passed out of 101
```

Fails on the unfixed code. Verified by restoring the hardcoded assignment, with the relink confirmed first:

```
[100%] Linking CXX executable test_advanced_modality_proto_abi
FAIL: an explicit normalize=false reaches the C ABI as NONE
      (...test_advanced_modality_proto_abi.cpp:934) raw.normalize == RAC_EMBEDDINGS_NORMALIZE_NONE
```

On lint: unchecked because `core/scripts/lint-cpp.sh` wants the repo's pinned `clang-format` and only Apple `clang-format 21` is here. `rac_proto_adapters.cpp` is fully clean under it, including my continuation-line alignment, which I corrected after it flagged a one-space difference.

The edited function is inside `#if defined(RAC_HAVE_PROTOBUF)`; protobuf-off builds do not compile it.

No platform boxes ticked: commons-only, exercised through the C++ suite on macOS.

## Labels
**SDKs:**
- [x] `Commons` - Changes to shared native code (`core`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Embedding options now respect an explicitly disabled normalization setting, returning raw pooled vectors when selected.
  * Default and enabled normalization behavior continues to use L2 normalization.

* **Tests**
  * Added coverage for enabled, disabled, and default embedding normalization settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->