### PR TITLE
fix(android,rn): stop file callbacks leaking exceptions or null directory entries

### DIFF
--- a/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/foundation/bridge/extensions/CppBridgeFileManager.kt
+++ b/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/foundation/bridge/extensions/CppBridgeFileManager.kt
@@ -174,32 +174,57 @@ object CppBridgeFileManager {
 
         @Suppress("unused") // Called from JNI
         fun listDirectory(path: String): Array<String>? {
-            return File(path).list()
+            return try {
+                File(path).list()
+            } catch (_: Exception) {
+                null // sentinel: directory missing / unreadable
+            }
         }
 
         @Suppress("unused") // Called from JNI
         fun pathExists(path: String): Boolean {
-            return File(path).exists()
+            return try {
+                File(path).exists()
+            } catch (_: Exception) {
+                false
+            }
         }
 
         @Suppress("unused") // Called from JNI
         fun isDirectory(path: String): Boolean {
-            return File(path).isDirectory
+            return try {
+                File(path).isDirectory
+            } catch (_: Exception) {
+                false
+            }
         }
 
         @Suppress("unused") // Called from JNI
         fun getFileSize(path: String): Long {
-            val file = File(path)
-            return if (file.isFile) file.length() else -1L
+            return try {
+                val file = File(path)
+                if (file.isFile) file.length() else -1L
+            } catch (_: Exception) {
+                -1L
+            }
         }
 
         @Suppress("unused") // Called from JNI
-        fun getAvailableSpace(): Long = CppBridgeFileManager.availableSpace()
+        fun getAvailableSpace(): Long {
+            return try {
+                CppBridgeFileManager.availableSpace()
+            } catch (_: Exception) {
+                -1L
+            }
+        }
 
         @Suppress("unused") // Called from JNI
         fun getTotalSpace(): Long {
-            val baseDir = File(CppBridgeModelPaths.getBaseDirectory())
-            return baseDir.totalSpace
+            return try {
+                File(CppBridgeModelPaths.getBaseDirectory()).totalSpace
+            } catch (_: Exception) {
+                -1L
+            }
         }
     }
 }

