### PR TITLE
fix(commons): reject proto adapter allocation failures

### DIFF
--- a/core/src/foundation/rac_proto_adapters.cpp
+++ b/core/src/foundation/rac_proto_adapters.cpp
@@ -276,9 +276,24 @@ bool rac_tts_options_from_proto(const ::runanywhere::v1::TTSOptions& in, rac_tts
     if (!out)
         return false;
     *out = RAC_TTS_OPTIONS_DEFAULT;
+    bool language_owned = false;
+    auto fail = [&]() {
+        rac_free(const_cast<char*>(out->voice));
+        if (language_owned) {
+            rac_free(const_cast<char*>(out->language));
+        }
+        *out = RAC_TTS_OPTIONS_DEFAULT;
+        return false;
+    };
     out->voice = copy_string(in.voice());
-    if (!in.language_code().empty())
+    if (!in.voice().empty() && !out->voice)
+        return fail();
+    if (!in.language_code().empty()) {
         out->language = copy_string(in.language_code());
+        if (!out->language)
+            return fail();
+        language_owned = true;
+    }
     if (in.speed() > 0.0f)
         out->rate = in.speed();
     if (in.pitch() > 0.0f)
@@ -317,8 +332,19 @@ bool rac_tts_synthesis_metadata_from_proto(const ::runanywhere::v1::TTSSynthesis
                                            rac_tts_synthesis_metadata_t* out) {
     if (!out)
         return false;
+    *out = {};
+    auto fail = [&]() {
+        rac_free(const_cast<char*>(out->voice));
+        rac_free(const_cast<char*>(out->language));
+        *out = {};
+        return false;
+    };
     out->voice = copy_string(in.voice_id());
+    if (!in.voice_id().empty() && !out->voice)
+        return fail();
     out->language = copy_string(in.language_code());
+    if (!in.language_code().empty() && !out->language)
+        return fail();
     out->processing_time_ms = in.processing_time_ms();
     out->character_count = in.input_bytes();
     // Compute characters_per_second from processing_time_ms.
@@ -569,11 +595,20 @@ bool rac_vlm_image_from_proto(const ::runanywhere::v1::VLMImage& in, rac_vlm_ima
     if (!out)
         return false;
     std::memset(out, 0, sizeof(*out));
+    auto fail = [&]() {
+        rac_free(const_cast<char*>(out->file_path));
+        rac_free(const_cast<uint8_t*>(out->pixel_data));
+        rac_free(const_cast<char*>(out->base64_data));
+        std::memset(out, 0, sizeof(*out));
+        return false;
+    };
     out->width = static_cast<uint32_t>(in.width());
     out->height = static_cast<uint32_t>(in.height());
     if (in.has_file_path()) {
         out->format = RAC_VLM_IMAGE_FORMAT_FILE_PATH;
         out->file_path = copy_string_required(in.file_path());
+        if (!out->file_path)
+            return fail();
     } else if (in.has_raw_rgb()) {
         // 3 bytes/px, tightly packed -- no alpha to drop.
         const ::std::string& src = in.raw_rgb();
@@ -584,7 +619,7 @@ bool rac_vlm_image_from_proto(const ::runanywhere::v1::VLMImage& in, rac_vlm_ima
 
         uint8_t* buf = static_cast<uint8_t*>(rac_alloc(rgb_size));
         if (!buf)
-            return false;
+            return fail();
         std::memcpy(buf, src.data(), rgb_size);
 
         out->format = RAC_VLM_IMAGE_FORMAT_RGB_PIXELS;
@@ -610,7 +645,7 @@ bool rac_vlm_image_from_proto(const ::runanywhere::v1::VLMImage& in, rac_vlm_ima
         }
         uint8_t* buf = static_cast<uint8_t*>(rac_alloc(rgb_size));
         if (!buf)
-            return false;
+            return fail();
 
         const uint8_t* in_px = reinterpret_cast<const uint8_t*>(src.data());
         const size_t pixels = rgb_size / 3;
@@ -626,6 +661,8 @@ bool rac_vlm_image_from_proto(const ::runanywhere::v1::VLMImage& in, rac_vlm_ima
     } else if (in.has_base64()) {
         out->format = RAC_VLM_IMAGE_FORMAT_BASE64;
         out->base64_data = copy_string_required(in.base64());
+        if (!out->base64_data)
+            return fail();
         out->data_size = in.base64().size();
     } else if (in.has_data()) {
         // `data` (renamed from `encoded`) carries compressed JPEG/PNG/WEBP


### PR DESCRIPTION
## Description
Harden the remaining TTS and VLM-image proto adapters against allocation failures. Conversions now return `false`, release partially owned state, and restore safe output defaults instead of accepting incomplete data or dereferencing failed allocations.

`rac_diffusion_options_from_proto` was audited and already applies equivalent allocation checks and cleanup.

Fixes #898

## Type of Change
- [x] Bug fix
- [ ] New feature
- [ ] Documentation update
- [ ] Refactoring

## Testing
- [ ] Lint passes locally
- [ ] Added/updated tests for changes

Validation completed:
- Protobuf-enabled MSVC C++20 syntax compilation passed for `core/src/foundation/rac_proto_adapters.cpp`.
- CMake configuration completed with Protobuf enabled and tests disabled.
- `git diff --check` passed.

The full `rac_commons` build could not complete on this host because MSVC 19.29 rejects vendored Protobuf 35.1 generated constexpr parse tables with `C3615`, before Commons compilation. The lint script could not run because `clang-format` is unavailable. No tests were added or run, following the repository instruction for this scoped fix.

### Platform-Specific Testing (check all that apply)
**Swift SDK / iOS Sample:**
- [ ] Tested on iPhone (Simulator or Device)
- [ ] Tested on iPad / Tablet
- [ ] Tested on Mac (macOS target)

**Kotlin SDK / Android Sample:**
- [ ] Tested on Android Phone (Emulator or Device)
- [ ] Tested on Android Tablet

**Flutter SDK / Flutter Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**React Native SDK / React Native Sample:**
- [ ] Tested on iOS
- [ ] Tested on Android

**Web SDK / Web Sample:**
- [ ] Tested in Chrome (Desktop)
- [ ] Tested in Firefox
- [ ] Tested in Safari
- [ ] WASM backends load (LlamaCpp + ONNX)
- [ ] OPFS storage persistence verified (survives page refresh)
- [ ] Settings persistence verified (localStorage)

## Labels
- [x] `Commons` - Changes to shared native code (`core`)

## Checklist
- [ ] Code follows project style guidelines
- [x] Self-review completed
- [x] Documentation updated (not needed; no public API or documented behavior changed)

## Screenshots
Not applicable; this change has no UI impact.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of memory allocation failures when processing text-to-speech options and synthesis metadata.
  * Prevented partial image data and related resources from remaining after image processing failures.
  * Ensured affected data is safely reset when allocation or data-copy operations fail.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->