### PR TITLE
fix(rag): every chunk of a CJK document is invalid UTF-8

### DIFF
--- a/core/src/features/rag/rag_chunker.cpp
+++ b/core/src/features/rag/rag_chunker.cpp
@@ -61,9 +61,29 @@ void perform_recursive_chunking(std::string_view text_view, const std::string& o
 
     std::vector<std::string_view> splits;
     if (separator.empty()) {
-        for (size_t i = 0; i < text_view.length(); i += chunk_size_chars) {
-            splits.push_back(
-                text_view.substr(i, std::min(chunk_size_chars, text_view.length() - i)));
+        // Last-resort split: no separator matched, so cut on size alone. The
+        // budget is a byte count, so land it on a UTF-8 character boundary or
+        // every chunk of a script without spaces (CJK reaches this branch
+        // routinely, since none of "\n\n" / ". " / " " occur in it) carries a
+        // half character at each end.
+        size_t i = 0;
+        while (i < text_view.length()) {
+            size_t end = std::min(i + chunk_size_chars, text_view.length());
+            while (end > i && end < text_view.length() &&
+                   (static_cast<unsigned char>(text_view[end]) & 0xC0) == 0x80) {
+                --end;
+            }
+            if (end == i) {
+                // One character is wider than the whole budget: emit it whole
+                // rather than spin, since a partial character is never useful.
+                end = i + 1;
+                while (end < text_view.length() &&
+                       (static_cast<unsigned char>(text_view[end]) & 0xC0) == 0x80) {
+                    ++end;
+                }
+            }
+            splits.push_back(text_view.substr(i, end - i));
+            i = end;
         }
     } else {
         size_t start = 0;

--- a/core/src/features/rag/rag_chunker.cpp
+++ b/core/src/features/rag/rag_chunker.cpp
@@ -8,10 +8,41 @@
 #include <algorithm>
 #include <cctype>
 #include <string_view>
+#include <vector>
 
 namespace runanywhere::rag {
 
 namespace {
+
+// Append size-budgeted slices of `text` to `out`, never cutting through a
+// UTF-8 character. Used by both size-only split paths below: the top-level
+// one when no separator matched, and the per-split one when a piece is
+// oversized and there is no finer separator left to try.
+void append_utf8_bounded_slices(std::string_view text, size_t budget,
+                                std::vector<std::string_view>& out) {
+    if (budget == 0) {
+        out.push_back(text);
+        return;
+    }
+    size_t i = 0;
+    while (i < text.length()) {
+        size_t end = std::min(i + budget, text.length());
+        while (end > i && end < text.length() &&
+               (static_cast<unsigned char>(text[end]) & 0xC0) == 0x80) {
+            --end;
+        }
+        if (end == i) {
+            // One character is wider than the whole budget: emit it intact
+            // rather than spin or hand back a partial character.
+            end = i + 1;
+            while (end < text.length() && (static_cast<unsigned char>(text[end]) & 0xC0) == 0x80) {
+                ++end;
+            }
+        }
+        out.push_back(text.substr(i, end - i));
+        i = end;
+    }
+}
 
 void perform_recursive_chunking(std::string_view text_view, const std::string& original_text,
                                 const std::vector<std::string>& separators, size_t chunk_size_chars,
@@ -61,30 +92,10 @@ void perform_recursive_chunking(std::string_view text_view, const std::string& o
 
     std::vector<std::string_view> splits;
     if (separator.empty()) {
-        // Last-resort split: no separator matched, so cut on size alone. The
-        // budget is a byte count, so land it on a UTF-8 character boundary or
-        // every chunk of a script without spaces (CJK reaches this branch
-        // routinely, since none of "\n\n" / ". " / " " occur in it) carries a
-        // half character at each end.
-        size_t i = 0;
-        while (i < text_view.length()) {
-            size_t end = std::min(i + chunk_size_chars, text_view.length());
-            while (end > i && end < text_view.length() &&
-                   (static_cast<unsigned char>(text_view[end]) & 0xC0) == 0x80) {
-                --end;
-            }
-            if (end == i) {
-                // One character is wider than the whole budget: emit it whole
-                // rather than spin, since a partial character is never useful.
-                end = i + 1;
-                while (end < text_view.length() &&
-                       (static_cast<unsigned char>(text_view[end]) & 0xC0) == 0x80) {
-                    ++end;
-                }
-            }
-            splits.push_back(text_view.substr(i, end - i));
-            i = end;
-        }
+        // Last-resort split: no separator matched, so cut on size alone. A
+        // script without spaces reaches this routinely (none of "\n\n" / ". "
+        // / " " occur in CJK), so the cut must land on a character boundary.
+        append_utf8_bounded_slices(text_view, chunk_size_chars, splits);
     } else {
         size_t start = 0;
         size_t pos = text_view.find(separator);
@@ -143,9 +154,12 @@ void perform_recursive_chunking(std::string_view text_view, const std::string& o
                 perform_recursive_chunking(split, original_text, next_separators, chunk_size_chars,
                                            chunk_overlap_chars, output_chunks, chunk_index);
             } else {
-                for (size_t j = 0; j < split.length(); j += chunk_size_chars) {
-                    std::string_view sub_split =
-                        split.substr(j, std::min(chunk_size_chars, split.length() - j));
+                // Same boundary rule as the size-only path above: this
+                // slices an oversized piece by size, so it must not cut
+                // through a character either.
+                std::vector<std::string_view> sub_splits;
+                append_utf8_bounded_slices(split, chunk_size_chars, sub_splits);
+                for (const auto& sub_split : sub_splits) {
                     current_batch.push_back(sub_split);
                     emit_chunk();
                     current_batch.clear();

--- a/core/tests/test_rag_e2e.cpp
+++ b/core/tests/test_rag_e2e.cpp
@@ -457,6 +457,26 @@ static bool chunker_utf8_boundaries_hold() {
 
     runanywhere::rag::DocumentChunker chunker{runanywhere::rag::ChunkerConfig{}};
     bool ok = true;
+
+    // A budget narrower than one character. The size-only paths must emit the
+    // character whole rather than slice it, and must not then re-slice it.
+    {
+        runanywhere::rag::ChunkerConfig tiny;
+        tiny.chunk_size = 1;
+        tiny.chars_per_token = 2;  // 2-byte budget, narrower than a 3-byte CJK char
+        runanywhere::rag::DocumentChunker narrow{tiny};
+        std::string doc;
+        for (int i = 0; i < 40; ++i) {
+            doc += "\xe6\x9c\xba\xe5\x99\xa8";
+        }
+        for (const auto& chunk : narrow.chunk_document(doc)) {
+            if (!valid_utf8(chunk.text)) {
+                std::fprintf(stderr, "FAIL: narrow-budget chunk is not valid UTF-8\n");
+                ok = false;
+                break;
+            }
+        }
+    }
     // The one-byte prefixes matter: an unshifted CJK string happens to land the
     // 720-byte budget on a character boundary, so the bug hides without them.
     for (const char* prefix : {"", "a", "ab"}) {

--- a/core/tests/test_rag_e2e.cpp
+++ b/core/tests/test_rag_e2e.cpp
@@ -29,6 +29,7 @@
 #include <string>
 #include <vector>
 
+#include "features/rag/rag_chunker.h"
 #include "rac/backends/rac_llm_llamacpp.h"
 #include "rac/core/rac_core.h"
 #include "rac/core/rac_platform_adapter.h"
@@ -421,8 +422,66 @@ void run_scoping_case(const std::string& embed_id, const std::string& llm_id,
 
 }  // namespace
 
+// The chunker needs no model, so this runs before the model gate below.
+// Its last-resort branch (no separator matched) cuts on a byte budget, and a
+// script without spaces reaches that branch routinely: none of "\n\n", ". "
+// or " " occur in CJK. Cutting there on a raw byte offset put half a
+// character at both ends of every chunk, and those chunks are what gets
+// embedded, stored, and returned in RAGResult's string fields.
+static bool chunker_utf8_boundaries_hold() {
+    auto valid_utf8 = [](const std::string& s) {
+        size_t i = 0;
+        while (i < s.size()) {
+            const unsigned char c = static_cast<unsigned char>(s[i]);
+            size_t need = 99;
+            if (c < 0x80) {
+                need = 0;
+            } else if ((c & 0xE0) == 0xC0) {
+                need = 1;
+            } else if ((c & 0xF0) == 0xE0) {
+                need = 2;
+            } else if ((c & 0xF8) == 0xF0) {
+                need = 3;
+            } else {
+                return false;  // continuation byte or invalid lead
+            }
+            for (size_t k = 1; k <= need; ++k) {
+                if (i + k >= s.size() || (static_cast<unsigned char>(s[i + k]) & 0xC0) != 0x80) {
+                    return false;  // truncated or malformed sequence
+                }
+            }
+            i += need + 1;
+        }
+        return true;
+    };
+
+    runanywhere::rag::DocumentChunker chunker{runanywhere::rag::ChunkerConfig{}};
+    bool ok = true;
+    // The one-byte prefixes matter: an unshifted CJK string happens to land the
+    // 720-byte budget on a character boundary, so the bug hides without them.
+    for (const char* prefix : {"", "a", "ab"}) {
+        std::string doc = prefix;
+        for (int i = 0; i < 200; ++i) {
+            doc += "\xe6\x9c\xba\xe5\x99\xa8\xe5\xad\xa6\xe4\xb9\xa0";  // CJK, 3 bytes each
+        }
+        for (const auto& chunk : chunker.chunk_document(doc)) {
+            if (!valid_utf8(chunk.text)) {
+                std::fprintf(stderr, "FAIL: chunk is not valid UTF-8 (prefix=\"%s\")\n", prefix);
+                ok = false;
+                break;
+            }
+        }
+    }
+    return ok;
+}
+
 int main() {
     std::fprintf(stdout, "=== RAG end-to-end test ===\n");
+
+    if (!chunker_utf8_boundaries_hold()) {
+        return 1;
+    }
+    std::fprintf(stdout, "OK: chunker keeps UTF-8 boundaries\n");
 
     const std::string embed_model = env_or("RAG_TEST_EMBED_MODEL", "");
     const std::string embed_vocab = env_or("RAG_TEST_EMBED_VOCAB", "");


### PR DESCRIPTION
## Description

Ingesting a Chinese or Japanese document produces chunks that are not valid UTF-8. Every chunk, not the last one.

`DocumentChunker` walks a separator list and, when nothing matches, falls back to cutting on size alone:

```cpp
// core/src/features/rag/rag_chunker.cpp
if (separator.empty()) {
    for (size_t i = 0; i < text_view.length(); i += chunk_size_chars) {
        splits.push_back(text_view.substr(i, std::min(chunk_size_chars, text_view.length() - i)));
    }
}
```

`chunk_size_chars` is a byte count despite the name (`chunk_size` 180 x `chars_per_token` 4 = 720 bytes), and `text_view` is bytes, so the cut lands wherever 720 falls.

That branch is not an edge case for these scripts. The default separators are:

```cpp
std::vector<std::string> separators = {"\n\n", "\n", ". ", "? ", "! ", "; ", ", ", " ", ""};
```

CJK has no spaces and ends sentences with `。`, so none of the real separators match and the empty one is selected. The size-only split is the normal path for that content.

Running the real chunker over 200 repetitions of a CJK sentence:

```
                chunks  invalid_utf8
english              9             0
chinese             15             0
chinese + "a"       15            15
chinese + "ab"      15            15
```

The unshifted row is the trap. 720 is divisible by 3, so a CJK document that happens to start on a boundary cuts cleanly and looks fine; shift it by one byte and every chunk is corrupt. A real document with any ASCII in it (a date, a name, a number) is shifted.

This matters more than a display artifact because of where chunks go. They are embedded, persisted in the vector store, and returned in `RAGResult`'s string fields, and the codebase already documents what invalid UTF-8 does there:

```cpp
// core/src/features/rag/rag_backend.cpp:307 — for the source preview
// Truncate the source preview at a UTF-8 character boundary, not a raw
// byte offset: a mid-sequence cut emits invalid UTF-8, which strict proto
// decoders (e.g. SwiftProtobuf) reject ... Lenient decoders (Android/Wire,
// Flutter/dart) tolerated it via U+FFFD substitution, masking the corruption.
```

The preview was fixed. The chunk text it previews was not.

The fix walks the cut back off continuation bytes, the same way `rag_backend.cpp` does, with a guard so a single character wider than the whole budget is emitted intact rather than spinning.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [x] Added/updated tests for changes

Added `chunker_utf8_boundaries_hold()` to `core/tests/test_rag_e2e.cpp`, called from `main()` **before** the `SKIP: models not found` gate, because the chunker needs no model and everything after that gate is skipped in CI.

I put it there rather than in `core/tests/chunker_test.cpp`, which looks like the natural home but is a gtest file that is not registered in `core/tests/CMakeLists.txt` and never runs. A regression parked there would not have protected anything.

The test covers the shifted cases specifically, since the unshifted one passes either way.

```
$ cmake --build build -j 10 && ctest --test-dir build -j 10
100% tests passed out of 103
```

Fails on the unfixed code. Verified by restoring only the byte-offset loop, with the recompile and relink confirmed first:

```
[ 72%] Building CXX object .../rac_backend_rag.dir/rag_chunker.cpp.o
[100%] Linking CXX executable test_rag_e2e
FAIL: chunk is not valid UTF-8 (prefix="a")
FAIL: chunk is not valid UTF-8 (prefix="ab")
```

On lint: unchecked because `core/scripts/lint-cpp.sh` needs the repo's pinned `clang-format` and only Apple `clang-format 21` is here. Both files are clean under it; the diff is three hunks in the test and one in the chunker, with no pre-existing lines reformatted.

The edited code is not inside any `#if`, so it compiles in every configuration.

No platform boxes ticked: commons-only, exercised through the C++ suite on macOS.

## Labels
**SDKs:**
- [x] `Commons` - Changes to shared native code (`core`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved text chunking for UTF-8 content, preventing chunks from splitting characters incorrectly.
  * Ensured oversized individual characters are preserved whole when chunk size limits are too small.
  * Improved reliability when processing multilingual text across different chunking scenarios.
* **Tests**
  * Added coverage for UTF-8 boundary handling, including multilingual text, without requiring a model.
  * Added regression checks for very small chunk size limits.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->