### PR TITLE
fix(rn-sdk): use ensureServicesReadyOrIgnore in refreshModelRegistry

### DIFF
--- a/bindings/react-native/packages/core/src/Public/Extensions/Models/RunAnywhere+ModelRegistry.ts
+++ b/bindings/react-native/packages/core/src/Public/Extensions/Models/RunAnywhere+ModelRegistry.ts
@@ -1061,7 +1061,7 @@ export async function refreshModelRegistry(
   } = options;
   const native = requireNativeModule();
   try {
-    await ensureServicesReady();
+    await ensureServicesReadyOrIgnore();
     await native.refreshModelRegistry(
       includeRemoteCatalog,
       rescanLocal,


### PR DESCRIPTION
## Problem

Fixes #852. When `ensureServicesReady()` rejects (services init fails), the native `refreshModelRegistry()` call was never reached, unlike Swift (`try?`) and Kotlin (catch-and-continue) which still rescan locally.

## Approach

Changed `ensureServicesReady()` to `ensureServicesReadyOrIgnore()` (already imported and used by `listModels` and `getModel` in the same file) so the native refresh runs even when services init fails.

## Verification

- The function is non-throwing by contract (matches Swift parity comment at line 1042)
- The catch block at line 1070 already handles errors gracefully
- `ensureServicesReadyOrIgnore` is already used by `listModels` (line 405) and `getModel` (line 470) in the same file for the same reason

## Known Issues

Could not run the full test suite due to yarn workspace dependency resolution issues in the CI-like environment. The fix is minimal (1 line change) and follows the exact pattern already established in the same file.

@ayaangazali - this follows the suggested approach from the issue. The fix uses the existing `ensureServicesReadyOrIgnore` function that was already noted as the correct call site in `ServicesReadyGuard.ts:36-38`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Model registry refreshes can now proceed even when service-readiness checks fail, while preserving the existing refresh behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->