### PR TITLE
fix(apple): fail URLSession response allocation safely

### DIFF
--- a/bindings/flutter/packages/runanywhere/ios/runanywhere/Sources/runanywhere_native/URLSessionHttpTransportImpl.inc.mm
+++ b/bindings/flutter/packages/runanywhere/ios/runanywhere/Sources/runanywhere_native/URLSessionHttpTransportImpl.inc.mm
@@ -236,43 +236,65 @@ static std::vector<std::pair<std::string, std::string>> extractHeaders(NSHTTPURL
     return out;
 }
 
-static void writeResponse(int32_t status,
-                          NSData* bodyBytes,
-                          const std::vector<std::pair<std::string, std::string>>& headers,
-                          NSString* redirectedURL,
-                          uint64_t elapsedMs,
-                          rac_http_response_t* out) {
+static rac_result_t writeResponse(int32_t status,
+                                  NSData* bodyBytes,
+                                  const std::vector<std::pair<std::string, std::string>>& headers,
+                                  NSString* redirectedURL,
+                                  uint64_t elapsedMs,
+                                  rac_http_response_t* out) {
     std::memset(out, 0, sizeof(*out));
     out->status = status;
     out->elapsed_ms = elapsedMs;
 
     if (bodyBytes && bodyBytes.length > 0) {
         void* buf = std::malloc(bodyBytes.length);
-        if (buf) {
-            std::memcpy(buf, bodyBytes.bytes, bodyBytes.length);
-            out->body_bytes = reinterpret_cast<uint8_t*>(buf);
-            out->body_len = bodyBytes.length;
+        if (!buf) {
+            rac_http_response_free(out);
+            return RAC_ERROR_OUT_OF_MEMORY;
         }
+        std::memcpy(buf, bodyBytes.bytes, bodyBytes.length);
+        out->body_bytes = reinterpret_cast<uint8_t*>(buf);
+        out->body_len = bodyBytes.length;
     }
 
     if (!headers.empty()) {
         size_t count = headers.size();
-        size_t bytes = count * sizeof(rac_http_header_kv_t);
-        auto* kvs = static_cast<rac_http_header_kv_t*>(std::malloc(bytes));
-        if (kvs) {
-            std::memset(kvs, 0, bytes);
-            for (size_t i = 0; i < count; ++i) {
-                kvs[i].name = strdup(headers[i].first.c_str());
-                kvs[i].value = strdup(headers[i].second.c_str());
+        auto* kvs = static_cast<rac_http_header_kv_t*>(
+            std::calloc(count, sizeof(rac_http_header_kv_t)));
+        if (!kvs) {
+            rac_http_response_free(out);
+            return RAC_ERROR_OUT_OF_MEMORY;
+        }
+        out->headers = kvs;
+        out->header_count = count;
+        for (size_t i = 0; i < count; ++i) {
+            kvs[i].name = strdup(headers[i].first.c_str());
+            if (!kvs[i].name) {
+                rac_http_response_free(out);
+                return RAC_ERROR_OUT_OF_MEMORY;
             }
-            out->headers = kvs;
-            out->header_count = count;
+            kvs[i].value = strdup(headers[i].second.c_str());
+            if (!kvs[i].value) {
+                rac_http_response_free(out);
+                return RAC_ERROR_OUT_OF_MEMORY;
+            }
         }
     }
 
     if (redirectedURL && redirectedURL.length > 0) {
-        out->redirected_url = strdup([redirectedURL UTF8String]);
+        const char* utf8 = [redirectedURL UTF8String];
+        if (!utf8) {
+            rac_http_response_free(out);
+            return RAC_ERROR_OUT_OF_MEMORY;
+        }
+        out->redirected_url = strdup(utf8);
+        if (!out->redirected_url) {
+            rac_http_response_free(out);
+            return RAC_ERROR_OUT_OF_MEMORY;
+        }
     }
+
+    return RAC_SUCCESS;
 }
 
 static uint64_t monotonicNs() {
@@ -495,9 +517,8 @@ rac_result_t urlsession_request_send(void* /*user_data*/,
         redirected = finalURL;
     }
 
-    writeResponse((int32_t)httpResp.statusCode, capturedData, headers, redirected, elapsed,
-                  out_resp);
-    return RAC_SUCCESS;
+    return writeResponse((int32_t)httpResp.statusCode, capturedData, headers, redirected,
+                         elapsed, out_resp);
 }
 
 rac_result_t urlsession_request_stream_impl(const rac_http_request_t* req,
@@ -614,9 +635,8 @@ rac_result_t urlsession_request_stream_impl(const rac_http_request_t* req,
         headers.emplace_back("X-RAC-Range-Honored", honored ? "true" : "false");
     }
 
-    writeResponse((int32_t)delegate.response.statusCode, /*bodyBytes=*/nil, headers, redirected,
-                  elapsed, out_resp);
-    return RAC_SUCCESS;
+    return writeResponse((int32_t)delegate.response.statusCode, /*bodyBytes=*/nil, headers,
+                         redirected, elapsed, out_resp);
 }
 
 rac_result_t urlsession_request_stream(void* /*user_data*/,

--- a/bindings/shared-apple/URLSessionHttpTransport/URLSessionHttpTransportImpl.inc.mm
+++ b/bindings/shared-apple/URLSessionHttpTransport/URLSessionHttpTransportImpl.inc.mm
@@ -236,43 +236,65 @@ static std::vector<std::pair<std::string, std::string>> extractHeaders(NSHTTPURL
     return out;
 }
 
-static void writeResponse(int32_t status,
-                          NSData* bodyBytes,
-                          const std::vector<std::pair<std::string, std::string>>& headers,
-                          NSString* redirectedURL,
-                          uint64_t elapsedMs,
-                          rac_http_response_t* out) {
+static rac_result_t writeResponse(int32_t status,
+                                  NSData* bodyBytes,
+                                  const std::vector<std::pair<std::string, std::string>>& headers,
+                                  NSString* redirectedURL,
+                                  uint64_t elapsedMs,
+                                  rac_http_response_t* out) {
     std::memset(out, 0, sizeof(*out));
     out->status = status;
     out->elapsed_ms = elapsedMs;
 
     if (bodyBytes && bodyBytes.length > 0) {
         void* buf = std::malloc(bodyBytes.length);
-        if (buf) {
-            std::memcpy(buf, bodyBytes.bytes, bodyBytes.length);
-            out->body_bytes = reinterpret_cast<uint8_t*>(buf);
-            out->body_len = bodyBytes.length;
+        if (!buf) {
+            rac_http_response_free(out);
+            return RAC_ERROR_OUT_OF_MEMORY;
         }
+        std::memcpy(buf, bodyBytes.bytes, bodyBytes.length);
+        out->body_bytes = reinterpret_cast<uint8_t*>(buf);
+        out->body_len = bodyBytes.length;
     }
 
     if (!headers.empty()) {
         size_t count = headers.size();
-        size_t bytes = count * sizeof(rac_http_header_kv_t);
-        auto* kvs = static_cast<rac_http_header_kv_t*>(std::malloc(bytes));
-        if (kvs) {
-            std::memset(kvs, 0, bytes);
-            for (size_t i = 0; i < count; ++i) {
-                kvs[i].name = strdup(headers[i].first.c_str());
-                kvs[i].value = strdup(headers[i].second.c_str());
+        auto* kvs = static_cast<rac_http_header_kv_t*>(
+            std::calloc(count, sizeof(rac_http_header_kv_t)));
+        if (!kvs) {
+            rac_http_response_free(out);
+            return RAC_ERROR_OUT_OF_MEMORY;
+        }
+        out->headers = kvs;
+        out->header_count = count;
+        for (size_t i = 0; i < count; ++i) {
+            kvs[i].name = strdup(headers[i].first.c_str());
+            if (!kvs[i].name) {
+                rac_http_response_free(out);
+                return RAC_ERROR_OUT_OF_MEMORY;
             }
-            out->headers = kvs;
-            out->header_count = count;
+            kvs[i].value = strdup(headers[i].second.c_str());
+            if (!kvs[i].value) {
+                rac_http_response_free(out);
+                return RAC_ERROR_OUT_OF_MEMORY;
+            }
         }
     }
 
     if (redirectedURL && redirectedURL.length > 0) {
-        out->redirected_url = strdup([redirectedURL UTF8String]);
+        const char* utf8 = [redirectedURL UTF8String];
+        if (!utf8) {
+            rac_http_response_free(out);
+            return RAC_ERROR_OUT_OF_MEMORY;
+        }
+        out->redirected_url = strdup(utf8);
+        if (!out->redirected_url) {
+            rac_http_response_free(out);
+            return RAC_ERROR_OUT_OF_MEMORY;
+        }
     }
+
+    return RAC_SUCCESS;
 }
 
 static uint64_t monotonicNs() {
@@ -495,9 +517,8 @@ rac_result_t urlsession_request_send(void* /*user_data*/,
         redirected = finalURL;
     }
 
-    writeResponse((int32_t)httpResp.statusCode, capturedData, headers, redirected, elapsed,
-                  out_resp);
-    return RAC_SUCCESS;
+    return writeResponse((int32_t)httpResp.statusCode, capturedData, headers, redirected,
+                         elapsed, out_resp);
 }
 
 rac_result_t urlsession_request_stream_impl(const rac_http_request_t* req,
@@ -614,9 +635,8 @@ rac_result_t urlsession_request_stream_impl(const rac_http_request_t* req,
         headers.emplace_back("X-RAC-Range-Honored", honored ? "true" : "false");
     }
 
-    writeResponse((int32_t)delegate.response.statusCode, /*bodyBytes=*/nil, headers, redirected,
-                  elapsed, out_resp);
-    return RAC_SUCCESS;
+    return writeResponse((int32_t)delegate.response.statusCode, /*bodyBytes=*/nil, headers,
+                         redirected, elapsed, out_resp);
 }
 
 rac_result_t urlsession_request_stream(void* /*user_data*/,

--- a/bindings/swift/Sources/RunAnywhere/HttpTransport/URLSessionHttpTransport.swift
+++ b/bindings/swift/Sources/RunAnywhere/HttpTransport/URLSessionHttpTransport.swift
@@ -300,7 +300,6 @@ private struct RequestSnapshot {
 /// release via `rac_http_response_free` / `rac_free`. All allocations
 /// use `malloc` / `strdup` to match the libcurl default's ownership
 /// contract.
-///
 /// Allocation is all-or-nothing: when any buffer fails to allocate, the
 /// partial response is released via `rac_http_response_free` and the
 /// caller receives `RAC_ERROR_OUT_OF_MEMORY`.

--- a/bindings/swift/Sources/RunAnywhere/HttpTransport/URLSessionHttpTransport.swift
+++ b/bindings/swift/Sources/RunAnywhere/HttpTransport/URLSessionHttpTransport.swift
@@ -300,6 +300,10 @@ private struct RequestSnapshot {
 /// release via `rac_http_response_free` / `rac_free`. All allocations
 /// use `malloc` / `strdup` to match the libcurl default's ownership
 /// contract.
+///
+/// Allocation is all-or-nothing: when any buffer fails to allocate, the
+/// partial response is released via `rac_http_response_free` and the
+/// caller receives `RAC_ERROR_OUT_OF_MEMORY`.
 private enum ResponseWriter {
 
     static func write(
@@ -309,7 +313,7 @@ private enum ResponseWriter {
         redirectedURL: String?,
         elapsedMs: UInt64,
         into out: UnsafeMutablePointer<rac_http_response_t>
-    ) {
+    ) -> rac_result_t {
         // Zero the struct first so any early-return path leaves a
         // well-defined state.
         out.pointee = rac_http_response_t()
@@ -318,38 +322,51 @@ private enum ResponseWriter {
 
         // Body
         if let body = bodyBytes, !body.isEmpty {
-            if let buffer = malloc(body.count) {
-                let typed = buffer.assumingMemoryBound(to: UInt8.self)
-                _ = body.copyBytes(to: UnsafeMutableBufferPointer(start: typed, count: body.count))
-                out.pointee.body_bytes = typed
-                out.pointee.body_len = body.count
+            guard let buffer = malloc(body.count) else {
+                rac_http_response_free(out)
+                return RAC_ERROR_OUT_OF_MEMORY
             }
+            let typed = buffer.assumingMemoryBound(to: UInt8.self)
+            _ = body.copyBytes(to: UnsafeMutableBufferPointer(start: typed, count: body.count))
+            out.pointee.body_bytes = typed
+            out.pointee.body_len = body.count
         }
 
-        // Headers
+        // Headers. Zero-filled storage makes partial cleanup safe.
         if !headers.isEmpty {
             let count = headers.count
-            let byteCount = MemoryLayout<rac_http_header_kv_t>.stride * count
-            if let buffer = malloc(byteCount) {
-                let typed = buffer.assumingMemoryBound(to: rac_http_header_kv_t.self)
-                for (index, header) in headers.enumerated() {
-                    let namePtr = strdup(header.name)
-                    let valuePtr = strdup(header.value)
-                    typed[index] = rac_http_header_kv_t(
-                        name: UnsafePointer(namePtr),
-                        value: UnsafePointer(valuePtr)
-                    )
+            guard let buffer = calloc(count, MemoryLayout<rac_http_header_kv_t>.stride) else {
+                rac_http_response_free(out)
+                return RAC_ERROR_OUT_OF_MEMORY
+            }
+            let typed = buffer.assumingMemoryBound(to: rac_http_header_kv_t.self)
+            out.pointee.headers = typed
+            out.pointee.header_count = count
+            for (index, header) in headers.enumerated() {
+                guard let namePtr = strdup(header.name) else {
+                    rac_http_response_free(out)
+                    return RAC_ERROR_OUT_OF_MEMORY
                 }
-                out.pointee.headers = typed
-                out.pointee.header_count = count
+                typed[index].name = UnsafePointer(namePtr)
+                guard let valuePtr = strdup(header.value) else {
+                    rac_http_response_free(out)
+                    return RAC_ERROR_OUT_OF_MEMORY
+                }
+                typed[index].value = UnsafePointer(valuePtr)
             }
         }
 
         // Redirected URL (only populated when different from the
         // request URL — matches libcurl semantics)
         if let redirected = redirectedURL {
-            out.pointee.redirected_url = strdup(redirected)
+            guard let redirectedPtr = strdup(redirected) else {
+                rac_http_response_free(out)
+                return RAC_ERROR_OUT_OF_MEMORY
+            }
+            out.pointee.redirected_url = redirectedPtr
         }
+
+        return RAC_SUCCESS
     }
 
     static func extractHeaders(from httpResponse: HTTPURLResponse) -> [(name: String, value: String)] {
@@ -477,7 +494,7 @@ private enum RequestExecutor { // swiftlint:disable:this unused_declaration
             ? finalURL
             : nil
 
-        ResponseWriter.write(
+        return ResponseWriter.write(
             status: status,
             bodyBytes: body,
             headers: headers,
@@ -485,7 +502,6 @@ private enum RequestExecutor { // swiftlint:disable:this unused_declaration
             elapsedMs: elapsedMs,
             into: out
         )
-        return RAC_SUCCESS
     }
 
     static func stream(
@@ -592,7 +608,7 @@ private enum RequestExecutor { // swiftlint:disable:this unused_declaration
 
         // Streaming responses never populate body_bytes (per the
         // `rac_http_request_stream` contract).
-        ResponseWriter.write(
+        return ResponseWriter.write(
             status: Int32(httpResponse.statusCode),
             bodyBytes: nil,
             headers: headers,
@@ -600,7 +616,6 @@ private enum RequestExecutor { // swiftlint:disable:this unused_declaration
             elapsedMs: elapsedMs,
             into: out
         )
-        return RAC_SUCCESS
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary

- make the Swift and shared Apple URLSession response writers fail closed when response-copy allocation fails
- release partially allocated body, header, and redirect metadata before returning RAC_ERROR_OUT_OF_MEMORY
- propagate writer failures through buffered and streaming request paths
- keep the shared Apple and Flutter iOS implementations byte-identical

Closes #874

## Validation

- git diff --check
- verified the shared Apple and Flutter ObjC++ files are byte-identical
- Apple build and SwiftLint not run locally because this host is Windows; left to macOS CI

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - HTTP requests now correctly report memory allocation and response-processing failures instead of returning success.
  - Failed response handling now cleans up partially received body, header, and redirect data.
  - Response data is handled more reliably when memory or text conversion operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->