### PR TITLE
fix(vlm): streamed VLM chunks are invalid UTF-8 for any character the vocab splits

### DIFF
--- a/bindings/swift/Sources/RunAnywhere/CRACommons/include/rac_vlm_component.h
+++ b/bindings/swift/Sources/RunAnywhere/CRACommons/include/rac_vlm_component.h
@@ -163,7 +163,12 @@ RAC_API rac_bool_t rac_vlm_component_supports_streaming(rac_handle_t handle);
  * @param image Image input
  * @param prompt Text prompt
  * @param options Generation options (can be NULL for defaults)
- * @param token_callback Called for each generated token
+ * @param token_callback Called with the next run of decoded text. Not one call
+ *                       per token: a chunk is emitted only up to its last
+ *                       complete UTF-8 character, so a token whose bytes finish
+ *                       a character started by the previous token arrives
+ *                       merged with it, and a token that only starts one is
+ *                       held until it is complete.
  * @param complete_callback Called when generation completes
  * @param error_callback Called on error
  * @param user_data User context passed to callbacks

--- a/bindings/swift/Sources/RunAnywhere/CRACommons/include/rac_vlm_types.h
+++ b/bindings/swift/Sources/RunAnywhere/CRACommons/include/rac_vlm_types.h
@@ -370,7 +370,9 @@ typedef struct rac_vlm_info {
 /**
  * @brief Simple VLM streaming callback
  *
- * Called for each generated token during streaming.
+ * Called with successive runs of decoded text during streaming, each ending on
+ * a complete UTF-8 character. This is not one call per token: see
+ * rac_vlm_component_process_stream.
  *
  * @param token The generated token string
  * @param user_data User-provided context

--- a/core/include/rac/features/vlm/rac_vlm_component.h
+++ b/core/include/rac/features/vlm/rac_vlm_component.h
@@ -174,7 +174,12 @@ RAC_API rac_bool_t rac_vlm_component_supports_streaming(rac_handle_t handle);
  * @param image Image input
  * @param prompt Text prompt
  * @param options Generation options (can be NULL for defaults)
- * @param token_callback Called for each generated token
+ * @param token_callback Called with the next run of decoded text. Not one call
+ *                       per token: a chunk is emitted only up to its last
+ *                       complete UTF-8 character, so a token whose bytes finish
+ *                       a character started by the previous token arrives
+ *                       merged with it, and a token that only starts one is
+ *                       held until it is complete.
  * @param complete_callback Called when generation completes
  * @param error_callback Called on error
  * @param user_data User context passed to callbacks

--- a/core/include/rac/features/vlm/rac_vlm_types.h
+++ b/core/include/rac/features/vlm/rac_vlm_types.h
@@ -406,7 +406,9 @@ typedef struct rac_vlm_info {
 /**
  * @brief Simple VLM streaming callback
  *
- * Called for each generated token during streaming.
+ * Called with successive runs of decoded text during streaming, each ending on
+ * a complete UTF-8 character. This is not one call per token: see
+ * rac_vlm_component_process_stream.
  *
  * @param token The generated token string
  * @param user_data User-provided context

--- a/core/src/features/common/utf8_stream_boundary.h
+++ b/core/src/features/common/utf8_stream_boundary.h
@@ -44,6 +44,52 @@ inline size_t incomplete_utf8_tail(const std::string& text) {
     return 0;  // three continuations with no lead in reach: already complete
 }
 
+/**
+ * Per-stream UTF-8 assembler. `feed()` returns the bytes that are safe to hand
+ * on now, holding back a trailing partial character until the rest arrives;
+ * `flush()` releases whatever is left at end of stream.
+ *
+ * Shaped like `rac::tokens::StreamFilter` on purpose, and held alongside one:
+ * both VLM stream funnels need the same per-stream shaping, so the logic lives
+ * in one type rather than being written out at each callback.
+ *
+ * Both return a reference to a buffer owned by the assembler, valid until the
+ * next `feed()` / `flush()` on the same instance.
+ */
+class Utf8Assembler {
+   public:
+    const std::string& feed(const std::string& chunk) {
+        out_.clear();
+        pending_ += chunk;
+        const size_t hold = incomplete_utf8_tail(pending_);
+        if (pending_.size() > hold) {
+            out_.assign(pending_, 0, pending_.size() - hold);
+            pending_.erase(0, pending_.size() - hold);
+        }
+        return out_;
+    }
+
+    /**
+     * End of stream. A remainder here is a character the backend never
+     * finished emitting, so it cannot render; dropping it keeps every
+     * delivered chunk valid UTF-8. Callers that accumulate the unassembled
+     * text separately still have those bytes in their own total.
+     */
+    const std::string& flush() {
+        out_.clear();
+        const size_t hold = incomplete_utf8_tail(pending_);
+        if (pending_.size() > hold) {
+            out_.assign(pending_, 0, pending_.size() - hold);
+        }
+        pending_.clear();
+        return out_;
+    }
+
+   private:
+    std::string pending_;
+    std::string out_;
+};
+
 }  // namespace tokens
 }  // namespace rac
 

