### PR TITLE
fix(commons): report VLM raw image validation errors

### DIFF
--- a/core/include/rac/features/vlm/rac_vlm_proto_adapters.h
+++ b/core/include/rac/features/vlm/rac_vlm_proto_adapters.h
@@ -16,6 +16,7 @@
 
 #include "rac/core/rac_types.h"
 #include "rac/features/vlm/rac_vlm_types.h"
+#include "rac/foundation/rac_proto_buffer.h"
 
 #ifdef __cplusplus
 
@@ -44,7 +45,8 @@ bool rac_vlm_options_from_proto(const ::runanywhere::v1::LLMGenerationOptions& i
 void rac_vlm_options_free_owned(rac_vlm_options_t* options);
 
 bool rac_vlm_result_to_proto(const rac_vlm_result_t* in, ::runanywhere::v1::VLMResult* out);
-bool rac_vlm_image_from_proto(const ::runanywhere::v1::VLMImage& in, rac_vlm_image_t* out);
+rac_result_t rac_vlm_image_from_proto(const ::runanywhere::v1::VLMImage& in,
+                                      rac_vlm_image_t* out, rac_proto_buffer_t* out_error);
 
 }  // namespace rac::foundation
 

--- a/core/src/features/vlm/vlm_module.cpp
+++ b/core/src/features/vlm/vlm_module.cpp
@@ -1007,8 +1007,12 @@ rac_result_t parse_vlm_generation_request(const uint8_t* request_bytes, size_t r
     // of the options message, so the adapter no longer produces it.
     *out_prompt = out_request->prompt().c_str();
 
-    if (!rac::foundation::rac_vlm_image_from_proto(out_request->images(0), out_image) ||
-        !rac::foundation::rac_vlm_options_from_proto(options_proto, vision_proto, out_options)) {
+    const rac_result_t image_rc = rac::foundation::rac_vlm_image_from_proto(
+        out_request->images(0), out_image, out_error);
+    if (image_rc != RAC_SUCCESS) {
+        return image_rc;
+    }
+    if (!rac::foundation::rac_vlm_options_from_proto(options_proto, vision_proto, out_options)) {
         return rac_proto_buffer_set_error(out_error, RAC_ERROR_DECODING_ERROR,
                                           "failed to convert VLMGenerationRequest");
     }
@@ -1397,6 +1401,13 @@ rac_result_t rac_vlm_stream_proto(const uint8_t* request_proto_bytes, size_t req
         rc = check_lifecycle_model(request, ref, &error_buffer);
     }
     if (rc != RAC_SUCCESS) {
+        GeneratedStreamCtx error_ctx;
+        error_ctx.callback = callback;
+        error_ctx.user_data = user_data;
+        error_ctx.request_id = request.request_id();
+        dispatch_vlm_terminal_once(&error_ctx, runanywhere::v1::VLM_STREAM_EVENT_KIND_ERROR,
+                                   nullptr, error_buffer.error_message,
+                                   static_cast<int32_t>(rc));
         publish_failure(rc, "vlm.stream", error_buffer.error_message);
         rac_proto_buffer_free(&error_buffer);
         free_vlm_image(&image);

--- a/core/src/foundation/rac_proto_adapters.cpp
+++ b/core/src/foundation/rac_proto_adapters.cpp
@@ -112,6 +112,27 @@ bool checked_raw_image_size(int32_t width, int32_t height, size_t bytes_per_pixe
     return true;
 }
 
+rac_result_t set_vlm_image_error(rac_proto_buffer_t* out_error, rac_result_t code,
+                                 const std::string& message) {
+    if (!out_error)
+        return code;
+    return rac_proto_buffer_set_error(out_error, code, message.c_str());
+}
+
+std::string raw_image_dimensions_error(const char* field, int32_t width, int32_t height,
+                                       size_t bytes_per_pixel) {
+    return std::string("VLMImage.") + field + " dimensions " + std::to_string(width) + "x" +
+           std::to_string(height) + " cannot produce a valid width*height*" +
+           std::to_string(bytes_per_pixel) + " byte length";
+}
+
+std::string raw_image_length_error(const char* field, size_t actual_size, size_t expected_size,
+                                   size_t bytes_per_pixel) {
+    return std::string("VLMImage.") + field + " length " + std::to_string(actual_size) +
+           " does not match width*height*" + std::to_string(bytes_per_pixel) + " = " +
+           std::to_string(expected_size);
+}
+
 // ---- Audio format enum mapping --------------------------------------------
 // Both enums share the same ordering for the formats they overlap on. The C
 // enum starts at PCM=0; proto starts at UNSPECIFIED=0 with PCM=1. Apply +1 / -1
@@ -565,26 +586,40 @@ bool rac_vlm_result_to_proto(const rac_vlm_result_t* in, ::runanywhere::v1::VLMR
     return true;
 }
 
-bool rac_vlm_image_from_proto(const ::runanywhere::v1::VLMImage& in, rac_vlm_image_t* out) {
+rac_result_t rac_vlm_image_from_proto(const ::runanywhere::v1::VLMImage& in,
+                                      rac_vlm_image_t* out, rac_proto_buffer_t* out_error) {
     if (!out)
-        return false;
+        return RAC_ERROR_NULL_POINTER;
     std::memset(out, 0, sizeof(*out));
     out->width = static_cast<uint32_t>(in.width());
     out->height = static_cast<uint32_t>(in.height());
     if (in.has_file_path()) {
         out->format = RAC_VLM_IMAGE_FORMAT_FILE_PATH;
         out->file_path = copy_string_required(in.file_path());
+        if (!out->file_path) {
+            return set_vlm_image_error(out_error, RAC_ERROR_OUT_OF_MEMORY,
+                                       "failed to allocate VLMImage.file_path");
+        }
     } else if (in.has_raw_rgb()) {
         // 3 bytes/px, tightly packed -- no alpha to drop.
         const ::std::string& src = in.raw_rgb();
         size_t rgb_size = 0;
-        if (!checked_raw_image_size(in.width(), in.height(), 3, &rgb_size) ||
-            src.size() != rgb_size)
-            return false;
+        if (!checked_raw_image_size(in.width(), in.height(), 3, &rgb_size)) {
+            return set_vlm_image_error(
+                out_error, RAC_ERROR_INVALID_ARGUMENT,
+                raw_image_dimensions_error("raw_rgb", in.width(), in.height(), 3));
+        }
+        if (src.size() != rgb_size) {
+            return set_vlm_image_error(
+                out_error, RAC_ERROR_INVALID_ARGUMENT,
+                raw_image_length_error("raw_rgb", src.size(), rgb_size, 3));
+        }
 
         uint8_t* buf = static_cast<uint8_t*>(rac_alloc(rgb_size));
-        if (!buf)
-            return false;
+        if (!buf) {
+            return set_vlm_image_error(out_error, RAC_ERROR_OUT_OF_MEMORY,
+                                       "failed to allocate VLMImage.raw_rgb pixel buffer");
+        }
         std::memcpy(buf, src.data(), rgb_size);
 
         out->format = RAC_VLM_IMAGE_FORMAT_RGB_PIXELS;
@@ -602,15 +637,21 @@ bool rac_vlm_image_from_proto(const ::runanywhere::v1::VLMImage& in, rac_vlm_ima
         size_t rgba_size = 0;
         size_t rgb_size = 0;
         if (!checked_raw_image_size(in.width(), in.height(), 4, &rgba_size) ||
-            !checked_raw_image_size(in.width(), in.height(), 3, &rgb_size) ||
-            src.size() != rgba_size) {
-            // Dimensions inconsistent with RGBA payload — refuse rather
-            // than read past the buffer.
-            return false;
+            !checked_raw_image_size(in.width(), in.height(), 3, &rgb_size)) {
+            return set_vlm_image_error(
+                out_error, RAC_ERROR_INVALID_ARGUMENT,
+                raw_image_dimensions_error("raw_rgba", in.width(), in.height(), 4));
+        }
+        if (src.size() != rgba_size) {
+            return set_vlm_image_error(
+                out_error, RAC_ERROR_INVALID_ARGUMENT,
+                raw_image_length_error("raw_rgba", src.size(), rgba_size, 4));
         }
         uint8_t* buf = static_cast<uint8_t*>(rac_alloc(rgb_size));
-        if (!buf)
-            return false;
+        if (!buf) {
+            return set_vlm_image_error(out_error, RAC_ERROR_OUT_OF_MEMORY,
+                                       "failed to allocate VLMImage.raw_rgba RGB buffer");
+        }
 
         const uint8_t* in_px = reinterpret_cast<const uint8_t*>(src.data());
         const size_t pixels = rgb_size / 3;
@@ -626,6 +667,10 @@ bool rac_vlm_image_from_proto(const ::runanywhere::v1::VLMImage& in, rac_vlm_ima
     } else if (in.has_base64()) {
         out->format = RAC_VLM_IMAGE_FORMAT_BASE64;
         out->base64_data = copy_string_required(in.base64());
+        if (!out->base64_data) {
+            return set_vlm_image_error(out_error, RAC_ERROR_OUT_OF_MEMORY,
+                                       "failed to allocate VLMImage.base64");
+        }
         out->data_size = in.base64().size();
     } else if (in.has_data()) {
         // `data` (renamed from `encoded`) carries compressed JPEG/PNG/WEBP
@@ -636,13 +681,14 @@ bool rac_vlm_image_from_proto(const ::runanywhere::v1::VLMImage& in, rac_vlm_ima
         // the proto boundary so the caller sees a clean decoding error
         // instead of a backend crash. SDKs must decode containers to
         // RAW_RGB or supply a file path before calling C.
-        return false;
+        return set_vlm_image_error(out_error, RAC_ERROR_DECODING_ERROR,
+                                   "VLMImage.data requires decoding before native VLM dispatch");
     } else {
         // No source set — leave pointers NULL and pick FILE_PATH as the
         // safest default (matches RAC_VLM_IMAGE_FORMAT_FILE_PATH = 0).
         out->format = RAC_VLM_IMAGE_FORMAT_FILE_PATH;
     }
-    return true;
+    return RAC_SUCCESS;
 }
 
 // ===========================================================================


### PR DESCRIPTION
## Description

VLM protobuf raw-image validation currently collapses exact-size failures into a generic decoding error. Return the canonical validation status from the shared Commons adapter and include the raw field's actual and expected byte counts in the diagnostic.

The one-shot path preserves that typed status and message in its proto output buffer. The streaming path emits the same failure as a terminal `VLMStreamEvent.error`, so bindings receive the structured `SDKError` instead of inferring from a bare return code.

This remains scoped to protobuf image conversion. Direct `rac_vlm_image_t` validation is tracked in #893, and the comprehensive adapter test matrix is tracked in #895.

Fixes #894

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

Validation completed:
- `git diff --check`
- Declaration/definition/call-site audit for `rac_vlm_image_from_proto`
- Full self-review of the focused three-file diff

Local limitations:
- The repository `windows-debug` preset requires Visual Studio 17 2022, which is not installed on this host.
- The available GCC 16.1 + Ninja fallback entered the protobuf-enabled root configuration successfully, but the bundled libarchive platform-probe phase was timeboxed before project generation.
- `clang-format` and `lefthook` are not installed on this host PATH.
- No tests were added because #895 separately owns the raw RGB/RGBA adapter test matrix.

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels
- [x] `Commons` - Changes to shared native code (`core`)

## Checklist
- [x] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (not needed; no public API or schema change)

## Screenshots

Not applicable; no UI changes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved validation of VLM image inputs, including file-based, raw pixel, Base64, and encoded image data.
  - Errors now provide more specific failure codes and descriptive messages for invalid dimensions, data lengths, missing outputs, and memory issues.
  - VLM streaming callbacks now receive terminal error events when request setup, parsing, model validation, lifecycle initialization, or streaming support checks fail, with relevant error details when available.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->