### PR TITLE
fix(android): classify host-dispatcher stream cancellation as RAC_ERROR_CANCELLED

### DIFF
--- a/bindings/flutter/packages/runanywhere/android/src/main/kotlin/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt
+++ b/bindings/flutter/packages/runanywhere/android/src/main/kotlin/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt
@@ -37,6 +37,7 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
+import java.io.InterruptedIOException
 import java.time.Duration
 import java.util.concurrent.Callable
 import java.util.concurrent.ConcurrentHashMap
@@ -464,7 +465,7 @@ object OkHttpHttpTransport {
                 statusCode = 0,
                 headers = emptyArray(),
                 errorMessage = "${e.javaClass.simpleName}: ${e.message ?: "unknown"}",
-                cancelled = activeCall != null && synchronized(slot) { slot.cancelRequested },
+                cancelled = isStreamCancellation(e, activeCall, slot),
             )
         } finally {
             inFlightStreams.remove(streamId)
@@ -494,7 +495,11 @@ object OkHttpHttpTransport {
                     try {
                         input.read(buffer)
                     } catch (io: IOException) {
-                        if (synchronized(slot) { slot.cancelRequested }) {
+                        // A cancelled call surfaces as an IOException — treat
+                        // that as a clean cancellation rather than a transport
+                        // failure. Timeouts stay transport errors (see
+                        // [isStreamCancellation]).
+                        if (isStreamCancellation(io, call, slot)) {
                             cancelled = true
                             break
                         }
@@ -530,6 +535,26 @@ object OkHttpHttpTransport {
     // ---------------------------------------------------------------------
     // Helpers
     // ---------------------------------------------------------------------
+
+    /**
+     * Classifies a streaming failure as cancellation.
+     *
+     * True when the SDK-owned [StreamSlot.cancelRequested] marker is set (the
+     * native chunk callback returned `false`, or [cancelAllStreams] ran), or
+     * the OkHttp [Call] was cancelled by some other owner — e.g. a host
+     * client's shared `Dispatcher.cancelAll()` reached through [setHttpClient].
+     *
+     * OkHttp's own call/read timeouts cancel too, but surface as
+     * [InterruptedIOException] (which `SocketTimeoutException` extends), so
+     * they stay transport errors for JNI to map to `RAC_ERROR_TIMEOUT`.
+     */
+    private fun isStreamCancellation(failure: Throwable, call: Call?, slot: StreamSlot): Boolean {
+        if (synchronized(slot) { slot.cancelRequested }) return true
+        return call != null &&
+            call.isCanceled() &&
+            failure is IOException &&
+            failure !is InterruptedIOException
+    }
 
     private fun buildRequest(
         method: String,

--- a/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt
+++ b/bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt
@@ -42,6 +42,7 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
+import java.io.InterruptedIOException
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
 import java.util.concurrent.atomic.AtomicLong
@@ -547,7 +548,7 @@ object OkHttpHttpTransport {
                 statusCode = 0,
                 headers = emptyArray(),
                 errorMessage = "${e.javaClass.simpleName}: ${e.message ?: "unknown"}",
-                cancelled = activeCall != null && synchronized(slot) { slot.cancelRequested },
+                cancelled = isStreamCancellation(e, activeCall, slot),
             )
         } finally {
             inFlightStreams.remove(streamId)
@@ -578,10 +579,11 @@ object OkHttpHttpTransport {
                     try {
                         input.read(buffer)
                     } catch (io: IOException) {
-                        // If the caller cancelled, OkHttp surfaces the abort
-                        // as an IOException — treat that as a clean
-                        // cancellation rather than a transport failure.
-                        if (synchronized(slot) { slot.cancelRequested }) {
+                        // A cancelled call surfaces as an IOException — treat
+                        // that as a clean cancellation rather than a transport
+                        // failure. Timeouts stay transport errors (see
+                        // [isStreamCancellation]).
+                        if (isStreamCancellation(io, call, slot)) {
                             cancelled = true
                             break
                         }
@@ -616,6 +618,26 @@ object OkHttpHttpTransport {
     }
 
     // Helpers
+
+    /**
+     * Classifies a streaming failure as cancellation.
+     *
+     * True when the SDK-owned [StreamSlot.cancelRequested] marker is set (the
+     * native chunk callback returned `false`, or [cancelAllStreams] ran), or
+     * the OkHttp [Call] was cancelled by some other owner — e.g. a host
+     * client's shared `Dispatcher.cancelAll()` reached through [setHttpClient].
+     *
+     * OkHttp's own call/read timeouts cancel too, but surface as
+     * [InterruptedIOException] (which `SocketTimeoutException` extends), so
+     * they stay transport errors for JNI to map to `RAC_ERROR_TIMEOUT`.
+     */
+    private fun isStreamCancellation(failure: Throwable, call: Call?, slot: StreamSlot): Boolean {
+        if (synchronized(slot) { slot.cancelRequested }) return true
+        return call != null &&
+            call.isCanceled() &&
+            failure is IOException &&
+            failure !is InterruptedIOException
+    }
 
     private fun buildRequest(
         method: String,

--- a/bindings/react-native/packages/core/android/src/main/java/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt
+++ b/bindings/react-native/packages/core/android/src/main/java/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt
@@ -28,6 +28,7 @@ import okhttp3.Request
 import okhttp3.RequestBody
 import okhttp3.RequestBody.Companion.toRequestBody
 import java.io.IOException
+import java.io.InterruptedIOException
 import java.time.Duration
 import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.TimeUnit
@@ -426,7 +427,7 @@ object OkHttpHttpTransport {
                 statusCode = 0,
                 headers = emptyArray(),
                 errorMessage = "${e.javaClass.simpleName}: ${e.message ?: "unknown"}",
-                cancelled = activeCall != null && synchronized(slot) { slot.cancelRequested },
+                cancelled = isStreamCancellation(e, activeCall, slot),
             )
         } finally {
             inFlightStreams.remove(streamId)
@@ -451,7 +452,11 @@ object OkHttpHttpTransport {
                 val n = try {
                     input.read(buffer)
                 } catch (io: IOException) {
-                    if (synchronized(slot) { slot.cancelRequested }) {
+                    // A cancelled call surfaces as an IOException — treat that
+                    // as a clean cancellation rather than a transport failure.
+                    // Timeouts stay transport errors (see
+                    // [isStreamCancellation]).
+                    if (isStreamCancellation(io, call, slot)) {
                         cancelled = true
                         break
                     }
@@ -486,6 +491,26 @@ object OkHttpHttpTransport {
     // -------------------------------------------------------------------------
     // Helpers
     // -------------------------------------------------------------------------
+
+    /**
+     * Classifies a streaming failure as cancellation.
+     *
+     * True when the SDK-owned [StreamSlot.cancelRequested] marker is set (the
+     * native chunk callback returned `false`, or [cancelAllStreams] ran), or
+     * the OkHttp [Call] was cancelled by some other owner — e.g. a host
+     * client's shared `Dispatcher.cancelAll()` reached through [setHttpClient].
+     *
+     * OkHttp's own call/read timeouts cancel too, but surface as
+     * [InterruptedIOException] (which `SocketTimeoutException` extends), so
+     * they stay transport errors for JNI to map to `RAC_ERROR_TIMEOUT`.
+     */
+    private fun isStreamCancellation(failure: Throwable, call: Call?, slot: StreamSlot): Boolean {
+        if (synchronized(slot) { slot.cancelRequested }) return true
+        return call != null &&
+            call.isCanceled() &&
+            failure is IOException &&
+            failure !is InterruptedIOException
+    }
 
     private fun buildRequest(
         method: String,


### PR DESCRIPTION
## Description

Follow-up to #741 (issue #870). A streaming call cancelled through a host-installed `OkHttpClient`'s own `Dispatcher` (for example `dispatcher.cancelAll()` after `setHttpClient()`) aborts with an `IOException`, but the SDK-owned `StreamSlot.cancelRequested` marker is never set — so the failure was reported as a network error and handed to the download orchestrator's retry policy instead of surfacing as `RAC_ERROR_CANCELLED`.

All three Android transport copies now classify cancellation the same way:

| File | Change |
|---|---|
| `bindings/kotlin/src/main/kotlin/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt` | shared `isStreamCancellation` helper + `java.io.InterruptedIOException` import |
| `bindings/flutter/packages/runanywhere/android/src/main/kotlin/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt` | same |
| `bindings/react-native/packages/core/android/src/main/java/com/runanywhere/sdk/httptransport/OkHttpHttpTransport.kt` | same |

```kotlin
private fun isStreamCancellation(failure: Throwable, call: Call?, slot: StreamSlot): Boolean {
    if (synchronized(slot) { slot.cancelRequested }) return true
    return call != null &&
        call.isCanceled() &&
        failure is IOException &&
        failure !is InterruptedIOException
}
```

Used by both failure sites so the setup-time catch and the body-read catch cannot drift:

- `streamInternal` catch → `cancelled = isStreamCancellation(e, activeCall, slot)`
- `drainBody` read catch → clean cancellation when the helper matches, otherwise rethrown unchanged

`SocketTimeoutException` is covered through its `InterruptedIOException` inheritance; no message matching or raw error strings are introduced. The SDK's own cancel paths (`cancelAllStreams()` and the chunk callback returning `false`) and every other `IOException` are unchanged. No C++ error mapping, retry policy, or public API changes.

## Type of Change

- [x] Bug fix

## Testing

- [x] Lint passes locally
- [ ] Added/updated tests for changes — per the plan for this issue: no unit tests; validated with the existing checks plus focused behavioral review

Validation performed:

- ktlint 1.5.0 (repo pin) over the three files, on the working tree and on a pristine `main` checkout: identical results (30/94/94 findings), so the change adds no ktlint violations.
- detekt 1.23.8 (repo pin) with `bindings/kotlin/detekt.yml` on the Kotlin copy: exit 0, no findings.
- Compiled all three transport owners with kotlinc 2.0.21 against real okhttp 4.12.0 + okio 3.6.0 (project/Android types stubbed outside the repo): exit 0 for each.
- Behavioral probe against real OkHttp 4.12.0:

| Scenario | exception | `call.isCanceled()` | classified as cancellation |
|---|---|---|---|
| `Call.cancel()` | `IOException` | true | yes |
| host `dispatcher.cancelAll()` in flight | `SocketException` | true | yes |
| OkHttp `callTimeout` | `InterruptedIOException` | true | no |
| connect timeout | `SocketTimeoutException` | false | no |

- JNI contract re-confirmed unchanged: `cancelled = true` → `RAC_ERROR_CANCELLED`; a `SocketTimeoutException`/`InterruptedIOException` error-message prefix → `RAC_ERROR_TIMEOUT`; otherwise `RAC_ERROR_NETWORK_ERROR`.

## Labels

- [x] `Kotlin SDK` - Changes to Kotlin SDK (`bindings/kotlin`)
- [x] `Flutter SDK` - Changes to Flutter SDK (`bindings/flutter`)
- [x] `React Native SDK` - Changes to React Native SDK (`bindings/react-native`)

Note: this PR changes only Kotlin source under `bindings/...`; the Flutter and React Native Android copies are compiled by CI once #869 lands (that PR adds focused `compileDebugKotlin` coverage for both). Until then, CI compiles the Kotlin SDK copy via the existing `kotlin-android` job.

Fixes #870.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of cancelled streaming requests, including cancellations initiated outside the SDK.
  - Prevented cancelled streams from being incorrectly reported as transport failures.
  - Preserved timeout reporting so timed-out requests continue to be identified as timeout errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->