### PR TITLE
docs: four stale references (skills rcli, npm pins, packaging, ABI history)

### DIFF
--- a/.agents/skills/sdk-publish/SKILL.md
+++ b/.agents/skills/sdk-publish/SKILL.md
@@ -375,21 +375,24 @@ This is enforced, not just documented: once `v$VERSION` is tagged on `runanywher
 
 **If you force-move a tag, SwiftPM/Xcode consumers cache the OLD commit in several places — clearing just `Package.resolved` is not enough.** Verifying your own fix (or having a downstream consumer verify it) can silently keep failing even after the fix is correctly pushed, because: (1) any consumer repo's own tracked `*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` pins the exact old resolution and `xcodebuild -resolvePackageDependencies` respects it rather than re-resolving; (2) `~/Library/Caches/org.swift.swiftpm/repositories/<pkg>-<hash>/` is a global shared clone cache keyed by repo, oblivious to a moved tag; (3) `~/Library/org.swift.swiftpm/security/fingerprints/<pkg>-<hash>.json` records the fingerprint SwiftPM saw for that tag and can silently keep using it after a mismatch instead of failing loud. To actually re-resolve after moving a tag: delete the consumer's tracked `Package.resolved`, `rm -rf .build .swiftpm` and any `~/Library/Developer/Xcode/DerivedData/<Scheme>-*`, AND clear the matching entries under both global `org.swift.swiftpm` cache directories for every affected package identity — then resolve fresh.
 
-## 5. macOS rcli notarization
+## 5. rcli ships from RunanywhereAI/RCLI, not from this release
 
-CI (`native_rcli_macos` in `release.yml`) usually already produces a notarized, stapled artifact when Developer ID + notary secrets are configured in repo secrets. **Check the release assets first** before assuming you need to notarize anything yourself locally:
+rcli is not built, versioned, or released here. `release.yml` says so in its own header:
+
+> Official CLI bottles (rcli) are NOT produced here — they ship from
+> RunanywhereAI/RCLI, which consumes those kits via `find_package(RunAnywhere)`.
+
+So when cutting a release of *this* repo:
+
+- **Do not look for rcli assets on `v$VERSION`.** `v0.20.25` was the last release that carried any (`rcli-macos-arm64-v0.20.25.tar.gz` and friends); `v0.20.30` and `v0.20.31` carry none, and there is no `native_rcli_macos` job in `release.yml` to produce them.
+- **RCLI has its own version line and its own asset naming.** It was at `v0.5.2` while this repo was at `0.20.31`, and its assets are `rcli-0.5.2-macos-arm64.tar.gz` (+ `.sha256`) — neither the version nor the filename shape can be derived from `$VERSION` here.
+- **Signing and notarization are RCLI's, and only RCLI's docs describe them.** Read `docs/RELEASING.md` and `scripts/package-rcli.sh` in that repo rather than a copy kept here. The `RCLI_*` names are maintained there and the copy in this file had already drifted: it named `RCLI_MACOS_FULL_RELEASE`, `RCLI_MACOS_SWIFT_BIN_DIR` and a `build-mlx-cli.sh`, none of which appear anywhere in RCLI.
+
+What this repo still owes RCLI is the desktop kit it consumes, so check those assets are present instead:
 
 ```bash
