### PR TITLE
fix(core): use 64-bit Windows file offsets

### DIFF
--- a/core/src/desktop/desktop_adapter.cpp
+++ b/core/src/desktop/desktop_adapter.cpp
@@ -193,11 +193,19 @@ rac_result_t desktop_file_read(const char* path, void** out_data, size_t* out_si
 
     rac_result_t result = RAC_SUCCESS;
     void* buffer = nullptr;
+#if defined(_WIN32)
+    __int64 file_size = -1;
+    if (_fseeki64(f, 0, SEEK_END) == 0) {
+        file_size = _ftelli64(f);
+    }
+    if (file_size < 0 || _fseeki64(f, 0, SEEK_SET) != 0) {
+#else
     long file_size = -1;
     if (std::fseek(f, 0, SEEK_END) == 0) {
         file_size = std::ftell(f);
     }
     if (file_size < 0 || std::fseek(f, 0, SEEK_SET) != 0) {
+#endif
         result = RAC_ERROR_FILE_READ_FAILED;
     } else {
         // malloc so callers can release with rac_free (it wraps free()).


### PR DESCRIPTION
## Description

The commons desktop adapter measured file sizes with `std::ftell`, whose `long` return type remains 32-bit on Windows. Files at or above 2 GiB could therefore overflow to a negative size and return `RAC_ERROR_FILE_READ_FAILED` before reading.

Use the Microsoft CRT's `_fseeki64` / `_ftelli64` pair and `__int64` on Windows, matching the existing Electron and Python Win32 adapters. Non-Windows sizing and all allocation, read, cleanup, error, and output behavior remain unchanged.

Fixes #884

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing

- [x] `git diff --check`
- [x] Focused MSVC x64 syntax compilation of `core/src/desktop/desktop_adapter.cpp`
- [x] Focused MSVC x64 compilation with `/W4 /WX /D_CRT_SECURE_NO_WARNINGS`
- [ ] Runtime read of a file >=2 GiB was not run because the host had only 1.86 GiB of free physical memory, below the allocation required by `desktop_file_read`
- [ ] Full Windows preset build was not run because this host has Visual Studio Build Tools 2019 while the repository presets require Visual Studio 2022

No tests were added or modified; this is a Windows CRT correction matching two existing Win32 adapter implementations.

## Labels

- [x] `Commons`

## Checklist

- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] No public API or ABI changes
- [x] No documentation update required

## Screenshots

Not applicable; no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved file handling on Windows for files larger than 2 GB.
  - File sizes are now detected accurately, allowing large files to be opened and processed correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->