--- a/bindings/react-native/packages/core/cpp/bridges/FileManagerBridge.cpp
+++ b/bindings/react-native/packages/core/cpp/bridges/FileManagerBridge.cpp
@@ -103,6 +103,17 @@ static rac_result_t posixDeletePath(const char* path, int recursive, void* /*use
     }
 }
 
+// Free a directory-entry array produced by posixListDirectory. Shared by the
+// rollback path below and the registered free_entries callback so a partially
+// filled array is never leaked.
+static void freeEntryArray(char** entries, size_t count) {
+    if (!entries) return;
+    for (size_t i = 0; i < count; i++) {
+        free(entries[i]);
+    }
+    free(entries);
+}
+
 static rac_result_t posixListDirectory(const char* path, char*** outEntries,
                                         size_t* outCount, void* /*userData*/) {
     if (!path || !outEntries || !outCount) return RAC_ERROR_NULL_POINTER;
@@ -135,14 +146,22 @@ static rac_result_t posixListDirectory(const char* path, char*** outEntries,
         return RAC_ERROR_OUT_OF_MEMORY;
     }
 
-    // Second pass: fill entries
+    // Second pass: fill entries. A failed strdup rolls the whole listing back —
+    // commons must never receive a "successful" array with a null slot, since it
+    // strcmp()s every entry and would crash on the null.
     rewinddir(dir);
     size_t i = 0;
     while ((entry = readdir(dir)) != nullptr && i < count) {
         if (strcmp(entry->d_name, ".") == 0 || strcmp(entry->d_name, "..") == 0) {
             continue;
         }
-        entries[i] = strdup(entry->d_name);
+        char* copy = strdup(entry->d_name);
+        if (copy == nullptr) {
+            closedir(dir);
+            freeEntryArray(entries, i);
+            return RAC_ERROR_OUT_OF_MEMORY;
+        }
+        entries[i] = copy;
         i++;
     }
     closedir(dir);
@@ -153,11 +172,7 @@ static rac_result_t posixListDirectory(const char* path, char*** outEntries,
 }
 
 static void posixFreeEntries(char** entries, size_t count, void* /*userData*/) {
-    if (!entries) return;
-    for (size_t i = 0; i < count; i++) {
-        free(entries[i]);
-    }
-    free(entries);
+    freeEntryArray(entries, count);
 }
 
 static rac_bool_t posixPathExists(const char* path, rac_bool_t* outIsDirectory,

--- a/core/src/jni/runanywhere_commons_jni.cpp
+++ b/core/src/jni/runanywhere_commons_jni.cpp
@@ -3957,10 +3957,18 @@ static rac_result_t jni_fc_create_directory(const char* path, int recursive, voi
     JNIEnv* env = getJNIEnv();
     if (env == nullptr || g_file_callbacks_obj == nullptr)
         return RAC_ERROR_NOT_INITIALIZED;
+    if (path == nullptr)
+        return RAC_ERROR_NULL_POINTER;
     jstring jPath = env->NewStringUTF(path);
+    if (jPath == nullptr) {
+        jniClearPendingException(env);
+        return RAC_ERROR_OUT_OF_MEMORY;
+    }
     jint result = env->CallIntMethod(g_file_callbacks_obj, g_fc_create_directory, jPath,
                                      static_cast<jboolean>(recursive != 0));
     env->DeleteLocalRef(jPath);
+    if (jniClearPendingException(env))
+        return RAC_ERROR_INTERNAL;
     return static_cast<rac_result_t>(result);
 }
 
@@ -3968,10 +3976,18 @@ static rac_result_t jni_fc_delete_path(const char* path, int recursive, void* us
     JNIEnv* env = getJNIEnv();
     if (env == nullptr || g_file_callbacks_obj == nullptr)
         return RAC_ERROR_NOT_INITIALIZED;
+    if (path == nullptr)
+        return RAC_ERROR_NULL_POINTER;
     jstring jPath = env->NewStringUTF(path);
+    if (jPath == nullptr) {
+        jniClearPendingException(env);
+        return RAC_ERROR_OUT_OF_MEMORY;
+    }
     jint result = env->CallIntMethod(g_file_callbacks_obj, g_fc_delete_path, jPath,
                                      static_cast<jboolean>(recursive != 0));
     env->DeleteLocalRef(jPath);
+    if (jniClearPendingException(env))
+        return RAC_ERROR_INTERNAL;
     return static_cast<rac_result_t>(result);
 }
 
@@ -3989,17 +4005,14 @@ static rac_result_t jni_fc_list_directory(const char* path, char*** out_entries,
 
     jstring jPath = env->NewStringUTF(path);
     if (jPath == nullptr) {
-        if (env->ExceptionCheck() == JNI_TRUE) {
-            env->ExceptionClear();
-        }
+        jniClearPendingException(env);
         return RAC_ERROR_OUT_OF_MEMORY;
     }
     jobjectArray jEntries = static_cast<jobjectArray>(
         env->CallObjectMethod(g_file_callbacks_obj, g_fc_list_directory, jPath));
     env->DeleteLocalRef(jPath);
 
-    if (env->ExceptionCheck() == JNI_TRUE) {
-        env->ExceptionClear();
+    if (jniClearPendingException(env)) {
         if (jEntries != nullptr) {
             env->DeleteLocalRef(jEntries);
         }
@@ -4033,10 +4046,7 @@ static rac_result_t jni_fc_list_directory(const char* path, char*** out_entries,
     for (jsize i = 0; i < count; i++) {
         auto jEntry = static_cast<jstring>(env->GetObjectArrayElement(jEntries, i));
         if (jEntry == nullptr) {
-            const bool has_exception = env->ExceptionCheck() == JNI_TRUE;
-            if (has_exception) {
-                env->ExceptionClear();
-            }
+            const bool has_exception = jniClearPendingException(env);
             free_directory_entry_copies(entries, static_cast<size_t>(i));
             env->DeleteLocalRef(jEntries);
             return has_exception ? RAC_ERROR_INTERNAL : RAC_ERROR_INVALID_ARGUMENT;
@@ -4044,9 +4054,7 @@ static rac_result_t jni_fc_list_directory(const char* path, char*** out_entries,
 
         const char* entryChars = env->GetStringUTFChars(jEntry, nullptr);
         if (entryChars == nullptr) {
-            if (env->ExceptionCheck() == JNI_TRUE) {
-                env->ExceptionClear();
-            }
+            jniClearPendingException(env);
             env->DeleteLocalRef(jEntry);
             free_directory_entry_copies(entries, static_cast<size_t>(i));
             env->DeleteLocalRef(jEntries);
@@ -4074,16 +4082,38 @@ static void jni_fc_free_entries(char** entries, size_t count, void* user_data) {
 
 static rac_bool_t jni_fc_path_exists(const char* path, rac_bool_t* out_is_directory,
                                      void* user_data) {
+    if (out_is_directory != nullptr) {
+        *out_is_directory = RAC_FALSE;
+    }
+
     JNIEnv* env = getJNIEnv();
     if (env == nullptr || g_file_callbacks_obj == nullptr)
         return RAC_FALSE;
 
-    jstring jPath = env->NewStringUTF(path);
-    jboolean exists = env->CallBooleanMethod(g_file_callbacks_obj, g_fc_path_exists, jPath);
+    if (path == nullptr)
+        return RAC_FALSE;
 
-    if (out_is_directory != nullptr && exists) {
+    jstring jPath = env->NewStringUTF(path);
+    if (jPath == nullptr) {
+        jniClearPendingException(env);
+        return RAC_FALSE;
+    }
+
+    jboolean exists = env->CallBooleanMethod(g_file_callbacks_obj, g_fc_path_exists, jPath);
+    if (jniClearPendingException(env)) {
+        // pathExists raised: skip the isDirectory probe so we never issue a JNI
+        // call with a pending exception still set on this thread.
+        env->DeleteLocalRef(jPath);
+        return RAC_FALSE;
+    }
+
+    if (exists && out_is_directory != nullptr) {
         jboolean isDir = env->CallBooleanMethod(g_file_callbacks_obj, g_fc_is_directory, jPath);
-        *out_is_directory = isDir ? RAC_TRUE : RAC_FALSE;
+        if (jniClearPendingException(env)) {
+            *out_is_directory = RAC_FALSE;
+        } else {
+            *out_is_directory = isDir ? RAC_TRUE : RAC_FALSE;
+        }
     }
 
     env->DeleteLocalRef(jPath);
@@ -4094,9 +4124,17 @@ static int64_t jni_fc_get_file_size(const char* path, void* user_data) {
     JNIEnv* env = getJNIEnv();
     if (env == nullptr || g_file_callbacks_obj == nullptr)
         return -1;
+    if (path == nullptr)
+        return -1;
     jstring jPath = env->NewStringUTF(path);
-    jlong size = env->CallLongMethod(g_file_callbacks_obj, g_fc_get_file_size, jPath);
+    if (jPath == nullptr) {
+        jniClearPendingException(env);
+        return -1;
+    }
+    const jlong size = env->CallLongMethod(g_file_callbacks_obj, g_fc_get_file_size, jPath);
     env->DeleteLocalRef(jPath);
+    if (jniClearPendingException(env))
+        return -1;
     return static_cast<int64_t>(size);
 }
 
@@ -4104,15 +4142,20 @@ static int64_t jni_fc_get_available_space(void* user_data) {
     JNIEnv* env = getJNIEnv();
     if (env == nullptr || g_file_callbacks_obj == nullptr)
         return -1;
-    return static_cast<int64_t>(
-        env->CallLongMethod(g_file_callbacks_obj, g_fc_get_available_space));
+    const jlong size = env->CallLongMethod(g_file_callbacks_obj, g_fc_get_available_space);
+    if (jniClearPendingException(env))
+        return -1;
+    return static_cast<int64_t>(size);
 }
 
 static int64_t jni_fc_get_total_space(void* user_data) {
     JNIEnv* env = getJNIEnv();
     if (env == nullptr || g_file_callbacks_obj == nullptr)
         return -1;
-    return static_cast<int64_t>(env->CallLongMethod(g_file_callbacks_obj, g_fc_get_total_space));
+    const jlong size = env->CallLongMethod(g_file_callbacks_obj, g_fc_get_total_space);
+    if (jniClearPendingException(env))
+        return -1;
+    return static_cast<int64_t>(size);
 }
 
 /**


### PR DESCRIPTION
## Description
Closes #865, #866 — one focused fix to the platform file-callback boundary: a
callback must not leak a language-runtime exception, and must not hand commons a
partially initialised directory-entry array.

Android/Kotlin (#865): the JNI `rac_file_callbacks_t` thunks
(`jni_fc_create_directory`, `jni_fc_delete_path`, `jni_fc_path_exists`,
`jni_fc_get_file_size`, `jni_fc_get_available_space`, `jni_fc_get_total_space`)
now null-check their path, verify `NewStringUTF`, and clear/translate a pending
Java exception after every invocation. `jni_fc_list_directory` routes its four
hand-written `ExceptionCheck`/`ExceptionClear` blocks through
`jniClearPendingException` (error mapping unchanged), and `jni_fc_path_exists`
skips the `isDirectory` probe — returning `RAC_FALSE` with a safe-false
directory output — when `pathExists` raises. The remaining
`FileCallbackProvider` methods catch ordinary file-operation exceptions and
return their documented sentinels (`null` / `false` / `-1L`); `Throwable` is not
caught — the JNI boundary stays the final containment layer.

React Native (#866): `posixListDirectory` checks every `strdup(entry->d_name)`
and, on failure, rolls the whole listing back (closes the `DIR*`, frees the
already-copied entries plus the pointer array, leaves `outEntries == nullptr` /
`outCount == 0`) and returns `RAC_ERROR_OUT_OF_MEMORY` — instead of reporting
success with a null slot that commons later `strcmp()`s.

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [x] Lint passes locally (`git diff --check` clean; the changed C++ regions
      compile with `g++ -std=gnu++17 -fsyntax-only` in a stub harness)
- [ ] Added/updated tests for changes — the repo validates end-to-end through
      the example apps and does not add unit tests unless the change asks for them.

### Platform-Specific Testing (check all that apply)
**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

No Android NDK / JDK / Gradle or RN toolchain is available on this host, so
`ktlintCheck`/`detekt` and the Android-JNI + RN native builds are left to PR CI.

## Labels
**SDKs:**
- [x] `Kotlin SDK` - Changes to Kotlin SDK (`bindings/kotlin`)
- [x] `React Native SDK` - Changes to React Native SDK (`bindings/react-native`)
- [x] `Commons` - Changes to shared native code (`core`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [ ] Documentation updated (if needed) — not applicable (no public API change)

## Screenshots
Not applicable — no UI change.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reliability when accessing files and directories, including cases involving invalid paths, unavailable storage information, or unexpected file-system errors.
  - Directory listings now handle incomplete results and memory-related failures more safely, preventing corrupted entries and improving cleanup.
  - Native and platform integrations now report file-operation failures consistently instead of allowing errors to propagate unexpectedly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->