-gh release view v$VERSION --json assets --jq '.assets[].name' | grep -iE 'rcli-macos|\.dmg'
+gh release view v$VERSION --json assets --jq '.assets[].name' | grep cpp-desktop
 ```
-Baseline expectation is `rcli-macos-arm64-v$VERSION.tar.gz` (+ `.sha256`); a `.dmg` only appears when `RCLI_MACOS_FULL_RELEASE=1` was set for that build (see below). If a plain tarball is already present and its contents pass the general verification discipline, there is usually nothing further to do here.
-
-**If you do need to notarize locally**, everything lives in `rcli/scripts/package-rcli.sh` (read its header comment — it documents its own contract in detail):
-
-- One-time setup, check before redoing: `xcrun notarytool history --keychain-profile runanywhere-notary` (confirmed configured on this machine — a fresh submission history returns without error). If missing: `xcrun notarytool store-credentials "runanywhere-notary" --apple-id <email> --team-id <team> --password <app-specific-password>`.
-- Codesign identity: `security find-identity -v -p codesigning | grep "Developer ID Application"` — confirmed present on this machine as `"Developer ID Application: RunAnywhere, Inc (<TEAM_ID>)"`. Grep for it fresh rather than hardcoding the team-id suffix, it can rotate.
-- Invocation contract (env vars, from the script header): `RCLI_CODESIGN_IDENTITY`, `RCLI_MACOS_NOTARIZE=1`, `RCLI_MACOS_FULL_RELEASE=1`, `RCLI_MACOS_SWIFT_BIN_DIR=<output of build-mlx-cli.sh>`. `RCLI_MACOS_FULL_RELEASE=1` is what additionally stages `mlx.metallib` and SwiftPM resource bundles and is what causes a notarized, stapled `.dmg` to be emitted alongside the Homebrew-style tarball. `RCLI_CODESIGN_KEYCHAIN` / `RCLI_NOTARYTOOL_KEYCHAIN` matter only if the identity/profile live in a non-default keychain.
-- Call shape: `rcli/scripts/package-rcli.sh <build-dir> macos-arm64` with the env vars above exported.
 
 ## 6. Electron — build AND packaging are now in `release.yml`; publish is still manual
 

--- a/.agents/skills/sdk-test-starters/SKILL.md
+++ b/.agents/skills/sdk-test-starters/SKILL.md
@@ -121,13 +121,15 @@ Most loggers use `com.runanywhere.RunAnywhereAI`; a few use plain
 covers all of them. On a physical device use `idevicesyslog | grep "com.runanywhere"`
 instead.
 
-## 4. macOS/Swift — no separate repo, use the in-tree example or rcli
+## 4. macOS/Swift — no consumer repo, use the in-tree example
 
-There is no `runanywhere-macos` consumer repo. Two in-monorepo options, both inside
+There is no `runanywhere-macos` consumer repo. Use the in-tree example, inside
 `~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks`:
 
 - `bindings/swift/example/` — a minimal SwiftPM example app/executable.
-- `rcli/` — the C++ core's CLI, `rac_*` C ABI consumer.
+
+The CLI is no longer in this repo; it moved to `RunanywhereAI/RCLI`, so it is not a
+second in-monorepo option any more.
 
 **The critical gotcha**: the repo's own `Package.swift` is fail-closed toward the
 *real published release* — it resolves the remote `binaryTargets` unless you

--- a/.agents/skills/telemetry-e2e/SKILL.md
+++ b/.agents/skills/telemetry-e2e/SKILL.md
@@ -146,7 +146,7 @@ ctest --test-dir build --output-on-failure
 
 `telemetry_extraction_tests` and `device_identity_tests` are registered in
 `core/tests/CMakeLists.txt`; `rcli_telemetry_live_tests` is registered separately in
-`rcli/tests/CMakeLists.txt`. All three are hand-rolled assertion runners — `CHECK()` in
+`tests/CMakeLists.txt` in `RunanywhereAI/RCLI`. All three are hand-rolled assertion runners — `CHECK()` in
 some files, `ASSERT_EQ`/`ASSERT_TRUE` (from `core/tests/test_common.h`) in others — never
 GoogleTest:
 
@@ -282,7 +282,7 @@ public staging backend — `--environment development --base-url <origin> teleme
 12) and prints a `MODALITY | RESULT | STATUS | RECEIVED | STORED | SKIPPED` table parsed
 directly from the backend's own batch response — **the `STORED` column is authoritative
 server-side confirmation**, not just an HTTP 2xx. `run_telemetry_blast()`'s own exit-code
-logic (`rcli/src/commands/cmd_telemetry.cpp`) does fold `stored >= count` into its overall
+logic (`src/commands/cmd_telemetry.cpp` in `RunanywhereAI/RCLI`) does fold `stored >= count` into its overall
 pass/fail, so a genuine storage shortfall on any modality does make the process exit
 non-zero, not just a transport error — but the exit code is one bit for all 12 modalities
 combined, so a non-zero exit still requires reading the table to know *which* modality
