### PR TITLE
fix(rag): rerank snippets are cut mid-UTF-8 character

### DIFF
--- a/core/src/features/rag/rag_rerank.cpp
+++ b/core/src/features/rag/rag_rerank.cpp
@@ -30,6 +30,17 @@ std::string flatten_and_truncate(const std::string& text, size_t max_chars) {
             break;
         out.push_back((c == '\n' || c == '\r' || c == '\t') ? ' ' : c);
     }
+    // Back off to a UTF-8 character boundary. The budget is a byte count, so
+    // a passage in any non-Latin script is cut mid-sequence and the snippet
+    // handed to the scorer ends in an incomplete character. The whitespace
+    // substitution above is 1 byte for 1 byte, so offsets into `out` and
+    // `text` still line up. Same walk as rag_backend.cpp's source preview.
+    size_t cut = out.size();
+    while (cut > 0 && cut < text.size() &&
+           (static_cast<unsigned char>(text[cut]) & 0xC0) == 0x80) {
+        --cut;
+    }
+    out.resize(cut);
     return out;
 }
 

--- a/core/src/features/rag/rag_rerank.cpp
+++ b/core/src/features/rag/rag_rerank.cpp
@@ -36,8 +36,7 @@ std::string flatten_and_truncate(const std::string& text, size_t max_chars) {
     // substitution above is 1 byte for 1 byte, so offsets into `out` and
     // `text` still line up. Same walk as rag_backend.cpp's source preview.
     size_t cut = out.size();
-    while (cut > 0 && cut < text.size() &&
-           (static_cast<unsigned char>(text[cut]) & 0xC0) == 0x80) {
+    while (cut > 0 && cut < text.size() && (static_cast<unsigned char>(text[cut]) & 0xC0) == 0x80) {
         --cut;
     }
     out.resize(cut);


### PR DESCRIPTION
## Description

`rerank_llm_pointwise` builds the scorer prompt from truncated passages, and the truncation stops at a byte count:

```cpp
constexpr size_t kMaxChunkChars = 360;

std::string flatten_and_truncate(const std::string& text, size_t max_chars) {
    std::string out;
    for (char c : text) {
        if (out.size() >= max_chars)   // bytes, not characters
            break;
        out.push_back((c == '\n' || c == '\r' || c == '\t') ? ' ' : c);
    }
    return out;
}
```

So a passage in any non-Latin script is cut mid-sequence and the snippet handed to the model ends in an incomplete character. Running that exact function over realistic inputs:

```
                bytes  codepoints  valid_utf8
ASCII             360         360     yes
CJK (aligned)     360         120     yes
CJK (+1 byte)     360         121     NO
Russian           360         191     NO
emoji             360         292     NO
```

The aligned CJK row is the trap: with a passage whose length happens to be a multiple of 3 the cut lands on a boundary and everything looks fine, so this does not reproduce reliably unless you shift the input by a byte.

This is the same defect the codebase already fixed one directory over, and the comment there explains why it was worth fixing:

```cpp
// core/src/features/rag/rag_backend.cpp:307
// Truncate the source preview at a UTF-8 character boundary, not a raw
// byte offset: a mid-sequence cut emits invalid UTF-8, which strict proto
// decoders (e.g. SwiftProtobuf) reject ...
```

This one feeds a prompt rather than a proto field, so the consequence is milder: the scorer sees a mangled trailing character rather than a decode failure. It is still worth correcting, because it is a per-passage corruption that only affects non-English content and the fix is the same three lines.

The fix mirrors `rag_backend.cpp` exactly, walking back off continuation bytes. The whitespace substitution above is one byte for one byte, so offsets into `out` and `text` still line up.

**One thing I deliberately did not change.** `kMaxChunkChars` is named for characters but counts bytes, so a CJK passage gets 120 characters of context where an English one gets 360. That is arguably the bigger quality issue for non-English RAG, but fixing it would roughly triple the prompt size for those languages, which is a context-budget and cost decision rather than a bug fix. Flagging it here rather than making that call unasked.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

No test added. `flatten_and_truncate` is a file-local helper in an anonymous namespace, and the only exported entry point that reaches it, `rerank_llm_pointwise`, needs a live LLM handle. Making it testable would mean widening the module's surface to suit the test, which is a worse trade than the fix is worth. The existing `test_rag_rerank.cpp` deliberately covers `parse_rerank_scores` and `reorder_by_scores` "directly, without a" model, and this helper does not fit that shape.

Instead I verified against a standalone copy of the exact function, before and after:

```
before:  Russian bytes=360 valid_utf8=NO    emoji bytes=360 valid_utf8=NO
after:   Russian bytes=359 valid_utf8=yes   emoji bytes=357 valid_utf8=yes
         ASCII   bytes=360 valid_utf8=yes   (unchanged)
```

Full suite green on the real build:

```
$ cmake --build build -j 10 && ctest --test-dir build -j 10
100% tests passed out of 101
```

On lint: unchecked because `core/scripts/lint-cpp.sh` needs the repo's pinned `clang-format` and only Apple `clang-format 21` is available here. Under it this file is completely clean, including the line I added, which I reformatted after it flagged my initial wrapping.

The edited code is not inside any `#if`, so it compiles in every configuration.

No platform boxes ticked: commons-only, exercised through the C++ suite on macOS.

## Labels
**SDKs:**
- [x] `Commons` - Changes to shared native code (`core`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Prevented truncated text from ending with incomplete UTF-8 characters.
  - Preserved the existing byte-size limit when shortening text.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->