--- a/core/src/features/common/utf8_stream_boundary.h
+++ b/core/src/features/common/utf8_stream_boundary.h
@@ -1,0 +1,50 @@
+#ifndef RAC_FEATURES_COMMON_UTF8_STREAM_BOUNDARY_H
+#define RAC_FEATURES_COMMON_UTF8_STREAM_BOUNDARY_H
+
+#include <string>
+
+/**
+ * @file utf8_stream_boundary.h
+ * @brief Hold back a trailing partial UTF-8 sequence between stream chunks.
+ *
+ * A tokenizer piece is not guaranteed to be a whole character. Byte-level BPE
+ * vocabularies carry single-byte fallback tokens (Qwen2.5 has all 64 bare
+ * continuation bytes 0x80-0xBF), so any character without a whole-character
+ * token in the vocab is emitted as two or more pieces, none of them valid
+ * UTF-8 on its own. Delivering such a piece straight to a caller produces a
+ * chunk that strict decoders reject and lenient ones mangle into U+FFFD.
+ */
+namespace rac {
+namespace tokens {
+
+/**
+ * Number of bytes at the end of @p text that begin a UTF-8 sequence which is
+ * not yet complete. Returns 0 when @p text ends on a character boundary, and
+ * 0 for a malformed tail so a bad byte is never held forever.
+ */
+inline size_t incomplete_utf8_tail(const std::string& text) {
+    const size_t n = text.size();
+    // A UTF-8 sequence is at most 4 bytes, so only the last 3 can be partial.
+    const size_t limit = n < 3 ? n : 3;
+    for (size_t back = 1; back <= limit; ++back) {
+        const unsigned char c = static_cast<unsigned char>(text[n - back]);
+        if ((c & 0xC0) == 0x80)
+            continue;  // continuation byte; keep walking back to the lead
+        size_t need = 0;
+        if ((c & 0xE0) == 0xC0)
+            need = 2;
+        else if ((c & 0xF0) == 0xE0)
+            need = 3;
+        else if ((c & 0xF8) == 0xF0)
+            need = 4;
+        else
+            return 0;  // ASCII, or a stray byte we must not stall on
+        return back < need ? back : 0;
+    }
+    return 0;  // three continuations with no lead in reach: already complete
+}
+
+}  // namespace tokens
+}  // namespace rac
+
+#endif  // RAC_FEATURES_COMMON_UTF8_STREAM_BOUNDARY_H

--- a/core/src/features/vlm/vlm_module.cpp
+++ b/core/src/features/vlm/vlm_module.cpp
@@ -24,6 +24,7 @@
 #include "core/internal/platform_compat.h"
 #include "features/common/rac_component_lifecycle_internal.h"
 #include "features/common/special_token_filter.h"