@@ -302,7 +302,7 @@ didn't recognize — a real bug to chase, not the same failure class at all).
 ```
 
 `auth login` only has a path in `production` — `development`'s keyless mode has no login
-step by design (see `rcli/src/commands/cmd_auth.cpp`'s own subcommand help text).
+step by design (see `src/commands/cmd_auth.cpp`'s own subcommand help text in `RunanywhereAI/RCLI`).
 
 **To inspect the actual request body**, not just the summary table, add `--json` for
 machine-readable CLI output and `-v` for debug logging (the debug log includes the

--- a/.claude/skills/sdk-publish/SKILL.md
+++ b/.claude/skills/sdk-publish/SKILL.md
@@ -375,21 +375,24 @@ This is enforced, not just documented: once `v$VERSION` is tagged on `runanywher
 
 **If you force-move a tag, SwiftPM/Xcode consumers cache the OLD commit in several places — clearing just `Package.resolved` is not enough.** Verifying your own fix (or having a downstream consumer verify it) can silently keep failing even after the fix is correctly pushed, because: (1) any consumer repo's own tracked `*.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved` pins the exact old resolution and `xcodebuild -resolvePackageDependencies` respects it rather than re-resolving; (2) `~/Library/Caches/org.swift.swiftpm/repositories/<pkg>-<hash>/` is a global shared clone cache keyed by repo, oblivious to a moved tag; (3) `~/Library/org.swift.swiftpm/security/fingerprints/<pkg>-<hash>.json` records the fingerprint SwiftPM saw for that tag and can silently keep using it after a mismatch instead of failing loud. To actually re-resolve after moving a tag: delete the consumer's tracked `Package.resolved`, `rm -rf .build .swiftpm` and any `~/Library/Developer/Xcode/DerivedData/<Scheme>-*`, AND clear the matching entries under both global `org.swift.swiftpm` cache directories for every affected package identity — then resolve fresh.
 
-## 5. macOS rcli notarization
+## 5. rcli ships from RunanywhereAI/RCLI, not from this release
 
-CI (`native_rcli_macos` in `release.yml`) usually already produces a notarized, stapled artifact when Developer ID + notary secrets are configured in repo secrets. **Check the release assets first** before assuming you need to notarize anything yourself locally:
+rcli is not built, versioned, or released here. `release.yml` says so in its own header:
+
+> Official CLI bottles (rcli) are NOT produced here — they ship from
+> RunanywhereAI/RCLI, which consumes those kits via `find_package(RunAnywhere)`.
+
+So when cutting a release of *this* repo:
+
+- **Do not look for rcli assets on `v$VERSION`.** `v0.20.25` was the last release that carried any (`rcli-macos-arm64-v0.20.25.tar.gz` and friends); `v0.20.30` and `v0.20.31` carry none, and there is no `native_rcli_macos` job in `release.yml` to produce them.
+- **RCLI has its own version line and its own asset naming.** It was at `v0.5.2` while this repo was at `0.20.31`, and its assets are `rcli-0.5.2-macos-arm64.tar.gz` (+ `.sha256`) — neither the version nor the filename shape can be derived from `$VERSION` here.
+- **Signing and notarization are RCLI's, and only RCLI's docs describe them.** Read `docs/RELEASING.md` and `scripts/package-rcli.sh` in that repo rather than a copy kept here. The `RCLI_*` names are maintained there and the copy in this file had already drifted: it named `RCLI_MACOS_FULL_RELEASE`, `RCLI_MACOS_SWIFT_BIN_DIR` and a `build-mlx-cli.sh`, none of which appear anywhere in RCLI.
+
+What this repo still owes RCLI is the desktop kit it consumes, so check those assets are present instead:
 
 ```bash
-gh release view v$VERSION --json assets --jq '.assets[].name' | grep -iE 'rcli-macos|\.dmg'
+gh release view v$VERSION --json assets --jq '.assets[].name' | grep cpp-desktop
 ```
