### PR TITLE
fix(commons): validate direct VLM raw image sizes

### DIFF
--- a/core/src/features/vlm/rac_vlm_service.cpp
+++ b/core/src/features/vlm/rac_vlm_service.cpp
@@ -11,6 +11,7 @@
 
 #include <cstdlib>
 #include <cstring>
+#include <limits>
 #include <string>
 
 #include "../common/rac_service_factory_internal.h"
@@ -24,6 +25,30 @@ namespace {
 
 const rac_vlm_service_ops_t* vlm_ops(const rac_engine_vtable_t* vt) {
     return vt ? vt->vlm_ops : nullptr;
+}
+
+rac_result_t validate_image(const rac_vlm_image_t* image) {
+    if (image->format != RAC_VLM_IMAGE_FORMAT_RGB_PIXELS) {
+        return RAC_SUCCESS;
+    }
+    if (!image->pixel_data || image->width == 0 || image->height == 0) {
+        return RAC_ERROR_INVALID_ARGUMENT;
+    }
+
+    constexpr size_t kRgbBytesPerPixel = 3;
+    const size_t width = static_cast<size_t>(image->width);
+    const size_t height = static_cast<size_t>(image->height);
+    const size_t max_size = std::numeric_limits<size_t>::max();
+    if (width > max_size / height) {
+        return RAC_ERROR_INVALID_ARGUMENT;
+    }
+
+    const size_t pixels = width * height;
+    if (pixels > max_size / kRgbBytesPerPixel ||
+        image->data_size != pixels * kRgbBytesPerPixel) {
+        return RAC_ERROR_INVALID_ARGUMENT;
+    }
+    return RAC_SUCCESS;
 }
 
 }  // namespace