+#include "features/common/utf8_stream_boundary.h"
 #include "features/vlm/rac_vlm_lifecycle_bridge.h"
 #include "rac/core/capabilities/rac_lifecycle.h"
 #include "rac/core/rac_core.h"
@@ -535,6 +536,12 @@ struct vlm_stream_context {
     // `<end_of_utterance>` across two callbacks, and neither half is
     // recognisable on its own.
     rac::tokens::StreamFilter filter;
+
+    // Trailing bytes of a UTF-8 character the backend has only partly emitted.
+    // Held until the rest arrives so no chunk handed to the caller is invalid
+    // UTF-8. Accumulation into `cleaned_text` is deliberately not delayed, so
+    // the final result is unaffected.
+    std::string utf8_tail;
 };
 
 /**
@@ -569,9 +576,18 @@ static rac_bool_t vlm_stream_token_callback(const char* token, void* user_data) 
     ctx->cleaned_text += cleaned;
     ctx->token_count++;
 
-    // Forward only non-empty cleaned tokens to the user callback
+    // Forward only non-empty cleaned tokens to the user callback, and only up
+    // to the last complete character: a piece may end mid-sequence, and its
+    // remaining bytes arrive on a later callback.
     if (!cleaned.empty() && ctx->token_callback) {
-        return ctx->token_callback(cleaned.c_str(), ctx->user_data);
+        ctx->utf8_tail += cleaned;
+        const size_t hold = rac::tokens::incomplete_utf8_tail(ctx->utf8_tail);
+        if (ctx->utf8_tail.size() > hold) {
+            const std::string deliverable = ctx->utf8_tail.substr(0, ctx->utf8_tail.size() - hold);
+            ctx->utf8_tail.erase(0, ctx->utf8_tail.size() - hold);
+            return ctx->token_callback(deliverable.c_str(), ctx->user_data);
+        }
+        return RAC_TRUE;  // whole chunk is a partial character; wait for the rest
     }
 
     return RAC_TRUE;
@@ -654,8 +670,22 @@ extern "C" rac_result_t rac_vlm_component_process_stream(
     if (!held_tail.empty()) {
         ctx.cleaned_text += held_tail;
         if (token_callback) {
-            token_callback(held_tail.c_str(), user_data);
+            ctx.utf8_tail += held_tail;
         }
+    }
+
+    // Anything still held is a character the backend never finished emitting
+    // (generation hit max_tokens or was cancelled mid-sequence). Deliver only
+    // what completes; the leftover bytes cannot render and would put an
+    // invalid chunk on the stream. `cleaned_text` already has them, so the
+    // final result is unchanged.
+    if (token_callback && !ctx.utf8_tail.empty()) {
+        const size_t hold = rac::tokens::incomplete_utf8_tail(ctx.utf8_tail);
+        if (ctx.utf8_tail.size() > hold) {
+            const std::string final_chunk = ctx.utf8_tail.substr(0, ctx.utf8_tail.size() - hold);
+            token_callback(final_chunk.c_str(), user_data);
+        }
+        ctx.utf8_tail.clear();
     }
 
     // Build final result for completion callback

--- a/core/src/features/vlm/vlm_module.cpp
+++ b/core/src/features/vlm/vlm_module.cpp
@@ -537,11 +537,11 @@ struct vlm_stream_context {
     // recognisable on its own.
     rac::tokens::StreamFilter filter;
 
-    // Trailing bytes of a UTF-8 character the backend has only partly emitted.
-    // Held until the rest arrives so no chunk handed to the caller is invalid
-    // UTF-8. Accumulation into `cleaned_text` is deliberately not delayed, so
-    // the final result is unaffected.
-    std::string utf8_tail;
+    // Holds back a trailing partial UTF-8 character between callbacks, so no
+    // chunk handed to the caller is invalid UTF-8. Accumulation into
+    // `cleaned_text` is deliberately not delayed, so the final result is
+    // unaffected.
+    rac::tokens::Utf8Assembler utf8;
 };
 
 /**
@@ -580,14 +580,11 @@ static rac_bool_t vlm_stream_token_callback(const char* token, void* user_data) 
     // to the last complete character: a piece may end mid-sequence, and its
     // remaining bytes arrive on a later callback.
     if (!cleaned.empty() && ctx->token_callback) {
-        ctx->utf8_tail += cleaned;
-        const size_t hold = rac::tokens::incomplete_utf8_tail(ctx->utf8_tail);
-        if (ctx->utf8_tail.size() > hold) {
-            const std::string deliverable = ctx->utf8_tail.substr(0, ctx->utf8_tail.size() - hold);
-            ctx->utf8_tail.erase(0, ctx->utf8_tail.size() - hold);
-            return ctx->token_callback(deliverable.c_str(), ctx->user_data);
+        const std::string& deliverable = ctx->utf8.feed(cleaned);
+        if (deliverable.empty()) {
+            return RAC_TRUE;  // whole chunk is a partial character; wait for the rest
         }
-        return RAC_TRUE;  // whole chunk is a partial character; wait for the rest
+        return ctx->token_callback(deliverable.c_str(), ctx->user_data);
     }
 
     return RAC_TRUE;
@@ -669,23 +666,20 @@ extern "C" rac_result_t rac_vlm_component_process_stream(
     const std::string held_tail = ctx.filter.flush();
     if (!held_tail.empty()) {
         ctx.cleaned_text += held_tail;
-        if (token_callback) {
-            ctx.utf8_tail += held_tail;
-        }
     }
 
-    // Anything still held is a character the backend never finished emitting
-    // (generation hit max_tokens or was cancelled mid-sequence). Deliver only
-    // what completes; the leftover bytes cannot render and would put an
-    // invalid chunk on the stream. `cleaned_text` already has them, so the
-    // final result is unchanged.
-    if (token_callback && !ctx.utf8_tail.empty()) {
-        const size_t hold = rac::tokens::incomplete_utf8_tail(ctx.utf8_tail);
-        if (ctx.utf8_tail.size() > hold) {
-            const std::string final_chunk = ctx.utf8_tail.substr(0, ctx.utf8_tail.size() - hold);
-            token_callback(final_chunk.c_str(), user_data);
+    // Release whatever the assembler still holds. A remainder is a character
+    // the backend never finished emitting, so it cannot render; `cleaned_text`
+    // already carries those bytes, leaving the final result unchanged.
+    if (token_callback) {
+        std::string deliverable;
+        if (!held_tail.empty()) {
+            deliverable = ctx.utf8.feed(held_tail);
         }
-        ctx.utf8_tail.clear();
+        deliverable += ctx.utf8.flush();
+        if (!deliverable.empty()) {
+            token_callback(deliverable.c_str(), user_data);
+        }
     }
 
     // Build final result for completion callback
@@ -1113,6 +1107,12 @@ struct GeneratedStreamCtx {
 
     // Per-stream sentinel filter; see vlm_stream_context::filter.
     rac::tokens::StreamFilter filter;
+
+    // Per-stream UTF-8 assembler; see vlm_stream_context::utf8. Required here
+    // too: `generation.token` and the VLM stream event's text are proto string
+    // fields, and a partial character makes the message invalid UTF-8 for the
+    // five SDKs that consume this path.
+    rac::tokens::Utf8Assembler utf8;
 };
 
 bool serialize_vlm_stream_event(const runanywhere::v1::VLMStreamEvent& event,
@@ -1197,24 +1197,31 @@ rac_bool_t generated_stream_token_trampoline(const char* token, void* user_data)
         }
     }
 
+    // Emit only up to the last complete character. `generation.token` and the
+    // VLM stream event text are proto `string` fields, so a chunk cut through a
+    // multi-byte character is an invalid message for every SDK on this path.
+    // `ctx->text` above keeps the unassembled text, so the final result is
+    // unchanged and only chunk boundaries move.
+    const std::string emit = ctx->utf8.feed(display);
+
     runanywhere::v1::SDKEvent event;
     populate_envelope(&event, runanywhere::v1::ERROR_SEVERITY_INFO);
     auto* generation = event.mutable_generation();
     generation->set_kind(ctx->token_count == 1
                              ? runanywhere::v1::GENERATION_EVENT_KIND_FIRST_TOKEN_GENERATED
                              : runanywhere::v1::GENERATION_EVENT_KIND_TOKEN_GENERATED);
-    generation->set_token(display);
+    generation->set_token(emit);
     generation->set_output_tokens(ctx->token_count);
     if (ctx->ref->model_id)
         generation->set_model_id(ctx->ref->model_id);
     publish_event(event);
 
-    if (display.empty()) {
+    if (emit.empty()) {
         return RAC_TRUE;
     }
 
     return dispatch_vlm_stream_event(ctx, runanywhere::v1::VLM_STREAM_EVENT_KIND_TOKEN,
-                                     display.c_str(), false, nullptr, nullptr, 0);
+                                     emit.c_str(), false, nullptr, nullptr, 0);
 }
 
 // Release whatever sentinel prefix the filter is still holding once the
@@ -1226,12 +1233,22 @@ void flush_held_stream_text(GeneratedStreamCtx* ctx) {
         return;
     }
     const std::string tail = ctx->filter.flush();
-    if (tail.empty()) {
+    if (!tail.empty()) {
+        ctx->text += tail;
+        ++ctx->token_count;
+    }
+    // Assemble the sentinel filter's tail, then release anything the UTF-8
+    // assembler still holds. A leftover partial character cannot render, and
+    // `ctx->text` already carries it.
+    std::string emit;
+    if (!tail.empty()) {
+        emit = ctx->utf8.feed(tail);
+    }
+    emit += ctx->utf8.flush();
+    if (emit.empty()) {
         return;
     }
-    ctx->text += tail;
-    ++ctx->token_count;
-    dispatch_vlm_stream_event(ctx, runanywhere::v1::VLM_STREAM_EVENT_KIND_TOKEN, tail.c_str(),
+    dispatch_vlm_stream_event(ctx, runanywhere::v1::VLM_STREAM_EVENT_KIND_TOKEN, emit.c_str(),
                               false, nullptr, nullptr, 0);
 }
 


### PR DESCRIPTION
## Description

`vlm_stream_token_callback` forwards each backend piece straight to the caller:

```cpp
// core/src/features/vlm/vlm_module.cpp:573 on main
if (!cleaned.empty() && ctx->token_callback) {
    return ctx->token_callback(cleaned.c_str(), ctx->user_data);
}
```

A tokenizer piece is not guaranteed to be a whole character, so some of those chunks are not valid UTF-8.

**Why it is wrong.** Byte-level BPE vocabularies carry single-byte fallback tokens, so any character without a whole-character token must be emitted as several pieces. Measured against the real Qwen2.5 vocabulary (`tokenizer.json`, 151643 tokens):

- 1448 tokens are not valid UTF-8 on their own
- all 64 bare continuation bytes `0x80`-`0xBF` are present as single-byte tokens

Whether a given character splits is decidable without reference to merge order, by asking whether the whole character exists as one token:

| character | whole-character token in vocab | consequence |
|---|---|---|
| U+1FAE0 melting face | no | must split mid-character |
| U+1F979 | no | must split mid-character |
| U+9F9C (rare CJK) | no | must split mid-character |
| U+1F600, U+65E5 | yes | safe |

That last row is why this has gone unnoticed. The characters used in casual testing have whole-character tokens; the ones that do not are the failure cases.

**What the caller sees.** The C callback is consumed directly by `bindings/python/native/module.cpp:917`, whose `stream_token_cb` hands the `std::string` to pybind11 for a strict UTF-8 decode:

```
>>> b'\xf0\x9f'.decode('utf-8')
UnicodeDecodeError: 'utf-8' codec can't decode bytes in position 0-1: unexpected end of data
```

So this does not degrade to replacement characters on that binding, it raises, and `module.cpp:743` re-throws the exception on the main thread. Lenient consumers substitute U+FFFD instead, which is the same mangling `rag_backend.cpp` already documents for RAG previews.

The LLM decode loop already solves this engine-side with a UTF-8 DFA (`engines/llamacpp/llamacpp_backend.cpp`, `Utf8State` plus `partial_utf8_buffer`). Notably the *same* Python `stream_token_cb` is used for LLM streaming and is safe there, purely because the engine buffers before calling back. The VLM streaming loop has no equivalent, and its own comment says it "Mirrors the LLM backend's stop_window pattern in run_decode_loop" while omitting the boundary walk that pattern depends on.

**What this changes.** A chunk is delivered only up to its last complete character; a trailing partial sequence is held until the rest arrives.

The guard goes in `vlm_module.cpp` rather than in the llamacpp engine because the component token callback is the single funnel every VLM backend's stream passes through, so one guard also covers backends that do not exist yet. The new `features/common/utf8_stream_boundary.h` matches the shape of the existing `features/common/special_token_filter.h`, the other per-stream chunk-shaping helper in that directory.

Accumulation into `cleaned_text` is deliberately not delayed, so the final result text is byte-for-byte unchanged. Only chunk boundaries move.

One judgment call worth flagging: if generation stops mid-character (max_tokens or cancellation), the leftover bytes are not delivered on the stream. They cannot render, and emitting them would put an invalid chunk on the stream for the sake of an incomplete character. `cleaned_text` still contains them, so the final result is unaffected.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

`cmake -B build -DRAC_BUILD_TESTS=ON -DCMAKE_BUILD_TYPE=Debug` plus `ctest`: builds with 0 errors, 101/101 pass.

Both boxes above are left unticked deliberately:

- **Lint.** I do not have the repo's pinned `clang-format` here. The version I do have (23.1.0) reports 1467 violations on the *untouched* `main` copy of `vlm_module.cpp`, so it disagrees with whatever CI uses and its verdict on the whole file is meaningless. What I can report: the new header is clean under it, and the one line of mine it flagged was rewritten to a form that does not depend on the version.
- **Tests.** No test is committed. The sibling helper in the same directory (`special_token_filter.h`) has no dedicated test either, so adding one here would exceed the convention for this class of header. I verified the logic with a throwaway harness instead (8 boundary assertions plus a simulation of the funnel): the U+1FAE0 piece sequence yields 2 chunks, both valid UTF-8, text preserved; without the guard 3 of 3 chunks are invalid. Happy to commit that as a test file if you would prefer it in-tree.

Not run: any on-device VLM streaming check. I have no VLM model or device here, so I have not observed the corrupted caption end to end. The claim rests on the vocabulary measurement above plus the code path, not on a live capture.

`core/` guard check: all four edited regions are outside any `#if`, and the new header includes only `<string>`, so no build configuration sees a different result.

### Platform-Specific Testing (check all that apply)
None. This is native `core/` code with no binding or app changes.

## Labels
**SDKs:**
- [ ] `Swift SDK`
- [ ] `Kotlin SDK`
- [ ] `Flutter SDK`
- [ ] `React Native SDK`
- [ ] `Web SDK`
- [x] `Commons` - Changes to shared native code (`core`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)

The header carries the rationale, so no separate docs change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved VLM streaming to prevent incomplete or malformed UTF-8 characters from appearing in incremental output.
  - Streaming callbacks now receive only complete characters, reducing display issues when text is split across streamed chunks.
  - Final accumulated responses remain unchanged while partial output is handled more reliably.

- **Documentation**
  - Clarified streaming callback behavior, including how text chunks are combined or held until complete UTF-8 characters are available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->