### PR TITLE
fix(ci): compile the Flutter and React Native Android transports in PR CI

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -500,6 +500,14 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
         with:
           platform: flutter
+      # The core plugin's Android module (packages/runanywhere/android) is a real
+      # Kotlin source set, but `flutter analyze`/`test` below only read Dart: a
+      # Kotlin syntax or dependency error in OkHttpHttpTransport.kt used to ship
+      # with every job green. Add the pinned JDK + Android SDK so the plugin's own
+      # Kotlin task can be compiled (issue #869).
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          platform: android
       # The Dart bindings under packages/runanywhere/lib/generated are IDL codegen output and are not tracked; generate
       # before anything compiles them.
       - uses: ./.github/actions/generate-idl
@@ -513,6 +521,40 @@ jobs:
           dart run melos bootstrap
           dart run melos run analyze
           dart run melos run test
+      # `flutter analyze`/`test` never compile the plugin's Android copy of
+      # OkHttpHttpTransport.kt, so compile the core plugin's Kotlin module here.
+      # `:runanywhere` is the module dev.flutter.flutter-plugin-loader registers
+      # from `.flutter-plugins-dependencies`, which `flutter pub get` in the
+      # example writes; that single task compiles the same source set a full
+      # `flutter build apk` would, for a fraction of the cost.
+      #
+      # android/local.properties (flutter.sdk + sdk.dir) is gitignored and
+      # normally written by `flutter build`; create it when pub get did not,
+      # mirroring bindings/flutter/scripts/test-android-remote-downloads.sh.
+      #
+      # preBuild - and therefore every AGP compile path - depends on
+      # downloadNativeLibs, which fails closed on a clean checkout because the
+      # plugin's jniLibs are not tracked. It only stages native libraries, which
+      # the Kotlin source set does not need, so exclude it rather than pull
+      # release archives into PR CI.
+      - name: Compile Flutter Android transport
+        working-directory: bindings/flutter/example
+        run: |
+          set -euo pipefail
+          flutter pub get
+          if [ ! -f android/local.properties ]; then
+            _sdk_dir="${ANDROID_SDK_ROOT:-${ANDROID_HOME:-}}"
+            _flutter_sdk="$(cd "$(dirname "$(command -v flutter)")/.." 2>/dev/null && pwd || true)"
+            {
+              [ -n "${_sdk_dir}" ] && echo "sdk.dir=${_sdk_dir}"
+              [ -n "${_flutter_sdk}" ] && echo "flutter.sdk=${_flutter_sdk}"
+            } > android/local.properties
+          fi
+          android/gradlew -p android \
+            :runanywhere:compileDebugKotlin \
+            --no-daemon \
+            --max-workers="$(nproc)" \
+            -x downloadNativeLibs
 
   rn-typecheck:
     runs-on: ubuntu-22.04
@@ -521,6 +563,14 @@ jobs:
       - uses: ./.github/actions/setup-toolchain
         with:
           platform: node
+      # The core package's Android module (packages/core/android) is a real
+      # Kotlin source set, but nothing above compiles it: a Kotlin syntax or
+      # dependency error in OkHttpHttpTransport.kt used to ship with every job
+      # green. Add the pinned JDK + Android SDK so the core module's own Kotlin
+      # task can be compiled below (issue #869).
+      - uses: ./.github/actions/setup-toolchain
+        with:
+          platform: android
       # Repo root and bindings/react-native pin `packageManager: yarn@3.6.1`
       # (Yarn Berry). The runner's global yarn is 1.x and refuses to run, so we
       # activate the pinned version through Corepack before any `yarn` call.
@@ -584,6 +634,28 @@ jobs:
       - name: Jest unit tests (React Native example)
         working-directory: bindings/react-native
         run: yarn workspace runanywhere-ai-example test --runInBand --config jest.config.js