-Baseline expectation is `rcli-macos-arm64-v$VERSION.tar.gz` (+ `.sha256`); a `.dmg` only appears when `RCLI_MACOS_FULL_RELEASE=1` was set for that build (see below). If a plain tarball is already present and its contents pass the general verification discipline, there is usually nothing further to do here.
-
-**If you do need to notarize locally**, everything lives in `rcli/scripts/package-rcli.sh` (read its header comment — it documents its own contract in detail):
-
-- One-time setup, check before redoing: `xcrun notarytool history --keychain-profile runanywhere-notary` (confirmed configured on this machine — a fresh submission history returns without error). If missing: `xcrun notarytool store-credentials "runanywhere-notary" --apple-id <email> --team-id <team> --password <app-specific-password>`.
-- Codesign identity: `security find-identity -v -p codesigning | grep "Developer ID Application"` — confirmed present on this machine as `"Developer ID Application: RunAnywhere, Inc (<TEAM_ID>)"`. Grep for it fresh rather than hardcoding the team-id suffix, it can rotate.
-- Invocation contract (env vars, from the script header): `RCLI_CODESIGN_IDENTITY`, `RCLI_MACOS_NOTARIZE=1`, `RCLI_MACOS_FULL_RELEASE=1`, `RCLI_MACOS_SWIFT_BIN_DIR=<output of build-mlx-cli.sh>`. `RCLI_MACOS_FULL_RELEASE=1` is what additionally stages `mlx.metallib` and SwiftPM resource bundles and is what causes a notarized, stapled `.dmg` to be emitted alongside the Homebrew-style tarball. `RCLI_CODESIGN_KEYCHAIN` / `RCLI_NOTARYTOOL_KEYCHAIN` matter only if the identity/profile live in a non-default keychain.
-- Call shape: `rcli/scripts/package-rcli.sh <build-dir> macos-arm64` with the env vars above exported.
 
 ## 6. Electron — build AND packaging are now in `release.yml`; publish is still manual
 

--- a/.claude/skills/sdk-test-starters/SKILL.md
+++ b/.claude/skills/sdk-test-starters/SKILL.md
@@ -121,13 +121,15 @@ Most loggers use `com.runanywhere.RunAnywhereAI`; a few use plain
 covers all of them. On a physical device use `idevicesyslog | grep "com.runanywhere"`
 instead.
 
-## 4. macOS/Swift — no separate repo, use the in-tree example or rcli
+## 4. macOS/Swift — no consumer repo, use the in-tree example
 
-There is no `runanywhere-macos` consumer repo. Two in-monorepo options, both inside
+There is no `runanywhere-macos` consumer repo. Use the in-tree example, inside
 `~/development/ODLM/MONOREPOOO/Qualcomm/runanywhere-sdks`:
 
 - `bindings/swift/example/` — a minimal SwiftPM example app/executable.
-- `rcli/` — the C++ core's CLI, `rac_*` C ABI consumer.
+
+The CLI is no longer in this repo; it moved to `RunanywhereAI/RCLI`, so it is not a
+second in-monorepo option any more.
 
 **The critical gotcha**: the repo's own `Package.swift` is fail-closed toward the
 *real published release* — it resolves the remote `binaryTargets` unless you

--- a/.claude/skills/telemetry-e2e/SKILL.md
+++ b/.claude/skills/telemetry-e2e/SKILL.md
@@ -146,7 +146,7 @@ ctest --test-dir build --output-on-failure
 
 `telemetry_extraction_tests` and `device_identity_tests` are registered in
 `core/tests/CMakeLists.txt`; `rcli_telemetry_live_tests` is registered separately in
-`rcli/tests/CMakeLists.txt`. All three are hand-rolled assertion runners — `CHECK()` in
+`tests/CMakeLists.txt` in `RunanywhereAI/RCLI`. All three are hand-rolled assertion runners — `CHECK()` in
 some files, `ASSERT_EQ`/`ASSERT_TRUE` (from `core/tests/test_common.h`) in others — never
 GoogleTest:
 
@@ -282,7 +282,7 @@ public staging backend — `--environment development --base-url <origin> teleme
 12) and prints a `MODALITY | RESULT | STATUS | RECEIVED | STORED | SKIPPED` table parsed
 directly from the backend's own batch response — **the `STORED` column is authoritative
 server-side confirmation**, not just an HTTP 2xx. `run_telemetry_blast()`'s own exit-code
-logic (`rcli/src/commands/cmd_telemetry.cpp`) does fold `stored >= count` into its overall
+logic (`src/commands/cmd_telemetry.cpp` in `RunanywhereAI/RCLI`) does fold `stored >= count` into its overall
 pass/fail, so a genuine storage shortfall on any modality does make the process exit
 non-zero, not just a transport error — but the exit code is one bit for all 12 modalities
 combined, so a non-zero exit still requires reading the table to know *which* modality
@@ -302,7 +302,7 @@ didn't recognize — a real bug to chase, not the same failure class at all).
 ```
 
 `auth login` only has a path in `production` — `development`'s keyless mode has no login
