### PR TITLE
fix(server): reflect requested CORS headers like the hosted gateway

### DIFF
--- a/core/src/server/http_server.cpp
+++ b/core/src/server/http_server.cpp
@@ -291,7 +291,15 @@ void HttpServer::setupCors() {
         [origins](const httplib::Request& req, httplib::Response& res) {
             res.set_header("Access-Control-Allow-Origin", origins);
             res.set_header("Access-Control-Allow-Methods", "GET, POST, OPTIONS");
-            res.set_header("Access-Control-Allow-Headers", "Content-Type, Authorization");
+            // Reflect whatever headers the browser asked to send, the way the
+            // hosted LiteLLM gateway does (verified against the dev deployment
+            // 2026-09-06). A pinned allowlist silently breaks any client that
+            // adds a benign header — the console's X-RA-Harness attribution
+            // header was the one that exposed this. CORS is not an auth
+            // boundary; the Authorization check happens in the handlers.
+            std::string requested = req.get_header_value("Access-Control-Request-Headers");
+            res.set_header("Access-Control-Allow-Headers",
+                           requested.empty() ? "Content-Type, Authorization" : requested);
 
             // Handle preflight
             if (req.method == "OPTIONS") {


### PR DESCRIPTION
Found while wiring the console's local end-to-end sim against `wally serve`.

The server pins `Access-Control-Allow-Headers` to `Content-Type, Authorization`, so any browser client that sends one more header fails preflight and never reaches a handler. The console's `X-RA-Harness` attribution header (monorepo, CON-29) was the one that exposed it: the same request passes against the hosted LiteLLM gateway, which reflects `Access-Control-Request-Headers` — verified live against the dev deployment on 2026-09-06.

This makes the local server behave like the gateway: reflect what the browser asked to send, fall back to the old pair when no preflight header is present. CORS is not an auth boundary — the Authorization check stays in the handlers; this only stops benign headers from killing requests before they reach it.

Verified: the changed logic compiled and exercised against cpp-httplib directly (the full core build needs generated headers this environment does not produce). A follow-up kit release is what actually delivers this to `wally serve`, since the CLI consumes the pinned prebuilt kit.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CORS preflight handling by allowing requested headers to be reflected correctly.
  * Retained the default `Content-Type` and `Authorization` headers when no specific headers are requested.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->