+      # `yarn typecheck`/`lint` and the C++ header check above never compile the
+      # core package's Android copy of OkHttpHttpTransport.kt. Compile just the
+      # core module's Kotlin task instead of a full app assembly: :runanywhere_core
+      # is the project example/android/settings.gradle maps to
+      # node_modules/@runanywhere/core/android, so this compiles the same Kotlin
+      # source set `./gradlew assembleDebug` would.
+      #
+      # The example's android/gradle.properties is gitignored, so seed it from the
+      # documented template - it carries android.useAndroidX and keeps
+      # useLocalNatives=true, which also detaches the core module's
+      # downloadNativeLibs from preBuild. `-x downloadNativeLibs` keeps the step
+      # hermetic even if that property changes.
+      - name: Compile React Native Android transport
+        working-directory: bindings/react-native/example
+        run: |
+          set -euo pipefail
+          cp android/gradle.properties.example android/gradle.properties
+          android/gradlew -p android \
+            :runanywhere_core:compileDebugKotlin \
+            --no-daemon \
+            --max-workers="$(nproc)" \
+            -x downloadNativeLibs
 
   web-typecheck:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
## Description

Neither `pr-build` job ever invoked Gradle, so a Kotlin syntax or dependency error in either Android copy of `OkHttpHttpTransport.kt` shipped with every check green:

- `bindings/flutter/packages/runanywhere/android/src/main/kotlin/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt`
- `bindings/react-native/packages/core/android/src/main/java/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt`

`flutter-pubget` only ran `flutter analyze`/`test` (Dart), and `rn-typecheck` only ran TypeScript/ESLint/Jest plus a C++ header check.

This adds the pinned JDK + Android SDK toolchain to both jobs and compiles **only the core module's Kotlin task** instead of a full application assembly:

| Job | New step | Scoped task |
|---|---|---|
| `flutter-pubget` | `Compile Flutter Android transport` | `:runanywhere:compileDebugKotlin` |
| `rn-typecheck` | `Compile React Native Android transport` | `:runanywhere_core:compileDebugKotlin` |

`:runanywhere` is the module `dev.flutter.flutter-plugin-loader` registers from `.flutter-plugins-dependencies`, and `:runanywhere_core` is declared in `bindings/react-native/example/android/settings.gradle`. Both compile the same Kotlin source set an app build would, for a fraction of the cost.

Both steps stay hermetic:

- `compileDebugKotlin` depends on `preBuild`, and the Flutter plugin's `preBuild.dependsOn downloadNativeLibs` **fails closed on a clean checkout** because its `jniLibs` are not tracked. `downloadNativeLibs` only stages native libraries, which Kotlin compilation does not need, so both runs pass `-x downloadNativeLibs` rather than pull release archives into PR CI.
- The Flutter step writes the gitignored `android/local.properties` the same way `bindings/flutter/scripts/test-android-remote-downloads.sh` does.
- The RN step seeds the gitignored `android/gradle.properties` from `gradle.properties.example` (carries `android.useAndroidX`, keeps `useLocalNatives=true`).

No transport implementation was modified and no unit tests were added - this issue is purely a build-coverage gap.

## Type of Change

- [x] Bug fix

## Testing

- [x] Lint passes locally (`git diff --check` clean; workflow parses with a YAML parser)
- [ ] Added/updated tests for changes - not applicable, this is CI compile coverage

The workflow diff is limited to `.github/workflows/pr-build.yml` (72 insertions, 0 deletions). The two scoped Gradle commands are validated by this PR's CI run: the authoring host had no Android/Flutter SDK and the React Native Gradle scripts only support Linux/macOS hosts.

## Labels

- [x] `Flutter SDK` - Changes to Flutter SDK (`bindings/flutter`)
- [x] `React Native SDK` - Changes to React Native SDK (`bindings/react-native`)

Fixes #869.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Tests**
  - Expanded automated checks for Android builds across Flutter and React Native integrations.
  - Added Kotlin compilation validation to detect Android integration issues earlier in the development process.
  - Improved CI setup for dependency retrieval and Android project configuration during pull request checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->