-step by design (see `rcli/src/commands/cmd_auth.cpp`'s own subcommand help text).
+step by design (see `src/commands/cmd_auth.cpp`'s own subcommand help text in `RunanywhereAI/RCLI`).
 
 **To inspect the actual request body**, not just the summary table, add `--json` for
 machine-readable CLI output and `-v` for debug logging (the debug log includes the

--- a/bindings/python/PACKAGING.md
+++ b/bindings/python/PACKAGING.md
@@ -15,16 +15,18 @@ wheel. The sdist is source-only.
 | `runanywhere-*.tar.gz` (sdist) | scikit-build-core | — | source only (no binaries) |
 
 CI (`.github/workflows/pr-build.yml`) already builds + repairs + validates + hermetic-tests the
-wheel on `python-windows`, `python-linux`, and `python-macos`. The release just collects those
-artifacts.
+wheel on `python-windows` and `python-macos`. The release just collects those artifacts.
+`python-linux` was removed in #757, so the manylinux wheel above is not built by CI today.
 
 ## Dry-run checklist (before `twine upload`)
 
 1. **Version** — bump `core/VERSION`; `scripts/release/sync-versions.sh` propagates
    it into `pyproject.toml`. Confirm `pip show`/`__version__` match.
 2. **Build sdist** — `python -m build --sdist -o dist`.
-3. **Build + repair each wheel** on its platform (Win/Linux/macOS) via the CI recipe (build →
-   delvewheel/auditwheel/delocate).
+3. **Build + repair each wheel** on its platform (Win/Linux/macOS) (build →
+   delvewheel/auditwheel/delocate). Windows and macOS can follow the `python-windows` /
+   `python-macos` jobs in `pr-build.yml`; since #757 removed `python-linux` there is no CI recipe
+   left to copy for the manylinux wheel, so it has to be built and `auditwheel`-repaired by hand.
 4. **Validate the release boundary** — `python scripts/validate_public_packages.py --dist dist
    --expected-version <VERSION>` (asserts: `_core` + sidecar libs present in the right dir per
    platform, no host-path leaks in text/metadata members, the sdist has sources only, version matches).

--- a/bindings/react-native/README.md
+++ b/bindings/react-native/README.md
@@ -34,10 +34,10 @@ Apple Silicon devices and Android phones with 6 GB+ RAM are recommended for 3B+ 
 
 ## Installation
 
-Install the core package plus the backends you need. Pin to **0.20.11**:
+Install the core package plus the backends you need. Pin to **0.20.27**:
 
 ```bash
-npm install @runanywhere/core@0.20.11 @runanywhere/llamacpp@0.20.11
+npm install @runanywhere/core@0.20.27 @runanywhere/llamacpp@0.20.27
 ```
 
 | Package | Purpose |

--- a/bindings/react-native/packages/core/README.md
+++ b/bindings/react-native/packages/core/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @runanywhere/core@0.20.11 react-native-nitro-modules
+npm install @runanywhere/core@0.20.27 react-native-nitro-modules
 ```
 
 ```bash

--- a/bindings/react-native/packages/llamacpp/README.md
+++ b/bindings/react-native/packages/llamacpp/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @runanywhere/core@0.20.11 @runanywhere/llamacpp@0.20.11
+npm install @runanywhere/core@0.20.27 @runanywhere/llamacpp@0.20.27
 cd ios && pod install && cd ..
 ```
 

--- a/bindings/react-native/packages/onnx/README.md
+++ b/bindings/react-native/packages/onnx/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @runanywhere/core@0.20.11 @runanywhere/onnx@0.20.11
+npm install @runanywhere/core@0.20.27 @runanywhere/onnx@0.20.27
 cd ios && pod install && cd ..
 ```
 

--- a/bindings/react-native/packages/qhexrt/README.md
+++ b/bindings/react-native/packages/qhexrt/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @runanywhere/core@0.20.11 @runanywhere/qhexrt@0.20.11
+npm install @runanywhere/core@0.20.19 @runanywhere/qhexrt@0.20.19
 ```
 
 See the [React Native SDK README](../../README.md) for Android setup.

--- a/bindings/web/README.md
+++ b/bindings/web/README.md
@@ -4,7 +4,7 @@ Strictly typed, on-device AI for browser applications. The Web SDK exposes a Swi
 
 The packages target ESM-aware browser bundlers such as Vite and webpack. They are not a server-side Node.js inference runtime.
 
-**Current release:** `0.20.11`
+**Current release:** `0.20.27`
 
 ## Packages
 
@@ -24,13 +24,13 @@ Install core plus only the backends your application needs. Pin compatible versi
 
 ```bash
 # Full SDK
-npm install @runanywhere/web@0.20.11 @runanywhere/web-llamacpp@0.20.11 @runanywhere/web-onnx@0.20.11
+npm install @runanywhere/web@0.20.27 @runanywhere/web-llamacpp@0.20.27 @runanywhere/web-onnx@0.20.27
 
 # LLM, GGUF embeddings, and VLM only
-npm install @runanywhere/web@0.20.11 @runanywhere/web-llamacpp@0.20.11
+npm install @runanywhere/web@0.20.27 @runanywhere/web-llamacpp@0.20.27
 
 # Speech and ONNX embeddings only
-npm install @runanywhere/web@0.20.11 @runanywhere/web-onnx@0.20.11
+npm install @runanywhere/web@0.20.27 @runanywhere/web-onnx@0.20.27
 ```
 
 Keep all three package versions aligned. Backend peer dependencies declare the supported core version range.
@@ -158,7 +158,7 @@ Threaded WebAssembly uses `SharedArrayBuffer`, which browsers only expose in cro
 No. These packages target browser bundlers with WASM and OPFS. Use the Python SDK or CLI for server-side local inference.
 
 **Which package version should I pin?**  
-Use `0.20.11` for all three packages unless release notes specify otherwise. Mismatched core/backend versions may fail peer dependency checks.
+Use `0.20.27` for all three packages unless release notes specify otherwise. Mismatched core/backend versions may fail peer dependency checks.
 
 **Where are models stored?**  
 In the browser's Origin Private File System (OPFS), scoped to your origin.

--- a/bindings/web/packages/core/README.md
+++ b/bindings/web/packages/core/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @runanywhere/web@0.20.11
+npm install @runanywhere/web@0.20.27
 ```
 
 Add `@runanywhere/web-llamacpp` and/or `@runanywhere/web-onnx` for inference backends. See the [Web SDK README](../../README.md) for COOP/COEP headers, Vite config, and bundler setup.

--- a/bindings/web/packages/llamacpp/README.md
+++ b/bindings/web/packages/llamacpp/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @runanywhere/web@0.20.11 @runanywhere/web-llamacpp@0.20.11
+npm install @runanywhere/web@0.20.27 @runanywhere/web-llamacpp@0.20.27
 ```
 
 See the [Web SDK README](../../README.md) for bundler configuration and cross-origin isolation headers.

--- a/bindings/web/packages/onnx/README.md
+++ b/bindings/web/packages/onnx/README.md
@@ -7,7 +7,7 @@
 ## Installation
 
 ```bash
-npm install @runanywhere/web@0.20.11 @runanywhere/web-onnx@0.20.11
+npm install @runanywhere/web@0.20.27 @runanywhere/web-onnx@0.20.27
 ```
 
 See the [Web SDK README](../../README.md) for bundler configuration and cross-origin isolation headers.

--- a/core/include/rac/plugin/rac_plugin_entry.h
+++ b/core/include/rac/plugin/rac_plugin_entry.h
@@ -100,6 +100,19 @@ extern "C" {
  *                 Engines compiled against v8 are rejected until rebuilt;
  *                 NULL `get_stream_token_counts` means counts must be marked
  *                 estimated. Engine-vtable reserved_slot_3 is unchanged.
+ *  10u — promoted reserved primitive wire value 12 to image embedding
+ *                 (`RAC_PRIMITIVE_EMBED_IMAGE`) and renamed engine-vtable
+ *                 reserved_slot_3 -> `image_embedding_ops`, same binary
+ *                 offset, exactly as rerank_ops was promoted in v8. Engines
+ *                 compiled against v9 are rejected until rebuilt; a NULL
+ *                 `image_embedding_ops` means the engine does not serve the
+ *                 primitive.
+ *  11u — promoted reserved primitive wire value 13 to optical character
+ *                 recognition (`RAC_PRIMITIVE_OCR`) and renamed engine-vtable
+ *                 reserved_slot_4 -> `ocr_ops`, same binary offset, so the
+ *                 17-pointer tail is unchanged and only the ABI version gates
+ *                 it. Engines compiled against v10 are rejected until
+ *                 rebuilt.
  */
 #define RAC_PLUGIN_API_VERSION 11u
 

--- a/scripts/validation/verify_default_pool.sh
+++ b/scripts/validation/verify_default_pool.sh
@@ -23,7 +23,7 @@
 # Exit codes:
 #   0  Every language agrees with the proto.
 #   1  At least one value disagrees, or a language is missing a field.
-#   2  A generated file is missing (run idl/codegen/generate_defaults_pool.sh).
+#   2  A generated file is missing (run idl/codegen/generate_defaults_pool.py).
 
 set -euo pipefail
 


### PR DESCRIPTION
## Description

Four documentation findings, each of which I had opened as its own PR. That was my mistake: four separate docs PRs is four review threads for what should be one. Consolidating them here and closing #822, #800, #758 and #829 in favour of this.

All four re-verified on `45e91276e` (0.20.36).

**1. Skill docs walk through a binary that is not in this repo.** `sdk-publish`, `sdk-test-starters` and `telemetry-e2e` all give `rcli` commands. There is no `rcli` directory in the tree; it moved out. Both the `.agents/` and `.claude/` copies are updated, since they are separate files rather than symlinks.

**2. npm install commands pin a version that was never published.** The React Native and Web READMEs say `@0.20.11`:

```
$ npm view @runanywhere/core versions          # 0.20.11 present? False
$ npm view @runanywhere/web-llamacpp versions  # 0.20.11 present? False
```

Copying the documented command fails. Changed to `0.20.27`, which is the current published release for all three packages.

`bindings/react-native/packages/qhexrt/README.md` deliberately keeps `0.20.19`: that is qhexrt's own latest published version, not a stale pin.

**3. Two stale references in packaging docs.** `bindings/python/PACKAGING.md` tells you to follow the `python-linux` CI job; `grep -c python-linux .github/workflows/pr-build.yml` returns 0, because #757 removed it. The manylinux wheel therefore has no CI recipe left to copy, which the doc now says. Separately, `scripts/validation/verify_default_pool.sh` tells you to run `idl/codegen/generate_defaults_pool.sh`; the file on disk is `generate_defaults_pool.py`.

**4. The plugin ABI history stops two versions short.** `RAC_PLUGIN_API_VERSION` is `11u` but the history block's last entry is `9u`, so the two most recent ABI breaks are undocumented. Added both, in the style of the surrounding entries: 10u for image embedding (`reserved_slot_3` to `image_embedding_ops`) and 11u for OCR (`reserved_slot_4` to `ocr_ops`).

## Type of Change
- [ ] Bug fix
- [ ] New feature
- [x] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

Neither applies and neither is ticked. Every added line in the one non-markdown source file (`rac_plugin_entry.h`) is a comment, verified mechanically: of the added lines, 0 are not comment lines. `verify_default_pool.sh` changes one comment line. No behaviour to test and nothing for a linter to judge beyond prose.

### Platform-Specific Testing (check all that apply)
None. Documentation and comments only.

## Labels
**SDKs:**
- [ ] `Swift SDK`
- [ ] `Kotlin SDK`
- [ ] `Flutter SDK`
- [x] `React Native SDK` - README install commands
- [x] `Web SDK` - README install commands
- [x] `Commons` - ABI history comment in `core/include`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (if needed)