@@ -146,6 +171,11 @@ rac_result_t rac_vlm_process(rac_handle_t handle, const rac_vlm_image_t* image, 
     if (!handle || !image || !prompt || !out_result)
         return RAC_ERROR_NULL_POINTER;
 
+    const rac_result_t validation_result = validate_image(image);
+    if (validation_result != RAC_SUCCESS) {
+        return validation_result;
+    }
+
     auto* service = static_cast<rac_vlm_service_t*>(handle);
     if (!service->ops || !service->ops->process) {
         return RAC_ERROR_NOT_SUPPORTED;
@@ -159,6 +189,11 @@ rac_result_t rac_vlm_process_stream(rac_handle_t handle, const rac_vlm_image_t* 
                                     rac_vlm_stream_callback_fn callback, void* user_data) {
     if (!handle || !image || !prompt || !callback)
         return RAC_ERROR_NULL_POINTER;
+
+    const rac_result_t validation_result = validate_image(image);
+    if (validation_result != RAC_SUCCESS) {
+        return validation_result;
+    }
 
     auto* service = static_cast<rac_vlm_service_t*>(handle);
     if (!service->ops || !service->ops->process_stream) {

--- a/core/tests/CMakeLists.txt
+++ b/core/tests/CMakeLists.txt
@@ -226,6 +226,17 @@ rac_link_archive_deps(test_vlm_options_defaults)
 target_compile_features(test_vlm_options_defaults PRIVATE cxx_std_17)
 add_test(NAME vlm_options_defaults_tests COMMAND test_vlm_options_defaults)
 
+# --- Direct C-struct VLM raw-image validation -----------------------
+add_executable(test_vlm_image_validation test_vlm_image_validation.cpp)
+target_include_directories(test_vlm_image_validation PRIVATE
+    ${CMAKE_CURRENT_SOURCE_DIR}
+    ${CMAKE_SOURCE_DIR}/include
+)
+target_link_libraries(test_vlm_image_validation PRIVATE rac_commons)
+rac_link_archive_deps(test_vlm_image_validation)
+target_compile_features(test_vlm_image_validation PRIVATE cxx_std_17)
+add_test(NAME vlm_image_validation_tests COMMAND test_vlm_image_validation)
+
 # --- MemoryPool<T> tests ------------------------------
 # Header-only template; verifies acquire/release, blocking, cancel, and a
 # concurrent stress test.

--- a/core/tests/test_vlm_image_validation.cpp
+++ b/core/tests/test_vlm_image_validation.cpp
@@ -1,0 +1,111 @@
+/**
+ * @file test_vlm_image_validation.cpp
+ * @brief Regression coverage for direct C-struct VLM raw-image validation.
+ */
+
+#include <cstdint>
+#include <cstdio>
+#include <limits>
+
+#include "rac/features/vlm/rac_vlm_service.h"
+
+namespace {
+
+#define EXPECT_TRUE(_cond)                                                          \
+    do {                                                                            \
+        if (!(_cond)) {                                                             \
+            std::fprintf(stderr, "FAIL @ %s:%d: %s\n", __FILE__, __LINE__, #_cond); \
+            return 1;                                                               \
+        }                                                                           \
+    } while (0)
+
+struct DispatchCounts {
+    int process = 0;
+    int process_stream = 0;
+};
+
+rac_result_t fake_process(void* impl, const rac_vlm_image_t*, const char*,
+                          const rac_vlm_options_t*, rac_vlm_result_t*) {
+    ++static_cast<DispatchCounts*>(impl)->process;
+    return RAC_SUCCESS;
+}
+
+rac_result_t fake_process_stream(void* impl, const rac_vlm_image_t*, const char*,
+                                 const rac_vlm_options_t*, rac_vlm_stream_callback_fn, void*) {
+    ++static_cast<DispatchCounts*>(impl)->process_stream;
+    return RAC_SUCCESS;
+}
+
+rac_bool_t keep_streaming(const char*, void*) {
+    return RAC_TRUE;
+}
+
+int test_direct_rgb_image_validation() {
+    DispatchCounts dispatch_counts;
+    rac_vlm_service_ops_t ops{};
+    ops.process = fake_process;
+    ops.process_stream = fake_process_stream;
+    rac_vlm_service_t service{&ops, &dispatch_counts, "test-vlm"};
+
+    uint8_t pixels[12]{};
+    rac_vlm_image_t image{};
+    image.format = RAC_VLM_IMAGE_FORMAT_RGB_PIXELS;
+    image.pixel_data = pixels;
+    image.width = 2;
+    image.height = 2;
+    image.data_size = sizeof(pixels) - 1;
+
+    rac_vlm_result_t result{};
+    EXPECT_TRUE(rac_vlm_process(&service, &image, "describe", nullptr, &result) ==
+                RAC_ERROR_INVALID_ARGUMENT);
+    EXPECT_TRUE(rac_vlm_process_stream(&service, &image, "describe", nullptr, keep_streaming,
+                                       nullptr) == RAC_ERROR_INVALID_ARGUMENT);
+    EXPECT_TRUE(dispatch_counts.process == 0);
+    EXPECT_TRUE(dispatch_counts.process_stream == 0);
+
+    image.data_size = sizeof(pixels);
+    EXPECT_TRUE(rac_vlm_process(&service, &image, "describe", nullptr, &result) == RAC_SUCCESS);
+    EXPECT_TRUE(rac_vlm_process_stream(&service, &image, "describe", nullptr, keep_streaming,
+                                       nullptr) == RAC_SUCCESS);
+    EXPECT_TRUE(dispatch_counts.process == 1);
+    EXPECT_TRUE(dispatch_counts.process_stream == 1);
+
+    image.width = 0;
+    EXPECT_TRUE(rac_vlm_process(&service, &image, "describe", nullptr, &result) ==
+                RAC_ERROR_INVALID_ARGUMENT);
+
+    image.width = 2;
+    image.height = 0;
+    EXPECT_TRUE(rac_vlm_process(&service, &image, "describe", nullptr, &result) ==
+                RAC_ERROR_INVALID_ARGUMENT);
+
+    image.height = 2;
+    image.pixel_data = nullptr;
+    EXPECT_TRUE(rac_vlm_process(&service, &image, "describe", nullptr, &result) ==
+                RAC_ERROR_INVALID_ARGUMENT);
+
+    image.pixel_data = pixels;
+    image.width = std::numeric_limits<uint32_t>::max();
+    image.height = std::numeric_limits<uint32_t>::max();
+    image.data_size = std::numeric_limits<size_t>::max();
+    EXPECT_TRUE(rac_vlm_process(&service, &image, "describe", nullptr, &result) ==
+                RAC_ERROR_INVALID_ARGUMENT);
+    EXPECT_TRUE(dispatch_counts.process == 1);
+
+    image = {};
+    image.format = RAC_VLM_IMAGE_FORMAT_FILE_PATH;
+    image.file_path = "/tmp/image.png";
+    EXPECT_TRUE(rac_vlm_process(&service, &image, "describe", nullptr, &result) == RAC_SUCCESS);
+    EXPECT_TRUE(dispatch_counts.process == 2);
+    return 0;
+}
+
+}  // namespace
+
+int main() {
+    if (test_direct_rgb_image_validation() != 0) {
+        return 1;
+    }
+    std::printf("vlm image validation tests passed\n");
+    return 0;
+}


### PR DESCRIPTION
## Description

Validate direct `rac_vlm_image_t` RGB inputs at the shared Commons VLM service boundary before dispatching to any backend. Blocking and streaming entry points now reject null pixel buffers, zero dimensions, overflowed `width * height * 3` calculations, and payload sizes that do not exactly match the declared dimensions.

Add a backend-free regression test covering malformed native C structs, valid RGB dispatch, and unchanged file-path dispatch. The change does not alter the public C ABI or protobuf schema and does not include the separate error-detail or proto-adapter coverage tracked by #894 and #895.

Fixes #893

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally — `core/scripts/lint-cpp.sh` could not run because `clang-format` is not installed on this host
- [x] Added/updated tests for changes
- [x] `git diff --check`
- [x] `rac_vlm_service.cpp` compiled with GCC 16, C++20, `-Wall -Wextra -Werror`
- [x] `test_vlm_image_validation.cpp` compiled with GCC 16, C++17, `-Wall -Wextra -Werror`
- [x] Focused direct-struct regression executable passed
- [ ] Full Windows CMake test target — `windows-debug` requires Visual Studio 2022, which is not installed on this host

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels

**SDKs:**
- [ ] `Swift SDK`
- [ ] `Kotlin SDK`
- [ ] `Flutter SDK`
- [ ] `React Native SDK`
- [ ] `Web SDK`
- [x] `Commons`

**Sample Apps:**
- [ ] `Flutter Sample`
- [ ] `React Native Sample`
- [ ] `Minimal Examples`

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (not required; no public contract change)

## Screenshots

Not applicable; no UI changes.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added validation for raw RGB images before VLM processing.
  * Invalid images—including those with missing data, zero dimensions, incorrect sizes, or oversized dimensions—now return an invalid-argument error instead of being processed.
  * Valid RGB images and file-based images continue to process normally.

* **Tests**
  * Added regression coverage for valid and invalid VLM image inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->